### PR TITLE
chore(tests): add makefile target to update JSON snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ build-all-platforms: clean tidy format lint ## Build the project for all platfor
 test: ## Run the tests
 	go test -count=1 -v ./...
 
+.PHONY: test-update-snapshots
+test-update-snapshots: ## Update test snapshots for toolset tests
+	UPDATE_TOOLSETS_JSON=1 go test -count=1 -v ./pkg/mcp
+
 .PHONY: format
 format: ## Format the code
 	go fmt ./...

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -203,6 +203,10 @@ func (s *ToolsetsSuite) InitMcpClient() {
 	s.McpClient = test.NewMcpClient(s.T(), s.mcpServer.ServeHTTP())
 }
 
+// assertJsonSnapshot compares actual data against a JSON snapshot file.
+// When the snapshot doesn't match, the test fails with instructions on how to update it.
+// Set UPDATE_TOOLSETS_JSON=1 environment variable to regenerate snapshot files.
+// Example: UPDATE_TOOLSETS_JSON=1 go test ./pkg/mcp -v
 func (s *ToolsetsSuite) assertJsonSnapshot(snapshotFile string, actual any) {
 	_, file, _, _ := runtime.Caller(1)
 	snapshotPath := filepath.Join(filepath.Dir(file), "testdata", snapshotFile)


### PR DESCRIPTION
Follows up on #514 to simplify the snapshot updates by adding a makefile target.
```bash
make test-update-snapshots
```