### PR TITLE
fix:test: prevent usage of real cluster in tests

### DIFF
--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -69,7 +69,7 @@ func (c *httpContext) beforeEach(t *testing.T) {
 	mockKubeConfig := c.mockServer.KubeConfig()
 	kubeConfig := filepath.Join(t.TempDir(), "config")
 	_ = clientcmd.WriteToFile(*mockKubeConfig, kubeConfig)
-	_ = os.Setenv("KUBECONFIG", kubeConfig)
+	c.StaticConfig.KubeConfig = kubeConfig
 	// Capture logging
 	c.klogState = klog.CaptureState()
 	flags := flag.NewFlagSet("test", flag.ContinueOnError)

--- a/pkg/kubernetes/common_test.go
+++ b/pkg/kubernetes/common_test.go
@@ -1,0 +1,19 @@
+package kubernetes
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Set up
+	_ = os.Setenv("KUBECONFIG", "/dev/null")     // Avoid interference from existing kubeconfig
+	_ = os.Setenv("KUBERNETES_SERVICE_HOST", "") // Avoid interference from in-cluster config
+	_ = os.Setenv("KUBERNETES_SERVICE_PORT", "") // Avoid interference from in-cluster config
+
+	// Run tests
+	code := m.Run()
+
+	// Tear down
+	os.Exit(code)
+}

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -52,6 +52,9 @@ var envTestUser = envtest.User{Name: "test-user", Groups: []string{"test:users"}
 
 func TestMain(m *testing.M) {
 	// Set up
+	_ = os.Setenv("KUBECONFIG", "/dev/null")     // Avoid interference from existing kubeconfig
+	_ = os.Setenv("KUBERNETES_SERVICE_HOST", "") // Avoid interference from in-cluster config
+	_ = os.Setenv("KUBERNETES_SERVICE_PORT", "") // Avoid interference from in-cluster config
 	envTestDir, err := store.DefaultStoreDir()
 	if err != nil {
 		panic(err)

--- a/pkg/mcp/configuration_test.go
+++ b/pkg/mcp/configuration_test.go
@@ -1,12 +1,13 @@
 package mcp
 
 import (
+	"testing"
+
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/mark3labs/mcp-go/mcp"
 	"k8s.io/client-go/rest"
 	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/yaml"
-	"testing"
 )
 
 func TestConfigurationView(t *testing.T) {
@@ -78,7 +79,7 @@ func TestConfigurationView(t *testing.T) {
 		})
 		t.Run("configuration_view with minified=false returns additional context info", func(t *testing.T) {
 			if len(decoded.Contexts) != 2 {
-				t.Errorf("invalid context count, expected2, got %v", len(decoded.Contexts))
+				t.Fatalf("invalid context count, expected2, got %v", len(decoded.Contexts))
 			}
 			if decoded.Contexts[0].Name != "additional-context" {
 				t.Errorf("additional-context not found: %v", decoded.Contexts)


### PR DESCRIPTION
Supersedes closes #280
Closes https://github.com/openshift/openshift-mcp-server/pull/26
Fixes #273 

Test set up processes are incomplete and don't override all of the deteted environment settings.

This PR ensures that the tests run on any environment under the same conditions.

/cc @ardaguclu 