### PR TITLE
test(mcp): use envtest built-in features to apply CRDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/google/jsonschema-go v0.3.0
 	github.com/mark3labs/mcp-go v0.43.1
 	github.com/modelcontextprotocol/go-sdk v1.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
@@ -104,6 +103,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/pkg/mcp/common_crd_test.go
+++ b/pkg/mcp/common_crd_test.go
@@ -1,0 +1,137 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	apiextensionsv1spec "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/utils/ptr"
+)
+
+func CRD(group, version, resource, kind, singular string, namespaced bool) *apiextensionsv1spec.CustomResourceDefinition {
+	scope := "Cluster"
+	if namespaced {
+		scope = "Namespaced"
+	}
+	crd := &apiextensionsv1spec.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiextensionsv1spec.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s.%s", resource, group)},
+		Spec: apiextensionsv1spec.CustomResourceDefinitionSpec{
+			Group: group,
+			Versions: []apiextensionsv1spec.CustomResourceDefinitionVersion{
+				{
+					Name:    version,
+					Served:  false,
+					Storage: true,
+					Schema: &apiextensionsv1spec.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1spec.JSONSchemaProps{
+							Type:                   "object",
+							XPreserveUnknownFields: ptr.To(true),
+						},
+					},
+				},
+			},
+			Scope: apiextensionsv1spec.ResourceScope(scope),
+			Names: apiextensionsv1spec.CustomResourceDefinitionNames{
+				Plural:     resource,
+				Singular:   singular,
+				Kind:       kind,
+				ShortNames: []string{singular},
+			},
+		},
+	}
+	return crd
+}
+
+func EnvTestEnableCRD(ctx context.Context, group, version, resource string) error {
+	apiExtensionsV1Client := apiextensionsv1.NewForConfigOrDie(envTestRestConfig)
+	_, err := apiExtensionsV1Client.CustomResourceDefinitions().Patch(
+		ctx,
+		fmt.Sprintf("%s.%s", resource, group),
+		types.JSONPatchType,
+		[]byte(`[{"op": "replace", "path": "/spec/versions/0/served", "value": true}]`),
+		metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	return EnvTestWaitForAPIResourceCondition(ctx, group, version, resource, true)
+}
+
+func EnvTestDisableCRD(ctx context.Context, group, version, resource string) error {
+	apiExtensionsV1Client := apiextensionsv1.NewForConfigOrDie(envTestRestConfig)
+	_, err := apiExtensionsV1Client.CustomResourceDefinitions().Patch(
+		ctx,
+		fmt.Sprintf("%s.%s", resource, group),
+		types.JSONPatchType,
+		[]byte(`[{"op": "replace", "path": "/spec/versions/0/served", "value": false}]`),
+		metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	return EnvTestWaitForAPIResourceCondition(ctx, group, version, resource, false)
+}
+
+func EnvTestWaitForAPIResourceCondition(ctx context.Context, group, version, resource string, shouldBeAvailable bool) error {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(envTestRestConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create discovery client: %w", err)
+	}
+
+	groupVersion := fmt.Sprintf("%s/%s", group, version)
+	if group == "" {
+		groupVersion = version
+	}
+
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		resourceList, err := discoveryClient.ServerResourcesForGroupVersion(groupVersion)
+		if err != nil {
+			// If we're waiting for the resource to be unavailable and we get an error, it might be gone
+			if !shouldBeAvailable {
+				return true, nil
+			}
+			// Otherwise, keep polling
+			return false, nil
+		}
+
+		// Check if the resource exists in the list
+		found := false
+		for _, apiResource := range resourceList.APIResources {
+			if apiResource.Name == resource {
+				found = true
+				break
+			}
+		}
+
+		// Return true if the condition is met
+		if shouldBeAvailable {
+			return found, nil
+		}
+		return !found, nil
+	})
+}
+
+// EnvTestInOpenShift sets up the kubernetes environment to seem to be running OpenShift
+func EnvTestInOpenShift(ctx context.Context) error {
+	tasks, _ := errgroup.WithContext(ctx)
+	tasks.Go(func() error { return EnvTestEnableCRD(ctx, "project.openshift.io", "v1", "projects") })
+	tasks.Go(func() error { return EnvTestEnableCRD(ctx, "route.openshift.io", "v1", "routes") })
+	return tasks.Wait()
+}
+
+// EnvTestInOpenShiftClear clears the kubernetes environment so it no longer seems to be running OpenShift
+func EnvTestInOpenShiftClear(ctx context.Context) error {
+	tasks, _ := errgroup.WithContext(ctx)
+	tasks.Go(func() error { return EnvTestDisableCRD(ctx, "project.openshift.io", "v1", "projects") })
+	tasks.Go(func() error { return EnvTestDisableCRD(ctx, "route.openshift.io", "v1", "routes") })
+	return tasks.Wait()
+}

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -401,7 +401,7 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdate() {
 			_, err = apiExtensionsV1Client.CustomResourceDefinitions().Get(s.T().Context(), "customs.example.com", metav1.GetOptions{})
 			s.Nilf(err, "custom resource definition not found")
 		})
-		s.Require().NoError(EnvTestCrdWaitUntilReady(s.T().Context(), "customs.example.com"))
+		s.Require().NoError(EnvTestWaitForAPIResourceCondition(s.T().Context(), "example.com", "v1", "customs", true))
 	})
 
 	s.Run("resources_create_or_update creates custom resource", func() {


### PR DESCRIPTION
Trying to speed up the test cases that require additional
kubernetes APIs.

Each time a test suite or test case requires an additional
API (like OpenShift Routes or Kiali CRDs), provided by
k8s.io/apiextensions, a fixed 2 seconds delay is introduced.

There's no way to reduce that delay by using envtest features
or APIServer CLI flags.

The delays are introduced by kube-aggregator, apiextensions, and others:

https://github.com/kubernetes/kube-aggregator/blob/a00232cf7e758c2771b3542033bec19e69e6451a/pkg/controllers/openapiv3/controller.go#L34

https://github.com/kubernetes/apiextensions-apiserver/blob/8db5ab628dd026827c1c9677944432db70c065c3/pkg/apiserver/customresource_handler.go#L381-L394

To mitigate this, we're going to declare all CRDs used in the test in
the common_test.go TestMain function.

This will make sure we only have a single delay at the beginning of
the entire test suite instead of per test suite or test case.

The CRDs are NOT served by default.

For each test suite we'll be able to enable them or disable them
by using the EnvTestEnableCRD and EnvTestDisableCRD functions.
These will also ensure that the API server lists the new APIs or not.