### PR TITLE
docs: add Claude Code configuration and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,31 @@ extensions:
 
 ```
 
+### Claude Code
+
+[Claude Code](https://claude.ai/code) provides an integrated command-line interface for Claude with MCP server support.
+
+For reliable connection with Claude Code, use the JSON configuration format:
+
+```bash
+claude mcp add-json kubectl '{"command":"npx","args":["-y","kubernetes-mcp-server@latest"],"env":{"KUBECONFIG":"${HOME}/.kube/config"}}' -s user
+```
+
+This ensures:
+- ✅ Reliable stdio transport connection
+- ✅ User-level scope (works across all projects) 
+- ✅ Proper environment variable handling
+- ✅ Auto-managed server lifecycle
+
+#### Troubleshooting
+
+If you see "Failed to connect" in health checks but the server works when you run kubectl commands, this is expected behavior. The health check timeout may be too aggressive for stdio transport, but the server will function correctly when Claude Code actually uses it.
+
+For connection issues, ensure you're using:
+- **JSON format**: Use `claude mcp add-json` with proper JSON structure instead of command-line arguments
+- **Separate args array**: `"args":["-y","kubernetes-mcp-server@latest"]` instead of combined strings
+- **Environment variables**: Set `KUBECONFIG` in the `env` object for proper kubectl access
+
 ## 🎥 Demos <a id="demos"></a>
 
 ### Diagnosing and automatically fixing an OpenShift Deployment


### PR DESCRIPTION
## Summary

This PR adds comprehensive Claude Code configuration documentation to help users easily set up the kubernetes-mcp-server with Claude Code CLI.

## Changes Made

- **Added Claude Code section** to README.md with tested configuration command
- **Included troubleshooting guidance** for common stdio transport connection issues
- **Documented proper JSON format** usage to avoid "Failed to connect" errors
- **Explained environment variable handling** for KUBECONFIG
- **Added user-level scope installation** instructions for cross-project availability

## Key Configuration

The documented command that works reliably:
```bash
claude mcp add-json kubectl '{"command":"npx","args":["-y","kubernetes-mcp-server@latest"],"env":{"KUBECONFIG":"${HOME}/.kube/config"}}' -s user
```

## Problem Solved

Many users experience "Failed to connect" issues when trying to add this MCP server to Claude Code. This documentation provides:

1. **Correct JSON format** instead of command-line argument format
2. **Proper environment variable setup** for kubectl access  
3. **Troubleshooting guidance** explaining that health check failures are normal but don't affect functionality
4. **User-level scope** configuration for cross-project availability

## Testing

The configuration has been tested and verified to work with Claude Code, providing reliable kubectl functionality across all projects.

## Documentation Placement

The new Claude Code section is positioned after the Goose CLI section, maintaining consistency with other tool integrations in the README.

This change makes it significantly easier for Claude Code users to integrate kubernetes-mcp-server into their workflow with a single, tested command.