### PR TITLE
feat: add gevals action to github workflows

### DIFF
--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -1,0 +1,155 @@
+name: Gevals MCP Evaluation
+
+on:
+  # Weekly schedule - runs every Monday at 9 AM UTC
+  schedule:
+    - cron: '0 9 * * 1'
+
+  # Manual trigger via PR comments
+  issue_comment:
+    types: [created]
+
+  # Allow manual workflow dispatch for testing
+  workflow_dispatch:
+    inputs:
+      task-filter:
+        description: 'Regular expression to filter tasks (optional)'
+        required: false
+        default: ''
+      verbose:
+        description: 'Enable verbose output'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: 1.25
+  KIND_CLUSTER_NAME: mcp-eval-cluster
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Check if workflow should run based on trigger
+  check-trigger:
+    name: Check if evaluation should run
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/run-gevals'))
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+      pr-number: ${{ steps.check.outputs.pr-number }}
+      pr-ref: ${{ steps.check.outputs.pr-ref }}
+    steps:
+      - name: Check trigger conditions
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+            # Check if commenter is a maintainer (has write access)
+            PERMISSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission" \
+              | jq -r '.permission')
+
+            if [[ "$PERMISSION" == "admin" || "$PERMISSION" == "write" ]]; then
+              echo "should-run=true" >> $GITHUB_OUTPUT
+              echo "pr-number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+              echo "pr-ref=refs/pull/${{ github.event.issue.number }}/head" >> $GITHUB_OUTPUT
+            else
+              echo "should-run=false" >> $GITHUB_OUTPUT
+              echo "User ${{ github.event.comment.user.login }} does not have permission to trigger evaluations"
+            fi
+          else
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "pr-ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          fi
+
+  # Run gevals evaluation with Kind cluster
+  run-evaluation:
+    name: Run MCP Evaluation
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.check-trigger.outputs.pr-ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Setup Kind cluster
+        run: make kind-create-cluster KIND_CLUSTER_NAME=${{ env.KIND_CLUSTER_NAME }}
+
+      - name: Start MCP server
+        run: make run-server
+
+      - name: Run gevals evaluation
+        id: gevals
+        uses: genmcp/gevals/.github/actions/gevals-action@main
+        with:
+          eval-config: 'evals/openai-agent/eval.yaml'
+          gevals-version: 'latest'
+          task-filter: ${{ github.event.inputs.task-filter || '' }}
+          output-format: 'json'
+          verbose: ${{ github.event.inputs.verbose || 'false' }}
+          upload-artifacts: 'true'
+          artifact-name: 'gevals-results'
+          fail-on-error: 'false'
+          task-pass-threshold: '0.8'
+          assertion-pass-threshold: '0.8'
+          working-directory: '.'
+        env:
+          # OpenAI Agent configuration
+          MODEL_BASE_URL: ${{ secrets.MODEL_BASE_URL }}
+          MODEL_KEY: ${{ secrets.MODEL_KEY }}
+          MODEL_NAME: ${{ secrets.MODEL_NAME }}
+          # LLM Judge configuration
+          JUDGE_BASE_URL: ${{ secrets.JUDGE_BASE_URL }}
+          JUDGE_API_KEY: ${{ secrets.JUDGE_API_KEY }}
+          JUDGE_MODEL_NAME: ${{ secrets.JUDGE_MODEL_NAME }}
+
+      - name: Cleanup
+        if: always()
+        run: |
+          make stop-server || true
+          make kind-delete-cluster KIND_CLUSTER_NAME=${{ env.KIND_CLUSTER_NAME }} || true
+
+      - name: Post results comment on PR
+        if: github.event_name == 'issue_comment' && always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PASS_RATE=$(awk "BEGIN {printf \"%.1f\", ${{ steps.gevals.outputs.task-pass-rate }} * 100}")
+
+          gh pr comment ${{ needs.check-trigger.outputs.pr-number }} --body "$(cat <<EOF
+          ## Gevals MCP Evaluation Results
+
+          **Summary:** ${{ steps.gevals.outputs.tasks-passed }}/${{ steps.gevals.outputs.tasks-total }} tasks passed (${PASS_RATE}%)
+
+          | Metric | Result |
+          |--------|--------|
+          | Tasks Passed | ${{ steps.gevals.outputs.tasks-passed }}/${{ steps.gevals.outputs.tasks-total }} |
+          | Assertions Passed | ${{ steps.gevals.outputs.assertions-passed }}/${{ steps.gevals.outputs.assertions-total }} |
+          | Overall | ${{ steps.gevals.outputs.passed == 'true' && 'Passed' || 'Failed' }} |
+
+          [View full results](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          EOF
+          )"

--- a/build/gevals.mk
+++ b/build/gevals.mk
@@ -1,0 +1,35 @@
+# Gevals evaluation support
+
+MCP_PORT ?= 8080
+MCP_HEALTH_TIMEOUT ?= 60
+MCP_HEALTH_INTERVAL ?= 2
+
+.PHONY: run-server
+run-server: build ## Start MCP server in background and wait for health check
+	@echo "Starting MCP server on port $(MCP_PORT)..."
+	@./$(BINARY_NAME) --port $(MCP_PORT) & echo $$! > .mcp-server.pid
+	@echo "MCP server started with PID $$(cat .mcp-server.pid)"
+	@echo "Waiting for MCP server to be ready..."
+	@elapsed=0; \
+	while [ $$elapsed -lt $(MCP_HEALTH_TIMEOUT) ]; do \
+		if curl -s http://localhost:$(MCP_PORT)/health > /dev/null 2>&1; then \
+			echo "MCP server is ready"; \
+			exit 0; \
+		fi; \
+		echo "  Waiting... ($$elapsed/$(MCP_HEALTH_TIMEOUT)s)"; \
+		sleep $(MCP_HEALTH_INTERVAL); \
+		elapsed=$$((elapsed + $(MCP_HEALTH_INTERVAL))); \
+	done; \
+	echo "ERROR: MCP server failed to start within $(MCP_HEALTH_TIMEOUT) seconds"; \
+	exit 1
+
+.PHONY: stop-server
+stop-server: ## Stop the MCP server started by run-server
+	@if [ -f .mcp-server.pid ]; then \
+		PID=$$(cat .mcp-server.pid); \
+		echo "Stopping MCP server (PID: $$PID)"; \
+		kill $$PID 2>/dev/null || true; \
+		rm -f .mcp-server.pid; \
+	else \
+		echo "No .mcp-server.pid file found"; \
+	fi

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,110 @@
+# Kubernetes MCP Server Test Examples
+
+This directory contains examples for testing the **same Kubernetes MCP server** using different AI agents.
+
+## Structure
+
+```
+kube-mcp-server/
+├── README.md                    # This file
+├── mcp-config.yaml              # Shared MCP server configuration
+├── tasks/                       # Shared test tasks
+│   ├── create-pod.yaml
+│   ├── setup.sh
+│   ├── verify.sh
+│   └── cleanup.sh
+├── claude-code/                 # Claude Code agent configuration
+│   ├── agent.yaml
+│   ├── eval.yaml
+│   └── eval-inline.yaml
+└── openai-agent/                # OpenAI-compatible agent configuration
+    ├── agent.yaml
+    ├── eval.yaml
+    └── eval-inline.yaml
+```
+
+## What This Tests
+
+Both examples test the **same Kubernetes MCP server** using **shared task definitions**:
+- Creates an nginx pod named `web-server` in the `create-pod-test` namespace
+- Verifies the pod is running
+- Validates that the agent called appropriate Kubernetes tools
+- Cleans up resources
+
+The tasks and MCP configuration are shared - only the agent configuration differs.
+
+## Prerequisites
+
+- Kubernetes cluster (kind, minikube, or any cluster)
+- kubectl configured
+- Kubernetes MCP server running at `http://localhost:8080/mcp`
+- Built binaries: `gevals` and `agent`
+
+## Running Examples
+
+### Option 1: Claude Code
+
+```bash
+./gevals eval examples/kube-mcp-server/claude-code/eval.yaml
+```
+
+**Requirements:**
+- Claude Code installed and in PATH
+
+**Tool Usage:**
+- Claude typically uses pod-specific tools like `pods_run`, `pods_create`
+
+---
+
+### Option 2: OpenAI-Compatible Agent (Built-in)
+
+```bash
+# Set your model credentials
+export MODEL_BASE_URL='https://your-api-endpoint.com/v1'
+export MODEL_KEY='your-api-key'
+export MODEL_NAME='your-model-name'
+
+# Run the test
+./gevals eval examples/kube-mcp-server/openai-agent/eval.yaml
+```
+
+**Note:** Different AI models may choose different tools from the MCP server (`pods_*` or `resources_*`) to accomplish the same task. Both approaches work correctly.
+
+## Assertions
+
+Both examples use flexible assertions that accept either tool approach:
+
+```yaml
+toolPattern: "(pods_.*|resources_.*)"  # Accepts both pod-specific and generic resource tools
+```
+
+This makes the tests robust across different AI models that may prefer different tools.
+
+## Key Difference: Agent Configuration
+
+### Claude Code (claude-code/agent.yaml)
+```yaml
+commands:
+  argTemplateMcpServer: "--mcp-config {{ .File }}"
+  argTemplateAllowedTools: "mcp__{{ .ServerName }}__{{ .ToolName }}"
+  runPrompt: |-
+    claude {{ .McpServerFileArgs }} --print "{{ .Prompt }}"
+```
+
+### OpenAI Agent (openai-agent/agent.yaml)
+```yaml
+builtin:
+  type: "openai-agent"
+  model: "gpt-4"
+```
+
+Uses the built-in OpenAI agent with model configuration.
+
+## Expected Results
+
+Both examples should produce:
+- ✅ Task passed - pod created successfully
+- ✅ Assertions passed - appropriate tools were called
+- ✅ Verification passed - pod exists and is running
+
+Results saved to: `gevals-<eval-name>-out.json`

--- a/evals/claude-code/agent.yaml
+++ b/evals/claude-code/agent.yaml
@@ -1,0 +1,5 @@
+kind: Agent
+metadata:
+  name: "claude-code"
+builtin:
+  type: "claude-code"

--- a/evals/claude-code/eval-inline.yaml
+++ b/evals/claude-code/eval-inline.yaml
@@ -1,0 +1,21 @@
+kind: Eval
+metadata:
+  name: "kubernetes-basic-operations"
+config:
+  # Inline agent configuration - no separate agent.yaml file needed
+  agent:
+    type: "builtin.claude-code"
+  mcpConfigFile: ../mcp-config.yaml
+  llmJudge:
+    env:
+      baseUrlKey: JUDGE_BASE_URL
+      apiKeyKey: JUDGE_API_KEY
+      modelNameKey: JUDGE_MODEL_NAME
+  taskSets:
+    - glob: ../tasks/*/*.yaml
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/evals/claude-code/eval.yaml
+++ b/evals/claude-code/eval.yaml
@@ -1,0 +1,21 @@
+kind: Eval
+metadata:
+  name: "kubernetes-basic-operations"
+config:
+  agent:
+    type: "file"
+    path: agent.yaml
+  mcpConfigFile: ../mcp-config.yaml
+  llmJudge:
+    env:
+      baseUrlKey: JUDGE_BASE_URL
+      apiKeyKey: JUDGE_API_KEY
+      modelNameKey: JUDGE_MODEL_NAME
+  taskSets:
+    - glob: ../tasks/*/*.yaml
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/evals/mcp-config.yaml
+++ b/evals/mcp-config.yaml
@@ -1,0 +1,5 @@
+mcpServers:
+  kubernetes:
+    type: http
+    url: http://localhost:8080/mcp
+    enableAllTools: true

--- a/evals/openai-agent/agent.yaml
+++ b/evals/openai-agent/agent.yaml
@@ -1,0 +1,9 @@
+kind: Agent
+metadata:
+  name: "openai-agent"
+builtin:
+  type: "openai-agent"
+  model: "gpt-4"  # Change to your model
+# Before running, set environment variables:
+#   export MODEL_BASE_URL="https://api.openai.com/v1"
+#   export MODEL_KEY="sk-..."

