### PR TITLE
feat(helm): enhance chart versioning for development and stable releases

### DIFF
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -33,10 +33,20 @@ jobs:
       with:
         version: '3.19.2'
 
-    - name: Extract versions
+    - name: Determine chart version
       id: versions
       run: |
-        CHART_VERSION=$(make helm-print-chart-version)
+        BASE_VERSION=$(make helm-print-chart-version)
+
+        # Use development version for workflow_dispatch, stable version for tags
+        if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          GIT_SHORT_SHA=$(git rev-parse --short HEAD)
+          CHART_VERSION="${BASE_VERSION}-dev.${GIT_SHORT_SHA}"
+          echo "::notice::Creating development release: ${CHART_VERSION}"
+        else
+          CHART_VERSION="${BASE_VERSION}"
+          echo "::notice::Creating stable release: ${CHART_VERSION}"
+        fi
         echo "chart_version=$CHART_VERSION" >> $GITHUB_OUTPUT
         echo "Chart version: $CHART_VERSION"
 
@@ -59,15 +69,25 @@ jobs:
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ steps.versions.outputs.helm_registry }} -u ${{ github.actor }} --password-stdin
 
-    - name: Package Helm chart and push chart to OCI registry
+    - name: Package and push Helm chart
+      env:
+        HELM_CHART_VERSION: ${{ steps.versions.outputs.chart_version }}
       run: make helm-push
 
     - name: Verify chart installation
+      env:
+        HELM_CHART_VERSION: ${{ steps.versions.outputs.chart_version }}
       run: make helm-verify
 
     - name: Generate release summary
       run: |
-        echo "## Helm Chart Release Summary" >> $GITHUB_STEP_SUMMARY
+        if [[ "${{ steps.versions.outputs.chart_version }}" == *"-dev."* ]]; then
+          RELEASE_TYPE="Development"
+        else
+          RELEASE_TYPE="Stable"
+        fi
+
+        echo "## Helm Chart Release Summary ($RELEASE_TYPE)" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "- **Chart Name:** ${{ steps.versions.outputs.chart_name }}" >> $GITHUB_STEP_SUMMARY
         echo "- **Chart Version:** ${{ steps.versions.outputs.chart_version }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Automates Helm chart releases via GitHub Actions, publishing to GHCR as OCI artifacts.

Continuation of #499

## Changes

**Makefile (`build/helm.mk`):**
  - Added targets: `helm-lint`, `helm-validate`, `helm-package`, `helm-push`, `helm-verify`
  - Auto-installs kubeconform to `_output/tools/bin/`
  - Dynamically sets `appVersion` from `GIT_TAG_VERSION` during packaging

**Workflow (`.github/workflows/release-helm.yaml`):**
  - **Tag push**: Creates stable releases (e.g., `0.1.0`)
  - **Manual trigger**: Creates dev releases (e.g., `0.1.0-dev.cd5a70b3`)
  - Validates, packages, and pushes to `ghcr.io/containers/charts/kubernetes-mcp-server`

**Chart:**
  - Added `appVersion` field
  - Updated README with OCI registry installation instructions
  - Fixed typos and template filename

## Installation

```bash
helm install kubernetes-mcp-server \
  oci://ghcr.io/containers/charts/kubernetes-mcp-server \
  --set ingress.host=<hostname> --version 0.1.0 \
  --create-namespace --namespace mcp-system
```
