### PR TITLE
feat(ci): update release configuration for npm publishing using OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,11 +12,11 @@ concurrency:
 
 env:
   GO_VERSION: 1.23
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
 
 permissions:
   contents: write
+  id-token: write  # Required for npmjs OIDC
   discussions: write
 
 jobs:
@@ -39,6 +39,12 @@ jobs:
           files: |
             LICENSE
             kubernetes-mcp-server-*
+      # Ensure npm 11.5.1 or later is installed (required for https://docs.npmjs.com/trusted-publishers)
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
       - name: Publish npm
         run:
           make npm-publish

--- a/Makefile
+++ b/Makefile
@@ -71,16 +71,14 @@ npm-publish: npm-copy-binaries ## Publish the npm packages
 	$(foreach os,$(OSES),$(foreach arch,$(ARCHS), \
 		DIRNAME="$(BINARY_NAME)-$(os)-$(arch)"; \
 		cd npm/$$DIRNAME; \
-		echo '//registry.npmjs.org/:_authToken=$(NPM_TOKEN)' >> .npmrc; \
 		jq '.version = "$(NPM_VERSION)"' package.json > tmp.json && mv tmp.json package.json; \
-		npm publish; \
+		npm publish --tag latest; \
 		cd ../..; \
 	))
 	cp README.md LICENSE ./npm/kubernetes-mcp-server/
-	echo '//registry.npmjs.org/:_authToken=$(NPM_TOKEN)' >> ./npm/kubernetes-mcp-server/.npmrc
 	jq '.version = "$(NPM_VERSION)"' ./npm/kubernetes-mcp-server/package.json > tmp.json && mv tmp.json ./npm/kubernetes-mcp-server/package.json; \
 	jq '.optionalDependencies |= with_entries(.value = "$(NPM_VERSION)")' ./npm/kubernetes-mcp-server/package.json > tmp.json && mv tmp.json ./npm/kubernetes-mcp-server/package.json; \
-	cd npm/kubernetes-mcp-server && npm publish
+	cd npm/kubernetes-mcp-server && npm publish --tag latest
 
 .PHONY: python-publish
 python-publish: ## Publish the python packages

--- a/npm/kubernetes-mcp-server-darwin-amd64/package.json
+++ b/npm/kubernetes-mcp-server-darwin-amd64/package.json
@@ -2,6 +2,10 @@
   "name": "kubernetes-mcp-server-darwin-amd64",
   "version": "0.0.0",
   "description": "Model Context Protocol (MCP) server for Kubernetes and OpenShift",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/containers/kubernetes-mcp-server.git"
+  },
   "os": [
     "darwin"
   ],

--- a/npm/kubernetes-mcp-server-darwin-arm64/package.json
+++ b/npm/kubernetes-mcp-server-darwin-arm64/package.json
@@ -2,6 +2,10 @@
   "name": "kubernetes-mcp-server-darwin-arm64",
   "version": "0.0.0",
   "description": "Model Context Protocol (MCP) server for Kubernetes and OpenShift",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/containers/kubernetes-mcp-server.git"
+  },
   "os": [
     "darwin"
   ],

--- a/npm/kubernetes-mcp-server-linux-amd64/package.json
+++ b/npm/kubernetes-mcp-server-linux-amd64/package.json
@@ -2,6 +2,10 @@
   "name": "kubernetes-mcp-server-linux-amd64",
   "version": "0.0.0",
   "description": "Model Context Protocol (MCP) server for Kubernetes and OpenShift",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/containers/kubernetes-mcp-server.git"
+  },
   "os": [
     "linux"
   ],

--- a/npm/kubernetes-mcp-server-linux-arm64/package.json
+++ b/npm/kubernetes-mcp-server-linux-arm64/package.json
@@ -2,6 +2,10 @@
   "name": "kubernetes-mcp-server-linux-arm64",
   "version": "0.0.0",
   "description": "Model Context Protocol (MCP) server for Kubernetes and OpenShift",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/containers/kubernetes-mcp-server.git"
+  },
   "os": [
     "linux"
   ],

--- a/npm/kubernetes-mcp-server-windows-amd64/package.json
+++ b/npm/kubernetes-mcp-server-windows-amd64/package.json
@@ -2,6 +2,10 @@
   "name": "kubernetes-mcp-server-windows-amd64",
   "version": "0.0.0",
   "description": "Model Context Protocol (MCP) server for Kubernetes and OpenShift",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/containers/kubernetes-mcp-server.git"
+  },
   "os": [
     "win32"
   ],

--- a/npm/kubernetes-mcp-server-windows-arm64/package.json
+++ b/npm/kubernetes-mcp-server-windows-arm64/package.json
@@ -2,6 +2,10 @@
   "name": "kubernetes-mcp-server-windows-arm64",
   "version": "0.0.0",
   "description": "Model Context Protocol (MCP) server for Kubernetes and OpenShift",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/containers/kubernetes-mcp-server.git"
+  },
   "os": [
     "win32"
   ],


### PR DESCRIPTION
Allows publishing the npm packages without the need for a token.

- https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/
- https://docs.npmjs.com/trusted-publishers