### PR TITLE
Add force, dryRun, and fieldManager options to resources_create_or_update

### DIFF
--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -204,7 +204,7 @@ func (k *Kubernetes) PodsRun(ctx context.Context, namespace, name, image string,
 		}
 		toCreate = append(toCreate, u)
 	}
-	return k.resourcesCreateOrUpdate(ctx, toCreate)
+	return k.resourcesCreateOrUpdate(ctx, toCreate, ResourcesCreateOrUpdateOptions{})
 }
 
 func (k *Kubernetes) PodsTop(ctx context.Context, options PodsTopOptions) (*metrics.PodMetricsList, error) {

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -365,6 +365,18 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "dryRun": {
+          "description": "Perform a dry-run validation without persisting changes to the cluster. Useful for testing changes before applying them. Defaults to false",
+          "type": "boolean"
+        },
+        "fieldManager": {
+          "description": "Custom field manager name for tracking ownership of applied fields. Defaults to 'kubernetes-mcp-server'",
+          "type": "string"
+        },
+        "force": {
+          "description": "Force apply to re-acquire conflicting fields owned by other field managers (e.g., kubectl, helm). Use with caution as this overrides field ownership. Defaults to false",
+          "type": "boolean"
+        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
@@ -618,6 +618,18 @@
           ],
           "type": "string"
         },
+        "dryRun": {
+          "description": "Perform a dry-run validation without persisting changes to the cluster. Useful for testing changes before applying them. Defaults to false",
+          "type": "boolean"
+        },
+        "fieldManager": {
+          "description": "Custom field manager name for tracking ownership of applied fields. Defaults to 'kubernetes-mcp-server'",
+          "type": "string"
+        },
+        "force": {
+          "description": "Force apply to re-acquire conflicting fields owned by other field managers (e.g., kubectl, helm). Use with caution as this overrides field ownership. Defaults to false",
+          "type": "boolean"
+        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -550,6 +550,18 @@
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "type": "string"
         },
+        "dryRun": {
+          "description": "Perform a dry-run validation without persisting changes to the cluster. Useful for testing changes before applying them. Defaults to false",
+          "type": "boolean"
+        },
+        "fieldManager": {
+          "description": "Custom field manager name for tracking ownership of applied fields. Defaults to 'kubernetes-mcp-server'",
+          "type": "string"
+        },
+        "force": {
+          "description": "Force apply to re-acquire conflicting fields owned by other field managers (e.g., kubectl, helm). Use with caution as this overrides field ownership. Defaults to false",
+          "type": "boolean"
+        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -479,6 +479,18 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "dryRun": {
+          "description": "Perform a dry-run validation without persisting changes to the cluster. Useful for testing changes before applying them. Defaults to false",
+          "type": "boolean"
+        },
+        "fieldManager": {
+          "description": "Custom field manager name for tracking ownership of applied fields. Defaults to 'kubernetes-mcp-server'",
+          "type": "string"
+        },
+        "force": {
+          "description": "Force apply to re-acquire conflicting fields owned by other field managers (e.g., kubectl, helm). Use with caution as this overrides field ownership. Defaults to false",
+          "type": "boolean"
+        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -466,6 +466,18 @@
     "inputSchema": {
       "type": "object",
       "properties": {
+        "dryRun": {
+          "description": "Perform a dry-run validation without persisting changes to the cluster. Useful for testing changes before applying them. Defaults to false",
+          "type": "boolean"
+        },
+        "fieldManager": {
+          "description": "Custom field manager name for tracking ownership of applied fields. Defaults to 'kubernetes-mcp-server'",
+          "type": "string"
+        },
+        "force": {
+          "description": "Force apply to re-acquire conflicting fields owned by other field managers (e.g., kubectl, helm). Use with caution as this overrides field ownership. Defaults to false",
+          "type": "boolean"
+        },
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
           "type": "string"


### PR DESCRIPTION

- Add ResourcesCreateOrUpdateOptions struct with Force, DryRun, and FieldManager fields
- Expose force flag to override field ownership from other managers (kubectl, helm)
- Add dryRun support for validation without persisting changes
- Allow custom fieldManager name for better change tracking
- Update tool schema with three new optional parameters
- Maintain backward compatibility with sensible defaults