### PR TITLE
PoC: Agentic scopes

### DIFF
--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -102,7 +102,7 @@ func AuthorizationMiddleware(requireOAuth bool, serverURL string, oidcProvider *
 			// 2. b. If this is not the only token in the headers, the token in here is used
 			// only for authentication and authorization. Therefore, we need to send TokenReview request
 			// with the other token in the headers (TODO: still need to validate aud and exp of this token separately).
-			_, _, err = mcpServer.VerifyTokenAPIServer(r.Context(), token, audience)
+			/*_, _, err = mcpServer.VerifyTokenAPIServer(r.Context(), token, audience)
 			if err != nil {
 				klog.V(1).Infof("Authentication failed - API Server token validation error: %s %s from %s, error: %v", r.Method, r.URL.Path, r.RemoteAddr, err)
 
@@ -113,7 +113,7 @@ func AuthorizationMiddleware(requireOAuth bool, serverURL string, oidcProvider *
 				}
 				http.Error(w, "Unauthorized: Invalid token", http.StatusUnauthorized)
 				return
-			}
+			}*/
 
 			next.ServeHTTP(w, r)
 		})

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 	"net/http"
 	"slices"
+
+	"k8s.io/klog/v2"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -170,12 +171,6 @@ func NewTextResult(content string, err error) *mcp.CallToolResult {
 }
 
 func contextFunc(ctx context.Context, r *http.Request) context.Context {
-	// Get the standard Authorization header (OAuth compliant)
-	authHeader := r.Header.Get(string(internalk8s.OAuthAuthorizationHeader))
-	if authHeader != "" {
-		return context.WithValue(ctx, internalk8s.OAuthAuthorizationHeader, authHeader)
-	}
-
 	// Fallback to custom header for backward compatibility
 	customAuthHeader := r.Header.Get(string(internalk8s.CustomAuthorizationHeader))
 	if customAuthHeader != "" {


### PR DESCRIPTION
This PR is used to fall back to in-cluster config of MCP Server to by pass the token which is issued for authentication/authorization not k8s usage.