### PR TITLE
feat(kiali): Possibility of renaming Kiali in the downstream distribution

### DIFF
--- a/pkg/mcp/testdata/toolsets-kiali-tools.json
+++ b/pkg/mcp/testdata/toolsets-kiali-tools.json
@@ -1,39 +1,6 @@
 [
   {
     "annotations": {
-      "title": "Topology: Mesh, Graph, Health, and Status",
-      "readOnlyHint": true,
-      "destructiveHint": false,
-      "openWorldHint": true
-    },
-    "description": "Returns the topology of a specific namespaces, health, status of the mesh and namespaces. Includes a mesh health summary overview with aggregated counts of healthy, degraded, and failing apps, workloads, and services. Use this for high-level overviews",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "graphType": {
-          "default": "versionedApp",
-          "description": "Type of graph to return: 'versionedApp', 'app', 'service', 'workload', 'mesh'",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Optional single namespace to include in the graph (alternative to namespaces)",
-          "type": "string"
-        },
-        "namespaces": {
-          "description": "Optional comma-separated list of namespaces to include in the graph",
-          "type": "string"
-        },
-        "rateInterval": {
-          "default": "10m",
-          "description": "Rate interval for fetching (e.g., '10m', '5m', '1h').",
-          "type": "string"
-        }
-      }
-    },
-    "name": "kiali_get_mesh_graph"
-  },
-  {
-    "annotations": {
       "title": "Get Metrics for a Resource",
       "readOnlyHint": true,
       "destructiveHint": false,
@@ -248,6 +215,39 @@
       ]
     },
     "name": "kiali_manage_istio_config"
