### PR TITLE
feat: Add label selectors to listing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,9 @@ Get a Kubernetes Pod in the current or provided namespace with the provided name
 
 List all the Kubernetes pods in the current cluster from all namespaces
 
-**Parameters:** None
+**Parameters:**
+- `labelSelector` (`string`, optional)
+  - Kubernetes label selector (e.g., 'app=myapp,env=prod' or 'app in (myapp,yourapp)'). Use this option to filter the pods by label
 
 ### `pods_list_in_namespace`
 
@@ -250,6 +252,8 @@ List all the Kubernetes pods in the specified namespace in the current cluster
 **Parameters:**
 - `namespace` (`string`, required)
   - Namespace to list pods from
+- `labelSelector` (`string`, optional)
+  - Kubernetes label selector (e.g., 'app=myapp,env=prod' or 'app in (myapp,yourapp)'). Use this option to filter the pods by label
 
 ### `pods_log`
 
@@ -343,6 +347,8 @@ List Kubernetes resources and objects in the current cluster
   - Namespace to retrieve the namespaced resources from
   - Ignored for cluster-scoped resources
   - Lists resources from all namespaces if not provided
+- `labelSelector` (`string`, optional)
+  - Kubernetes label selector (e.g., 'app=myapp,env=prod' or 'app in (myapp,yourapp)'). Use this option to filter the pods by label.
 
 ## 🧑‍💻 Development <a id="development"></a>
 

--- a/pkg/kubernetes/events.go
+++ b/pkg/kubernetes/events.go
@@ -12,7 +12,7 @@ import (
 func (k *Kubernetes) EventsList(ctx context.Context, namespace string) (string, error) {
 	unstructuredList, err := k.resourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Event",
-	}, namespace)
+	}, namespace, "")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/manusa/kubernetes-mcp-server/pkg/version"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,16 +18,16 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-func (k *Kubernetes) PodsListInAllNamespaces(ctx context.Context) (string, error) {
+func (k *Kubernetes) PodsListInAllNamespaces(ctx context.Context, labelSelector string) (string, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
-	}, "")
+	}, "", labelSelector)
 }
 
-func (k *Kubernetes) PodsListInNamespace(ctx context.Context, namespace string) (string, error) {
+func (k *Kubernetes) PodsListInNamespace(ctx context.Context, namespace string, labelSelector string) (string, error) {
 	return k.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
-	}, namespace)
+	}, namespace, labelSelector)
 }
 
 func (k *Kubernetes) PodsGet(ctx context.Context, namespace, name string) (string, error) {

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -262,6 +262,9 @@ func (c *mcpContext) crdWaitUntilReady(name string) {
 	watcher, err := c.newApiExtensionsClient().CustomResourceDefinitions().Watch(c.ctx, metav1.ListOptions{
 		FieldSelector: "metadata.name=" + name,
 	})
+	if err != nil {
+		panic(fmt.Errorf("failed to watch CRD %v", err))
+	}
 	_, err = toolswatch.UntilWithoutRetry(c.ctx, watcher, func(event watch.Event) (bool, error) {
 		for _, c := range event.Object.(*apiextensionsv1spec.CustomResourceDefinition).Status.Conditions {
 			if c.Type == apiextensionsv1spec.Established && c.Status == apiextensionsv1spec.ConditionTrue {
@@ -311,17 +314,45 @@ func createTestData(ctx context.Context) {
 	_, _ = kubernetesAdmin.CoreV1().Namespaces().
 		Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-to-delete"}}, metav1.CreateOptions{})
 	_, _ = kubernetesAdmin.CoreV1().Pods("default").Create(ctx, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "a-pod-in-default"},
-		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}}},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "a-pod-in-default",
+			Labels: map[string]string{"app": "nginx"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+				},
+			},
+		},
 	}, metav1.CreateOptions{})
 	// Pods for listing
 	_, _ = kubernetesAdmin.CoreV1().Pods("ns-1").Create(ctx, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "a-pod-in-ns-1"},
-		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}}},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a-pod-in-ns-1",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+				},
+			},
+		},
 	}, metav1.CreateOptions{})
 	_, _ = kubernetesAdmin.CoreV1().Pods("ns-2").Create(ctx, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "a-pod-in-ns-2"},
