### PR TITLE
deps: bump golangci-lint version to avoid panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LD_FLAGS = -s -w \
 COMMON_BUILD_ARGS = -ldflags "$(LD_FLAGS)"
 
 GOLANGCI_LINT = $(shell pwd)/_output/tools/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.2.2
+GOLANGCI_LINT_VERSION ?= v2.5.0
 
 # NPM version should not append the -dirty flag
 NPM_VERSION ?= $(shell echo $(shell git describe --tags --always) | sed 's/^v//')


### PR DESCRIPTION
On our current default version of `golangci-lint` there was a bug that led to panics sometimes when running the analysis. On my machine, I saw:
```
panic: close of closed channel

goroutine 190 [running]:
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).analyze(0x140028e2720, 0x140027778f0, 0x2, 0x14002777880)
	github.com/golangci/golangci-lint/v2/pkg/goanalysis/runner_loadingpackage.go:110 +0x278
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).analyzeRecursive.func1()
	github.com/golangci/golangci-lint/v2/pkg/goanalysis/runner_loadingpackage.go:61 +0x194
sync.(*Once).doSlow(0x1400045f910?, 0x1040f1c70?)
	sync/once.go:78 +0xf0
sync.(*Once).Do(...)
	sync/once.go:69
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).analyzeRecursive(0x1400045f910?, 0x14002245ba0?, 0x1040f1c70?, 0x14000633a70?)
	github.com/golangci/golangci-lint/v2/pkg/goanalysis/runner_loadingpackage.go:45 +0x50
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*runner).analyze.func2(0x4?)
	github.com/golangci/golangci-lint/v2/pkg/goanalysis/runner.go:273 +0x34
created by github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*runner).analyze in goroutine 1
	github.com/golangci/golangci-lint/v2/pkg/goanalysis/runner.go:272 +0x4c4
make: *** [lint] Error 2
```

This PR updates the version to `2.5.0` to avoid this issue. I tested and this bump fixed the panic for me