### PR TITLE
refactor(test): use msg variable consistently in denial test assertions

### DIFF
--- a/pkg/mcp/events_test.go
+++ b/pkg/mcp/events_test.go
@@ -137,7 +137,7 @@ func (s *EventsSuite) TestEventsListDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list events in all namespaces:(.+:)? resource not allowed: /v1, Kind=Event"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }

--- a/pkg/mcp/helm_test.go
+++ b/pkg/mcp/helm_test.go
@@ -107,9 +107,9 @@ func (s *HelmSuite) TestHelmInstallDenied() {
 		s.Run("describes denial", func() {
 			msg := toolResult.Content[0].(mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
-			s.Truef(strings.HasPrefix(msg, "failed to install helm chart"), "expected descriptive error, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(msg, "failed to install helm chart"), "expected descriptive error, got %v", msg)
 			expectedMessage := ": resource not allowed: /v1, Kind=Secret"
-			s.Truef(strings.HasSuffix(msg, expectedMessage), "expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasSuffix(msg, expectedMessage), "expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }
@@ -230,9 +230,9 @@ func (s *HelmSuite) TestHelmListDenied() {
 		s.Run("describes denial", func() {
 			msg := toolResult.Content[0].(mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
-			s.Truef(strings.HasPrefix(msg, "failed to list helm releases"), "expected descriptive error, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(msg, "failed to list helm releases"), "expected descriptive error, got %v", msg)
 			expectedMessage := ": resource not allowed: /v1, Kind=Secret"
-			s.Truef(strings.HasSuffix(msg, expectedMessage), "expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasSuffix(msg, expectedMessage), "expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }

--- a/pkg/mcp/namespaces_test.go
+++ b/pkg/mcp/namespaces_test.go
@@ -60,7 +60,7 @@ func (s *NamespacesSuite) TestNamespacesListDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list namespaces:(.+:)? resource not allowed: /v1, Kind=Namespace"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }
@@ -165,7 +165,7 @@ func (s *NamespacesSuite) TestProjectsListInOpenShiftDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list projects:(.+:)? resource not allowed: project.openshift.io/v1, Kind=Project"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, projectsList.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }

--- a/pkg/mcp/nodes_test.go
+++ b/pkg/mcp/nodes_test.go
@@ -331,7 +331,7 @@ func (s *NodesSuite) TestNodesStatsSummaryDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get node stats summary for does-not-matter:(.+:)? resource not allowed: /v1, Kind=Node"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }

--- a/pkg/mcp/nodes_top_test.go
+++ b/pkg/mcp/nodes_top_test.go
@@ -233,7 +233,7 @@ func (s *NodesTopSuite) TestNodesTopDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get nodes top:(.+:)? resource not allowed: metrics.k8s.io/v1beta1, Kind=NodeMetrics"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }

--- a/pkg/mcp/pods_exec_test.go
+++ b/pkg/mcp/pods_exec_test.go
@@ -131,7 +131,7 @@ func (s *PodsExecSuite) TestPodsExecDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to exec in pod pod-to-exec in namespace default:(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }

--- a/pkg/mcp/pods_run_test.go
+++ b/pkg/mcp/pods_run_test.go
@@ -105,7 +105,7 @@ func (s *PodsRunSuite) TestPodsRunDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to run pod  in namespace :(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, podsRun.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }

--- a/pkg/mcp/pods_test.go
+++ b/pkg/mcp/pods_test.go
@@ -166,7 +166,7 @@ func (s *PodsSuite) TestPodsListDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list pods in all namespaces:(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, podsList.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("pods_list_in_namespace (denied)", func() {
@@ -180,7 +180,7 @@ func (s *PodsSuite) TestPodsListDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list pods in namespace ns-1:(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, podsListInNamespace.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }
@@ -354,7 +354,7 @@ func (s *PodsSuite) TestPodsGetDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get pod a-pod-in-default in namespace :(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, podsGet.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }
@@ -457,7 +457,7 @@ func (s *PodsSuite) TestPodsDeleteDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to delete pod a-pod-in-default in namespace :(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, podsDelete.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }
@@ -611,7 +611,7 @@ func (s *PodsSuite) TestPodsLogDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get pod a-pod-in-default log in namespace :(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, podsLog.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }

--- a/pkg/mcp/pods_top_test.go
+++ b/pkg/mcp/pods_top_test.go
@@ -214,7 +214,7 @@ func (s *PodsTopSuite) TestPodsTopDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get pods top:(.+:)? resource not allowed: metrics.k8s.io/v1beta1, Kind=PodMetrics"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, result.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -122,7 +122,7 @@ func (s *ResourcesSuite) TestResourcesListDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list resources:(.+:)? resource not allowed: /v1, Kind=Secret"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_list (denied by group)", func() {
@@ -136,7 +136,7 @@ func (s *ResourcesSuite) TestResourcesListDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list resources:(.+:)? resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByGroup.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_list (not denied) returns list", func() {
@@ -299,7 +299,7 @@ func (s *ResourcesSuite) TestResourcesGetDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get resource:(.+:)? resource not allowed: /v1, Kind=Secret"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_get (denied by group)", func() {
@@ -313,7 +313,7 @@ func (s *ResourcesSuite) TestResourcesGetDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get resource:(.+:)? resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByGroup.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_get (not denied) returns resource", func() {
@@ -464,7 +464,7 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdateDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to create or update resources:(.+:)? resource not allowed: /v1, Kind=Secret"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_create_or_update (denied by group)", func() {
@@ -479,7 +479,7 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdateDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to create or update resources:(.+:)? resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByGroup.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_create_or_update (not denied) creates or updates resource", func() {
@@ -583,7 +583,7 @@ func (s *ResourcesSuite) TestResourcesDeleteDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to delete resource:(.+:)? resource not allowed: /v1, Kind=Secret"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_delete (denied by group)", func() {
@@ -597,7 +597,7 @@ func (s *ResourcesSuite) TestResourcesDeleteDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to delete resource:(.+:)? resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByGroup.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_delete (not denied) deletes resource", func() {
@@ -747,7 +747,7 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get/update resource scale:(.+:)? resource not allowed: /v1, Kind=ReplicationController"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_scale update (denied by kind)", func() {
@@ -767,7 +767,7 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get/update resource scale:(.+:)? resource not allowed: /v1, Kind=ReplicationController"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByKind.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_scale get (denied by group)", func() {
@@ -786,7 +786,7 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get/update resource scale:(.+:)? resource not allowed: apps/v1, Kind=StatefulSet"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByGroup.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 	s.Run("resources_scale update (denied by group)", func() {
@@ -806,7 +806,7 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get/update resource scale:(.+:)? resource not allowed: apps/v1, Kind=StatefulSet"
 			s.Regexpf(expectedMessage, msg,
-				"expected descriptive error '%s', got %v", expectedMessage, deniedByGroup.Content[0].(mcp.TextContent).Text)
+				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
 }


### PR DESCRIPTION
Replace redundant toolResult.Content[0].(mcp.TextContent).Text expressions with the already defined msg variable in Regexpf and Truef assertions within "describes denial" test blocks.