### PR TITLE
fix(nodes): nodes_log query and tailLines arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 - **projects_list** - List all the OpenShift projects in the current cluster
 
+- **nodes_log** - Get logs from a Kubernetes node (kubelet, kube-proxy, or other system logs). This accesses node logs through the Kubernetes API proxy to the kubelet
+  - `name` (`string`) **(required)** - Name of the node to get logs from
+  - `query` (`string`) **(required)** - query specifies services(s) or files from which to return logs (required). Example: "kubelet" to fetch kubelet logs, "/<log-file-name>" to fetch a specific log file from the node (e.g., "/var/log/kubelet.log" or "/var/log/kube-proxy.log")
+  - `tailLines` (`integer`) - Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)
+
 - **pods_list** - List all the Kubernetes pods in the current cluster from all namespaces
   - `labelSelector` (`string`) - Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label
 

--- a/pkg/kubernetes/accesscontrol_clientset.go
+++ b/pkg/kubernetes/accesscontrol_clientset.go
@@ -39,7 +39,7 @@ func (a *AccessControlClientset) DiscoveryClient() discovery.DiscoveryInterface 
 	return a.discoveryClient
 }
 
-func (a *AccessControlClientset) NodesLogs(ctx context.Context, name, logPath string) (*rest.Request, error) {
+func (a *AccessControlClientset) NodesLogs(ctx context.Context, name string) (*rest.Request, error) {
 	gvk := &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
 	if !isAllowed(a.staticConfig, gvk) {
 		return nil, isNotAllowedError(gvk)
@@ -52,8 +52,7 @@ func (a *AccessControlClientset) NodesLogs(ctx context.Context, name, logPath st
 	url := []string{"api", "v1", "nodes", name, "proxy", "logs"}
 	return a.delegate.CoreV1().RESTClient().
 		Get().
-		AbsPath(url...).
-		Param("query", logPath), nil
+		AbsPath(url...), nil
 }
 
 func (a *AccessControlClientset) Pods(namespace string) (corev1.PodInterface, error) {

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -5,21 +5,23 @@ import (
 	"fmt"
 )
 
-func (k *Kubernetes) NodesLog(ctx context.Context, name string, logPath string, tail int64) (string, error) {
+func (k *Kubernetes) NodesLog(ctx context.Context, name string, query string, tailLines int64) (string, error) {
 	// Use the node proxy API to access logs from the kubelet
+	// https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#log-query
 	// Common log paths:
 	// - /var/log/kubelet.log - kubelet logs
 	// - /var/log/kube-proxy.log - kube-proxy logs
 	// - /var/log/containers/ - container logs
 
-	req, err := k.AccessControlClientset().NodesLogs(ctx, name, logPath)
+	req, err := k.AccessControlClientset().NodesLogs(ctx, name)
 	if err != nil {
 		return "", err
 	}
 
+	req.Param("query", query)
 	// Query parameters for tail
-	if tail > 0 {
-		req.Param("tailLines", fmt.Sprintf("%d", tail))
+	if tailLines > 0 {
+		req.Param("tailLines", fmt.Sprintf("%d", tailLines))
 	}
 
 	result := req.Do(ctx)

--- a/pkg/mcp/nodes_test.go
+++ b/pkg/mcp/nodes_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -43,29 +44,27 @@ func (s *NodesSuite) TestNodesLog() {
 			}`))
 			return
 		}
-		// Check for log proxy requests based on path and query parameters
+		// Get Proxy Logs
 		if req.URL.Path == "/api/v1/nodes/existing-node/proxy/logs" {
-			logPath := req.URL.Query().Get("query")
-
-			// Get Empty Log response
-			if logPath == "empty.log" {
-				w.Header().Set("Content-Type", "text/plain")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(``))
+			w.Header().Set("Content-Type", "text/plain")
+			query := req.URL.Query().Get("query")
+			var logContent string
+			switch query {
+			case "/empty.log":
+				logContent = ""
+			case "/kubelet.log":
+				logContent = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
+			default:
+				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-
-			// Get Kubelet Log response
-			if logPath == "kubelet.log" {
-				w.Header().Set("Content-Type", "text/plain")
-				w.WriteHeader(http.StatusOK)
-				logContent := "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
-				if req.URL.Query().Get("tailLines") != "" {
-					logContent = "Line 4\nLine 5\n"
-				}
-				_, _ = w.Write([]byte(logContent))
-				return
+			_, err := strconv.Atoi(req.URL.Query().Get("tailLines"))
+			if err == nil {
+				logContent = "Line 4\nLine 5\n"
 			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(logContent))
+			return
 		}
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -83,9 +82,25 @@ func (s *NodesSuite) TestNodesLog() {
 				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
 		})
 	})
-	s.Run("nodes_log(name=inexistent-node)", func() {
+	s.Run("nodes_log(name=existing-node, query=nil)", func() {
 		toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
-			"name": "inexistent-node",
+			"name": "existing-node",
+		})
+		s.Require().NotNil(toolResult, "toolResult should not be nil")
+		s.Run("has error", func() {
+			s.Truef(toolResult.IsError, "call tool should fail")
+			s.Nilf(err, "call tool should not return error object")
+		})
+		s.Run("describes missing name", func() {
+			expectedMessage := "failed to get node log, missing argument query"
+			s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
+				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+		})
+	})
+	s.Run("nodes_log(name=inexistent-node, query=/kubelet.log)", func() {
+		toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
+			"name":  "inexistent-node",
+			"query": "/kubelet.log",
 		})
 		s.Require().NotNil(toolResult, "toolResult should not be nil")
 		s.Run("has error", func() {
@@ -98,10 +113,10 @@ func (s *NodesSuite) TestNodesLog() {
 				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
 		})
 	})
-	s.Run("nodes_log(name=existing-node, log_path=missing.log)", func() {
+	s.Run("nodes_log(name=existing-node, query=/missing.log)", func() {
 		toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
-			"name":     "existing-node",
-			"log_path": "missing.log",
+			"name":  "existing-node",
+			"query": "/missing.log",
 		})
 		s.Require().NotNil(toolResult, "toolResult should not be nil")
 		s.Run("has error", func() {
@@ -114,10 +129,10 @@ func (s *NodesSuite) TestNodesLog() {
 				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
 		})
 	})
-	s.Run("nodes_log(name=existing-node, log_path=empty.log)", func() {
+	s.Run("nodes_log(name=existing-node, query=/empty.log)", func() {
 		toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
-			"name":     "existing-node",
-			"log_path": "empty.log",
+			"name":  "existing-node",
+			"query": "/empty.log",
 		})
 		s.Require().NotNil(toolResult, "toolResult should not be nil")
 		s.Run("no error", func() {
@@ -130,10 +145,10 @@ func (s *NodesSuite) TestNodesLog() {
 				"expected descriptive message '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
 		})
 	})
-	s.Run("nodes_log(name=existing-node, log_path=kubelet.log)", func() {
+	s.Run("nodes_log(name=existing-node, query=/kubelet.log)", func() {
 		toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
-			"name":     "existing-node",
-			"log_path": "kubelet.log",
+			"name":  "existing-node",
+			"query": "/kubelet.log",
 		})
 		s.Require().NotNil(toolResult, "toolResult should not be nil")
 		s.Run("no error", func() {
@@ -147,11 +162,11 @@ func (s *NodesSuite) TestNodesLog() {
 		})
 	})
 	for _, tailCase := range []interface{}{2, int64(2), float64(2)} {
-		s.Run("nodes_log(name=existing-node, log_path=kubelet.log, tail=2)", func() {
+		s.Run("nodes_log(name=existing-node, query=/kubelet.log, tailLines=2)", func() {
 			toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
-				"name":     "existing-node",
-				"log_path": "kubelet.log",
-				"tail":     tailCase,
+				"name":      "existing-node",
+				"query":     "/kubelet.log",
+				"tailLines": tailCase,
 			})
 			s.Require().NotNil(toolResult, "toolResult should not be nil")
 			s.Run("no error", func() {
@@ -164,11 +179,11 @@ func (s *NodesSuite) TestNodesLog() {
 					"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
 			})
 		})
-		s.Run("nodes_log(name=existing-node, log_path=kubelet.log, tail=-1)", func() {
+		s.Run("nodes_log(name=existing-node, query=/kubelet.log, tailLines=-1)", func() {
 			toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
-				"name":     "existing-node",
-				"log_path": "kubelet.log",
-				"tail":     -1,
+				"name":  "existing-node",
+				"query": "/kubelet.log",
+				"tail":  -1,
 			})
 			s.Require().NotNil(toolResult, "toolResult should not be nil")
 			s.Run("no error", func() {
@@ -191,7 +206,8 @@ func (s *NodesSuite) TestNodesLogDenied() {
 	s.InitMcpClient()
 	s.Run("nodes_log (denied)", func() {
 		toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
-			"name": "does-not-matter",
+			"name":  "does-not-matter",
+			"query": "/does-not-matter-either.log",
 		})
 		s.Require().NotNil(toolResult, "toolResult should not be nil")
 		s.Run("has error", func() {

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -45,16 +45,15 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "log_path": {
-          "default": "kubelet.log",
-          "description": "Path to the log file on the node (e.g. 'kubelet.log', 'kube-proxy.log'). Default is 'kubelet.log'",
-          "type": "string"
-        },
         "name": {
           "description": "Name of the node to get logs from",
           "type": "string"
         },
-        "tail": {
+        "query": {
+          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file from the node (e.g., \"/var/log/kubelet.log\" or \"/var/log/kube-proxy.log\")",
+          "type": "string"
+        },
+        "tailLines": {
           "default": 100,
           "description": "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
           "minimum": 0,
@@ -62,7 +61,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "query"
       ]
     },
     "name": "nodes_log"

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
@@ -215,16 +215,15 @@
           ],
           "type": "string"
         },
-        "log_path": {
-          "default": "kubelet.log",
-          "description": "Path to the log file on the node (e.g. 'kubelet.log', 'kube-proxy.log'). Default is 'kubelet.log'",
-          "type": "string"
-        },
         "name": {
           "description": "Name of the node to get logs from",
           "type": "string"
         },
-        "tail": {
+        "query": {
+          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file from the node (e.g., \"/var/log/kubelet.log\" or \"/var/log/kube-proxy.log\")",
+          "type": "string"
+        },
+        "tailLines": {
           "default": 100,
           "description": "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
           "minimum": 0,
@@ -232,7 +231,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "query"
       ]
     },
     "name": "nodes_log"

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -191,16 +191,15 @@
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "type": "string"
         },
-        "log_path": {
-          "default": "kubelet.log",
-          "description": "Path to the log file on the node (e.g. 'kubelet.log', 'kube-proxy.log'). Default is 'kubelet.log'",
-          "type": "string"
-        },
         "name": {
           "description": "Name of the node to get logs from",
           "type": "string"
         },
-        "tail": {
+        "query": {
+          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file from the node (e.g., \"/var/log/kubelet.log\" or \"/var/log/kube-proxy.log\")",
+          "type": "string"
+        },
+        "tailLines": {
           "default": 100,
           "description": "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
           "minimum": 0,
@@ -208,7 +207,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "query"
       ]
     },
     "name": "nodes_log"

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -151,16 +151,15 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "log_path": {
-          "default": "kubelet.log",
-          "description": "Path to the log file on the node (e.g. 'kubelet.log', 'kube-proxy.log'). Default is 'kubelet.log'",
-          "type": "string"
-        },
         "name": {
           "description": "Name of the node to get logs from",
           "type": "string"
         },
-        "tail": {
+        "query": {
+          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file from the node (e.g., \"/var/log/kubelet.log\" or \"/var/log/kube-proxy.log\")",
+          "type": "string"
+        },
+        "tailLines": {
           "default": 100,
           "description": "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
           "minimum": 0,
@@ -168,7 +167,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "query"
       ]
     },
     "name": "nodes_log"

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -151,16 +151,15 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "log_path": {
-          "default": "kubelet.log",
-          "description": "Path to the log file on the node (e.g. 'kubelet.log', 'kube-proxy.log'). Default is 'kubelet.log'",
-          "type": "string"
-        },
         "name": {
           "description": "Name of the node to get logs from",
           "type": "string"
         },
-        "tail": {
+        "query": {
+          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file from the node (e.g., \"/var/log/kubelet.log\" or \"/var/log/kube-proxy.log\")",
+          "type": "string"
+        },
+        "tailLines": {
           "default": 100,
           "description": "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
           "minimum": 0,
@@ -168,7 +167,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "query"
       ]
     },
     "name": "nodes_log"


### PR DESCRIPTION
I'm using the recently added Node log query to get Kubelet logs. It didn't work even after enabling the feature gate NodeLogQuery.
A small fix was required to using the "query" param as per the docs: https://kubernetes.io/docs/concepts/cluster-administration/system-logs/
```
# Fetch kubelet logs from a node named node-1.example
kubectl get --raw "/api/v1/nodes/node-1.example/proxy/logs/?query=kubelet"
```
Tested with OpenShift Cluster. Here are the test results:
** Before **
```
Using kubernetes-local-mcp-server mcp server get the node logs of ip-10-0-125-163.ec2.internal with the query "kubelet" as log_path

⏺ I'll get the node logs from ip-10-0-125-163.ec2.internal with the kubelet log path.

⏺ kubernetes-local-mcp-server - Node: Log (MCP)(name: "ip-10-0-125-163.ec2.internal", log_path: "kubelet")
  ⎿  Error: failed to get node log for ip-10-0-125-163.ec2.internal: failed to get node logs: the server could not find the requested resource
```

** After **
```

> Using kubernetes-local-mcp-server mcp server get the node logs of ip-10-0-125-163.ec2.internal with the query "kubelet" as log_path

⏺ I'll get the node logs for you using the kubernetes-local-mcp-server.

⏺ kubernetes-local-mcp-server - Node: Log (MCP)(name: "ip-10-0-125-163.ec2.internal", log_path: "kubelet")
  ⎿  ⚠ Large MCP response (~475.7k tokens), this can fill up context quickly
  ⎿ Oct 27 01:26:39.357782 ip-10-0-125-163 systemd[1]: Starting Kubernetes Kubelet...
    Oct 27 01:26:39.789882 ip-10-0-125-163 kubenswrapper[2501]: Flag --container-runtime-endpoint has been deprecated, This parameter should be set via the c
    onfig file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
    … +16108 lines (ctrl+o to expand)

```

Error 413 is expected. Its a claude issue. But with this fix, MCP server should be able to fetch kubelet logs using the proxy API.