--- a/evals/openai-agent/eval-inline.yaml
+++ b/evals/openai-agent/eval-inline.yaml
@@ -1,0 +1,25 @@
+kind: Eval
+metadata:
+  name: "openai-agent-kubernetes-test"
+config:
+  # Inline agent configuration - no separate agent.yaml file needed
+  agent:
+    type: "builtin.openai-agent"
+    model: "gpt-4"  # Change to your model
+  # Before running, set environment variables:
+  #   export MODEL_BASE_URL="https://api.openai.com/v1"
+  #   export MODEL_KEY="sk-..."
+  mcpConfigFile: ../mcp-config.yaml
+  llmJudge:
+    env:
+      baseUrlKey: JUDGE_BASE_URL
+      apiKeyKey: JUDGE_API_KEY
+      modelNameKey: JUDGE_MODEL_NAME
+  taskSets:
+    - glob: ../tasks/*/*.yaml
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/evals/openai-agent/eval.yaml
+++ b/evals/openai-agent/eval.yaml
@@ -1,0 +1,21 @@
+kind: Eval
+metadata:
+  name: "openai-agent-kubernetes-test"
+config:
+  agent:
+    type: "file"
+    path: agent.yaml
+  mcpConfigFile: ../mcp-config.yaml
+  llmJudge:
+    env:
+      baseUrlKey: JUDGE_BASE_URL
+      apiKeyKey: JUDGE_API_KEY
+      modelNameKey: JUDGE_MODEL_NAME
+  taskSets:
+    - glob: ../tasks/*/*.yaml
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/evals/tasks/create-canary-deployment/artifacts/deployment-v1.yaml
+++ b/evals/tasks/create-canary-deployment/artifacts/deployment-v1.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: engine-v2-0
+  labels:
+    app: recommendation-engine
+    version: v2.0
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: recommendation-engine
+      version: v2.0
+  template:
+    metadata:
+      labels:
+        app: recommendation-engine
+        version: v2.0
+    spec:
+      containers:
+      - name: rec-engine
+        image: nginx:1.28
+        ports:
+        - containerPort: 80

--- a/evals/tasks/create-canary-deployment/artifacts/service.yaml
+++ b/evals/tasks/create-canary-deployment/artifacts/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendation-engine
+spec:
+  selector:
+    app: recommendation-engine
+    version: v2.0
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/evals/tasks/create-canary-deployment/cleanup.sh
+++ b/evals/tasks/create-canary-deployment/cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+NAMESPACE="canary-deployment-ns"
+
+# Delete the namespace
+kubectl delete namespace $NAMESPACE --wait=false --ignore-not-found

--- a/evals/tasks/create-canary-deployment/create-canary-deployment.yaml
+++ b/evals/tasks/create-canary-deployment/create-canary-deployment.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: create-canary-deployment
+  difficulty: hard
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "We want to test a new version of our recommendation engine (image tag 1.29) in production without disturbing the existing stable deployment. Can you deploy it as a canary (as engine-v2-1)? We want about 50% of traffic to go to the new version. The current deployment is named engine-v2-0 in the canary-deployment-ns."

--- a/evals/tasks/create-canary-deployment/setup.sh
+++ b/evals/tasks/create-canary-deployment/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+NAMESPACE="canary-deployment-ns"
+
+# Create the namespace
+kubectl delete namespace $NAMESPACE --ignore-not-found
+kubectl create namespace $NAMESPACE
+
+# Apply the initial stable deployment and the service pointing only to it
+kubectl apply -n $NAMESPACE -f artifacts/deployment-v1.yaml
+kubectl apply -n $NAMESPACE -f artifacts/service.yaml

