### PR TITLE
fix: do not use in-use port in example run command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ local-env-setup: ## Setup complete local development environment with Kind clust
 	@echo "  _output/config.toml"
 	@echo ""
 	@echo "Run the MCP server with:"
-	@echo "  ./$(BINARY_NAME) --port 8080 --config _output/config.toml"
+	@echo "  ./$(BINARY_NAME) --port 8008 --config _output/config.toml"
 	@echo ""
 	@echo "Or run with MCP inspector:"
 	@echo "  npx @modelcontextprotocol/inspector@latest \$$(pwd)/$(BINARY_NAME) --config _output/config.toml"


### PR DESCRIPTION
Currently, if you run `make local-env-setup` it will tell you:

```
Run the MCP server with:
  ./kubernetes-mcp-server --port 8080 --conifg _output/config.toml
```

However, because of the way we set up keycloak, this does not work as keycloak is listening on that port.

This PR updates the port we recommend from 8080 to 8008