### PR TITLE
fix(auth): ensure OIDC auth plugin is included in compiled binary

### DIFF
--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -17,6 +17,10 @@ import (
 	"strings"
 )
 
+import (
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
+
 var rootCmd = &cobra.Command{
 	Use:   "kubernetes-mcp-server [command] [options]",
 	Short: "Kubernetes Model Context Protocol (MCP) server",


### PR DESCRIPTION
### Summary:

This PR fixes startup failures when the server is pointed at clusters that authenticate with OIDC.
We add a single side-effect import:

```go
import _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
```

which registers the OIDC plug-in at init() time so that client-go can recognise the auth-provider: oidc stanza found in many kubeconfigs.


### Motivation: 

Running `npx kubernetes-mcp-server@0.0.30` against an OIDC-backed cluster produced:

```
Failed to initialize MCP server: no Auth Provider found for name "oidc"
```
