### PR TITLE
chore(ci): pin gevals version to releases, not main

### DIFF
--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run gevals evaluation
         id: gevals
-        uses: genmcp/gevals/.github/actions/gevals-action@main
+        uses: genmcp/gevals/.github/actions/gevals-action@v0.0.1
         with:
           eval-config: 'evals/openai-agent/eval.yaml'
           gevals-version: 'latest'


### PR DESCRIPTION
This switches to using a specific release, instead of `main` for gevals