### PR TITLE
make AccessControlClientset public for creating a kubernetes client outside pkg/kubernetes

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -41,6 +41,12 @@ type Kubernetes struct {
 	manager *Manager
 }
 
+// AccessControlClientset returns the access-controlled clientset
+// This ensures that any denied resources configured in the system are properly enforced
+func (k *Kubernetes) AccessControlClientset() *AccessControlClientset {
+	return k.manager.accessControlClientSet
+}
+
 type Manager struct {
 	cfg                     *rest.Config
 	clientCmdConfig         clientcmd.ClientConfig


### PR DESCRIPTION
With this change, the clients outside pkg/kuberntes, such as the one getting developed for openshift-mcp-server, can assemble a statically typed client. 

With this change we can assemble a typed client like this, [https://github.com/openshift/openshift-mcp-server/compare/main...harche:kubernetes-mcp-server:exec_tool?expand=1#diff-b880f18e8c0[…]405fe48bac8bR110](https://github.com/openshift/openshift-mcp-server/compare/main...harche:kubernetes-mcp-server:exec_tool?expand=1#diff-b880f18e8c099373d7fbac298d4ce4ca4120111987890ff1d4ef405fe48bac8bR110)
and then create an object (a pod in this case) like this, [https://github.com/openshift/openshift-mcp-server/compare/main...harche:kubernetes-mcp-server:exec_tool?expand=1#diff-b880f18e8c0[…]405fe48bac8bR195](https://github.com/openshift/openshift-mcp-server/compare/main...harche:kubernetes-mcp-server:exec_tool?expand=1#diff-b880f18e8c099373d7fbac298d4ce4ca4120111987890ff1d4ef405fe48bac8bR195)

Even if we are making the rest config public, this doesn't increase the attack surface because the user would have been able to create arbitrary CRs allowed by their authorization using  existing `ResourcesCreateOrUpdate` anyway. 