### PR TITLE
refactor(auth): temporarily disable scope authorization

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -62,7 +62,7 @@ func NewServer(configuration Configuration) (*Server, error) {
 		server.WithLogging(),
 		server.WithToolHandlerMiddleware(toolCallLoggingMiddleware),
 	)
-	if configuration.StaticConfig.RequireOAuth {
+	if configuration.StaticConfig.RequireOAuth && false { // TODO: Disabled scope auth validation for now
 		serverOptions = append(serverOptions, server.WithToolHandlerMiddleware(toolScopedAuthorizationMiddleware))
 	}
 


### PR DESCRIPTION
It's unclear how the scopes are going to be populated in the JWT. Disable scope authorization for the time being.

/cc @ardaguclu 