### PR TITLE
fix(ci): gevals workflow concurrency group is corrected

### DIFF
--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -29,7 +29,8 @@ permissions:
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # For issue_comment events, use PR number as group to avoid different PRs canceling each other.
+  group: ${{ github.workflow }}-${{ github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Fixes #525 

It looks like the issue was that `github.ref` was always to the main branch when this was triggered by a comment

This switches to using the PR number in the concurrency group - IMO the correct concurrency should be "at most one running eval per PR"