### PR TITLE
Support for multiple contexts in kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A powerful and flexible Kubernetes [Model Context Protocol (MCP)](https://blog.m
 - **✅ Configuration**:
   - Automatically detect changes in the Kubernetes configuration and update the MCP server.
   - **View** and manage the current [Kubernetes `.kube/config`](https://blog.marcnuri.com/where-is-my-default-kubeconfig-file) or in-cluster configuration.
+  - **Multi-cluster support**: Switch between different Kubernetes contexts on the fly using the optional `context` parameter on any cluster-specific tool.
+  - **List available contexts**: Discover all available Kubernetes contexts in your kubeconfig with `contexts_list`.
 - **✅ Generic Kubernetes Resources**: Perform operations on **any** Kubernetes or OpenShift resource.
   - Any CRUD operation (Create or Update, Get, List, Delete).
 - **✅ Pods**: Perform Pod-specific operations.
@@ -196,11 +198,21 @@ Get the current Kubernetes configuration content as a kubeconfig YAML
   - If `true`, keeps only the current-context and relevant configuration pieces
   - If `false`, returns all contexts, clusters, auth-infos, and users
 
+### `contexts_list`
+
+List all available Kubernetes contexts from your kubeconfig with their cluster server URLs
+
+**Parameters:** None
+
+**Output format:** `[*] CONTEXT_NAME -> CLUSTER_SERVER_URL` where `*` indicates the current active context.
+
 ### `events_list`
 
 List all the Kubernetes events in the current cluster from all namespaces
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `namespace` (`string`, optional)
   - Namespace to retrieve the events from. If not provided, will list events from all namespaces
 
@@ -209,6 +221,8 @@ List all the Kubernetes events in the current cluster from all namespaces
 Install a Helm chart in the current or provided namespace with the provided name and chart
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `chart` (`string`, required)
   - Name of the Helm chart to install
   - Can be a local path or a remote URL
@@ -228,6 +242,8 @@ Install a Helm chart in the current or provided namespace with the provided name
 List all the Helm releases in the current or provided namespace (or in all namespaces if specified)
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `namespace` (`string`, optional)
   - Namespace to list the Helm releases from
   - If not provided, will use the configured namespace
@@ -240,6 +256,8 @@ List all the Helm releases in the current or provided namespace (or in all names
 Uninstall a Helm release in the current or provided namespace with the provided name
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `name` (`string`, required)
   - Name of the Helm release to uninstall
 - `namespace` (`string`, optional)
@@ -250,13 +268,17 @@ Uninstall a Helm release in the current or provided namespace with the provided 
 
 List all the Kubernetes namespaces in the current cluster
 
-**Parameters:** None
+**Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 
 ### `pods_delete`
 
 Delete a Kubernetes Pod in the current or provided namespace with the provided name
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `name` (`string`, required)
   - Name of the Pod to delete
 - `namespace` (`string`, required)
@@ -267,6 +289,8 @@ Delete a Kubernetes Pod in the current or provided namespace with the provided n
 Execute a command in a Kubernetes Pod in the current or provided namespace with the provided name and command
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `command` (`string[]`, required)
   - Command to execute in the Pod container
   - First item is the command, rest are arguments
@@ -283,6 +307,8 @@ Execute a command in a Kubernetes Pod in the current or provided namespace with 
 Get a Kubernetes Pod in the current or provided namespace with the provided name
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `name` (`string`, required)
   - Name of the Pod
 - `namespace` (`string`, required)
@@ -293,6 +319,8 @@ Get a Kubernetes Pod in the current or provided namespace with the provided name
 List all the Kubernetes pods in the current cluster from all namespaces
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `labelSelector` (`string`, optional)
   - Kubernetes label selector (e.g., 'app=myapp,env=prod' or 'app in (myapp,yourapp)'). Use this option to filter the pods by label
 
@@ -301,6 +329,8 @@ List all the Kubernetes pods in the current cluster from all namespaces
 List all the Kubernetes pods in the specified namespace in the current cluster
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `namespace` (`string`, required)
   - Namespace to list pods from
 - `labelSelector` (`string`, optional)
@@ -311,6 +341,8 @@ List all the Kubernetes pods in the specified namespace in the current cluster
 Get the logs of a Kubernetes Pod in the current or provided namespace with the provided name
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `name` (`string`, required)
   - Name of the Pod to get logs from
 - `namespace` (`string`, required)
@@ -325,6 +357,8 @@ Get the logs of a Kubernetes Pod in the current or provided namespace with the p
 Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `image` (`string`, required)
   - Container Image to run in the Pod
 - `namespace` (`string`, required)
@@ -340,6 +374,8 @@ Run a Kubernetes Pod in the current or provided namespace with the provided cont
 Lists the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Pods in the all namespaces, the provided namespace, or the current namespace
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `all_namespaces` (`boolean`, optional, default: `true`)
   - If `true`, lists resource consumption for Pods in all namespaces
   - If `false`, lists resource consumption for Pods in the configured or provided namespace
@@ -356,11 +392,17 @@ Lists the resource consumption (CPU and memory) as recorded by the Kubernetes Me
 
 List all the OpenShift projects in the current cluster
 
+**Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
+
 ### `resources_create_or_update`
 
 Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `resource` (`string`, required)
   - A JSON or YAML containing a representation of the Kubernetes resource
   - Should include top-level fields such as apiVersion, kind, metadata, and spec
@@ -377,6 +419,8 @@ Create or update a Kubernetes resource in the current cluster by providing a YAM
 Delete a Kubernetes resource in the current cluster
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `apiVersion` (`string`, required)
   - apiVersion of the resource (e.g., `v1`, `apps/v1`, `networking.k8s.io/v1`)
 - `kind` (`string`, required)
@@ -393,6 +437,8 @@ Delete a Kubernetes resource in the current cluster
 Get a Kubernetes resource in the current cluster
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `apiVersion` (`string`, required)
   - apiVersion of the resource (e.g., `v1`, `apps/v1`, `networking.k8s.io/v1`)
 - `kind` (`string`, required)
@@ -409,6 +455,8 @@ Get a Kubernetes resource in the current cluster
 List Kubernetes resources and objects in the current cluster
 
 **Parameters:**
+- `context` (`string`, optional)
+  - Kubernetes context to use for this operation. If not provided, uses the current context
 - `apiVersion` (`string`, required)
   - apiVersion of the resources (e.g., `v1`, `apps/v1`, `networking.k8s.io/v1`)
 - `kind` (`string`, required)

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -3,11 +3,35 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 	"github.com/google/jsonschema-go/jsonschema"
 )
+
+// ContextParameterSchema is the reusable context parameter schema for multi-cluster tools
+var ContextParameterSchema = &jsonschema.Schema{
+	Type:        "string",
+	Description: "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+}
+
+// GetKubernetesWithContext returns a Kubernetes client for the specified context, or the default client if no context is specified
+func GetKubernetesWithContext(params ToolHandlerParams) (*internalk8s.Kubernetes, error) {
+	contextName := params.GetArguments()["context"]
+	if contextName == nil || contextName == "" {
+		// No context specified, use default
+		return params.Kubernetes, nil
+	}
+
+	// Create client for specified context
+	contextClient, err := params.WithContext(contextName.(string))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client for context '%s': %v", contextName, err)
+	}
+
+	return contextClient, nil
+}
 
 type ServerTool struct {
 	Tool    Tool

--- a/pkg/kubernetes/configuration.go
+++ b/pkg/kubernetes/configuration.go
@@ -2,7 +2,10 @@ package kubernetes
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
@@ -112,4 +115,92 @@ func (k *Kubernetes) ConfigurationView(minify bool) (runtime.Object, error) {
 		//return "", err
 	}
 	return latest.Scheme.ConvertToVersion(&cfg, latest.ExternalVersion)
+}
+
+// ContextsList returns the available contexts from kubeconfig
+// Returns a map of context names to cluster servers and the current active context
+func (k *Kubernetes) ContextsList() (map[string]string, string, error) {
+	if k.manager.IsInCluster() {
+		// In cluster mode, there's only one context
+		return map[string]string{"cluster": k.manager.cfg.Host}, "cluster", nil
+	}
+
+	cfg, err := k.manager.clientCmdConfig.RawConfig()
+	if err != nil {
+		return nil, "", err
+	}
+
+	contexts := make(map[string]string)
+	for contextName, context := range cfg.Contexts {
+		cluster, exists := cfg.Clusters[context.Cluster]
+		if exists {
+			contexts[contextName] = cluster.Server
+		} else {
+			contexts[contextName] = "unknown"
+		}
+	}
+
+	return contexts, cfg.CurrentContext, nil
+}
+
+// newManagerForContext creates a new Manager instance configured for the specified context
+func (m *Manager) newManagerForContext(contextName string) (*Manager, error) {
+	if m.IsInCluster() {
+		// In cluster mode, context switching is not applicable
+		return m, nil
+	}
+
+	if contextName == "" {
+		// Empty context means use default, return current manager
+		return m, nil
+	}
+
+	// Create new client config with context override
+	pathOptions := clientcmd.NewDefaultPathOptions()
+	if m.staticConfig.KubeConfig != "" {
+		pathOptions.LoadingRules.ExplicitPath = m.staticConfig.KubeConfig
+	}
+
+	clientCmdConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		pathOptions.LoadingRules,
+		&clientcmd.ConfigOverrides{
+			CurrentContext: contextName,
+		})
+
+	// Create new rest config for the context
+	cfg, err := clientCmdConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	if cfg.UserAgent == "" {
+		cfg.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	// Create new manager with context-specific config
+	newManager := &Manager{
+		cfg:             cfg,
+		clientCmdConfig: clientCmdConfig,
+		staticConfig:    m.staticConfig,
+	}
+
+	// Initialize clients for new manager
+	newManager.accessControlClientSet, err = NewAccessControlClientset(newManager.cfg, newManager.staticConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize discovery client and REST mapper
+	newManager.discoveryClient = memory.NewMemCacheClient(newManager.accessControlClientSet.DiscoveryClient())
+	newManager.accessControlRESTMapper = NewAccessControlRESTMapper(
+		restmapper.NewDeferredDiscoveryRESTMapper(newManager.discoveryClient),
+		newManager.staticConfig,
+	)
+
+	// Initialize dynamic client for Kubernetes API operations
+	newManager.dynamicClient, err = dynamic.NewForConfig(newManager.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return newManager, nil
 }

--- a/pkg/kubernetes/configuration_test.go
+++ b/pkg/kubernetes/configuration_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
@@ -151,5 +153,213 @@ users:
 		if m.cfg.Host != "https://example.com" {
 			t.Errorf("expected host https://example.com, got %s", m.cfg.Host)
 		}
+	})
+}
+
+func TestKubernetes_ContextsList(t *testing.T) {
+	t.Run("with multiple contexts returns correct context map", func(t *testing.T) {
+		// Create a temporary kubeconfig file with multiple contexts for testing
+		tempDir := t.TempDir()
+		kubeconfigPath := path.Join(tempDir, "config")
+		kubeconfigContent := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://production-cluster.example.com
+  name: production-cluster
+- cluster:
+    server: https://staging-cluster.example.com
+  name: staging-cluster
+- cluster:
+    server: https://development-cluster.example.com
+  name: development-cluster
+contexts:
+- context:
+    cluster: production-cluster
+    user: prod-user
+  name: production
+- context:
+    cluster: staging-cluster
+    user: staging-user
+  name: staging
+- context:
+    cluster: development-cluster
+    user: dev-user
+  name: development
+current-context: staging
+users:
+- name: prod-user
+  user:
+    token: prod-token
+- name: staging-user
+  user:
+    token: staging-token
+- name: dev-user
+  user:
+    token: dev-token
+`
+		require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0644), "failed to create kubeconfig file")
+
+		testStaticConfig := &config.StaticConfig{
+			KubeConfig: kubeconfigPath,
+		}
+
+		testManager, err := NewManager(testStaticConfig)
+		require.NoError(t, err, "failed to create manager")
+		defer testManager.Close()
+
+		k8s := &Kubernetes{manager: testManager}
+
+		contexts, currentContext, err := k8s.ContextsList()
+		require.NoError(t, err, "ContextsList should not return error")
+
+		// Verify contexts map
+		expectedContexts := map[string]string{
+			"production":  "https://production-cluster.example.com",
+			"staging":     "https://staging-cluster.example.com",
+			"development": "https://development-cluster.example.com",
+		}
+		assert.Equal(t, expectedContexts, contexts, "contexts should match expected map")
+
+		// Verify current context
+		assert.Equal(t, "staging", currentContext, "current context should be staging")
+	})
+
+	t.Run("with single context returns single context", func(t *testing.T) {
+		tempDir := t.TempDir()
+		kubeconfigPath := path.Join(tempDir, "config")
+		kubeconfigContent := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://single-cluster.example.com
+  name: single-cluster
+contexts:
+- context:
+    cluster: single-cluster
+    user: single-user
+  name: single-context
+current-context: single-context
+users:
+- name: single-user
+  user:
+    token: single-token
+`
+		require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0644), "failed to create kubeconfig file")
+
+		testStaticConfig := &config.StaticConfig{
+			KubeConfig: kubeconfigPath,
+		}
+
+		testManager, err := NewManager(testStaticConfig)
+		require.NoError(t, err, "failed to create manager")
+		defer testManager.Close()
+
+		k8s := &Kubernetes{manager: testManager}
+
+		contexts, currentContext, err := k8s.ContextsList()
+		require.NoError(t, err, "ContextsList should not return error")
+
+		expectedContexts := map[string]string{
+			"single-context": "https://single-cluster.example.com",
+		}
+		assert.Equal(t, expectedContexts, contexts, "contexts should match expected single context")
+		assert.Equal(t, "single-context", currentContext, "current context should be single-context")
+	})
+
+	t.Run("with context referencing missing cluster marks as unknown", func(t *testing.T) {
+		tempDir := t.TempDir()
+		kubeconfigPath := path.Join(tempDir, "config")
+		kubeconfigContent := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://existing-cluster.example.com
+  name: existing-cluster
+contexts:
+- context:
+    cluster: existing-cluster
+    user: valid-user
+  name: valid-context
+- context:
+    cluster: missing-cluster
+    user: invalid-user
+  name: invalid-context
+current-context: valid-context
+users:
+- name: valid-user
+  user:
+    token: valid-token
+- name: invalid-user
+  user:
+    token: invalid-token
+`
+		require.NoError(t, os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0644), "failed to create kubeconfig file")
+
+		testStaticConfig := &config.StaticConfig{
+			KubeConfig: kubeconfigPath,
+		}
+
+		testManager, err := NewManager(testStaticConfig)
+		require.NoError(t, err, "failed to create manager")
+		defer testManager.Close()
+
+		k8s := &Kubernetes{manager: testManager}
+
+		contexts, currentContext, err := k8s.ContextsList()
+		require.NoError(t, err, "ContextsList should not return error")
+
+		expectedContexts := map[string]string{
+			"valid-context":   "https://existing-cluster.example.com",
+			"invalid-context": "unknown",
+		}
+		assert.Equal(t, expectedContexts, contexts, "contexts should include unknown for missing cluster")
+		assert.Equal(t, "valid-context", currentContext, "current context should be valid-context")
+	})
+
+	t.Run("in-cluster returns single cluster context", func(t *testing.T) {
+		// Mock in-cluster configuration
+		originalInClusterConfig := InClusterConfig
+		InClusterConfig = func() (*rest.Config, error) {
+			return &rest.Config{
+				Host: "https://kubernetes.default.svc",
+			}, nil
+		}
+		defer func() {
+			InClusterConfig = originalInClusterConfig
+		}()
+
+		inClusterStaticConfig := &config.StaticConfig{}
+		inClusterManager, err := NewManager(inClusterStaticConfig)
+		require.NoError(t, err, "failed to create in-cluster manager")
+		defer inClusterManager.Close()
+
+		k8s := &Kubernetes{manager: inClusterManager}
+
+		contexts, currentContext, err := k8s.ContextsList()
+		require.NoError(t, err, "ContextsList should not return error for in-cluster")
+
+		expectedContexts := map[string]string{
+			"cluster": "https://kubernetes.default.svc",
+		}
+		assert.Equal(t, expectedContexts, contexts, "in-cluster should return single cluster context")
+		assert.Equal(t, "cluster", currentContext, "current context should be cluster")
+	})
+
+	t.Run("with nonexistent kubeconfig file returns error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		kubeconfigPath := path.Join(tempDir, "nonexistent-config")
+
+		testStaticConfig := &config.StaticConfig{
+			KubeConfig: kubeconfigPath,
+		}
+
+		// This should fail during Manager creation due to missing file
+		_, err := NewManager(testStaticConfig)
+		assert.Error(t, err, "NewManager should return error for nonexistent kubeconfig")
+		assert.Contains(t, err.Error(), "no such file or directory", "error should mention missing file")
 	})
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -212,3 +212,12 @@ func (k *Kubernetes) NewHelm() *helm.Helm {
 	// This is a derived Kubernetes, so it already has the Helm initialized
 	return helm.NewHelm(k.manager)
 }
+
+// WithContext creates a new Kubernetes instance configured for the specified context
+func (k *Kubernetes) WithContext(contextName string) (*Kubernetes, error) {
+	contextManager, err := k.manager.newManagerForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+	return &Kubernetes{manager: contextManager}, nil
+}

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -21,16 +21,34 @@
   },
   {
     "annotations": {
+      "title": "Contexts: List",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    },
+    "description": "List all available contexts from the kubeconfig file. Shows context names mapped to their cluster server URLs, indicates the current active context, and provides usage examples. Output format: [*] CONTEXT_NAME -\u003e CLUSTER_SERVER_URL",
+    "inputSchema": {
+      "type": "object"
+    },
+    "name": "contexts_list"
+  },
+  {
+    "annotations": {
       "title": "Events: List",
       "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List all the Kubernetes events in the current cluster from all namespaces",
+    "description": "List all the Kubernetes events in the cluster (current or provided context) from all namespaces",
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "namespace": {
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
@@ -53,6 +71,10 @@
       "properties": {
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "name": {
@@ -90,6 +112,10 @@
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
           "type": "boolean"
         },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "namespace": {
           "description": "Namespace to list Helm releases from (Optional, all namespaces if not provided)",
           "type": "string"
@@ -110,6 +136,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Helm release to uninstall",
           "type": "string"
@@ -133,9 +163,15 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List all the Kubernetes namespaces in the current cluster",
+    "description": "List all the Kubernetes namespaces in the cluster (current or provided context)",
     "inputSchema": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        }
+      }
     },
     "name": "namespaces_list"
   },
@@ -151,6 +187,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod to delete",
           "type": "string"
@@ -189,6 +229,10 @@
           "description": "Name of the Pod container where the command will be executed (Optional)",
           "type": "string"
         },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod where the command will be executed",
           "type": "string"
@@ -217,6 +261,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod",
           "type": "string"
@@ -240,10 +288,14 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List all the Kubernetes pods in the current cluster from all namespaces",
+    "description": "List all the Kubernetes pods in the cluster (current or provided context) from all namespaces",
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -261,10 +313,14 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List all the Kubernetes pods in the specified namespace in the current cluster",
+    "description": "List all the Kubernetes pods in the specified namespace in the cluster (current or provided context)",
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -295,6 +351,10 @@
       "properties": {
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "name": {
@@ -328,6 +388,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "image": {
           "description": "Container Image to run in the Pod",
           "type": "string"
@@ -368,6 +432,10 @@
           "description": "If true, list the resource consumption for all Pods in all namespaces. If false, list the resource consumption for Pods in the provided namespace or the current namespace",
           "type": "boolean"
         },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "label_selector": {
           "description": "Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label (Optional, only applicable when name is not provided)",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -393,9 +461,15 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List all the OpenShift projects in the current cluster",
+    "description": "List all the OpenShift projects in the cluster (current or provided context)",
     "inputSchema": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        }
+      }
     },
     "name": "projects_list"
   },
@@ -407,10 +481,14 @@
       "idempotentHint": true,
       "openWorldHint": true
     },
-    "description": "Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
+    "description": "Create or update a Kubernetes resource in the cluster (current or provided context) by providing a YAML or JSON representation of the resource\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"
@@ -430,12 +508,16 @@
       "idempotentHint": true,
       "openWorldHint": true
     },
-    "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
+    "description": "Delete a Kubernetes resource in the cluster (current or provided context) by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "kind": {
@@ -467,12 +549,16 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
+    "description": "Get a Kubernetes resource in the cluster (current or provided context) by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "kind": {
@@ -504,12 +590,16 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
+    "description": "List Kubernetes resources and objects in the cluster (current or provided context) by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "kind": {

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -21,16 +21,34 @@
   },
   {
     "annotations": {
+      "title": "Contexts: List",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false
+    },
+    "description": "List all available contexts from the kubeconfig file. Shows context names mapped to their cluster server URLs, indicates the current active context, and provides usage examples. Output format: [*] CONTEXT_NAME -\u003e CLUSTER_SERVER_URL",
+    "inputSchema": {
+      "type": "object"
+    },
+    "name": "contexts_list"
+  },
+  {
+    "annotations": {
       "title": "Events: List",
       "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List all the Kubernetes events in the current cluster from all namespaces",
+    "description": "List all the Kubernetes events in the cluster (current or provided context) from all namespaces",
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "namespace": {
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
@@ -53,6 +71,10 @@
       "properties": {
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "name": {
@@ -90,6 +112,10 @@
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
           "type": "boolean"
         },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "namespace": {
           "description": "Namespace to list Helm releases from (Optional, all namespaces if not provided)",
           "type": "string"
@@ -110,6 +136,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Helm release to uninstall",
           "type": "string"
@@ -133,9 +163,15 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List all the Kubernetes namespaces in the current cluster",
+    "description": "List all the Kubernetes namespaces in the cluster (current or provided context)",
     "inputSchema": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        }
+      }
     },
     "name": "namespaces_list"
   },
@@ -151,6 +187,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod to delete",
           "type": "string"
@@ -189,6 +229,10 @@
           "description": "Name of the Pod container where the command will be executed (Optional)",
           "type": "string"
         },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod where the command will be executed",
           "type": "string"
@@ -217,6 +261,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "name": {
           "description": "Name of the Pod",
           "type": "string"
@@ -240,10 +288,14 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List all the Kubernetes pods in the current cluster from all namespaces",
+    "description": "List all the Kubernetes pods in the cluster (current or provided context) from all namespaces",
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -261,10 +313,14 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List all the Kubernetes pods in the specified namespace in the current cluster",
+    "description": "List all the Kubernetes pods in the specified namespace in the cluster (current or provided context)",
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "labelSelector": {
           "description": "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -295,6 +351,10 @@
       "properties": {
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "name": {
@@ -328,6 +388,10 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "image": {
           "description": "Container Image to run in the Pod",
           "type": "string"
@@ -368,6 +432,10 @@
           "description": "If true, list the resource consumption for all Pods in all namespaces. If false, list the resource consumption for Pods in the provided namespace or the current namespace",
           "type": "boolean"
         },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "label_selector": {
           "description": "Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label (Optional, only applicable when name is not provided)",
           "pattern": "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]",
@@ -393,10 +461,14 @@
       "idempotentHint": true,
       "openWorldHint": true
     },
-    "description": "Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Create or update a Kubernetes resource in the cluster (current or provided context) by providing a YAML or JSON representation of the resource\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "type": "object",
       "properties": {
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
+          "type": "string"
+        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"
@@ -416,12 +488,16 @@
       "idempotentHint": true,
       "openWorldHint": true
     },
-    "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Delete a Kubernetes resource in the cluster (current or provided context) by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "kind": {
@@ -453,12 +529,16 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Get a Kubernetes resource in the cluster (current or provided context) by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "kind": {
@@ -490,12 +570,16 @@
       "idempotentHint": false,
       "openWorldHint": true
     },
-    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "List Kubernetes resources and objects in the cluster (current or provided context) by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional Kubernetes context to use for this operation (if not provided, uses the current context)",
           "type": "string"
         },
         "kind": {

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -17,6 +17,7 @@ import (
 func TestFullToolsetTools(t *testing.T) {
 	expectedNames := []string{
 		"configuration_view",
+		"contexts_list",
 		"events_list",
 		"helm_install",
 		"helm_list",

--- a/pkg/toolsets/full/configuration.go
+++ b/pkg/toolsets/full/configuration.go
@@ -13,6 +13,20 @@ import (
 func initConfiguration() []api.ServerTool {
 	tools := []api.ServerTool{
 		{Tool: api.Tool{
+			Name:        "contexts_list",
+			Description: "List all available contexts from the kubeconfig file. Shows context names mapped to their cluster server URLs, indicates the current active context, and provides usage examples. Output format: [*] CONTEXT_NAME -> CLUSTER_SERVER_URL",
+			InputSchema: &jsonschema.Schema{
+				Type: "object",
+			},
+			Annotations: api.ToolAnnotations{
+				Title:           "Contexts: List",
+				ReadOnlyHint:    ptr.To(true),
+				DestructiveHint: ptr.To(false),
+				IdempotentHint:  ptr.To(true),
+				OpenWorldHint:   ptr.To(false),
+			},
+		}, Handler: contextsList},
+		{Tool: api.Tool{
 			Name:        "configuration_view",
 			Description: "Get the current Kubernetes configuration content as a kubeconfig YAML",
 			InputSchema: &jsonschema.Schema{
@@ -54,4 +68,36 @@ func configurationView(params api.ToolHandlerParams) (*api.ToolCallResult, error
 		err = fmt.Errorf("failed to get configuration: %v", err)
 	}
 	return api.NewToolCallResult(configurationYaml, err), nil
+}
+
+func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	contexts, currentContext, err := params.ContextsList()
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list contexts: %v", err)), nil
+	}
+
+	if len(contexts) == 0 {
+		return api.NewToolCallResult("No contexts found in kubeconfig", nil), nil
+	}
+
+	result := fmt.Sprintf("Available Kubernetes contexts (%d total, current: %s):\n\n", len(contexts), currentContext)
+	result += "Format: [*] CONTEXT_NAME -> CLUSTER_SERVER_URL\n"
+	result += "        (* indicates the current active context)\n\n"
+
+	result += "Contexts:\n"
+	result += "─────────\n"
+	for contextName, server := range contexts {
+		marker := "  "
+		if contextName == currentContext {
+			marker = "* "
+		}
+		result += fmt.Sprintf("%s%s -> %s\n", marker, contextName, server)
+	}
+	result += "─────────\n"
+
+	result += "\nUsage:\n"
+	result += "To use a specific context with any tool, add the 'context' parameter:\n"
+	result += `Example: {"name": "pods_list", "arguments": {"context": "` + currentContext + `"}}`
+
+	return api.NewToolCallResult(result, nil), nil
 }


### PR DESCRIPTION
Fixes https://github.com/containers/kubernetes-mcp-server/issues/83

1. New `contexts_list` tool for listing all available contexts in the cubeconfig.
2. All tools now have an optional `contex` param. If not specified then the default context is used.

Here is an example of `context_list` result:
```
Available Kubernetes contexts (3 total, current: cluster-1):

Format: [*] CONTEXT_NAME -> CLUSTER_SERVER_URL
        (* indicates the current active context)

Contexts:
─────────
* cluter-1 -> https://api.cluster-1.com:443
  cluter-2 -> https://api.cluster-2.com:443
  cluter-3 -> https://api.cluster-2.com:443
─────────

Usage:
To use a specific context with any tool, add the 'context' parameter:
Example: {"name": "pods_list", "arguments": {"context": "cluster-1"}}`
```