### PR TITLE
chore(docs): add multi-cluster to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ The following sets of tools are available (all on by default):
 
 ### Tools
 
+In case multi-cluster support is enabled (default) and you have access to multiple clusters, all applicable tools will include an additional `context` argument to specify the Kubernetes context (cluster) to use for that operation.
+
 <!-- AVAILABLE-TOOLSETS-TOOLS-START -->
 
 <details>


### PR DESCRIPTION
Relates to #83
Relates to #348 

Adds multi-cluster feature to README and documents configuration flag to opt-out.

_I'm sure this can be improved, just adding it to not forget_

/cc @Cali0707 @matzew 