+  },
+  {
+    "annotations": {
+      "title": "Topology: Mesh, Graph, Health, and Status",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "openWorldHint": true
+    },
+    "description": "Returns the topology of a specific namespaces, health, status of the mesh and namespaces. Includes a mesh health summary overview with aggregated counts of healthy, degraded, and failing apps, workloads, and services. Use this for high-level overviews",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "graphType": {
+          "default": "versionedApp",
+          "description": "Type of graph to return: 'versionedApp', 'app', 'service', 'workload', 'mesh'",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Optional single namespace to include in the graph (alternative to namespaces)",
+          "type": "string"
+        },
+        "namespaces": {
+          "description": "Optional comma-separated list of namespaces to include in the graph",
+          "type": "string"
+        },
+        "rateInterval": {
+          "default": "10m",
+          "description": "Rate interval for fetching (e.g., '10m', '5m', '1h').",
+          "type": "string"
+        }
+      }
+    },
+    "name": "kiali_mesh_graph"
   },
   {
     "annotations": {

--- a/pkg/toolsets/kiali/internal/defaults/defaults.go
+++ b/pkg/toolsets/kiali/internal/defaults/defaults.go
@@ -1,0 +1,22 @@
+package defaults
+
+const (
+	DefaultToolsetName        = "kiali"
+	DefaultToolsetDescription = "Most common tools for managing Kiali, check the [Kiali documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/KIALI.md) for more details."
+)
+
+func ToolsetName() string {
+	overrideName := ToolsetNameOverride()
+	if overrideName != "" {
+		return overrideName
+	}
+	return DefaultToolsetName
+}
+
+func ToolsetDescription() string {
+	overrideDescription := ToolsetDescriptionOverride()
+	if overrideDescription != "" {
+		return overrideDescription
+	}
+	return DefaultToolsetDescription
+}

--- a/pkg/toolsets/kiali/internal/defaults/defaults_override.go
+++ b/pkg/toolsets/kiali/internal/defaults/defaults_override.go
@@ -1,0 +1,14 @@
+package defaults
+
+const (
+	toolsetNameOverride        = ""
+	toolsetDescriptionOverride = ""
+)
+
+func ToolsetNameOverride() string {
+	return toolsetNameOverride
+}
+
+func ToolsetDescriptionOverride() string {
+	return toolsetDescriptionOverride
+}

--- a/pkg/toolsets/kiali/tools/get_mesh_graph.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_graph.go
@@ -1,4 +1,4 @@
-package kiali
+package tools
 
 import (
 	"fmt"
@@ -9,13 +9,15 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func initGetMeshGraph() []api.ServerTool {
+func InitGetMeshGraph() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
+	name := defaults.ToolsetName() + "_mesh_graph"
 	ret = append(ret, api.ServerTool{
 		Tool: api.Tool{
-			Name:        "kiali_get_mesh_graph",
+			Name:        name,
 			Description: "Returns the topology of a specific namespaces, health, status of the mesh and namespaces. Includes a mesh health summary overview with aggregated counts of healthy, degraded, and failing apps, workloads, and services. Use this for high-level overviews",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/toolsets/kiali/tools/get_metrics.go
+++ b/pkg/toolsets/kiali/tools/get_metrics.go
@@ -1,4 +1,4 @@
-package kiali
+package tools
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
 type resourceOperations struct {
@@ -32,12 +33,12 @@ var opsMap = map[string]resourceOperations{
 	},
 }
 
-func initGetMetrics() []api.ServerTool {
+func InitGetMetrics() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
-
+	name := defaults.ToolsetName() + "_get_metrics"
 	ret = append(ret, api.ServerTool{
 		Tool: api.Tool{
-			Name:        "kiali_get_metrics",
+			Name:        name,
 			Description: "Gets lists or detailed info for Kubernetes resources (services, workloads) within the mesh",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/toolsets/kiali/tools/get_resource_details.go
+++ b/pkg/toolsets/kiali/tools/get_resource_details.go
@@ -1,4 +1,4 @@
-package kiali
+package tools
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
 type listDetailsOperations struct {
@@ -39,12 +40,12 @@ var listDetailsOpsMap = map[string]listDetailsOperations{
 	},
 }
 
-func initGetResourceDetails() []api.ServerTool {
+func InitGetResourceDetails() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
-
+	name := defaults.ToolsetName() + "_get_resource_details"
 	ret = append(ret, api.ServerTool{
 		Tool: api.Tool{
-			Name:        "kiali_get_resource_details",
+			Name:        name,
 			Description: "Gets lists or detailed info for Kubernetes resources (services, workloads) within the mesh",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/toolsets/kiali/tools/get_traces.go
+++ b/pkg/toolsets/kiali/tools/get_traces.go
@@ -1,4 +1,4 @@
-package kiali
+package tools
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
 type tracesOperations struct {
@@ -40,12 +41,12 @@ var tracesOpsMap = map[string]tracesOperations{
 	},
 }
 
-func initGetTraces() []api.ServerTool {
+func InitGetTraces() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
-
+	name := defaults.ToolsetName() + "_get_traces"
 	ret = append(ret, api.ServerTool{
 		Tool: api.Tool{
-			Name:        "kiali_get_traces",
+			Name:        name,
 			Description: "Gets traces for a specific resource (app, service, workload) in a namespace, or gets detailed information for a specific trace by its ID. If traceId is provided, it returns detailed trace information and other parameters are not required.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/toolsets/kiali/tools/helpers.go
+++ b/pkg/toolsets/kiali/tools/helpers.go
@@ -1,4 +1,4 @@
-package kiali
+package tools
 
 import (
 	"encoding/json"

--- a/pkg/toolsets/kiali/tools/helpers_test.go
+++ b/pkg/toolsets/kiali/tools/helpers_test.go
@@ -1,4 +1,4 @@
-package kiali
+package tools
 
 import (
 	"encoding/json"

--- a/pkg/toolsets/kiali/tools/logs.go
+++ b/pkg/toolsets/kiali/tools/logs.go
@@ -1,4 +1,4 @@
-package kiali
+package tools
 
 import (
 	"fmt"
@@ -7,15 +7,16 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func initLogs() []api.ServerTool {
+func InitLogs() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
-
+	name := defaults.ToolsetName() + "_workload_logs"
 	// Workload logs tool
 	ret = append(ret, api.ServerTool{
 		Tool: api.Tool{
-			Name:        "kiali_workload_logs",
+			Name:        name,
 			Description: "Get logs for a specific workload's pods in a namespace. Only requires namespace and workload name - automatically discovers pods and containers. Optionally filter by container name, time range, and other parameters. Container is auto-detected if not specified.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/toolsets/kiali/tools/manage_istio_config.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config.go
@@ -1,4 +1,4 @@
-package kiali
+package tools
 
 import (
 	"fmt"
@@ -7,13 +7,15 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func initManageIstioConfig() []api.ServerTool {
+func InitManageIstioConfig() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
+	name := defaults.ToolsetName() + "_manage_istio_config"
 	ret = append(ret, api.ServerTool{
 		Tool: api.Tool{
-			Name:        "kiali_manage_istio_config",
+			Name:        name,
 			Description: "Manages Istio configuration objects (Gateways, VirtualServices, etc.). Can list (objects and validations), get, create, patch, or delete objects",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -6,6 +6,8 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
+	kialiTools "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
 )
 
 type Toolset struct{}
@@ -13,21 +15,21 @@ type Toolset struct{}
 var _ api.Toolset = (*Toolset)(nil)
 
 func (t *Toolset) GetName() string {
-	return "kiali"
+	return defaults.ToolsetName()
 }
 
 func (t *Toolset) GetDescription() string {
-	return "Most common tools for managing Kiali, check the [Kiali documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/KIALI.md) for more details."
+	return defaults.ToolsetDescription()
 }
 
 func (t *Toolset) GetTools(_ internalk8s.Openshift) []api.ServerTool {
 	return slices.Concat(
-		initGetMeshGraph(),
-		initManageIstioConfig(),
-		initGetResourceDetails(),
-		initGetMetrics(),
-		initLogs(),
-		initGetTraces(),
+		kialiTools.InitGetMeshGraph(),
+		kialiTools.InitManageIstioConfig(),
+		kialiTools.InitGetResourceDetails(),
+		kialiTools.InitGetMetrics(),
+		kialiTools.InitLogs(),
+		kialiTools.InitGetTraces(),
 	)
 }
 


### PR DESCRIPTION

Downstream we will add the following override in `pkg/config/config_default_overrides.go`:
```go
ToolsetKialiName: "ossm"
```
This allows the toolset to return `"ossm"` from `GetName()` instead of `"kiali"`.
think this approach works better than passing `internalk8s.Openshift` into `GetName()` the way `GetTools()` does, since it keeps things simpler, requires fewer modifications, and is overall lighter.

Also, each tool already checks whether the environment is **OpenShift** (following the same pattern as the `core` toolset). We expect users to run OpenShift with OSSM, not upstream Istio, so this behavior is consistent with that assumption.

<img width="762" height="378" alt="Screenshot From 2025-11-26 11-14-04" src="https://github.com/user-attachments/assets/6d7f8364-1820-4bb7-b8b2-f0fa934b2e25" />

cc @manusa WDYT?
