### PR TITLE
feat(auth): support for VSCode auth flow

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,11 @@ type StaticConfig struct {
 	// AuthorizationURL is the URL of the OIDC authorization server.
 	// It is used for token validation and for STS token exchange.
 	AuthorizationURL string `toml:"authorization_url,omitempty"`
+	// DisableDynamicClientRegistration indicates whether dynamic client registration is disabled.
+	// If true, the .well-known endpoints will not expose the registration endpoint.
+	DisableDynamicClientRegistration bool `toml:"disable_dynamic_client_registration,omitempty"`
+	// OAuthScopes are the supported **client** scopes requested during the **client/frontend** OAuth flow.
+	OAuthScopes []string `toml:"oauth_scopes,omitempty"`
 	// StsClientId is the OAuth client ID used for backend token exchange
 	StsClientId string `toml:"sts_client_id,omitempty"`
 	// StsClientSecret is the OAuth client secret used for backend token exchange

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -111,6 +111,7 @@ func AuthorizationMiddleware(staticConfig *config.StaticConfig, oidcProvider *oi
 			}
 			// Token exchange with OIDC provider
 			sts := NewFromConfig(staticConfig, oidcProvider)
+			// TODO: Maybe the token had already been exchanged, if it has the right audience and scopes, we can skip this step.
 			if err == nil && sts.IsEnabled() {
 				var exchangedToken *oauth2.Token
 				// If the token is valid, we can exchange it for a new token with the specified audience and scopes.


### PR DESCRIPTION
Adds `DisableDynamicClientRegistration` and `OAuthScopes` to be able to override the values proxied from the configured authorization server.

DisableDynamicClientRegistration removes the registration_endpoint field from the well-known authorization resource metadata.
This forces VSCode to show a for to input the Client ID and Client Secret since these can't be discovered.

The OAuthScopes allows to override the scopes_supported field. VSCode automatically makes an auth request for all of the supported scopes.
In many cases, this is not supported by the auth server. By providing this configuration, the user (MCP Server administrator) is able to set which scopes are effectively supported and force VSCode to only request these.