### PR TITLE
test(mcp): add tests for WatchKubeConfig tools reload

### DIFF
--- a/internal/test/mock_server.go
+++ b/internal/test/mock_server.go
@@ -59,6 +59,10 @@ func (m *MockServer) Handle(handler http.Handler) {
 	m.restHandlers = append(m.restHandlers, handler.ServeHTTP)
 }
 
+func (m *MockServer) ResetHandlers() {
+	m.restHandlers = make([]http.HandlerFunc, 0)
+}
+
 func (m *MockServer) Config() *rest.Config {
 	return m.config
 }

--- a/pkg/mcp/mcp_watch_test.go
+++ b/pkg/mcp/mcp_watch_test.go
@@ -1,0 +1,103 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/suite"
+)
+
+type WatchKubeConfigSuite struct {
+	BaseMcpSuite
+	mockServer *test.MockServer
+}
+
+func (s *WatchKubeConfigSuite) SetupTest() {
+	s.BaseMcpSuite.SetupTest()
+	s.mockServer = test.NewMockServer()
+	s.Cfg.KubeConfig = s.mockServer.KubeconfigFile(s.T())
+}
+
+func (s *WatchKubeConfigSuite) TearDownTest() {
+	s.BaseMcpSuite.TearDownTest()
+	if s.mockServer != nil {
+		s.mockServer.Close()
+	}
+}
+
+func (s *WatchKubeConfigSuite) WriteKubeconfig() {
+	f, _ := os.OpenFile(s.Cfg.KubeConfig, os.O_APPEND|os.O_WRONLY, 0644)
+	_, _ = f.WriteString("\n")
+	_ = f.Close()
+}
+
+// WaitForNotification waits for an MCP server notification or fails the test after a timeout
+func (s *WatchKubeConfigSuite) WaitForNotification() *mcp.JSONRPCNotification {
+	withTimeout, cancel := context.WithTimeout(s.T().Context(), 5*time.Second)
+	defer cancel()
+	var notification *mcp.JSONRPCNotification
+	s.OnNotification(func(n mcp.JSONRPCNotification) {
+		notification = &n
+	})
+	for notification == nil {
+		select {
+		case <-withTimeout.Done():
+			s.FailNow("timeout waiting for WatchKubeConfig notification")
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	return notification
+}
+
+func (s *WatchKubeConfigSuite) TestNotifiesToolsChange() {
+	// Given
+	s.InitMcpClient()
+	// When
+	s.WriteKubeconfig()
+	notification := s.WaitForNotification()
+	// Then
+	s.NotNil(notification, "WatchKubeConfig did not notify")
+	s.Equal("notifications/tools/list_changed", notification.Method, "WatchKubeConfig did not notify tools change")
+}
+
+func (s *WatchKubeConfigSuite) TestClearsNoLongerAvailableTools() {
+	s.mockServer.Handle(&test.InOpenShiftHandler{})
+	s.InitMcpClient()
+
+	s.Run("OpenShift tool is available", func() {
+		tools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+		s.Require().NoError(err, "call ListTools failed")
+		s.Require().NotNil(tools, "list tools failed")
+		var found bool
+		for _, tool := range tools.Tools {
+			if tool.Name == "projects_list" {
+				found = true
+				break
+			}
+		}
+		s.Truef(found, "expected OpenShift tool to be available")
+	})
+
+	s.Run("OpenShift tool is removed after kubeconfig change", func() {
+		// Reload Config without OpenShift
+		s.mockServer.ResetHandlers()
+		s.WriteKubeconfig()
+		s.WaitForNotification()
+
+		tools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+		s.Require().NoError(err, "call ListTools failed")
+		s.Require().NotNil(tools, "list tools failed")
+		for _, tool := range tools.Tools {
+			s.Require().Falsef(tool.Name == "projects_list", "expected OpenShift tool to be removed")
+		}
+	})
+}
+
+func TestWatchKubeConfig(t *testing.T) {
+	suite.Run(t, new(WatchKubeConfigSuite))
+}


### PR DESCRIPTION
Ensures #385 / #219 preserves current behavior.

Verifies that tools are added and **removed** when kubeconfig file changes.

Go SDK lacks a SetTools method, AddTool only upserts tools. This test verifies that internally we handle the case that no-longer applicable tools are removed from the list of tools.
