### PR TITLE
fix(kubernetes)!: Provider updated for each watcher callback

### DIFF
--- a/pkg/kubernetes/provider_watch_test.go
+++ b/pkg/kubernetes/provider_watch_test.go
@@ -1,0 +1,180 @@
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type ProviderWatchTargetsTestSuite struct {
+	suite.Suite
+	mockServer             *test.MockServer
+	discoveryClientHandler *test.DiscoveryClientHandler
+	kubeconfig             *clientcmdapi.Config
+	staticConfig           *config.StaticConfig
+}
+
+func (s *ProviderWatchTargetsTestSuite) SetupTest() {
+	s.mockServer = test.NewMockServer()
+	s.discoveryClientHandler = &test.DiscoveryClientHandler{}
+	s.mockServer.Handle(s.discoveryClientHandler)
+
+	s.T().Setenv("CLUSTER_STATE_POLL_INTERVAL_MS", "100")
+	s.T().Setenv("CLUSTER_STATE_DEBOUNCE_WINDOW_MS", "50")
+
+	// Add multiple fake contexts to allow testing of context changes
+	s.kubeconfig = s.mockServer.Kubeconfig()
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("context-%d", i)
+		s.kubeconfig.Contexts[name] = clientcmdapi.NewContext()
+		s.kubeconfig.Contexts[name].Cluster = s.kubeconfig.Contexts[s.kubeconfig.CurrentContext].Cluster
+		s.kubeconfig.Contexts[name].AuthInfo = s.kubeconfig.Contexts[s.kubeconfig.CurrentContext].AuthInfo
+	}
+
+	s.staticConfig = &config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), s.kubeconfig)}
+}
+
+func (s *ProviderWatchTargetsTestSuite) TearDownTest() {
+	s.mockServer.Close()
+}
+
+func (s *ProviderWatchTargetsTestSuite) TestClusterStateChanges() {
+	testCases := []func() (Provider, error){
+		func() (Provider, error) { return newKubeConfigClusterProvider(s.staticConfig) },
+		func() (Provider, error) {
+			return newSingleClusterProvider(config.ClusterProviderDisabled)(s.staticConfig)
+		},
+	}
+	for _, tc := range testCases {
+		provider, err := tc()
+		s.Require().NoError(err, "Expected no error from provider creation")
+
+		s.Run("With provider "+reflect.TypeOf(provider).String(), func() {
+			callback, waitForCallback := CallbackWaiter()
+			provider.WatchTargets(callback)
+			s.Run("Reloads provider on cluster changes", func() {
+				s.discoveryClientHandler.Groups = append(s.discoveryClientHandler.Groups, `{"name":"alex.example.com","versions":[{"groupVersion":"alex.example.com/v1","version":"v1"}],"preferredVersion":{"groupVersion":"alex.example.com/v1","version":"v1"}}`)
+
+				s.Require().NoError(waitForCallback(5 * time.Second))
+				// Provider-wise the watcher.ClusterState which triggers the callback has no effect.
+				// We might consider removing it at some point? (20251202)
+			})
+		})
+	}
+}
+
+func (s *ProviderWatchTargetsTestSuite) TestKubeConfigClusterProvider() {
+	provider, err := newKubeConfigClusterProvider(s.staticConfig)
+	s.Require().NoError(err, "Expected no error from provider creation")
+
+	callback, waitForCallback := CallbackWaiter()
+	provider.WatchTargets(callback)
+
+	s.Run("KubeConfigClusterProvider updates targets (reset) on kubeconfig change", func() {
+		s.kubeconfig.CurrentContext = "context-1"
+		s.Require().NoError(clientcmd.WriteToFile(*s.kubeconfig, s.staticConfig.KubeConfig))
+		s.Require().NoError(waitForCallback(5 * time.Second))
+
+		s.Run("Replaces default target with new context", func() {
+			s.Equal("context-1", provider.GetDefaultTarget(), "Expected default target context to be updated")
+		})
+		s.Run("Adds new context to targets", func() {
+			targets, err := provider.GetTargets(s.T().Context())
+			s.Require().NoError(err, "Expected no error from GetTargets")
+			s.Contains(targets, "context-1")
+		})
+		s.Run("Has derived Kubernetes for new context", func() {
+			k, err := provider.GetDerivedKubernetes(s.T().Context(), "context-1")
+			s.Require().NoError(err, "Expected no error from GetDerivedKubernetes for context-1")
+			s.NotNil(k, "Expected Kubernetes from GetDerivedKubernetes for context-1")
+			s.Run("Derived Kubernetes points to correct context", func() {
+				cfg, err := k.AccessControlClientset().ToRawKubeConfigLoader().RawConfig()
+				s.Require().NoError(err, "Expected no error from ToRawKubeConfigLoader")
+				s.Equal("context-1", cfg.CurrentContext, "Expected Kubernetes to point to changed-context")
+			})
+		})
+
+		s.Run("Keeps watching for further changes", func() {
+			s.kubeconfig.CurrentContext = "context-2"
+			s.Require().NoError(clientcmd.WriteToFile(*s.kubeconfig, s.staticConfig.KubeConfig))
+			s.Require().NoError(waitForCallback(5 * time.Second))
+
+			s.Run("Replaces default target with new context", func() {
+				s.Equal("context-2", provider.GetDefaultTarget(), "Expected default target context to be updated")
+			})
+		})
+	})
+}
+
+func (s *ProviderWatchTargetsTestSuite) TestSingleClusterProvider() {
+	provider, err := newSingleClusterProvider(config.ClusterProviderDisabled)(s.staticConfig)
+	s.Require().NoError(err, "Expected no error from provider creation")
+
+	callback, waitForCallback := CallbackWaiter()
+	provider.WatchTargets(callback)
+
+	s.Run("SingleClusterProvider reloads/resets on kubeconfig change", func() {
+		s.kubeconfig.CurrentContext = "context-1"
+		s.Require().NoError(clientcmd.WriteToFile(*s.kubeconfig, s.staticConfig.KubeConfig))
+		s.Require().NoError(waitForCallback(5 * time.Second))
+
+		s.Run("Derived Kubernetes points to updated context", func() {
+			k, err := provider.GetDerivedKubernetes(s.T().Context(), "")
+			s.Require().NoError(err, "Expected no error from GetDerivedKubernetes for context-1")
+			s.NotNil(k, "Expected Kubernetes from GetDerivedKubernetes for context-1")
+			s.Run("Derived Kubernetes points to correct context", func() {
+				cfg, err := k.AccessControlClientset().ToRawKubeConfigLoader().RawConfig()
+				s.Require().NoError(err, "Expected no error from ToRawKubeConfigLoader")
+				s.Equal("context-1", cfg.CurrentContext, "Expected Kubernetes to point to changed-context")
+			})
+		})
+
+		s.Run("Keeps watching for further changes", func() {
+			s.kubeconfig.CurrentContext = "context-2"
+			s.Require().NoError(clientcmd.WriteToFile(*s.kubeconfig, s.staticConfig.KubeConfig))
+			s.Require().NoError(waitForCallback(5 * time.Second))
+
+			s.Run("Derived Kubernetes points to updated context", func() {
+				k, err := provider.GetDerivedKubernetes(s.T().Context(), "")
+				s.Require().NoError(err, "Expected no error from GetDerivedKubernetes for context-2")
+				s.NotNil(k, "Expected Kubernetes from GetDerivedKubernetes for context-2")
+				cfg, err := k.AccessControlClientset().ToRawKubeConfigLoader().RawConfig()
+				s.Require().NoError(err, "Expected no error from ToRawKubeConfigLoader")
+				s.Equal("context-2", cfg.CurrentContext, "Expected Kubernetes to point to changed-context")
+			})
+		})
+	})
+}
+
+// CallbackWaiter returns a callback and wait function that can be used multiple times.
+func CallbackWaiter() (callback func() error, waitFunc func(timeout time.Duration) error) {
+	signal := make(chan struct{}, 1)
+	callback = func() error {
+		select {
+		case signal <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+	waitFunc = func(timeout time.Duration) error {
+		select {
+		case <-signal:
+		case <-time.After(timeout):
+			return errors.New("timeout waiting for callback")
+		}
+		return nil
+	}
+	return
+}
+
+func TestProviderWatchTargetsTestSuite(t *testing.T) {
+	suite.Run(t, new(ProviderWatchTargetsTestSuite))
+}

--- a/pkg/kubernetes/watcher/cluster.go
+++ b/pkg/kubernetes/watcher/cluster.go
@@ -137,7 +137,7 @@ func (w *ClusterState) Watch(onChange func() error) {
 }
 
 // Close stops the cluster state watcher
-func (w *ClusterState) Close() error {
+func (w *ClusterState) Close() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -146,17 +146,17 @@ func (w *ClusterState) Close() error {
 	}
 
 	if w.stopCh == nil || w.stoppedCh == nil {
-		return nil
+		return // Already closed
 	}
 
 	if !w.started {
-		return nil
+		return
 	}
 
 	select {
 	case <-w.stopCh:
 		// Already closed or stopped
-		return nil
+		return
 	default:
 		close(w.stopCh)
 		w.mu.Unlock()
@@ -167,7 +167,6 @@ func (w *ClusterState) Close() error {
 		w.stopCh = make(chan struct{})
 		w.stoppedCh = make(chan struct{})
 	}
-	return nil
 }
 
 func (w *ClusterState) captureState() clusterState {

--- a/pkg/kubernetes/watcher/kubeconfig.go
+++ b/pkg/kubernetes/watcher/kubeconfig.go
@@ -7,7 +7,7 @@ import (
 
 type Kubeconfig struct {
 	clientcmd.ClientConfig
-	close func() error
+	close func()
 }
 
 var _ Watcher = (*Kubeconfig)(nil)
@@ -46,14 +46,13 @@ func (w *Kubeconfig) Watch(onChange func() error) {
 		}
 	}()
 	if w.close != nil {
-		_ = w.close()
+		w.close()
 	}
-	w.close = watcher.Close
+	w.close = func() { _ = watcher.Close() }
 }
 
-func (w *Kubeconfig) Close() error {
+func (w *Kubeconfig) Close() {
 	if w.close != nil {
-		return w.close()
+		w.close()
 	}
-	return nil
 }

--- a/pkg/kubernetes/watcher/watcher.go
+++ b/pkg/kubernetes/watcher/watcher.go
@@ -2,5 +2,5 @@ package watcher
 
 type Watcher interface {
 	Watch(onChange func() error)
-	Close() error
+	Close()
 }


### PR DESCRIPTION
Fixes #522 
Replaces #531

The `kubernetes.Provider` watch-related functionality is restarted for each watch notification that affects its state.