### PR TITLE
fix(mcp): do not enable Resource / Prompts yet, as there are none

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -73,8 +73,6 @@ type Server struct {
 func NewServer(configuration Configuration) (*Server, error) {
 	var serverOptions []server.ServerOption
 	serverOptions = append(serverOptions,
-		server.WithResourceCapabilities(true, true),
-		server.WithPromptCapabilities(true),
 		server.WithToolCapabilities(true),
 		server.WithLogging(),
 		server.WithToolHandlerMiddleware(toolCallLoggingMiddleware),


### PR DESCRIPTION
there are no resources or prompts yet. Perhaps just not enabling?

@manusa I see in the migration PR for "official SDK" you do have them still enabled:

```go
    HasResources: true,
    HasPrompts:   true,
    HasTools:     true,
```

Feel free to ignore this PR, but I find it more intuitive just enabling those, when actually present.

but there might be some different background on the auto-enabling for these 