### PR TITLE
feat(api)!: add toolset prompts infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ role = "user"
 content = "Help me with {{resource_name}}"
 ```
 
-2. Toolset prompts implemented by toolset developers (can be disabled with disable_toolset_prompts = true)
+2. Toolset prompts implemented by toolset developers
 
 See docs/PROMPTS.md for detailed documentation.
 

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -68,7 +68,7 @@ Toolsets can provide built-in prompts by implementing the `GetPrompts()` method.
 ### Implementing Toolset Prompts
 
 ```go
-func (t *MyToolset) GetPrompts(o internalk8s.Openshift) []api.ServerPrompt {
+func (t *MyToolset) GetPrompts() []api.ServerPrompt {
     return []api.ServerPrompt{
         {
             Prompt: api.Prompt{
@@ -102,18 +102,6 @@ func (t *MyToolset) GetPrompts(o internalk8s.Openshift) []api.ServerPrompt {
         },
     }
 }
-```
-
-### Disabling Toolset Prompts
-
-Add `disable_toolset_prompts = true` in your `config.toml` to use only config-defined prompts:
-
-```toml
-disable_toolset_prompts = true
-
-[[prompts]]
-name = "my-custom-prompt"
-# ... rest of config
 ```
 
 ### Prompt Merging

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -45,7 +45,7 @@ type Toolset interface {
 	GetTools(o Openshift) []ServerTool
 	// GetPrompts returns the prompts provided by this toolset.
 	// Returns nil if the toolset doesn't provide any prompts.
-	GetPrompts(o Openshift) []ServerPrompt
+	GetPrompts() []ServerPrompt
 }
 
 type ToolCallRequest interface {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,9 +81,6 @@ type StaticConfig struct {
 	promptsDefined  bool           // Internal: tracks if prompts were defined in config
 	promptsMetadata toml.MetaData  // Internal: metadata for prompts decoding
 
-	// When true, disable toolset-defined prompts (only use config-defined prompts)
-	DisableToolsetPrompts bool `toml:"disable_toolset_prompts,omitempty"`
-
 	// Server instructions to be provided by the MCP server to the MCP client
 	// This can be used to provide specific instructions on how the client should use the server
 	ServerInstructions string `toml:"server_instructions,omitempty"`

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -171,17 +171,15 @@ func (s *Server) reloadToolsets() error {
 	applicablePrompts := make([]api.ServerPrompt, 0)
 	s.enabledPrompts = make([]string, 0)
 
-	// Load embedded toolset prompts (unless disabled)
-	if !s.configuration.DisableToolsetPrompts {
-		for _, toolset := range s.configuration.Toolsets() {
-			prompts := toolset.GetPrompts(s.p)
-			if prompts == nil {
-				continue
-			}
-			for _, prompt := range prompts {
-				applicablePrompts = append(applicablePrompts, prompt)
-				s.enabledPrompts = append(s.enabledPrompts, prompt.Prompt.Name)
-			}
+	// Load embedded toolset prompts
+	for _, toolset := range s.configuration.Toolsets() {
+		prompts := toolset.GetPrompts()
+		if prompts == nil {
+			continue
+		}
+		for _, prompt := range prompts {
+			applicablePrompts = append(applicablePrompts, prompt)
+			s.enabledPrompts = append(s.enabledPrompts, prompt.Prompt.Name)
 		}
 	}
 

--- a/pkg/toolsets/config/toolset.go
+++ b/pkg/toolsets/config/toolset.go
@@ -25,7 +25,7 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 	)
 }
 
-func (t *Toolset) GetPrompts(_ api.Openshift) []api.ServerPrompt {
+func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	// Config toolset does not provide prompts
 	return nil
 }

--- a/pkg/toolsets/core/toolset.go
+++ b/pkg/toolsets/core/toolset.go
@@ -29,7 +29,7 @@ func (t *Toolset) GetTools(o api.Openshift) []api.ServerTool {
 	)
 }
 
-func (t *Toolset) GetPrompts(_ api.Openshift) []api.ServerPrompt {
+func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	// Core toolset prompts will be added in Feature 3
 	return nil
 }

--- a/pkg/toolsets/helm/toolset.go
+++ b/pkg/toolsets/helm/toolset.go
@@ -25,7 +25,7 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 	)
 }
 
-func (t *Toolset) GetPrompts(_ api.Openshift) []api.ServerPrompt {
+func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	// Helm toolset does not provide prompts
 	return nil
 }

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -32,7 +32,7 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 	)
 }
 
-func (t *Toolset) GetPrompts(_ api.Openshift) []api.ServerPrompt {
+func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	// Kiali toolset does not provide prompts
 	return nil
 }

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -28,7 +28,7 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 	)
 }
 
-func (t *Toolset) GetPrompts(_ api.Openshift) []api.ServerPrompt {
+func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	// KubeVirt toolset does not provide prompts
 	return nil
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -34,7 +34,7 @@ func (t *TestToolset) GetDescription() string { return t.description }
 
 func (t *TestToolset) GetTools(_ api.Openshift) []api.ServerTool { return nil }
 
-func (t *TestToolset) GetPrompts(_ api.Openshift) []api.ServerPrompt { return nil }
+func (t *TestToolset) GetPrompts() []api.ServerPrompt { return nil }
 
 var _ api.Toolset = (*TestToolset)(nil)
 


### PR DESCRIPTION
Fixes: #556 

Enable toolset implementers to define MCP prompts programmatically as part of their toolset definition.

- Add GetPrompts() method to Toolset interface
- Collect prompts from all enabled toolsets
- Merge config and toolset prompts (config takes precedence)
- Add disable_toolset_prompts configuration option
- Update all existing toolsets to implement GetPrompts()