-		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}}},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a-pod-in-ns-2",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+				},
+			},
+		},
 	}, metav1.CreateOptions{})
 	_, _ = kubernetesAdmin.CoreV1().ConfigMaps("default").
 		Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "a-configmap-to-delete"}}, metav1.CreateOptions{})

--- a/pkg/mcp/pods_test.go
+++ b/pkg/mcp/pods_test.go
@@ -1,6 +1,9 @@
 package mcp
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -9,8 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/yaml"
-	"strings"
-	"testing"
 )
 
 func TestPodsListInAllNamespaces(t *testing.T) {
@@ -739,6 +740,112 @@ func TestPodsRunInOpenShift(t *testing.T) {
 			targetPort := decodedPodServiceRoute[2].Object["spec"].(map[string]interface{})["port"].(map[string]interface{})["targetPort"].(int64)
 			if targetPort != 80 {
 				t.Errorf("invalid route target port, expected 80, got %v", targetPort)
+				return
+			}
+		})
+	})
+}
+
+func TestPodsListWithLabelSelector(t *testing.T) {
+	testCase(t, func(c *mcpContext) {
+		c.withEnvTest()
+		kc := c.newKubernetesClient()
+		// Create pods with labels
+		_, _ = kc.CoreV1().Pods("default").Create(c.ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "pod-with-labels",
+				Labels: map[string]string{"app": "test", "env": "dev"},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}}},
+		}, metav1.CreateOptions{})
+		_, _ = kc.CoreV1().Pods("ns-1").Create(c.ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "another-pod-with-labels",
+				Labels: map[string]string{"app": "test", "env": "prod"},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}}},
+		}, metav1.CreateOptions{})
+
+		// Test pods_list with label selector
+		t.Run("pods_list with label selector returns filtered pods", func(t *testing.T) {
+			toolResult, err := c.callTool("pods_list", map[string]interface{}{
+				"labelSelector": "app=test",
+			})
+			if err != nil {
+				t.Fatalf("call tool failed %v", err)
+				return
+			}
+			if toolResult.IsError {
+				t.Fatalf("call tool failed")
+				return
+			}
+			var decoded []unstructured.Unstructured
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+			if err != nil {
+				t.Fatalf("invalid tool result content %v", err)
+				return
+			}
+			if len(decoded) != 2 {
+				t.Fatalf("invalid pods count, expected 2, got %v", len(decoded))
+				return
+			}
+		})
+
+		// Test pods_list_in_namespace with label selector
+		t.Run("pods_list_in_namespace with label selector returns filtered pods", func(t *testing.T) {
+			toolResult, err := c.callTool("pods_list_in_namespace", map[string]interface{}{
+				"namespace":     "ns-1",
+				"labelSelector": "env=prod",
+			})
+			if err != nil {
+				t.Fatalf("call tool failed %v", err)
+				return
+			}
+			if toolResult.IsError {
+				t.Fatalf("call tool failed")
+				return
+			}
+			var decoded []unstructured.Unstructured
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+			if err != nil {
+				t.Fatalf("invalid tool result content %v", err)
+				return
+			}
+			if len(decoded) != 1 {
+				t.Fatalf("invalid pods count, expected 1, got %v", len(decoded))
+				return
+			}
+			if decoded[0].GetName() != "another-pod-with-labels" {
+				t.Fatalf("invalid pod name, expected another-pod-with-labels, got %v", decoded[0].GetName())
+				return
+			}
+		})
+
+		// Test multiple label selectors
+		t.Run("pods_list with multiple label selectors returns filtered pods", func(t *testing.T) {
+			toolResult, err := c.callTool("pods_list", map[string]interface{}{
+				"labelSelector": "app=test,env=prod",
+			})
+			if err != nil {
+				t.Fatalf("call tool failed %v", err)
+				return
+			}
+			if toolResult.IsError {
+				t.Fatalf("call tool failed")
+				return
+			}
+			var decoded []unstructured.Unstructured
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+			if err != nil {
+				t.Fatalf("invalid tool result content %v", err)
+				return
+			}
+			if len(decoded) != 1 {
+				t.Fatalf("invalid pods count, expected 1, got %v", len(decoded))
+				return
+			}
+			if decoded[0].GetName() != "another-pod-with-labels" {
+				t.Fatalf("invalid pod name, expected another-pod-with-labels, got %v", decoded[0].GetName())
 				return
 			}
 		})

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,8 +17,8 @@ func (s *Server) initResources() []server.ServerTool {
 	}
 	commonApiVersion = fmt.Sprintf("(common apiVersion and kind include: %s)", commonApiVersion)
 	return []server.ServerTool{
-		{mcp.NewTool("resources_list",
-			mcp.WithDescription("List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace\n"+
+		{Tool: mcp.NewTool("resources_list",
+			mcp.WithDescription("List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n"+
 				commonApiVersion),
 			mcp.WithString("apiVersion",
 				mcp.Description("apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)"),
@@ -28,8 +29,11 @@ func (s *Server) initResources() []server.ServerTool {
 				mcp.Required(),
 			),
 			mcp.WithString("namespace",
-				mcp.Description("Optional Namespace to retrieve the namespaced resources from (ignored in case of cluster scoped resources). If not provided, will list resources from all namespaces"))), s.resourcesList},
-		{mcp.NewTool("resources_get",
+				mcp.Description("Optional Namespace to retrieve the namespaced resources from (ignored in case of cluster scoped resources). If not provided, will list resources from all namespaces")),
+			mcp.WithString("labelSelector",
+			mcp.Description("Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label"), mcp.Pattern("([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"))),
+			Handler: s.resourcesList},
+		{Tool: mcp.NewTool("resources_get",
 			mcp.WithDescription("Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n"+
 				commonApiVersion),
 			mcp.WithString("apiVersion",
@@ -44,16 +48,16 @@ func (s *Server) initResources() []server.ServerTool {
 				mcp.Description("Optional Namespace to retrieve the namespaced resource from (ignored in case of cluster scoped resources). If not provided, will get resource from configured namespace"),
 			),
 			mcp.WithString("name", mcp.Description("Name of the resource"), mcp.Required()),
-		), s.resourcesGet},
-		{mcp.NewTool("resources_create_or_update",
+		), Handler: s.resourcesGet},
+		{Tool: mcp.NewTool("resources_create_or_update",
 			mcp.WithDescription("Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource\n"+
 				commonApiVersion),
 			mcp.WithString("resource",
 				mcp.Description("A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec"),
 				mcp.Required(),
 			),
-		), s.resourcesCreateOrUpdate},
-		{mcp.NewTool("resources_delete",
+		), Handler: s.resourcesCreateOrUpdate},
+		{Tool: mcp.NewTool("resources_delete",
 			mcp.WithDescription("Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n"+
 				commonApiVersion),
 			mcp.WithString("apiVersion",
@@ -68,7 +72,7 @@ func (s *Server) initResources() []server.ServerTool {
 				mcp.Description("Optional Namespace to delete the namespaced resource from (ignored in case of cluster scoped resources). If not provided, will delete resource from configured namespace"),
 			),
 			mcp.WithString("name", mcp.Description("Name of the resource"), mcp.Required()),
-		), s.resourcesDelete},
+		), Handler: s.resourcesDelete},
 	}
 }
 
@@ -77,11 +81,15 @@ func (s *Server) resourcesList(ctx context.Context, ctr mcp.CallToolRequest) (*m
 	if namespace == nil {
 		namespace = ""
 	}
+	labelSelector := ctr.Params.Arguments["labelSelector"]
+	if labelSelector == nil {
+		labelSelector = ""
+	}
 	gvk, err := parseGroupVersionKind(ctr.Params.Arguments)
 	if err != nil {
 		return NewTextResult("", fmt.Errorf("failed to list resources, %s", err)), nil
 	}
-	ret, err := s.k.ResourcesList(ctx, gvk, namespace.(string))
+	ret, err := s.k.ResourcesList(ctx, gvk, namespace.(string), labelSelector.(string))
 	if err != nil {
 		return NewTextResult("", fmt.Errorf("failed to list resources: %v", err)), nil
 	}


### PR DESCRIPTION
This PR introduces the ability to filter Kubernetes resources by label using a labelSelector parameter for the following tools:

 * pods_list
 * pods_list_in_namespace
 * resources_list

This enhancement allows users to retrieve a more specific set of resources based on their labels, improving the flexibility and utility of these tools.

The labelSelector parameter accepts standard Kubernetes label selector syntax, such as app=myapp,env=prod or app in (myapp,yourapp).

Resolves: https://github.com/manusa/kubernetes-mcp-server/issues/54