--- a/evals/tasks/create-canary-deployment/verify.sh
+++ b/evals/tasks/create-canary-deployment/verify.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# A more robust script header
+# exit on any error, exit on undeclared variable, and fail pipe commands on the first error
+set -euo pipefail
+
+# All variables are defined here for easy modification
+NAMESPACE="canary-deployment-ns"
+CANARY_DEPLOYMENT="engine-v2-1"
+STABLE_DEPLOYMENT="engine-v2-0"
+SERVICE="recommendation-engine"
+CANARY_IMAGE="nginx:1.29"
+CANARY_REPLICAS=2
+STABLE_REPLICAS=2
+EXPECTED_TOTAL_ENDPOINTS=$((CANARY_REPLICAS + STABLE_REPLICAS))
+TIMEOUT="120s"
+
+# Wait for both deployments to be available and fully rolled out
+if ! kubectl wait deployment "$CANARY_DEPLOYMENT" -n "$NAMESPACE" \
+  --for=condition=Available=true \
+  --timeout="$TIMEOUT"; then
+    echo "ERROR: Failed to find available canary deployment: '$CANARY_DEPLOYMENT'."
+    exit 1
+fi
+
+if ! kubectl wait deployment "$CANARY_DEPLOYMENT" -n "$NAMESPACE" \
+  --for=condition=Available=true \
+  --for=jsonpath="{.status.updatedReplicas}=${CANARY_REPLICAS}" \
+  --timeout="$TIMEOUT"; then
+
+    echo "ERROR: Canary deployment does not have the correct amount of replicas."
+    exit 1
+fi
+
+
+if ! kubectl wait deployment "$STABLE_DEPLOYMENT" -n "$NAMESPACE" \
+  --for=condition=Available=true \
+  --for=jsonpath="{.status.updatedReplicas}=${STABLE_REPLICAS}" \
+  --timeout="$TIMEOUT"; then
+
+    echo "ERROR: Stable deployment does not have the correct amount of replicas."
+    exit 1
+fi
+
+# Verify the canary deployment is using the correct container image
+CURRENT_CANARY_IMAGE=$(kubectl get deployment "$CANARY_DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].image}')
+if [[ "$CURRENT_CANARY_IMAGE" != "$CANARY_IMAGE" ]]; then
+  echo "ERROR: Canary deployment image is '$CURRENT_CANARY_IMAGE', expected '$CANARY_IMAGE'."
+  exit 1
+fi
+
+# Verify the service selector targets the general app label without a version
+SERVICE_JSON=$(kubectl get svc "$SERVICE" -n "$NAMESPACE" -o json)
+SELECTOR_APP=$(echo "$SERVICE_JSON" | jq -r '.spec.selector.app')
+# 'jq' will output the string 'null' if the key doesn't exist
+SELECTOR_VERSION=$(echo "$SERVICE_JSON" | jq -r '.spec.selector.version')
+
+if [[ "$SELECTOR_APP" != "$SERVICE" ]] || [[ "$SELECTOR_VERSION" != "null" ]]; then
+    echo "ERROR: Service selector is incorrect. It should only target 'app: $SERVICE'."
+    echo "   Found: app='$SELECTOR_APP', version='$SELECTOR_VERSION'"
+    exit 1
+fi
+
+# Wait until the service has endpoints for all pods (stable + canary) to confirm traffic is flowing to all expected pods
+echo "--> Waiting for service '$SERVICE' to have '$EXPECTED_TOTAL_ENDPOINTS' endpoints..."
+success=false
+# This loop will try 18 times, waiting 5 seconds between each attempt (90s total timeout)
+for i in {1..18}; do
+    # Using jq for a readable and robust way to count ready addresses.
+    count=$(kubectl get endpoints "$SERVICE" -n "$NAMESPACE" -o json 2>/dev/null | jq '([.subsets[].addresses // [] | length] | add) // 0' || echo 0)
+
+    if [[ "$count" -eq "$EXPECTED_TOTAL_ENDPOINTS" ]]; then
+        echo "Success: Service has all $count endpoints."
+        success=true
+        break
+    fi
+
+    echo "  ($i/18) Waiting... found $count endpoints. Retrying in 5 seconds..."
+    sleep 5
+done
+
+if ! $success; then
+    echo "ERROR: Timed out waiting for service endpoints."
+    echo "  Found $count endpoints, but expected $EXPECTED_TOTAL_ENDPOINTS."
+    exit 1
+fi
+
+
+echo "--- Verification Successful! ---"
+echo "Canary deployment is correctly configured and receiving traffic."
+exit 0

--- a/evals/tasks/create-network-policy/artifacts/desired-policy.yaml
+++ b/evals/tasks/create-network-policy/artifacts/desired-policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: np
+  namespace: ns1
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ns2
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53

--- a/evals/tasks/create-network-policy/cleanup.sh
+++ b/evals/tasks/create-network-policy/cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Delete the namespaces which will also delete all resources in them
+kubectl delete namespace ns1 --ignore-not-found
+kubectl delete namespace ns2 --ignore-not-found
+
+echo "Cleanup completed" 

--- a/evals/tasks/create-network-policy/create-network-policy.yaml
+++ b/evals/tasks/create-network-policy/create-network-policy.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: create-network-policy
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Create a NetworkPolicy named 'np' in namespace 'ns1' that: 1. Allows egress traffic only to pods in namespace 'ns2' (incoming traffic not affected) 2. Allows DNS traffic (port 53 TCP and UDP) 3. Blocks all other outgoing traffic"

--- a/evals/tasks/create-network-policy/setup.sh
+++ b/evals/tasks/create-network-policy/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Cleanup existing namespaces if they exist
+kubectl delete namespace ns1 --ignore-not-found
+kubectl delete namespace ns2 --ignore-not-found
+
+TIMEOUT="120s"
+
+# Wait for namespaces to be fully deleted
+echo "Waiting for namespaces to be fully deleted..."
+while kubectl get namespace ns1 2>/dev/null || kubectl get namespace ns2 2>/dev/null; do
+    sleep 1
+done
+
+# Create the namespaces
+kubectl create namespace ns1
+kubectl create namespace ns2
+
+echo "Setup completed" 

--- a/evals/tasks/create-network-policy/verify.sh
+++ b/evals/tasks/create-network-policy/verify.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Starting verification for create-network-policy"
+POLICY_NAME="np"
+NAMESPACE="ns1"
+
+# Check if NetworkPolicy exists
+if ! kubectl get networkpolicy $POLICY_NAME -n $NAMESPACE -o name &>/dev/null; then
+    echo "Failed: NetworkPolicy '$POLICY_NAME' does not exist in namespace '$NAMESPACE'"
+    exit 1
+fi
+
+VERIFY_DIR=$(dirname -- "$0")
+YAML_FILE="${VERIFY_DIR}/artifacts/desired-policy.yaml"
+
+# This JQ filter normalizes the egress spec completely:
+# 1. map(...): Iterates over each rule in the 'egress' array.
+# 2. if .ports ...: If it finds a 'ports' rule, it sorts by 'port' and 'protocol' to make the order consistent.
+# 3. | sort_by(.): Sorts the top-level 'egress' array itself, so the 'ports' rule and 'to' rule can be in any order.
+# The 'jq -S' command handles sorting object keys (like 'port', 'protocol').
+JQ_FILTER='.spec.egress | map(if .ports then .ports |= sort_by(.port, .protocol) else . end) | sort_by(.)'
+
+# 1. Get the LIVE egress array, sort it completely
+LIVE_EGRESS_SPEC=$(kubectl get networkpolicy $POLICY_NAME -n $NAMESPACE -o json | jq -S "$JQ_FILTER")
+if [ -z "$LIVE_EGRESS_SPEC" ]; then
+    echo "Failed: Could not retrieve and normalize LIVE egress spec."
+    exit 1
+fi
+
+# 2. Get the DESIRED egress array from a dry-run, sort it completely
+DESIRED_EGRESS_SPEC=$(kubectl apply -f $YAML_FILE --dry-run=server -o json | jq -S "$JQ_FILTER")
+if [ -z "$DESIRED_EGRESS_SPEC" ]; then
+    echo "Failed: Could not perform and normalize server-side dry-run."
+    exit 1
+fi
+
+# 3. Compare the two fully-normalized JSON strings
+if ! diff -q <(echo "$LIVE_EGRESS_SPEC") <(echo "$DESIRED_EGRESS_SPEC") >/dev/null 2>&1; then
+    echo "Failed: NetworkPolicy egress specs don't match (after full normalization):"
+    # Pretty-print the diff for a readable failure message
+    diff --color=always <(echo "$LIVE_EGRESS_SPEC" | jq) <(echo "$DESIRED_EGRESS_SPEC" | jq)
+    exit 1
+fi
+
+echo "All verifications passed! NetworkPolicy egress spec is correctly configured."
+exit 0

--- a/evals/tasks/create-pod-mount-configmaps/cleanup.sh
+++ b/evals/tasks/create-pod-mount-configmaps/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+kubectl delete namespace color-size-settings --ignore-not-found
+echo "Cleanup completed" 

--- a/evals/tasks/create-pod-mount-configmaps/create-pod-mount-configmaps.yaml
+++ b/evals/tasks/create-pod-mount-configmaps/create-pod-mount-configmaps.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: create-pod-mount-configmaps
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Create namespace 'color-size-settings' with two ConfigMaps - 'color-settings' with key 'color=blue' and 'size-settings' with key 'size=medium'. Create an nginx:alpine pod 'pod1' in namespace 'color-size-settings'. The pod `pod1` should use the value of 'color' key from 'color-settings' ConfigMap as an env var 'COLOR' and mounts all keys in the 'size-settings' ConfigMap under '/etc/sizes/' directory."

--- a/evals/tasks/create-pod-mount-configmaps/setup.sh
+++ b/evals/tasks/create-pod-mount-configmaps/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Delete the namespace if it exists to ensure a clean state
+kubectl delete namespace color-size-settings --ignore-not-found

--- a/evals/tasks/create-pod-mount-configmaps/verify.sh
+++ b/evals/tasks/create-pod-mount-configmaps/verify.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+NAMESPACE="color-size-settings"
+TIMEOUT="120s"
+
+# Check if namespace exists
+if ! kubectl get namespace $NAMESPACE &>/dev/null; then
+    echo "Namespace '$NAMESPACE' does not exist"
+    exit 1
+fi
+
+# Check if configmaps exist
+if ! kubectl get configmap color-settings -n $NAMESPACE &>/dev/null; then
+    echo "ConfigMap 'color-settings' does not exist in namespace '$NAMESPACE'"
+    exit 1
+fi
+
+if ! kubectl get configmap size-settings -n $NAMESPACE &>/dev/null; then
+    echo "ConfigMap 'size-settings' does not exist in namespace '$NAMESPACE'"
+    exit 1
+fi
+
+# Check configmap contents
+COLOR_VALUE=$(kubectl get configmap color-settings -n $NAMESPACE -o jsonpath='{.data.color}')
+if [[ "$COLOR_VALUE" != "blue" ]]; then
+    echo "ConfigMap 'color-settings' has incorrect value for key 'color': '$COLOR_VALUE', expected: 'blue'"
+    exit 1
+fi
+
+SIZE_VALUE=$(kubectl get configmap size-settings -n $NAMESPACE -o jsonpath='{.data.size}')
+if [[ "$SIZE_VALUE" != "medium" ]]; then
+    echo "ConfigMap 'size-settings' has incorrect value for key 'size': '$SIZE_VALUE', expected: 'medium'"
+    exit 1
+fi
+
+# Wait for pod to be ready
+if ! kubectl wait --for=condition=Ready pod/pod1 -n $NAMESPACE --timeout=$TIMEOUT; then
+    echo "Pod 'pod1' is not ready in namespace '$NAMESPACE'"
+    exit 1
+fi
+
+# Verify pod has the correct image
+POD_IMAGE=$(kubectl get pod pod1 -n $NAMESPACE -o jsonpath='{.spec.containers[0].image}')
+if [[ "$POD_IMAGE" != "nginx:alpine" ]]; then
+    echo "Pod has incorrect image: $POD_IMAGE, expected: nginx:alpine"
+    exit 1
+fi
+
+# Verify the values are accessible in the pod
+echo "Verifying environment variable in pod..."
+ENV_TEST=$(kubectl exec pod1 -n $NAMESPACE -- sh -c 'echo $COLOR')
+if [[ "$ENV_TEST" != "blue" ]]; then
+    echo "Environment variable 'COLOR' is not accessible in the pod or has incorrect value: '$ENV_TEST'"
+    exit 1
+fi
+
+echo "Verifying volume mount in pod..."
+VOLUME_TEST=$(kubectl exec pod1 -n $NAMESPACE -- cat /etc/sizes/size)
+if [[ "$VOLUME_TEST" != "medium" ]]; then
+    echo "Volume mount is not accessible in the pod or file has incorrect content: '$VOLUME_TEST'"
+    exit 1
+fi
+
+# All verifications passed
+echo "All verifications passed!"
+exit 0 

--- a/evals/tasks/create-pod-resources-limits/cleanup.sh
+++ b/evals/tasks/create-pod-resources-limits/cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Delete the namespace which will also delete all resources in it
+kubectl delete namespace limits-test --ignore-not-found
+echo "Cleanup completed" 

--- a/evals/tasks/create-pod-resources-limits/create-pod-resources-limits.yaml
+++ b/evals/tasks/create-pod-resources-limits/create-pod-resources-limits.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: create-pod-resources-limits
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Create namespace 'limits-test' with a pod 'resource-limits-pod' using httpd:alpine image. Container 'my-container' should have CPU request 60m, limit 600m, and memory request/limit of 62Mi."

--- a/evals/tasks/create-pod-resources-limits/setup.sh
+++ b/evals/tasks/create-pod-resources-limits/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Delete the namespace if it exists to ensure a clean state
+kubectl delete namespace limits-test --ignore-not-found

--- a/evals/tasks/create-pod-resources-limits/verify.sh
+++ b/evals/tasks/create-pod-resources-limits/verify.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Check if namespace exists
+if ! kubectl get namespace limits-test &>/dev/null; then
+    echo "Namespace 'limits-test' does not exist"
+    exit 1
+fi
+
+# Wait for pod to be ready
+TIMEOUT="120s"
+if ! kubectl wait --for=condition=Ready pod/resource-limits-pod -n limits-test --timeout=$TIMEOUT; then
+    echo "Pod 'resource-limits-pod' is not ready in namespace 'limits-test'"
+    exit 1
+fi
+
+# Verify the pod has the correct image
+POD_IMAGE=$(kubectl get pod resource-limits-pod -n limits-test -o jsonpath='{.spec.containers[0].image}')
+if [[ "$POD_IMAGE" != "httpd:alpine" ]]; then
+    echo "Pod has incorrect image: $POD_IMAGE, expected: httpd:alpine"
+    exit 1
+fi
+
+# Verify the container name
+CONTAINER_NAME=$(kubectl get pod resource-limits-pod -n limits-test -o jsonpath='{.spec.containers[0].name}')
+if [[ "$CONTAINER_NAME" != "my-container" ]]; then
+    echo "Container has incorrect name: $CONTAINER_NAME, expected: my-container"
+    exit 1
+fi
+
+# Verify CPU request
+CPU_REQUEST=$(kubectl get pod resource-limits-pod -n limits-test -o jsonpath='{.spec.containers[0].resources.requests.cpu}')
+if [[ "$CPU_REQUEST" != "60m" ]]; then
+    echo "Container has incorrect CPU request: $CPU_REQUEST, expected: 60m"
+    exit 1
+fi
+
+# Verify CPU limit
+CPU_LIMIT=$(kubectl get pod resource-limits-pod -n limits-test -o jsonpath='{.spec.containers[0].resources.limits.cpu}')
+if [[ "$CPU_LIMIT" != "600m" ]]; then
+    echo "Container has incorrect CPU limit: $CPU_LIMIT, expected: 600m"
+    exit 1
+fi
+
+# Verify memory request
+MEMORY_REQUEST=$(kubectl get pod resource-limits-pod -n limits-test -o jsonpath='{.spec.containers[0].resources.requests.memory}')
+if [[ "$MEMORY_REQUEST" != "62Mi" ]]; then
+    echo "Container has incorrect memory request: $MEMORY_REQUEST, expected: 62Mi"
+    exit 1
+fi
+
+# Verify memory limit
+MEMORY_LIMIT=$(kubectl get pod resource-limits-pod -n limits-test -o jsonpath='{.spec.containers[0].resources.limits.memory}')
+if [[ "$MEMORY_LIMIT" != "62Mi" ]]; then
+    echo "Container has incorrect memory limit: $MEMORY_LIMIT, expected: 62Mi"
+    exit 1
+fi
+
+# All verifications passed
+echo "All verifications passed!"
+exit 0 

--- a/evals/tasks/create-pod/cleanup.sh
+++ b/evals/tasks/create-pod/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete pod web-server -n create-pod-test --ignore-not-found

--- a/evals/tasks/create-pod/create-pod.yaml
+++ b/evals/tasks/create-pod/create-pod.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: "create-nginx-pod"
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: Please create a nginx pod named web-server in the create-pod-test namespace

--- a/evals/tasks/create-pod/setup.sh
+++ b/evals/tasks/create-pod/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+kubectl delete namespace create-pod-test --ignore-not-found
+kubectl create namespace create-pod-test

--- a/evals/tasks/create-pod/verify.sh
+++ b/evals/tasks/create-pod/verify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wait for pod to be running with kubectl wait
+if kubectl wait --for=condition=Ready pod/web-server -n create-pod-test --timeout=120s; then
+    exit 0
+else
+    # If we get here, pod didn't reach Running state in time
+    exit 1
+fi

--- a/evals/tasks/create-simple-rbac/cleanup.sh
+++ b/evals/tasks/create-simple-rbac/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace create-simple-rbac --ignore-not-found=true

--- a/evals/tasks/create-simple-rbac/create-simple-rbac.yaml
+++ b/evals/tasks/create-simple-rbac/create-simple-rbac.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: create-simple-rbac
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Create a read-only role for pods bound to my reader-sa service account in the create-simple-rbac namespace."

--- a/evals/tasks/create-simple-rbac/setup.sh
+++ b/evals/tasks/create-simple-rbac/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+kubectl delete namespace create-simple-rbac --ignore-not-found # clean up, just in case
+kubectl create namespace create-simple-rbac
+kubectl create serviceaccount reader-sa -n create-simple-rbac

--- a/evals/tasks/create-simple-rbac/verify.sh
+++ b/evals/tasks/create-simple-rbac/verify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+NAMESPACE="create-simple-rbac"
+SERVICE_ACCOUNT="reader-sa"
+SERVICE_ACCOUNT_USER="system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT}"
+
+# Check for allowed permissions
+if ! kubectl auth can-i get pods --as=$SERVICE_ACCOUNT_USER -n $NAMESPACE &> /dev/null; then
+    echo "ServiceAccount cannot 'get' pods."
+    exit 1
+fi
+
+if ! kubectl auth can-i list pods --as=$SERVICE_ACCOUNT_USER -n $NAMESPACE &> /dev/null; then
+    echo "ServiceAccount cannot 'list' pods."
+    exit 1
+fi
+
+# Check for denied permissions
+if kubectl auth can-i delete pods --as=$SERVICE_ACCOUNT_USER -n $NAMESPACE &> /dev/null; then
+  echo "ServiceAccount has excessive permissions (can 'delete' pods)."
+  exit 1
+fi
+
+if kubectl auth can-i create pods --as=$SERVICE_ACCOUNT_USER -n $NAMESPACE &> /dev/null; then
+  echo "ServiceAccount has excessive permissions (can 'create' pods)."
+  exit 1
+fi
+
+if kubectl auth can-i create pods --as=$SERVICE_ACCOUNT_USER &> /dev/null; then
+  echo "ServiceAccount has excessive permissions (can 'create' pods in other namespace)."
+  exit 1
+fi
+
+if kubectl auth can-i list pods --as=$SERVICE_ACCOUNT_USER -A &> /dev/null; then
+  echo "ServiceAccount has excessive permissions (can 'list' pods in other namespace)."
+  exit 1
+fi
+
+echo "Verification successful: RBAC role and binding correctly configured."
+exit 0

--- a/evals/tasks/debug-app-logs/artifacts/calc-app-pod.yaml
+++ b/evals/tasks/debug-app-logs/artifacts/calc-app-pod.yaml
@@ -1,0 +1,19 @@
+# Pod for running the `calc-app.py` script
+apiVersion: v1
+kind: Pod
+metadata:
+  name: calc-app-pod
+  namespace: calc-app
+spec:
+  containers:
+  - name: calc-app-executor
+    image: python:3.9-slim-buster
+    command: ["python"]
+    args: ["/etc/config/calc-app.py"]
+    volumeMounts:
+    - name: calc-app-volume
+      mountPath: /etc/config
+  volumes:
+  - name: calc-app-volume
+    configMap:
+      name: calc-app-map

--- a/evals/tasks/debug-app-logs/artifacts/calc-app.py
+++ b/evals/tasks/debug-app-logs/artifacts/calc-app.py
@@ -1,0 +1,22 @@
+import random
+import sys
+import time
+
+print("Starting calc-app...")
+sys.stdout.flush()
+
+counter = 0
+while True:
+    counter += 1
+    if random.randint(1, 4) % 4 == 0:
+        try:
+            result = 1 / 0
+        except ZeroDivisionError as e:
+            print(f"Run {counter} failed with error: {e}")
+            sys.stdout.flush()
+    else:
+        print(f"Run {counter} succeeded")
+        sys.stdout.flush()
+
+    sleep_time = (1.2**counter)/20
+    time.sleep(sleep_time)

--- a/evals/tasks/debug-app-logs/cleanup.sh
+++ b/evals/tasks/debug-app-logs/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace calc-app

--- a/evals/tasks/debug-app-logs/debug-app-logs.yaml
+++ b/evals/tasks/debug-app-logs/debug-app-logs.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: debug-app-logs
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  prompt:
+    inline: "What wrong with my calc-app-pod in the calc-app namespace?"
+  cleanup:
+    file: cleanup.sh
+  verify:
+    contains: "division by zero"

--- a/evals/tasks/debug-app-logs/setup.sh
+++ b/evals/tasks/debug-app-logs/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+kubectl delete namespace calc-app --ignore-not-found # clean up, just in case
+kubectl create namespace calc-app
+kubectl create configmap calc-app-map --from-file=artifacts/calc-app.py --namespace=calc-app
+kubectl apply -f artifacts/calc-app-pod.yaml --namespace=calc-app
+
+# Wait for pod to be ready
+echo "Waiting for pod to be ready..."
+TIMEOUT="120s"
+kubectl wait --for=condition=Ready pod/calc-app-pod --namespace=calc-app --timeout=$TIMEOUT

--- a/evals/tasks/deployment-traffic-switch/artifacts/blue-deployment.yaml
+++ b/evals/tasks/deployment-traffic-switch/artifacts/blue-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-service-blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: checkout-service
+      version: blue
+  template:
+    metadata:
+      labels:
+        app: checkout-service
+        version: blue
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.25
+        ports:
+        - containerPort: 80

--- a/evals/tasks/deployment-traffic-switch/artifacts/green-deployment.yaml
+++ b/evals/tasks/deployment-traffic-switch/artifacts/green-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout-service-green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: checkout-service
+      version: green
+  template:
+    metadata:
+      labels:
+        app: checkout-service
+        version: green
+    spec:
+      containers:
+      - name: app
+        image: nginx:1.26 # Use a different image tag to represent a new version
+        ports:
+        - containerPort: 80

--- a/evals/tasks/deployment-traffic-switch/artifacts/service.yaml
+++ b/evals/tasks/deployment-traffic-switch/artifacts/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout-service
+spec:
+  selector:
+    # This selector initially targets the 'blue' version
+    app: checkout-service
+    version: blue
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/evals/tasks/deployment-traffic-switch/cleanup.sh
+++ b/evals/tasks/deployment-traffic-switch/cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+NAMESPACE="e-commerce"
+
+# Delete the namespace to clean up all resources created during the evaluation
+echo "Deleting namespace '$NAMESPACE'..."
+kubectl delete namespace $NAMESPACE --wait=false

--- a/evals/tasks/deployment-traffic-switch/deployment-traffix-switch.yaml
+++ b/evals/tasks/deployment-traffic-switch/deployment-traffix-switch.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: deployment-traffic-switch
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Our new checkout-service-green deployment in the e-commerce namespace has passed all tests. The current live version is checkout-service-blue. Can you switch all live traffic over to the green version now?"

--- a/evals/tasks/deployment-traffic-switch/setup.sh
+++ b/evals/tasks/deployment-traffic-switch/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+NAMESPACE="e-commerce"
+TIMEOUT="120s"
+
+# Create the namespace if it doesn't exist to make the script idempotent
+kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+
+# Apply all resource manifests from the artifacts directory
+echo "Applying Kubernetes resources from artifacts/ directory..."
+kubectl apply -n $NAMESPACE -f artifacts/
+
+# Wait for both deployments to be available to ensure a stable starting state
+echo "Waiting for blue deployment to be ready..."
+kubectl rollout status deployment/checkout-service-blue -n $NAMESPACE --timeout=$TIMEOUT
+
+echo "Waiting for green deployment to be ready..."
+kubectl rollout status deployment/checkout-service-green -n $NAMESPACE --timeout=$TIMEOUT
+
+echo "Setup complete. Service 'checkout-service' is pointing to 'blue'."

--- a/evals/tasks/deployment-traffic-switch/verify.sh
+++ b/evals/tasks/deployment-traffic-switch/verify.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+NAMESPACE="e-commerce"
+SERVICE_NAME="checkout-service"
+EXPECTED_SELECTOR_VERSION="green"
+TIMEOUT="120s"
+
+echo "Waiting for the Service '$SERVICE_NAME' to point to version '$EXPECTED_SELECTOR_VERSION'..."
+# Use 'kubectl wait' to verify the service selector condition
+if ! kubectl wait --for=jsonpath='{.spec.selector.version}'="$EXPECTED_SELECTOR_VERSION" service/$SERVICE_NAME -n $NAMESPACE --timeout=$TIMEOUT; then
+    echo "Failed to verify the service selector."
+    exit 1
+fi
+
+echo "Service selector updated correctly."
+
+echo "Verifying that service endpoints match the green deployment..."
+# Use a single command to check if at least one endpoint has the desired label
+kubectl get endpointslices -n $NAMESPACE -l kubernetes.io/service-name=$SERVICE_NAME \
+  -o jsonpath='{.items[0].endpoints[*].conditions.ready}' | grep -q "true" || { echo "Failed to verify service endpoints."; exit 1; }
+
+echo "Service endpoints correctly point to the green deployment."
+echo "Verification successful!"
+exit 0

--- a/evals/tasks/fix-crashloop/cleanup.sh
+++ b/evals/tasks/fix-crashloop/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace crashloop-test 

--- a/evals/tasks/fix-crashloop/fix-crashloop.yaml
+++ b/evals/tasks/fix-crashloop/fix-crashloop.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: "fix-crashloop"
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: Please fix the error in the deployment named 'app' in namespace 'crashloop-test'

--- a/evals/tasks/fix-crashloop/setup.sh
+++ b/evals/tasks/fix-crashloop/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+kubectl delete namespace crashloop-test --ignore-not-found
+# Create namespace and a deployment with an invalid command that will cause crashloop
+kubectl create namespace crashloop-test
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  namespace: crashloop-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        command: ["/bin/sh", "-c"]
+        args: ["nonexistent_command"]  # This will cause the pod to crash
+EOF
+
+# Wait for pod to enter crashloop state
+for i in {1..30}; do
+    if kubectl get pods -n crashloop-test -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' | grep -q "[1-9]"; then
+        exit 0
+    fi
+    sleep 1
+done 

--- a/evals/tasks/fix-crashloop/verify.sh
+++ b/evals/tasks/fix-crashloop/verify.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Wait for pod to be ready
+if kubectl wait --for=condition=Ready pod -l app=nginx -n crashloop-test --timeout=25s; then
+    # Get current restart count
+    restarts=$(kubectl get pods -n crashloop-test -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+    
+    # Wait additional 5 seconds to ensure stability
+    sleep 5
+    
+    # Check if restart count hasn't increased
+    new_restarts=$(kubectl get pods -n crashloop-test -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+    if [[ "$restarts" == "$new_restarts" ]]; then
+        exit 0
+    fi
+fi
+
+# If we get here, deployment's pod didn't stabilize in time
+exit 1 

--- a/evals/tasks/fix-image-pull/cleanup.sh
+++ b/evals/tasks/fix-image-pull/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace debug

--- a/evals/tasks/fix-image-pull/fix-image-pull.yaml
+++ b/evals/tasks/fix-image-pull/fix-image-pull.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: "fix-image-pull"
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: Please fix the error in the deployment named 'app' in the namespace 'debug'

--- a/evals/tasks/fix-image-pull/setup.sh
+++ b/evals/tasks/fix-image-pull/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Create namespace and a deployment with an invalid image that will cause ImagePullBackOff
+kubectl delete namespace debug --ignore-not-found
+kubectl create namespace debug
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  namespace: debug
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:invalid-tag  # This will cause ImagePullBackOff error
+EOF
+
+# Wait for deployment's pod to enter ImagePullBackOff state
+for i in {1..30}; do
+    if kubectl get pods -n debug -l app=nginx -o jsonpath='{.items[0].status.containerStatuses[0].state.waiting.reason}' | grep -q "ImagePullBackOff"; then
+        exit 0
+    fi
+    sleep 1
+done 

--- a/evals/tasks/fix-image-pull/verify.sh
+++ b/evals/tasks/fix-image-pull/verify.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+TIMEOUT="120s"
+
+# Wait for the deployment rollout to complete and become "Available"
+if kubectl wait --for=condition=Available deployment/app -n debug --timeout=$TIMEOUT; then
+    # Get the restart count *only* from the new, running pod.
+    restarts=$(kubectl get pods -n debug -l app=nginx --field-selector=status.phase=Running -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+    
+    # Wait additional 5 seconds to ensure stability
+    sleep 5
+    
+    # Check if restart count hasn't increased
+    new_restarts=$(kubectl get pods -n debug -l app=nginx --field-selector=status.phase=Running -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+    if [[ "$restarts" == "$new_restarts" ]]; then
+        echo "Pod is stable. Verification successful."
+        exit 0
+    else
+        echo "Verification failed: Pod restarted unexpectedly."
+        exit 1
+    fi
+fi
+
+# If we get here, the deployment never became available
+echo "Verification failed: Deployment 'app' did not become Available in $TIMEOUT."
+exit 1

--- a/evals/tasks/fix-pending-pod/artifacts/homepage-pod.yaml
+++ b/evals/tasks/fix-pending-pod/artifacts/homepage-pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: homepage-pod
+  namespace: homepage-ns
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+      ports:
+        - containerPort: 80
+      volumeMounts:
+        - name: my-persistent-storage
+          mountPath: /usr/share/nginx/html
+  volumes:
+    - name: my-persistent-storage
+      persistentVolumeClaim:
+        claimName: homepage-pvc

--- a/evals/tasks/fix-pending-pod/artifacts/homepage-pvc.yaml
+++ b/evals/tasks/fix-pending-pod/artifacts/homepage-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homepage-pvc
+  namespace: homepage-ns
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: sc 
+  resources:
+    requests:
+      storage: 1Gi

--- a/evals/tasks/fix-pending-pod/cleanup.sh
+++ b/evals/tasks/fix-pending-pod/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace homepage-ns --ignore-not-found=true

--- a/evals/tasks/fix-pending-pod/fix-pending-pod.yaml
+++ b/evals/tasks/fix-pending-pod/fix-pending-pod.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: fix-pending-pod
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "My pod homepage-pod in homepage-ns is stuck in pending state. Can you fix the issue so that pod status is in running state?"

--- a/evals/tasks/fix-pending-pod/setup.sh
+++ b/evals/tasks/fix-pending-pod/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+kubectl delete namespace homepage-ns --ignore-not-found
+kubectl create namespace homepage-ns
+
+kubectl apply -f artifacts/homepage-pvc.yaml
+kubectl apply -f artifacts/homepage-pod.yaml

--- a/evals/tasks/fix-pending-pod/verify.sh
+++ b/evals/tasks/fix-pending-pod/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Configuration
+POD_NAME="homepage-pod"
+NAMESPACE="homepage-ns"
+PVC_NAME="homepage-pvc"
+TIMEOUT="120s"
+TASK_NAME="fix-pending-pods"
+
+echo "Starting verification for $TASK_NAME..." 
+# Verify the PersistentVolumeClaim is bound
+echo "ℹWaiting for PVC '$PVC_NAME' to be 'Bound'..."
+if ! kubectl wait --for=jsonpath='{.status.phase}'=Bound pvc/$PVC_NAME -n $NAMESPACE --timeout=$TIMEOUT; then
+    echo "PVC '$PVC_NAME' did not become Bound within $TIMEOUT."
+    echo "Info for '$PVC_NAME' in namespace '$NAMESPACE':"
+    kubectl describe pvc $PVC_NAME -n $NAMESPACE
+    echo "---"
+    echo "Info for StorageClass and PersistentVolumes:"
+    kubectl get sc,pv
+    exit 1
+fi
+echo "'$PVC_NAME' is Bound. Verifying that desired state is realized..."
+
+# Verify the Pod is Ready
+echo "Waiting for Pod '$POD_NAME' to be 'Ready'..."
+if ! kubectl wait --for=condition=Ready pod/$POD_NAME -n $NAMESPACE --timeout=$TIMEOUT; then
+    echo "Pod '$POD_NAME' did not become Ready within $TIMEOUT."
+    echo "---"
+    echo "Info for Pod '$POD_NAME' in namespace '$NAMESPACE':"
+    kubectl describe pod $POD_NAME -n $NAMESPACE
+    exit 1
+fi
+echo "Pod '$POD_NAME' is Ready. Verification successful for $EVAL_NAME."
+exit 0

--- a/evals/tasks/fix-probes/cleanup.sh
+++ b/evals/tasks/fix-probes/cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Delete the namespace which will remove all resources created for this task
+kubectl delete namespace health-check --ignore-not-found
+
+echo "Cleanup completed"

--- a/evals/tasks/fix-probes/fix-probes.yaml
+++ b/evals/tasks/fix-probes/fix-probes.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: fix-probes
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: My webapp in the orders namespace is not working? Can you please fix it?

--- a/evals/tasks/fix-probes/setup.sh
+++ b/evals/tasks/fix-probes/setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Delete namespace if exists and create a fresh one
+kubectl delete namespace orders --ignore-not-found
+kubectl create namespace orders
+
+TIMEOUT="120s"
+
+# Create a deployment with problematic health checks
+cat <<YAML | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webapp
+  namespace: orders
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webapp
+  template:
+    metadata:
+      labels:
+        app: webapp
+    spec:
+      containers:
+      - name: webapp
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        # The problem: incorrect health probes causing restarts
+        livenessProbe:
+          httpGet:
+            path: /get_status 
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /is_ready  
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+YAML
+
+# Create a service for the webapp
+kubectl create service clusterip webapp -n orders --tcp=80:80
+
+# Wait for the pod to start and begin restarting due to failed probes
+echo "Waiting for pod to start and begin failing health checks..."
+if ! kubectl wait --for=condition=Available=False --timeout=$TIMEOUT deployment/webapp -n orders; then
+    echo "Error: Timed out waiting for the deployment to become unavailable."
+    exit 1
+fi
+
+echo "Setup successful: Deployment is no longer available."
+exit 0

--- a/evals/tasks/fix-probes/verify.sh
+++ b/evals/tasks/fix-probes/verify.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Check if the pod is in Running state with Ready status
+echo "Checking if the pod is running and ready..."
+
+TIMEOUT="120s"
+
+# Wait up to TIMEOUT seconds for pod to become ready using kubectl wait
+if kubectl wait --for=condition=Ready pod -l app=webapp -n orders --timeout=$TIMEOUT; then
+  echo "Success: Pod is now Ready"
+    
+    # Check if probes exist at all
+    LIVENESS_EXISTS=$(kubectl get deploy webapp -n orders -o jsonpath='{.spec.template.spec.containers[0].livenessProbe}')
+    READINESS_EXISTS=$(kubectl get deploy webapp -n orders -o jsonpath='{.spec.template.spec.containers[0].readinessProbe}')
+    
+    if [ -z "$LIVENESS_EXISTS" ] || [ -z "$READINESS_EXISTS" ]; then
+      echo "Failure: One or both probes have been removed completely."
+      echo "Probes should be fixed, not removed."
+      exit 1
+    fi
+    
+    # Get the current probe configurations
+    LIVENESS_PATH=$(kubectl get deploy webapp -n orders -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}')
+    READINESS_PATH=$(kubectl get deploy webapp -n orders -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.path}')
+    
+    echo "Current liveness probe path: $LIVENESS_PATH"
+    echo "Current readiness probe path: $READINESS_PATH"
+    
+    # Verify the probes are not using the nonexistent paths and have valid paths set
+    if [ "$LIVENESS_PATH" != "/get_status" ] && [ "$READINESS_PATH" != "/is_ready" ] && \
+       [ ! -z "$LIVENESS_PATH" ] && [ ! -z "$READINESS_PATH" ]; then
+      echo "Success: Both probe paths have been fixed"
+      
+      # Check if pod is stable with no recent restarts
+      RESTARTS=$(kubectl get pods -n orders -l app=webapp -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+      if [ "$RESTARTS" -lt 1 ]; then
+        echo "Success: Pod is stable with acceptable number of restarts"
+        exit 0
+      else
+        echo "Failure: Pod has too many restarts: $RESTARTS"
+        exit 1
+      fi
+    else
+      echo "Failure: One or both probe paths are still incorrect or missing:"
+      echo "Liveness path: $LIVENESS_PATH"
+      echo "Readiness path: $READINESS_PATH"
+      exit 1
+    fi
+else
+  echo "Failure: Pod is not Ready after waiting"
+  kubectl get pods -n orders -l app=webapp
+  exit 1
+fi

--- a/evals/tasks/fix-rbac-wrong-resource/cleanup.sh
+++ b/evals/tasks/fix-rbac-wrong-resource/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace simple-rbac-setup --ignore-not-found

--- a/evals/tasks/fix-rbac-wrong-resource/fix-rbac-wrong-resource.yaml
+++ b/evals/tasks/fix-rbac-wrong-resource/fix-rbac-wrong-resource.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: fix-rbac-wrong-resource
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Why can't I list pods with my pod-reader service account in simple-rbac-setup namespace ? Please fix it."

--- a/evals/tasks/fix-rbac-wrong-resource/setup.sh
+++ b/evals/tasks/fix-rbac-wrong-resource/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+kubectl delete namespace simple-rbac-setup --ignore-not-found
+kubectl create namespace simple-rbac-setup
+kubectl create serviceaccount pod-reader -n simple-rbac-setup
+# role is misconfigured to list deployments instead of pods
+kubectl create role pod-reader-role --verb=list --resource=deployments -n simple-rbac-setup
+kubectl create rolebinding pod-reader-binding --role=pod-reader-role --serviceaccount=simple-rbac-setup:pod-reader -n simple-rbac-setup

--- a/evals/tasks/fix-rbac-wrong-resource/verify.sh
+++ b/evals/tasks/fix-rbac-wrong-resource/verify.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+NAMESPACE=simple-rbac-setup
+SERVICE_ACCOUNT=pod-reader
+SERVICE_ACCOUNT_USER="system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT}"
+
+# Check for allowed permissions
+if ! kubectl auth can-i list pods --as=${SERVICE_ACCOUNT_USER} -n=${NAMESPACE} &> /dev/null; then
+    echo "ServiceAccount still can't list pods."
+    exit 1
+fi
+
+# Check for denied permissions
+if kubectl auth can-i list pods --as=${SERVICE_ACCOUNT_USER} -A &> /dev/null; then
+    echo "ServiceAccount has excessive permissions (can 'list' pods in other namespaces)."
+    exit 1
+fi
+
+echo "Verification successful: RBAC role correctly reconfigured."
+exit 0

--- a/evals/tasks/fix-service-routing/cleanup.sh
+++ b/evals/tasks/fix-service-routing/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace web 

--- a/evals/tasks/fix-service-routing/fix-service-routing.yaml
+++ b/evals/tasks/fix-service-routing/fix-service-routing.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: fix-service-routing
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Please diagnose and fix why the nginx service in namespace 'web' isn't accessible"

--- a/evals/tasks/fix-service-routing/setup.sh
+++ b/evals/tasks/fix-service-routing/setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Create namespace and deployment with one set of labels
+kubectl delete namespace web --ignore-not-found
+kubectl create namespace web
+
+# Create deployment with label app=nginx
+kubectl create deployment nginx --image=nginx -n web
+# kubectl label deployment nginx -n web app=nginx --overwrite
+
+# Create service with different selector (app=web)
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: web
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: web  # Mismatched label - deployment has app=nginx
+EOF
+
+# Wait for deployment to be ready
+for i in {1..30}; do
+    if kubectl get deployment nginx -n web -o jsonpath='{.status.availableReplicas}' | grep -q "1"; then
+        exit 0
+    fi
+    sleep 2
+done 

--- a/evals/tasks/fix-service-routing/verify.sh
+++ b/evals/tasks/fix-service-routing/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Check if service has endpoints
+endpoints=$(kubectl get endpoints nginx -n web -o jsonpath='{.subsets[0].addresses}')
+if [[ ! -z "$endpoints" ]]; then
+    # Verify service can access the pod
+    if kubectl run -n web test-connection --image=busybox --restart=Never --rm -i --wait --timeout=180s \
+        -- wget -qO- nginx; then
+        exit 0
+    fi
+fi
+
+# If we get here, service connection failed
+exit 1 

--- a/evals/tasks/fix-service-with-no-endpoints/artifacts/deployment.yaml
+++ b/evals/tasks/fix-service-with-no-endpoints/artifacts/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-app-deployment
+  namespace: webshop-frontend
+  labels:
+    app: web-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web-app
+  template:
+    metadata:
+      labels:
+        app: web-app
+    spec:
+      nodeSelector:
+        environment: production-gpu
+      containers:
+      - name: web-app-container
+        image: nginx:latest
+        ports:
+        - containerPort: 80

--- a/evals/tasks/fix-service-with-no-endpoints/artifacts/service.yaml
+++ b/evals/tasks/fix-service-with-no-endpoints/artifacts/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-app-service
+  namespace: webshop-frontend
+  labels:
+    app: web-app
+spec:
+  selector:
+    app: web-app
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80

--- a/evals/tasks/fix-service-with-no-endpoints/cleanup.sh
+++ b/evals/tasks/fix-service-with-no-endpoints/cleanup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Clean up all resources
+kubectl delete namespace webshop-frontend --ignore-not-found

--- a/evals/tasks/fix-service-with-no-endpoints/fix-service-with-no-endpoints.yaml
+++ b/evals/tasks/fix-service-with-no-endpoints/fix-service-with-no-endpoints.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: fix-service-with-no-endpoints
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Our frontend application in the webshop-frontend namespace is reporting connection errors. The logs show: 'Error: connection to web-app-service.webshop-frontend.svc.cluster.local failed: connection refused'. Can you help diagnose and fix this issue?"

--- a/evals/tasks/fix-service-with-no-endpoints/setup.sh
+++ b/evals/tasks/fix-service-with-no-endpoints/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+# Delete namespace if it exists
+kubectl delete namespace webshop-frontend --ignore-not-found
+
+# Create a fresh namespace
+kubectl create namespace webshop-frontend
+
+# Apply the service and deployment with the invalid node selector
+kubectl apply -f artifacts/service.yaml
+kubectl apply -f artifacts/deployment.yaml
+
+# Wait for the deployment to be available or timeout after 120 seconds
+echo "Waiting for resources to be created..."
+TIMEOUT="120s"
+kubectl wait --for=condition=Available=False --timeout=$TIMEOUT deployment/web-app-deployment -n webshop-frontend || true
+
+# Check the service has no endpoints (due to deployment with invalid node selector)
+ENDPOINTS=$(kubectl get endpoints web-app-service -n webshop-frontend -o jsonpath='{.subsets}')
+if [[ -z "$ENDPOINTS" ]]; then
+  echo "Setup successful: Service has no endpoints as expected"
+else
+  echo "Unexpected state: Service has endpoints"
+  exit 1
+fi

--- a/evals/tasks/fix-service-with-no-endpoints/verify.sh
+++ b/evals/tasks/fix-service-with-no-endpoints/verify.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+# Check if the deployment exists
+if ! kubectl get deployment web-app-deployment -n webshop-frontend &>/dev/null; then
+  echo "Deployment 'web-app-deployment' does not exist in namespace 'webshop-frontend'"
+  exit 1
+fi
+
+# Check if pods are being created successfully
+echo "Waiting for pods to become ready..."
+TIMEOUT="120s"
+if ! kubectl wait --for=condition=Ready pods -l app=web-app -n webshop-frontend --timeout=$TIMEOUT; then
+  echo "Pods are not reaching Ready state after fixing the node selector"
+  exit 1
+fi
+
+# Verify that the service now has endpoints
+ENDPOINTS=$(kubectl get endpoints web-app-service -n webshop-frontend -o jsonpath='{.subsets[0].addresses}')
+if [[ -z "$ENDPOINTS" ]]; then
+  echo "Service still has no endpoints after fixing the deployment"
+  exit 1
+fi

--- a/evals/tasks/horizontal-pod-autoscaler/cleanup.sh
+++ b/evals/tasks/horizontal-pod-autoscaler/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Tear down namespace and HPA resources
+kubectl delete namespace hpa-test --ignore-not-found
+exit 0

--- a/evals/tasks/horizontal-pod-autoscaler/horizontal-pod-autoscaler.yaml
+++ b/evals/tasks/horizontal-pod-autoscaler/horizontal-pod-autoscaler.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: horizontal-pod-autoscaler
+  difficulty: hard
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Create a HorizontalPodAutoscaler for deployment 'web-app' in namespace 'hpa-test' targeting 50% CPU utilization with min=1 and max=3 replicas"

--- a/evals/tasks/horizontal-pod-autoscaler/setup.sh
+++ b/evals/tasks/horizontal-pod-autoscaler/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Initialize namespace and deployment with CPU load generator
+kubectl delete namespace hpa-test --ignore-not-found
+kubectl create namespace hpa-test
+
+# Create a Deployment with CPU request to allow HPA to target utilization
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-app
+  namespace: hpa-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-app
+  template:
+    metadata:
+      labels:
+        app: web-app
+    spec:
+      containers:
+      - name: web-app
+        image: busybox
+        command: ["sh", "-c", "while true; do dd if=/dev/zero of=/dev/null; done"]
+        resources:
+          requests:
+            cpu: "100m"
+EOF

--- a/evals/tasks/horizontal-pod-autoscaler/verify.sh
+++ b/evals/tasks/horizontal-pod-autoscaler/verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Verify the HPA spec matches the desired state
+
+HPA_NAME=$(kubectl get hpa -n hpa-test -o jsonpath='{.items[0].metadata.name}')
+if [ -z "$HPA_NAME" ]; then
+    echo "Error: No HPA found in hpa-test namespace."
+    exit 1
+fi
+
+HPA_JSON=$(kubectl get hpa "$HPA_NAME" -n hpa-test -o json)
+
+SCALE_TARGET_REF_NAME=$(echo "$HPA_JSON" | jq -r '.spec.scaleTargetRef.name')
+MIN_REPLICAS=$(echo "$HPA_JSON" | jq -r '.spec.minReplicas')
+MAX_REPLICAS=$(echo "$HPA_JSON" | jq -r '.spec.maxReplicas')
+TARGET_CPU_UTILIZATION_API_V1=$(echo "$HPA_JSON" | jq -r '.spec.targetCPUUtilizationPercentage')
+TARGET_CPU_UTILIZATION_API_V2=$(echo "$HPA_JSON" | jq -r '.spec.metrics[0].resource.target.averageUtilization')
+
+if [ "$SCALE_TARGET_REF_NAME" != "web-app" ]; then
+    echo "Verification failed: Expected HPA target to be 'web-app' deployment, got '$SCALE_TARGET_REF_NAME'."
+    exit 1
+fi
+
+if [ "$MIN_REPLICAS" != "1" ]; then
+    echo "Verification failed: Expected HPA minReplicas to be set to 1, got '$MIN_REPLICAS'."
+    exit 1
+fi
+
+if [ "$MAX_REPLICAS" != "3" ]; then
+    echo "Verification failed: Expected HPA maxReplicas to be set to 3, got '$MAX_REPLICAS'."
+    exit 1
+fi
+
+if [ "$TARGET_CPU_UTILIZATION_API_V1" != "50" ] && [ "$TARGET_CPU_UTILIZATION_API_V2" != "50" ]; then
+    echo "Verification failed: Expected HPA target CPU utilization to be set to 50 for either v1 or v2 API, got v1: '$TARGET_CPU_UTILIZATION_API_V1', v2: '$TARGET_CPU_UTILIZATION_API_V2'."
+    exit 1
+fi
+
+echo "Waiting for HPA condition AbleToScale to be true..."
+if ! kubectl wait --for=condition=AbleToScale=true hpa/"$HPA_NAME" -n hpa-test --timeout=120s; then
+    echo "Verification failed: HPA condition AbleToScale did not become true within 120 seconds."
+    exit 1
+fi
+
+echo "Successful verification: HPA spec is configured as expected."
+exit 0

--- a/evals/tasks/list-images-for-pods/artifacts/manifest.yaml
+++ b/evals/tasks/list-images-for-pods/artifacts/manifest.yaml
@@ -1,0 +1,60 @@
+# artifacts/manifest.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+  namespace: list-images-for-pods
+stringData:
+  ROOT_PASSWORD: "S1VKd0hBOGRJcg=="
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: list-images-for-pods
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: mysql
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: list-images-for-pods
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  serviceName: "mysql"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - image: mysql:8.0.36 # Using the official, public MySQL image
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: ROOT_PASSWORD
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+  volumeClaimTemplates:
+  - metadata:
+      name: mysql-persistent-storage
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi

--- a/evals/tasks/list-images-for-pods/cleanup.sh
+++ b/evals/tasks/list-images-for-pods/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE=list-images-for-pods
+
+kubectl delete namespace ${NAMESPACE}

--- a/evals/tasks/list-images-for-pods/list-images-for-pods.yaml
+++ b/evals/tasks/list-images-for-pods/list-images-for-pods.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: list-images-for-pods
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    contains: "mysql:8.0.36"
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "What images are all pods running in the cluster?"

--- a/evals/tasks/list-images-for-pods/setup.sh
+++ b/evals/tasks/list-images-for-pods/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE=list-images-for-pods
+
+kubectl delete namespace ${NAMESPACE} --ignore-not-found
+kubectl create namespace ${NAMESPACE}
+
+# Create artifacts
+kubectl apply -f artifacts/manifest.yaml
+
+# Wait for everything to be ready
+# Can't wait for statefulset directly (sadly)
+# Needs a new version of kubectl: kubectl wait --for=create --timeout=30s Pod/mysql-0 -n ${NAMESPACE}
+sleep 5 # Wait for pod to be created (hopefully)
+kubectl wait --for=condition=Ready --timeout=180s Pod/mysql-0 -n ${NAMESPACE}

--- a/evals/tasks/multi-container-pod-communication/cleanup.sh
+++ b/evals/tasks/multi-container-pod-communication/cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+kubectl delete pod communication-pod -n multi-container-test --ignore-not-found
+kubectl delete configmap shared-data -n multi-container-test --ignore-not-found
+kubectl delete namespace multi-container-test --ignore-not-found

--- a/evals/tasks/multi-container-pod-communication/multi-container-pod-communication.yaml
+++ b/evals/tasks/multi-container-pod-communication/multi-container-pod-communication.yaml
@@ -1,0 +1,19 @@
+kind: Task
+metadata:
+  name: multi-container-pod-communication
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: |
+      In the multi-container-logging namespace, run a pod called communication-pod with two containers:
+      1. A 'web-server' nginx instance that serves traffic
+      2. A 'logger' busybox instance that processes those logs from a shared volume, 'logs-volume' with 'tail -f /var/log/nginx/access.log'
+
+      Both containers should mount logs-volume at '/var/log/nginx'.
+      The logger should only start once the web server is ready. The pod should be considered ready when the web server is serving traffic.

--- a/evals/tasks/multi-container-pod-communication/setup.sh
+++ b/evals/tasks/multi-container-pod-communication/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+kubectl delete namespace multi-container-test --ignore-not-found
+kubectl create namespace multi-container-test

--- a/evals/tasks/multi-container-pod-communication/verify.sh
+++ b/evals/tasks/multi-container-pod-communication/verify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="multi-container-logging"
+POD_NAME="communication-pod"
+TIMEOUT="120s"
+
+# Wait for pod to be running
+echo "Waiting for pod '$POD_NAME' to be ready..."
+if ! kubectl wait --for=condition=Ready pod/$POD_NAME -n "$NAMESPACE" --timeout=$TIMEOUT; then
+    echo "Pod failed to reach Ready state in time"
+    echo "Current pod status:"
+    kubectl describe pod "$POD_NAME" -n "$NAMESPACE"
+    exit 1
+fi
+
+echo "Pod is ready. Verifying configuration..."
+
+# then verify that both containers are running
+CONTAINERS=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.containers[*].name}')
+if [[ ! "$CONTAINERS" == *"web-server"* ]] || [[ ! "$CONTAINERS" == *"logger"* ]]; then
+    echo "Pod does not have both 'web-server' and 'logger' containers"
+    exit 1
+fi
+
+# does the shared volume exists
+VOLUMES=$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.volumes[*].name}')
+if [[ ! "$VOLUMES" == *"logs-volume"* ]]; then
+    echo "Pod does not have the required 'logs-volume' volume"
+    exit 1
+fi
+
+# is web server accessible
+echo "Testing web server access..."
+kubectl exec "$POD_NAME" -n "$NAMESPACE" -c web-server -- curl -s -o /dev/null -w "%{http_code}" localhost:80 | grep -q 200
+
+# logger container can see the access logs
+echo "Verifying logger container can access nginx logs..."
+kubectl exec "$POD_NAME" -n "$NAMESPACE" -c logger -- ls -la /var/log/nginx/access.log
+
+echo "All verification checks passed!"
+exit 0

--- a/evals/tasks/resize-pvc/artifacts/storage-pod.yaml
+++ b/evals/tasks/resize-pvc/artifacts/storage-pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: storage-pod
+  namespace: resize-pv
+spec:
+  volumes:
+    - name: my-storage
+      persistentVolumeClaim:
+        claimName: storage-pvc
+  containers:
+    - name: storage-user
+      image: nginx:alpine
+      volumeMounts:
+        - name: my-storage
+          mountPath: /usr/share/nginx/html
+      ports:
+        - containerPort: 80

--- a/evals/tasks/resize-pvc/artifacts/storage-pvc.yaml
+++ b/evals/tasks/resize-pvc/artifacts/storage-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+  namespace: resize-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: standard

--- a/evals/tasks/resize-pvc/cleanup.sh
+++ b/evals/tasks/resize-pvc/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace resize-pv --ignore-not-found=true

--- a/evals/tasks/resize-pvc/resize-pvc.yaml
+++ b/evals/tasks/resize-pvc/resize-pvc.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: resize-pvc
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "resize the storage volume to 15Gi for the storage-pod in `resize-pv` namespace"

--- a/evals/tasks/resize-pvc/setup.sh
+++ b/evals/tasks/resize-pvc/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+kubectl delete namespace resize-pv --ignore-not-found
+kubectl create namespace resize-pv
+
+kubectl apply -f artifacts/storage-pvc.yaml
+kubectl apply -f artifacts/storage-pod.yaml

--- a/evals/tasks/resize-pvc/verify.sh
+++ b/evals/tasks/resize-pvc/verify.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Configuration
+PVC_NAME="storage-pvc" 
+EXPECTED_SIZE="15Gi"
+TIMEOUT="120s"
+
+echo "Attempting to get PV name from PVC: $PVC_NAME"
+
+# Dynamically get the PV name from the PVC
+PV_NAME=$(kubectl get pvc "$PVC_NAME" -n resize-pv -o jsonpath='{.spec.volumeName}')
+
+if [ -z "$PV_NAME" ]; then
+  echo "Error: Could not retrieve PersistentVolume name for PVC '$PVC_NAME'. Make sure the PVC exists and is bound."
+  exit 1
+fi
+
+if ! kubectl wait --for=jsonpath='{.spec.capacity.storage}'='15Gi' pv/$PV_NAME --timeout=$TIMEOUT; then
+  echo "FAILURE: PersistentVolume '$PV_NAME' did not reach the expected capacity of $EXPECTED_SIZE."
+  exit 1 
+else 
+  echo "SUCCESS: PersistentVolume '$PV_NAME' reached the expected capacity of $EXPECTED_SIZE."
+fi

--- a/evals/tasks/rolling-update-deployment/cleanup.sh
+++ b/evals/tasks/rolling-update-deployment/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Tear down namespace and deployment
+kubectl delete namespace rollout-test --ignore-not-found
+exit 0

--- a/evals/tasks/rolling-update-deployment/rolling-update-deployment.yaml
+++ b/evals/tasks/rolling-update-deployment/rolling-update-deployment.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: rolling-update-deployment
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Update the image of the web-app in rollout-test namespace to 1.22 version. Ensure there is zero downtime (or minimize disruption)"

--- a/evals/tasks/rolling-update-deployment/setup.sh
+++ b/evals/tasks/rolling-update-deployment/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Initialize namespace and deployment with the old image
+kubectl delete namespace rollout-test --ignore-not-found
+kubectl create namespace rollout-test
+kubectl create deployment web-app --image=nginx:1.21 --replicas=3 -n rollout-test
+
+# Wait until all replicas are available
+TIMEOUT="120s"
+if kubectl wait deployment/web-app -n rollout-test --for=condition=Available=True --timeout=$TIMEOUT; then
+  echo "Setup succeeded for rolling-update-deployment"
+  exit 0
+else
+  echo "Setup failed for rolling-update-deployment. Initial deployment did not become ready in time"
+  exit 1
+fi

--- a/evals/tasks/rolling-update-deployment/verify.sh
+++ b/evals/tasks/rolling-update-deployment/verify.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Configuration constants
+NAMESPACE="rollout-test"
+DEPLOYMENT="web-app"
+EXPECTED_IMAGE="nginx:1.22"
+TIMEOUT="120s"
+TASK_NAME="rolling-update-deployment"
+
+echo "Starting verification for $TASK_NAME..."
+# Wait for the rollout to complete
+echo "Waiting for deployment '$DEPLOYMENT' in namespace '$NAMESPACE' to complete its rollout..."
+if ! kubectl rollout status deployment/$DEPLOYMENT -n $NAMESPACE --timeout=$TIMEOUT; then
+    echo "ERROR: Deployment rollout failed or timed out after $TIMEOUT."
+    exit 1
+fi
+echo "Deployment rollout completed successfully."
+
+# Verify each pod is running the new image
+echo "Verifying container images for all pods managed by the deployment..."
+FAILURE=0
+
+# Get the pod-template-hash from the new, active ReplicaSet
+# (The one that has a desired replica count greater than 0)
+ACTIVE_POD_HASH=$(kubectl get rs -n $NAMESPACE -l app=$DEPLOYMENT -o jsonpath='{.items[?(@.spec.replicas > 0)].metadata.labels.pod-template-hash}')
+
+if [ -z "$ACTIVE_POD_HASH" ]; then
+    echo "ERROR: Could not find active ReplicaSet hash for deployment '$DEPLOYMENT'."
+    exit 1
+fi
+
+echo "Found active pod-template-hash: $ACTIVE_POD_HASH. Verifying pods with this label..."
+
+# Get a list of pod names and images *only* from the active ReplicaSet
+POD_INFO=$(kubectl get pods -n $NAMESPACE -l app=$DEPLOYMENT,pod-template-hash=$ACTIVE_POD_HASH -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.containers[0].image}{"\n"}{end}')
+
+if [ -z "$POD_INFO" ]; then
+    echo "ERROR: Could not find any pods for deployment '$DEPLOYMENT' with hash '$ACTIVE_POD_HASH'."
+fi
+
+# Loop through each line of the pod info
+while read -r POD_NAME ACTUAL_IMAGE; do
+    if [[ "$ACTUAL_IMAGE" == "$EXPECTED_IMAGE" ]]; then
+        echo "PASSED: Pod '$POD_NAME' is running the correct image ($ACTUAL_IMAGE)."
+    else
+        echo "FAILED: Pod '$POD_NAME' has the wrong image. Expected: $EXPECTED_IMAGE, Found: $ACTUAL_IMAGE"
+        FAILURE=1
+    fi
+done <<< "$POD_INFO"
+
+if [ $FAILURE -eq 1 ]; then
+    echo "Verification failed: One or more pods are not running the correct image."
+    exit 1
+else 
+  echo "Verification successful for $TASK_NAME."
+  exit 0
+fi

--- a/evals/tasks/scale-deployment/cleanup.sh
+++ b/evals/tasks/scale-deployment/cleanup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Wait for deployment to scale to 2 replicas with kubectl wait
+TIMEOUT="120s"
+if kubectl wait --for=condition=Available=True --timeout=$TIMEOUT deployment/web-app -n scale-test; then
+    # Verify the replica count is exactly 2
+    if [ "$(kubectl get deployment web-app -n scale-test -o jsonpath='{.status.availableReplicas}')" = "2" ]; then
+        exit 0
+    fi
+fi
+
+# If we get here, deployment didn't scale up correctly in time
+echo "Verification failed for scale-deployment"
+exit 1 

--- a/evals/tasks/scale-deployment/scale-deployment.yaml
+++ b/evals/tasks/scale-deployment/scale-deployment.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: scale-deployment
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Scale up the replicas of deployment 'web-app' in namespace 'scale-test' by 100%"

--- a/evals/tasks/scale-deployment/setup.sh
+++ b/evals/tasks/scale-deployment/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Create namespace and a deployment with initial replicas
+kubectl delete namespace scale-test --ignore-not-found
+kubectl create namespace scale-test
+kubectl create deployment web-app --image=nginx --replicas=1 -n scale-test
+# Wait for initial deployment to be ready
+for i in {1..30}; do
+    if kubectl get deployment web-app -n scale-test -o jsonpath='{.status.availableReplicas}' | grep -q "1"; then
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "Setup failed for scale-deployment"
+exit 1

--- a/evals/tasks/scale-deployment/verify.sh
+++ b/evals/tasks/scale-deployment/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Wait for deployment to scale to 2 replicas with kubectl wait
+TIMEOUT="120s"
+if kubectl wait --for=condition=Available=True --timeout=$TIMEOUT deployment/web-app -n scale-test; then
+    # Verify the replica count is exactly 2
+    if [ "$(kubectl get deployment web-app -n scale-test -o jsonpath='{.status.availableReplicas}')" = "2" ]; then
+        exit 0
+    fi
+fi
+
+# If we get here, deployment didn't scale up correctly in time
+echo "Verification failed for scale-deployment"
+exit 1 

--- a/evals/tasks/scale-down-deployment/cleanup.sh
+++ b/evals/tasks/scale-down-deployment/cleanup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete namespace scale-down-test 

--- a/evals/tasks/scale-down-deployment/scale-down-deployment.yaml
+++ b/evals/tasks/scale-down-deployment/scale-down-deployment.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: scale-down-deployment
+  difficulty: medium
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Scale down the replicas of deployment 'web-service' in namespace 'scale-down-test' by 50%"

--- a/evals/tasks/scale-down-deployment/setup.sh
+++ b/evals/tasks/scale-down-deployment/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Create namespace and a deployment with initial replicas
+kubectl delete namespace scale-down-test --ignore-not-found
+kubectl create namespace scale-down-test
+kubectl create deployment web-service --image=nginx --replicas=2 -n scale-down-test
+# Wait for initial deployment to be ready
+for i in {1..30}; do
+    if kubectl --request-timeout=10s get deployment web-service -n scale-down-test -o jsonpath='{.status.availableReplicas}' | grep -q "2"; then
+        exit 0
+    fi
+    sleep 1
+done 

--- a/evals/tasks/scale-down-deployment/verify.sh
+++ b/evals/tasks/scale-down-deployment/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Wait for deployment to scale down to 1 replicas with kubectl wait
+TIMEOUT="120s"
+if kubectl wait --for=condition=Available=True --timeout=$TIMEOUT deployment/web-service -n scale-down-test; then
+    # Verify the replica count is exactly 1
+    if [ "$(kubectl get deployment web-service -n scale-down-test -o jsonpath='{.status.availableReplicas}')" = "1" ]; then
+        exit 0
+    fi
+fi
+
+# If we get here, deployment didn't scale down correctly in time
+echo "Verification failed for scale-down-deployment"
+exit 1 

--- a/evals/tasks/setup-dev-cluster/cleanup.sh
+++ b/evals/tasks/setup-dev-cluster/cleanup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "Cleaning up dev cluster eval resources..."
+
+# Delete all created namespaces (this will clean up most resources)
+kubectl delete namespace dev-alice dev-bob dev-charlie dev-shared staging prod --ignore-not-found=true
+
+# Clean up any cluster-level RBAC resources that might have been created
+kubectl delete clusterrole dev-* --ignore-not-found=true
+kubectl delete clusterrolebinding dev-* --ignore-not-found=true
+
+echo "Cleanup completed"

--- a/evals/tasks/setup-dev-cluster/setup-dev-cluster.md
+++ b/evals/tasks/setup-dev-cluster/setup-dev-cluster.md
@@ -1,0 +1,27 @@
+You are a Kubernetes administrator setting up a development cluster for a team of 3 developers (alice, bob, and charlie).
+
+Create a secure, multi-tenant development environment with the following requirements:
+
+1. **Namespaces**: Create separate namespaces for each developer (dev-alice, dev-bob, dev-charlie) plus shared namespaces (dev-shared, staging, prod)
+
+2. **RBAC Configuration**:
+    - Each developer should have full access to their own namespace
+    - Developers should have read-only access to the dev-shared namespace
+    - Only cluster admins should access staging and prod
+    - Create service accounts for each developer (alice-sa, bob-sa, charlie-sa) in their respective namespaces
+    - Each developer's service account should have full access to their respective namespace and read-only access to the dev-shared namespace
+
+3. **Resource Quotas**:
+    - Each developer namespace: max 2 CPUs, 4Gi memory, 10 pods, 5 services
+    - dev-shared namespace: max 4 CPUs, 8Gi memory, 20 pods, 10 services  
+    - staging/prod: max 8 CPUs, 16Gi memory, 50 pods, 20 services
+
+4. **Network Policies**:
+    - Developers can only access their own namespace and dev-shared
+    - Block cross-developer namespace communication
+    - Allow all namespaces to access DNS and system services
+    - staging and prod should be completely isolated from dev namespaces
+
+5. **Default Deny Policies**: Implement default deny network policies for all namespaces except system namespaces
+
+Ensure all configurations follow principle of least privilege and provide appropriate isolation between environments.

--- a/evals/tasks/setup-dev-cluster/setup-dev-cluster.yaml
+++ b/evals/tasks/setup-dev-cluster/setup-dev-cluster.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: setup-dev-cluster
+  difficulty: hard
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    file: setup-dev-cluster.md

--- a/evals/tasks/setup-dev-cluster/setup.sh
+++ b/evals/tasks/setup-dev-cluster/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo "Setting up cluster state for dev environment eval..."
+
+# Clean up any existing resources
+kubectl delete namespace dev-alice dev-bob dev-charlie dev-shared staging prod --ignore-not-found=true
+
+echo "Setup completed successfully"

--- a/evals/tasks/setup-dev-cluster/verify.sh
+++ b/evals/tasks/setup-dev-cluster/verify.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Configuration ---
+readonly DEVELOPERS=("alice" "bob" "charlie")
+readonly DEV_NAMESPACES=("dev-alice" "dev-bob" "dev-charlie")
+readonly ALL_NAMESPACES=("${DEV_NAMESPACES[@]}" "dev-shared" "staging" "prod")
+readonly TEST_LABEL="app=verification-test"
+
+# --- Cleanup Function ---
+cleanup() {
+  echo "Cleaning up test resources..."
+  for ns in "${ALL_NAMESPACES[@]}"; do
+    kubectl delete namespace "$ns" --ignore-not-found=true --grace-period=0 --force &
+  done
+  wait # Wait for all background delete jobs to finish
+  echo "Cleanup complete."
+}
+trap cleanup EXIT
+
+# --- Verification Functions ---
+
+# 1. Verify all namespaces exist in a single API call
+verify_namespaces() {
+  echo "Checking namespaces..."
+  local existing_ns
+  existing_ns=$(kubectl get namespace -o jsonpath='{.items[*].metadata.name}')
+  for ns in "${ALL_NAMESPACES[@]}"; do
+    if ! [[ "$existing_ns" =~ $ns ]]; then
+      echo "Namespace '$ns' does not exist"
+      exit 1
+    fi
+  done
+  echo "All namespaces exist."
+}
+
+# 2. Verify service accounts exist
+verify_service_accounts() {
+  echo "Checking service accounts..."
+  for dev in "${DEVELOPERS[@]}"; do
+    local sa_name="${dev}-sa"
+    local ns_name="dev-${dev}"
+    if ! kubectl get serviceaccount "$sa_name" -n "$ns_name" &>/dev/null; then
+      echo "ServiceAccount '$sa_name' does not exist in namespace '$ns_name'"
+      exit 1
+    fi
+  done
+  echo "All developer ServiceAccounts exist."
+}
+
+# 3. Verify RBAC permissions
+verify_rbac() {
+  echo "Testing RBAC permissions..."
+  for dev in "${DEVELOPERS[@]}"; do
+    local user_name="${dev}"
+    local sa_user="system:serviceaccount:dev-${dev}:${dev}-sa"
+    local own_ns="dev-${dev}"
+    
+    # --- Test *User* Permissions ---
+    # Users should have full access to their own namespaces
+    if ! kubectl auth can-i create pods --as="$user_name" -n "$own_ns" --quiet; then
+      echo "FAIL: $user_name (User) cannot create pods in their own namespace '$own_ns'"
+      exit 1
+    fi
+
+    # Users should have read access to dev-shared
+    if ! kubectl auth can-i get pods --as="$user_name" -n "dev-shared" --quiet; then
+      echo "FAIL: $user_name (User) cannot read pods in 'dev-shared' namespace"
+      exit 1
+    fi
+
+    # --- Test *Service Account* Permissions ---
+    # Service account should have full access to its own namespace
+    if ! kubectl auth can-i create pods --as="$sa_user" -n "$own_ns" --quiet; then
+      echo "FAIL: $sa_user (SA) cannot create pods in their own namespace '$own_ns'"
+      exit 1
+    fi
+    
+    # Service account should have read access to dev-shared
+    if ! kubectl auth can-i get pods --as="$sa_user" -n "dev-shared" --quiet; then
+      echo "FAIL: $sa_user (SA) cannot read pods in 'dev-shared' namespace"
+      exit 1
+    fi
+    
+    # --- Test Isolation for *BOTH* identities ---
+    for other_ns in "${ALL_NAMESPACES[@]}"; do
+      # Skip namespaces where access is expected
+      if [[ "$other_ns" == "$own_ns" || "$other_ns" == "dev-shared" ]]; then
+        continue
+      fi
+
+      # --- User Isolation Check ---
+      if kubectl auth can-i get pods --as="$user_name" -n "$other_ns" --quiet; then
+        echo "FAIL: $user_name (User) has unauthorized read access to '$other_ns' namespace"
+        exit 1
+      fi
+
+      # --- Service Account Isolation Check ---
+      if kubectl auth can-i get pods --as="$sa_user" -n "$other_ns" --quiet; then
+        echo "FAIL: $sa_user (SA) has unauthorized read access to '$other_ns' namespace"
+        exit 1
+      fi
+    done
+    
+  done
+  echo "RBAC permissions are correctly configured."
+}
+
+# 4. Verify Resource Quotas using precise jsonpath
+verify_quotas() {
+  echo "Checking resource quotas..."
+  declare -A expected_quotas=(
+      ["dev-alice"]="pods=10:services=5"
+      ["dev-bob"]="pods=10:services=5"
+      ["dev-charlie"]="pods=10:services=5"
+      ["dev-shared"]="pods=20:services=10"
+      ["staging"]="pods=50:services=20"
+      ["prod"]="pods=50:services=20"
+  )
+
+  for ns in "${!expected_quotas[@]}"; do
+    # First, find the name of the ResourceQuota object in the namespace.
+    local quota_name
+    quota_name=$(kubectl get resourcequota -n "$ns" -o jsonpath='{.items[0].metadata.name}')
+
+    if [[ -z "$quota_name" ]]; then
+      echo "No ResourceQuota object found in namespace '$ns'"
+      exit 1
+    fi
+
+    # Parse expected values from the array
+    local expected_values="${expected_quotas[$ns]}"
+    local expected_pods=$(echo "$expected_values" | cut -d: -f1 | cut -d= -f2)
+    local expected_services=$(echo "$expected_values" | cut -d: -f2 | cut -d= -f2)
+
+    # Get both actual values in a single API call, separated by a space
+    local actual_values
+    actual_values=$(kubectl get resourcequota "$quota_name" -n "$ns" -o=jsonpath='{.spec.hard.pods}{" "}{.spec.hard.services}')
+    
+    # Read the space-separated output into variables
+    local actual_pods actual_services
+    read -r actual_pods actual_services <<< "$actual_values"
+
+    # Check if either value does not match
+    if [[ "$actual_pods" != "$expected_pods" || "$actual_services" != "$expected_services" ]]; then
+      echo "ResourceQuota mismatch in namespace '$ns'."
+      echo "  - Expected: pods=${expected_pods}, services=${expected_services}"
+      echo "  - Found:    pods=${actual_pods}, services=${actual_services}"
+      exit 1
+    fi
+  done
+  echo "Resource quotas are correctly configured."
+}
+
+# 5. Verify Network Policies exist (without assuming a name)
+verify_network_policies() {
+  echo "Checking for existence of Network Policies..."
+  for ns in "${ALL_NAMESPACES[@]}"; do
+    # Get a count of NetworkPolicy objects in the namespace
+    local policy_count
+    policy_count=$(kubectl get networkpolicy -n "$ns" -o name | wc -l)
+    
+    if [[ "$policy_count" -eq 0 ]]; then
+      echo "No NetworkPolicy objects found in namespace '$ns'. A default deny policy is likely missing."
+      exit 1
+    fi
+  done
+  echo "At least one NetworkPolicy exists in all namespaces."
+}
+
+# 6. Test network isolation with a functional test
+test_network_isolation() {
+  echo "Testing network isolation..."
+  local manifest_yaml=""
+
+  # Generate a single YAML manifest for all test resources
+  for dev in "${DEVELOPERS[@]}"; do
+    local ns="dev-${dev}"
+    # The selector needs key: value format
+    local selector_key="app"
+    local selector_value="verification-test"
+
+    manifest_yaml+=$(cat <<EOF
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-${dev}
+  namespace: $ns
+  labels:
+    ${selector_key}: ${selector_value}
+spec:
+  containers:
+  - name: curl
+    image: curlimages/curl:latest
+    command: ["sleep", "3600"]
+    resources:
+        limits:
+            cpu: "100m"
+            memory: "128Mi"
+        requests:
+            cpu: "100m"
+            memory: "128Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service-${dev}
+  namespace: $ns
+  labels:
+    ${selector_key}: ${selector_value}
+spec:
+  selector:
+    ${selector_key}: ${selector_value} # Use same labels for selector
+  ports:
+  - port: 80
+EOF
+)
+  done
+
+  echo "  - Creating test pods and services..."
+  echo "$manifest_yaml" | kubectl apply -f -
+
+  echo "  - Waiting for test pods to be ready..."
+  for dev in "${DEVELOPERS[@]}"; do
+    kubectl wait --for=condition=Ready pod/test-pod-${dev} -n "dev-${dev}" --timeout=60s
+  done
+  
+  # Test that alice cannot reach bob's service
+  echo "  - Testing cross-namespace isolation (alice -> bob)..."
+  if kubectl exec -n dev-alice test-pod-alice -- curl -s --max-time 3 http://test-service-bob.dev-bob.svc.cluster.local &>/dev/null; then
+    echo "Network policy FAILED: dev-alice can reach dev-bob's service"
+    exit 1
+  fi
+  echo "  - Cross-namespace access is properly blocked."
+
+  # Test that DNS is working
+  echo "  - Testing DNS access..."
+  if ! kubectl exec -n dev-alice test-pod-alice -- nslookup -timeout=3 kubernetes.default.svc.cluster.local &>/dev/null; then
+    echo "DNS resolution FAILED (it should be allowed by network policies)"
+    exit 1
+  fi
+  echo "  - DNS access is working correctly."
+  echo "Network policies are functioning correctly."
+}
+
+
+# --- Main Execution ---
+main() {
+  echo "Starting comprehensive verification of dev cluster setup..."
+  verify_namespaces
+  verify_service_accounts
+  verify_rbac
+  verify_quotas
+  verify_network_policies
+  test_network_isolation
+  echo "All verifications passed! Cluster setup is correctly configured."
+}
+
+main

--- a/evals/tasks/statefulset-lifecycle/cleanup.sh
+++ b/evals/tasks/statefulset-lifecycle/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Tear down namespace and StatefulSet resources
+kubectl delete namespace statefulset-test --ignore-not-found
+exit 0

--- a/evals/tasks/statefulset-lifecycle/setup.sh
+++ b/evals/tasks/statefulset-lifecycle/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Teardown any existing namespace
+kubectl delete namespace statefulset-test --ignore-not-found
+
+# Create namespace
+kubectl create namespace statefulset-test

--- a/evals/tasks/statefulset-lifecycle/statefulset-lifecycle.yaml
+++ b/evals/tasks/statefulset-lifecycle/statefulset-lifecycle.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  name: statefulset-lifecycle
+  difficulty: hard
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    file: verify.sh
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: "Deploy a 3-replica StatefulSet db in namespace statefulset-test with each pod mounting a 1Gi PVC at /data containing a file `test` populated with the string `initial_data`. Then, scale back down to 1 replicas."

--- a/evals/tasks/statefulset-lifecycle/verify.sh
+++ b/evals/tasks/statefulset-lifecycle/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Configuration ---
+NAMESPACE="statefulset-test"
+STS_NAME="db"
+EXPECTED_CONTENT="initial_data"
+
+echo "Verifying old pods are deleted"
+# Wait for scale-down: 1 ready pods and deletion of old pods
+kubectl wait pod/db-1 pod/db-2 -n statefulset-test --for=delete --timeout=120s
+echo "Old pods are deleted"
+
+# Verify correct number of replicas
+echo "Verifying StatefulSet replica count"
+replicas=$(kubectl get sts "${STS_NAME}" -n "${NAMESPACE}" -o jsonpath='{.spec.replicas}')
+if [[ "${replicas}" -ne 1 ]]; then
+  echo "Expected 1 replicas, but got $replicas"
+  exit 1
+fi
+echo "StatefulSet is running with 1 replicas"
+
+# Verify db-0 exists and have the correct data
+for pod in db-0; do
+  if ! kubectl get pod "$pod" -n "${NAMESPACE}" &> /dev/null; then
+    echo "Pod $pod not found in namespace $NAMESPACE"
+    exit 1
+  fi
+
+  data=$(kubectl exec "$pod" -n "${NAMESPACE}" -- cat /data/test)
+  if [[ "$data" != "${EXPECTED_CONTENT}" ]]; then
+    echo "Data missing or incorrect in $pod"
+    exit 1
+  fi
+done
+
+exit 0


### PR DESCRIPTION
This PR adds the gevals action to run in github workflows. There are a few ways to trigger this:
1. Manually
2. Through a comment on a PR (`/run-gevals`)
3. It will run periodically once per week

I will do future follow ups to allow us to:
1. Specify which model to run
2. Run a matrix of models/agents in the weekly CI
3. Cleanup some of the start/configure server logic

