### PR TITLE
server add get mcp server function

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,6 +48,14 @@ type StaticConfig struct {
 	StsScopes            []string `toml:"sts_scopes,omitempty"`
 	CertificateAuthority string   `toml:"certificate_authority,omitempty"`
 	ServerURL            string   `toml:"server_url,omitempty"`
+	// HealthEndpoint is the health check endpoint
+	HealthEndpoint string `toml:"health_endpoint,omitempty"`
+	// SSEEndpoint is the SSE endpoint
+	SSEEndpoint string `toml:"sse_endpoint,omitempty"`
+	// SSEMessageEndpoint is the SSE message endpoint
+	SSEMessageEndpoint string `toml:"sse_message_endpoint,omitempty"`
+	// StreamableHttpEndpoint is the streamable http endpoint
+	StreamableHttpEndpoint string `toml:"streamable_http_endpoint,omitempty"`
 }
 
 type GroupVersionKind struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -65,6 +65,11 @@ denied_resources = [
 
 enabled_tools = ["configuration_view", "events_list", "namespaces_list", "pods_list", "resources_list", "resources_get", "resources_create_or_update", "resources_delete"]
 disabled_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"]
+
+health_endpoint = "/k8s/healthz"
+streamable_http_endpoint = "/k8s/mcp"
+sse_endpoint = "/k8s/sse"
+sse_message_endpoint = "/k8s/message"
 `)
 
 	config, err := ReadConfig(validConfigPath)
@@ -140,6 +145,26 @@ disabled_tools = ["pods_delete", "pods_top", "pods_log", "pods_run", "pods_exec"
 			if config.DisabledTools[i] != tool {
 				t.Errorf("Expected disabled tool %d to be %s, got %s", i, tool, config.DisabledTools[i])
 			}
+		}
+	})
+	t.Run("health_endpoint parsed correctly", func(t *testing.T) {
+		if config.HealthEndpoint != "/k8s/healthz" {
+			t.Fatalf("Unexpected health_endpoint value: %v", config.HealthEndpoint)
+		}
+	})
+	t.Run("streamable_http_endpoint parsed correctly", func(t *testing.T) {
+		if config.StreamableHttpEndpoint != "/k8s/mcp" {
+			t.Fatalf("Unexpected streamable_http_endpoint value: %v", config.StreamableHttpEndpoint)
+		}
+	})
+	t.Run("sse_endpoint parsed correctly", func(t *testing.T) {
+		if config.SSEEndpoint != "/k8s/sse" {
+			t.Fatalf("Unexpected sse_endpoint value: %v", config.SSEEndpoint)
+		}
+	})
+	t.Run("sse_message_endpoint parsed correctly", func(t *testing.T) {
+		if config.SSEMessageEndpoint != "/k8s/message" {
+			t.Fatalf("Unexpected sse_message_endpoint value: %v", config.SSEMessageEndpoint)
 		}
 	})
 }

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -65,6 +65,7 @@ type KubernetesApiTokenVerifier interface {
 func AuthorizationMiddleware(staticConfig *config.StaticConfig, oidcProvider *oidc.Provider, verifier KubernetesApiTokenVerifier) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			healthEndpoint := getEndpointOrDefault(staticConfig.HealthEndpoint, defaultHealthEndpoint)
 			if r.URL.Path == healthEndpoint || slices.Contains(WellKnownEndpoints, r.URL.EscapedPath()) {
 				next.ServeHTTP(w, r)
 				return

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -68,6 +68,11 @@ type MCPServerOptions struct {
 	CertificateAuthority string
 	ServerURL            string
 
+	HealthEndpoint         string
+	StreamableHttpEndpoint string
+	SseEndpoint            string
+	SseMessageEndpoint     string
+
 	ConfigPath   string
 	StaticConfig *config.StaticConfig
 
@@ -120,6 +125,10 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVar(&o.ReadOnly, "read-only", o.ReadOnly, "If true, only tools annotated with readOnlyHint=true are exposed")
 	cmd.Flags().BoolVar(&o.DisableDestructive, "disable-destructive", o.DisableDestructive, "If true, tools annotated with destructiveHint=true are disabled")
 	cmd.Flags().BoolVar(&o.RequireOAuth, "require-oauth", o.RequireOAuth, "If true, requires OAuth authorization as defined in the Model Context Protocol (MCP) specification. This flag is ignored if transport type is stdio")
+	cmd.Flags().StringVar(&o.HealthEndpoint, "health-endpoint", o.HealthEndpoint, "Use for set health endpoint to use for health checks, Default is /healthz")
+	cmd.Flags().StringVar(&o.StreamableHttpEndpoint, "streamable-http-endpoint", o.StreamableHttpEndpoint, "Use for set streamable http requests endpoint, Default is /mcp")
+	cmd.Flags().StringVar(&o.SseEndpoint, "sse-endpoint", o.SseEndpoint, "Use for set sse requests endpoint, Default is /sse")
+	cmd.Flags().StringVar(&o.SseMessageEndpoint, "sse-message-endpoint", o.SseMessageEndpoint, "Use for set sse message requests endpoint, Default is /message")
 	_ = cmd.Flags().MarkHidden("require-oauth")
 	cmd.Flags().StringVar(&o.OAuthAudience, "oauth-audience", o.OAuthAudience, "OAuth audience for token claims validation. Optional. If not set, the audience is not validated. Only valid if require-oauth is enabled.")
 	_ = cmd.Flags().MarkHidden("oauth-audience")
@@ -199,6 +208,18 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 	if cmd.Flag("certificate-authority").Changed {
 		m.StaticConfig.CertificateAuthority = m.CertificateAuthority
+	}
+	if cmd.Flag("health-endpoint").Changed {
+		m.StaticConfig.HealthEndpoint = m.HealthEndpoint
+	}
+	if cmd.Flag("streamable-http-endpoint").Changed {
+		m.StaticConfig.StreamableHttpEndpoint = m.StreamableHttpEndpoint
+	}
+	if cmd.Flag("sse-endpoint").Changed {
+		m.StaticConfig.SSEEndpoint = m.SseEndpoint
+	}
+	if cmd.Flag("sse-message-endpoint").Changed {
+		m.StaticConfig.SSEMessageEndpoint = m.SseMessageEndpoint
 	}
 }
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -143,6 +143,10 @@ func (s *Server) GetEnabledTools() []string {
 	return s.enabledTools
 }
 
+func (s *Server) GetMCPServer() *server.MCPServer {
+	return s.server
+}
+
 func (s *Server) Close() {
 	if s.k != nil {
 		s.k.Close()

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -104,11 +104,17 @@ func (s *Server) ServeStdio() error {
 	return server.ServeStdio(s.server)
 }
 
-func (s *Server) ServeSse(baseUrl string, httpServer *http.Server) *server.SSEServer {
+func (s *Server) ServeSse(baseUrl, sseEndpoint, sseMessageEndpoint string, httpServer *http.Server) *server.SSEServer {
 	options := make([]server.SSEOption, 0)
 	options = append(options, server.WithSSEContextFunc(contextFunc), server.WithHTTPServer(httpServer))
 	if baseUrl != "" {
 		options = append(options, server.WithBaseURL(baseUrl))
+	}
+	if sseEndpoint != "" {
+		options = append(options, server.WithSSEEndpoint(sseEndpoint))
+	}
+	if sseMessageEndpoint != "" {
+		options = append(options, server.WithMessageEndpoint(sseMessageEndpoint))
 	}
 	return server.NewSSEServer(s.server, options...)
 }
@@ -141,10 +147,6 @@ func (s *Server) GetKubernetesAPIServerHost() string {
 
 func (s *Server) GetEnabledTools() []string {
 	return s.enabledTools
-}
-
-func (s *Server) GetMCPServer() *server.MCPServer {
-	return s.server
 }
 
 func (s *Server) Close() {


### PR DESCRIPTION
when I use as a library, I want to define different sse endpoint, for example: 
```golang
package main

import (
	mcpConfig "github.com/containers/kubernetes-mcp-server/pkg/config"
	"github.com/containers/kubernetes-mcp-server/pkg/mcp"
	"github.com/containers/kubernetes-mcp-server/pkg/output"
	goMcpServer "github.com/mark3labs/mcp-go/server"
	"net/http"
)

func main() {
	config := &mcpConfig.StaticConfig{
		KubeConfig: "path/to/kubeconfig",
		// other config
	}
	server, err := mcp.NewServer(mcp.Configuration{
		Profile:      new(mcp.FullProfile),
		ListOutput:   output.Yaml,
		StaticConfig: config,
	})
	if err != nil {
		panic(err)
	}

	sseEndpoint := "/k8s/sse"
	sseMessageEndpoint := "/k8s/message"

	// get mcp server
	mcpServer := server.GetMCPServer()

	sseHandler := goMcpServer.NewSSEServer(
		mcpServer,
		goMcpServer.WithSSEEndpoint(sseEndpoint),
		goMcpServer.WithMessageEndpoint(sseMessageEndpoint),
	)

	http.Handle(sseEndpoint, sseHandler)
	http.Handle(sseMessageEndpoint, sseHandler)
	http.ListenAndServe(":9800", nil)
}
```
need server.GetMCPServer() function to get mcp server instance