### PR TITLE
feat: provider config parsers are able to resolve filepaths 

### DIFF
--- a/pkg/config/provider_config.go
+++ b/pkg/config/provider_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/BurntSushi/toml"
@@ -12,7 +13,27 @@ type ProviderConfig interface {
 	Validate() error
 }
 
-type ProviderConfigParser func(primitive toml.Primitive, md toml.MetaData) (ProviderConfig, error)
+type ProviderConfigParser func(ctx context.Context, primitive toml.Primitive, md toml.MetaData) (ProviderConfig, error)
+
+type configDirPathKey struct{}
+
+func withConfigDirPath(ctx context.Context, dirPath string) context.Context {
+	return context.WithValue(ctx, configDirPathKey{}, dirPath)
+}
+
+func ConfigDirPathFromContext(ctx context.Context) string {
+	val := ctx.Value(configDirPathKey{})
+
+	if val == nil {
+		return ""
+	}
+
+	if strVal, ok := val.(string); ok {
+		return strVal
+	}
+
+	return ""
+}
 
 var (
 	providerConfigParsers = make(map[string]ProviderConfigParser)


### PR DESCRIPTION
When adding provider specific config, it is sometimes useful to add file path / file names. However, when the file is run, these file paths are resolved relative to the CWD where the MCP server is run, not to the config file itself. IMO, this is unintuitive.

This PR adds support for providers to access the config path from the context if they want to, so they will be able to resolve those filepaths as they see appropriate