### PR TITLE
[WIP] feat: add IsValid check for toolsets

### DIFF
--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -44,6 +44,9 @@ type Toolset interface {
 	// Will be used to generate documentation and help text.
 	GetDescription() string
 	GetTools(o internalk8s.Openshift) []ServerTool
+	// IsValid returns whether or not the toolset is valid on the current cluster
+	// Used to identify if toolsets should be disabled despite the config based on what is installed in the cluster
+	IsValid(k *internalk8s.Kubernetes) bool
 }
 
 type ToolCallRequest interface {

--- a/pkg/toolsets/config/toolset.go
+++ b/pkg/toolsets/config/toolset.go
@@ -26,6 +26,10 @@ func (t *Toolset) GetTools(_ internalk8s.Openshift) []api.ServerTool {
 	)
 }
 
+func (t *Toolset) IsValid(_ *internalk8s.Kubernetes) bool {
+	return true
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/core/toolset.go
+++ b/pkg/toolsets/core/toolset.go
@@ -30,6 +30,10 @@ func (t *Toolset) GetTools(o internalk8s.Openshift) []api.ServerTool {
 	)
 }
 
+func (t *Toolset) IsValid(_ *internalk8s.Kubernetes) bool {
+	return true // core is always valid
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/helm/toolset.go
+++ b/pkg/toolsets/helm/toolset.go
@@ -26,6 +26,10 @@ func (t *Toolset) GetTools(_ internalk8s.Openshift) []api.ServerTool {
 	)
 }
 
+func (t *Toolset) IsValid(_ *internalk8s.Kubernetes) bool {
+	return true
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -1,6 +1,7 @@
 package kiali
 
 import (
+	"context"
 	"slices"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -37,6 +38,19 @@ func (t *Toolset) GetTools(_ internalk8s.Openshift) []api.ServerTool {
 		initLogs(),
 		initTraces(),
 	)
+}
+
+func (t *Toolset) IsValid(k *internalk8s.Kubernetes) bool {
+	// Create a Kiali client
+	kialiClient := k.NewKiali()
+
+	// Check if Kiali is actually accessible by making a lightweight API call
+	// We'll try to get the mesh status as it's a simple endpoint that doesn't require parameters
+	ctx := context.Background()
+	_, err := kialiClient.MeshStatus(ctx)
+
+	// If we can successfully call Kiali, it's valid
+	return err == nil
 }
 
 func init() {

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -35,6 +35,8 @@ func (t *TestToolset) GetDescription() string { return t.description }
 
 func (t *TestToolset) GetTools(_ kubernetes.Openshift) []api.ServerTool { return nil }
 
+func (t *TestToolset) IsValid(_ *kubernetes.Kubernetes) bool { return true }
+
 var _ api.Toolset = (*TestToolset)(nil)
 
 func (s *ToolsetsSuite) TestToolsetNames() {


### PR DESCRIPTION
This PR allows us to dynamically enable/disable toolsets, as well as the targets within tools, based on whether or not prerequisites for the toolset are installed in a given target cluster.

That way, users can enable e.g. `kiali` toolset, and if it is only installed in 3/4 clusters, we will only hint targets for those 3 clusters to the MCP client. Similarly, if none of the clusters have `kiali` installed, we will simply disable the toolset and not present it to any clients.