### PR TITLE
remove unnecessary yaml layer from prompts types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.19.0
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.19.3
 	k8s.io/api v0.34.3
 	k8s.io/apiextensions-apiserver v0.34.3
@@ -134,6 +133,7 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.34.3 // indirect
 	k8s.io/component-base v0.34.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect

--- a/pkg/api/prompt_serialization_test.go
+++ b/pkg/api/prompt_serialization_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v3"
 )
 
 // PromptSerializationSuite tests serialization of prompt data structures
@@ -42,33 +41,6 @@ func (s *PromptSerializationSuite) TestPromptJSONSerialization() {
 		s.Equal(original.Arguments[0].Name, unmarshaled.Arguments[0].Name)
 		s.Require().Len(unmarshaled.Templates, 1)
 		s.Equal(original.Templates[0].Content, unmarshaled.Templates[0].Content)
-	})
-}
-
-func (s *PromptSerializationSuite) TestPromptYAMLSerialization() {
-	s.Run("marshals and unmarshals Prompt correctly", func() {
-		original := Prompt{
-			Name:        "test-prompt",
-			Title:       "Test Prompt",
-			Description: "A test prompt",
-			Arguments: []PromptArgument{
-				{Name: "arg1", Description: "First argument", Required: true},
-			},
-			Templates: []PromptTemplate{
-				{Role: "user", Content: "Hello {{arg1}}"},
-			},
-		}
-
-		data, err := yaml.Marshal(original)
-		s.Require().NoError(err, "failed to marshal Prompt to YAML")
-
-		var unmarshaled Prompt
-		err = yaml.Unmarshal(data, &unmarshaled)
-		s.Require().NoError(err, "failed to unmarshal Prompt from YAML")
-
-		s.Equal(original.Name, unmarshaled.Name)
-		s.Equal(original.Title, unmarshaled.Title)
-		s.Equal(original.Description, unmarshaled.Description)
 	})
 }
 
@@ -152,15 +124,6 @@ func (s *PromptSerializationSuite) TestPromptArgumentSerialization() {
 		s.Require().NoError(err)
 		s.Equal(arg.Name, jsonArg.Name)
 		s.True(jsonArg.Required)
-
-		// YAML
-		yamlData, err := yaml.Marshal(arg)
-		s.Require().NoError(err)
-		var yamlArg PromptArgument
-		err = yaml.Unmarshal(yamlData, &yamlArg)
-		s.Require().NoError(err)
-		s.Equal(arg.Name, yamlArg.Name)
-		s.True(yamlArg.Required)
 	})
 
 	s.Run("serializes optional argument", func() {
@@ -227,15 +190,6 @@ func (s *PromptSerializationSuite) TestPromptMessageSerialization() {
 		s.Equal(msg.Role, jsonMsg.Role)
 		s.Equal(msg.Content.Type, jsonMsg.Content.Type)
 		s.Equal(msg.Content.Text, jsonMsg.Content.Text)
-
-		// YAML
-		yamlData, err := yaml.Marshal(msg)
-		s.Require().NoError(err)
-		var yamlMsg PromptMessage
-		err = yaml.Unmarshal(yamlData, &yamlMsg)
-		s.Require().NoError(err)
-		s.Equal(msg.Role, yamlMsg.Role)
-		s.Equal(msg.Content.Text, yamlMsg.Content.Text)
 	})
 }
 
@@ -254,15 +208,6 @@ func (s *PromptSerializationSuite) TestPromptContentSerialization() {
 		s.Require().NoError(err)
 		s.Equal(content.Type, jsonContent.Type)
 		s.Equal(content.Text, jsonContent.Text)
-
-		// YAML
-		yamlData, err := yaml.Marshal(content)
-		s.Require().NoError(err)
-		var yamlContent PromptContent
-		err = yaml.Unmarshal(yamlData, &yamlContent)
-		s.Require().NoError(err)
-		s.Equal(content.Type, yamlContent.Type)
-		s.Equal(content.Text, yamlContent.Text)
 	})
 }
 

--- a/pkg/api/prompts.go
+++ b/pkg/api/prompts.go
@@ -28,40 +28,40 @@ func (s *ServerPrompt) IsClusterAware() bool {
 // Prompt represents the metadata and content of an MCP prompt.
 // See MCP specification: https://spec.modelcontextprotocol.io/specification/server/prompts/
 type Prompt struct {
-	Name        string           `yaml:"name" json:"name" toml:"name"`
-	Title       string           `yaml:"title,omitempty" json:"title,omitempty" toml:"title,omitempty"`
-	Description string           `yaml:"description,omitempty" json:"description,omitempty" toml:"description,omitempty"`
-	Arguments   []PromptArgument `yaml:"arguments,omitempty" json:"arguments,omitempty" toml:"arguments,omitempty"`
-	Templates   []PromptTemplate `yaml:"messages,omitempty" json:"messages,omitempty" toml:"messages,omitempty"`
+	Name        string           `json:"name" toml:"name"`
+	Title       string           `json:"title,omitempty" toml:"title,omitempty"`
+	Description string           `json:"description,omitempty" toml:"description,omitempty"`
+	Arguments   []PromptArgument `json:"arguments,omitempty" toml:"arguments,omitempty"`
+	Templates   []PromptTemplate `json:"messages,omitempty" toml:"messages,omitempty"`
 }
 
 // PromptArgument defines a parameter that can be passed to a prompt.
 // See MCP specification: https://spec.modelcontextprotocol.io/specification/server/prompts/
 type PromptArgument struct {
-	Name        string `yaml:"name" json:"name" toml:"name"`
-	Description string `yaml:"description,omitempty" json:"description,omitempty" toml:"description,omitempty"`
-	Required    bool   `yaml:"required" json:"required" toml:"required"`
+	Name        string `json:"name" toml:"name"`
+	Description string `json:"description,omitempty" toml:"description,omitempty"`
+	Required    bool   `json:"required" toml:"required"`
 }
 
 // PromptTemplate represents a message template from configuration with placeholders like {{arg}}.
 // This is used for configuration parsing and gets rendered into PromptMessage at runtime.
 type PromptTemplate struct {
-	Role    string `yaml:"role" json:"role" toml:"role"`
-	Content string `yaml:"content" json:"content" toml:"content"`
+	Role    string `json:"role" toml:"role"`
+	Content string `json:"content" toml:"content"`
 }
 
 // PromptMessage represents a single message in a prompt response.
 // See MCP specification: https://spec.modelcontextprotocol.io/specification/server/prompts/
 type PromptMessage struct {
-	Role    string        `yaml:"role" json:"role" toml:"role"`
-	Content PromptContent `yaml:"content" json:"content" toml:"content"`
+	Role    string        `json:"role" toml:"role"`
+	Content PromptContent `json:"content" toml:"content"`
 }
 
 // PromptContent represents the content of a prompt message.
 // See MCP specification: https://spec.modelcontextprotocol.io/specification/server/prompts/
 type PromptContent struct {
-	Type string `yaml:"type" json:"type" toml:"type"`
-	Text string `yaml:"text,omitempty" json:"text,omitempty" toml:"text,omitempty"`
+	Type string `json:"type" toml:"type"`
+	Text string `json:"text,omitempty" toml:"text,omitempty"`
 }
 
 // PromptCallRequest interface for accessing prompt call arguments


### PR DESCRIPTION
follow up to #559 comment https://github.com/containers/kubernetes-mcp-server/pull/559#discussion_r2609742216 
