### PR TITLE
feat(mcp-registry): add MCP Registry metadata and server manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY ./ ./
 RUN make build
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+LABEL io.modelcontextprotocol.server.name="io.github.containers/kubernetes-mcp-server"
 WORKDIR /app
 COPY --from=builder /app/kubernetes-mcp-server /app/kubernetes-mcp-server
 USER 65532:65532

--- a/README.md
+++ b/README.md
@@ -568,3 +568,7 @@ make build
 # Run the Kubernetes MCP server with mcp-inspector
 npx @modelcontextprotocol/inspector@latest $(pwd)/kubernetes-mcp-server
 ```
+
+---
+
+mcp-name: io.github.containers/kubernetes-mcp-server

--- a/build/node.mk
+++ b/build/node.mk
@@ -41,7 +41,8 @@ npm-copy-project-files: npm-copy-binaries ## Copy the project files to the main 
 	@echo '"author": {"name": "Marc Nuri", "url": "https://www.marcnuri.com"},' >> $(MAIN_PACKAGE_JSON)
 	@echo '"license": "Apache-2.0",' >> $(MAIN_PACKAGE_JSON)
 	@echo '"bugs": {"url": "https://github.com/containers/kubernetes-mcp-server/issues"},' >> $(MAIN_PACKAGE_JSON)
-	@echo '"homepage": "https://github.com/containers/kubernetes-mcp-server#readme"' >> $(MAIN_PACKAGE_JSON)
+	@echo '"homepage": "https://github.com/containers/kubernetes-mcp-server#readme",' >> $(MAIN_PACKAGE_JSON)
+	@echo '"mcpName": "io.github.containers/kubernetes-mcp-server"' >> $(MAIN_PACKAGE_JSON)
 	@echo '}' >> $(MAIN_PACKAGE_JSON)
 	$(foreach os,$(OSES),$(foreach arch,$(ARCHS), \
 		OS_PACKAGE_JSON=./npm/$(NPM_PACKAGE)-$(os)-$(arch)/package.json; \

--- a/server.json
+++ b/server.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.containers/kubernetes-mcp-server",
+  "description": "A Model Context Protocol (MCP) server for Kubernetes and OpenShift",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/containers/kubernetes-mcp-server",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "kubernetes-mcp-server",
+      "version": "0.0.0",
+      "transport": {
+        "type": "stdio"
+      }
+    },
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "kubernetes-mcp-server",
+      "version": "0.0.0",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    },
+    {
+      "registryType": "oci",
+      "identifier": "quay.io/containers/kubernetes_mcp_server:0.0.0",
+      "version": "0.0.0",
+      "runtimeHint": "docker",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "-v",
+          "description": "Volume mount for kubeconfig access (host_path:container_path)",
+          "format": "string",
+          "isRequired": true,
+          "placeholder": "~/.kube/config:/kubeconfig:ro"
+        },
+        {
+          "type": "named",
+          "name": "-e",
+          "description": "Environment variable to set the kubeconfig path inside the container",
+          "format": "string",
+          "isRequired": true,
+          "default": "KUBECONFIG=/kubeconfig"
+        },
+        {
+          "type": "named",
+          "name": "-p",
+          "description": "Port mapping for MCP server HTTP endpoint (host_port:container_port)",
+          "format": "string",
+          "isRequired": true,
+          "default": "8080:8080"
+        }
+      ],
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://localhost:8080/mcp"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Part of #555 (1,2,3)

Add required metadata for publishing to the official Model Context Protocol (MCP) Registry:

- Add mcpName field to npm package.json generation
- Add mcp-name metadata to README.md for Python package
- Add io.modelcontextprotocol.server.name to container image
- Create server.json manifest with npm and PyPI package definitions