### PR TITLE
Add custom CA certificate support for OIDC providers

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -24,11 +24,11 @@ const (
 	sseMessageEndpoint = "/message"
 )
 
-func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.StaticConfig, oidcProvider *oidc.Provider) error {
+func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.StaticConfig, oidcProvider *oidc.Provider, httpClient *http.Client) error {
 	mux := http.NewServeMux()
 
 	wrappedMux := RequestMiddleware(
-		AuthorizationMiddleware(staticConfig, oidcProvider, mcpServer)(mux),
+		AuthorizationMiddleware(staticConfig, oidcProvider, mcpServer, httpClient)(mux),
 	)
 
 	httpServer := &http.Server{
@@ -44,7 +44,7 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.Stat
 	mux.HandleFunc(healthEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	mux.Handle("/.well-known/", WellKnownHandler(staticConfig))
+	mux.Handle("/.well-known/", WellKnownHandler(staticConfig, httpClient))
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -89,7 +89,7 @@ func (c *httpContext) beforeEach(t *testing.T) {
 	timeoutCtx, c.timeoutCancel = context.WithTimeout(t.Context(), 10*time.Second)
 	group, gc := errgroup.WithContext(timeoutCtx)
 	cancelCtx, c.StopServer = context.WithCancel(gc)
-	group.Go(func() error { return Serve(cancelCtx, mcpServer, c.StaticConfig, c.OidcProvider) })
+	group.Go(func() error { return Serve(cancelCtx, mcpServer, c.StaticConfig, c.OidcProvider, nil) })
 	c.WaitForShutdown = group.Wait
 	// Wait for HTTP server to start (using net)
 	for i := 0; i < 10; i++ {

--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -25,19 +25,24 @@ type WellKnown struct {
 	authorizationUrl                 string
 	scopesSupported                  []string
 	disableDynamicClientRegistration bool
+	httpClient                       *http.Client
 }
 
 var _ http.Handler = &WellKnown{}
 
-func WellKnownHandler(staticConfig *config.StaticConfig) http.Handler {
+func WellKnownHandler(staticConfig *config.StaticConfig, httpClient *http.Client) http.Handler {
 	authorizationUrl := staticConfig.AuthorizationURL
 	if authorizationUrl != "" && strings.HasSuffix("authorizationUrl", "/") {
 		authorizationUrl = strings.TrimSuffix(authorizationUrl, "/")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
 	}
 	return &WellKnown{
 		authorizationUrl:                 authorizationUrl,
 		disableDynamicClientRegistration: staticConfig.DisableDynamicClientRegistration,
 		scopesSupported:                  staticConfig.OAuthScopes,
+		httpClient:                       httpClient,
 	}
 }
 
@@ -51,7 +56,7 @@ func (w WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 		http.Error(writer, "Failed to create request: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	resp, err := http.DefaultClient.Do(req.WithContext(request.Context()))
+	resp, err := w.httpClient.Do(req.WithContext(request.Context()))
 	if err != nil {
 		http.Error(writer, "Failed to perform request: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -301,10 +301,11 @@ func (m *MCPServerOptions) Run() error {
 	}
 
 	var oidcProvider *oidc.Provider
+	var httpClient *http.Client
 	if m.StaticConfig.AuthorizationURL != "" {
 		ctx := context.Background()
 		if m.StaticConfig.CertificateAuthority != "" {
-			httpClient := &http.Client{}
+			httpClient = &http.Client{}
 			caCert, err := os.ReadFile(m.StaticConfig.CertificateAuthority)
 			if err != nil {
 				return fmt.Errorf("failed to read CA certificate from %s: %w", m.StaticConfig.CertificateAuthority, err)
@@ -341,7 +342,7 @@ func (m *MCPServerOptions) Run() error {
 
 	if m.StaticConfig.Port != "" {
 		ctx := context.Background()
-		return internalhttp.Serve(ctx, mcpServer, m.StaticConfig, oidcProvider)
+		return internalhttp.Serve(ctx, mcpServer, m.StaticConfig, oidcProvider, httpClient)
 	}
 
 	if err := mcpServer.ServeStdio(); err != nil && !errors.Is(err, context.Canceled) {


### PR DESCRIPTION
Stash the provided `certificate_authority` on to a new http client and pass it on to Wellknown/Authorization middleware handlers for oidc/https related requests.

This comes from my keycloak setup script, but it is not directly related to that, hence doing this in a separate PR 