### PR TITLE
fix(http): well-known mitm propagates original headers

### DIFF
--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -32,7 +32,7 @@ var _ http.Handler = &WellKnown{}
 
 func WellKnownHandler(staticConfig *config.StaticConfig, httpClient *http.Client) http.Handler {
 	authorizationUrl := staticConfig.AuthorizationURL
-	if authorizationUrl != "" && strings.HasSuffix("authorizationUrl", "/") {
+	if authorizationUrl != "" && strings.HasSuffix(authorizationUrl, "/") {
 		authorizationUrl = strings.TrimSuffix(authorizationUrl, "/")
 	}
 	if httpClient == nil {
@@ -55,6 +55,11 @@ func (w WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 	if err != nil {
 		http.Error(writer, "Failed to create request: "+err.Error(), http.StatusInternalServerError)
 		return
+	}
+	for key, values := range request.Header {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
 	}
 	resp, err := w.httpClient.Do(req.WithContext(request.Context()))
 	if err != nil {


### PR DESCRIPTION
Token authorization in MCP Inspector now works fine in standard browsers with CORS enabled (no need to disable CORS).

<img width="779" height="586" alt="localhost_6274__MCP_PROXY_AUTH_TOKEN=978b1c0082421360977d67b9d1e7ec7918e6b2c5b80c9813eb0306c7e61f87f5 (1)" src="https://github.com/user-attachments/assets/4dff1395-1c4a-43da-a95a-7bdbb9eb9dcf" />
