### PR TITLE
refactor(api)!: extract operational methods from KubernetesClient to Core struct

### DIFF
--- a/pkg/api/kubernetes.go
+++ b/pkg/api/kubernetes.go
@@ -5,15 +5,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/metrics/pkg/apis/metrics"
 	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 )
 
@@ -51,72 +47,14 @@ type KubernetesClient interface {
 	kubernetes.Interface
 	// NamespaceOrDefault returns the provided namespace or the default configured namespace if empty
 	NamespaceOrDefault(namespace string) string
+	// RESTConfig returns the REST config used to create clients
 	RESTConfig() *rest.Config
+	// RESTMapper returns the REST mapper used to map GVK to GVR
 	RESTMapper() meta.ResettableRESTMapper
+	// DiscoveryClient returns the cached discovery client
 	DiscoveryClient() discovery.CachedDiscoveryInterface
+	// DynamicClient returns the dynamic client
 	DynamicClient() dynamic.Interface
+	// MetricsV1beta1Client returns the metrics v1beta1 client
 	MetricsV1beta1Client() *metricsv1beta1.MetricsV1beta1Client
-
-	// TODO: To be removed in next iteration
-	// --- Resource Operations ---
-
-	// ResourcesList lists resources of the specified GroupVersionKind
-	ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, namespace string, options ListOptions) (runtime.Unstructured, error)
-	// ResourcesGet retrieves a single resource by name
-	ResourcesGet(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) (*unstructured.Unstructured, error)
-	// ResourcesCreateOrUpdate creates or updates resources from a YAML/JSON string
-	ResourcesCreateOrUpdate(ctx context.Context, resource string) ([]*unstructured.Unstructured, error)
-	// ResourcesDelete deletes a resource by name
-	ResourcesDelete(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) error
-	// ResourcesScale gets or sets the scale of a resource
-	ResourcesScale(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string, desiredScale int64, shouldScale bool) (*unstructured.Unstructured, error)
-
-	// --- Namespace Operations ---
-
-	// NamespacesList lists all namespaces
-	NamespacesList(ctx context.Context, options ListOptions) (runtime.Unstructured, error)
-	// ProjectsList lists all OpenShift projects
-	ProjectsList(ctx context.Context, options ListOptions) (runtime.Unstructured, error)
-
-	// --- Pod Operations ---
-
-	// PodsListInAllNamespaces lists pods across all namespaces
-	PodsListInAllNamespaces(ctx context.Context, options ListOptions) (runtime.Unstructured, error)
-	// PodsListInNamespace lists pods in a specific namespace
-	PodsListInNamespace(ctx context.Context, namespace string, options ListOptions) (runtime.Unstructured, error)
-	// PodsGet retrieves a single pod by name
-	PodsGet(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error)
-	// PodsDelete deletes a pod and its managed resources
-	PodsDelete(ctx context.Context, namespace, name string) (string, error)
-	// PodsLog retrieves logs from a pod container
-	PodsLog(ctx context.Context, namespace, name, container string, previous bool, tail int64) (string, error)
-	// PodsRun creates and runs a new pod with optional service and route
-	PodsRun(ctx context.Context, namespace, name, image string, port int32) ([]*unstructured.Unstructured, error)
-	// PodsTop retrieves pod metrics
-	PodsTop(ctx context.Context, options PodsTopOptions) (*metrics.PodMetricsList, error)
-	// PodsExec executes a command in a pod container
-	PodsExec(ctx context.Context, namespace, name, container string, command []string) (string, error)
-
-	// --- Node Operations ---
-
-	// NodesLog retrieves logs from a node
-	NodesLog(ctx context.Context, name string, query string, tailLines int64) (string, error)
-	// NodesStatsSummary retrieves stats summary from a node
-	NodesStatsSummary(ctx context.Context, name string) (string, error)
-	// NodesTop retrieves node metrics
-	NodesTop(ctx context.Context, options NodesTopOptions) (*metrics.NodeMetricsList, error)
-
-	// --- Event Operations ---
-
-	// EventsList lists events in a namespace
-	EventsList(ctx context.Context, namespace string) ([]map[string]any, error)
-
-	// --- Configuration Operations ---
-
-	// ConfigurationContextsList returns the list of available context names
-	ConfigurationContextsList() (map[string]string, error)
-	// ConfigurationContextsDefault returns the current context name
-	ConfigurationContextsDefault() (string, error)
-	// ConfigurationView returns the kubeconfig content
-	ConfigurationView(minify bool) (runtime.Object, error)
 }

--- a/pkg/kubernetes/configuration.go
+++ b/pkg/kubernetes/configuration.go
@@ -33,8 +33,8 @@ func IsInCluster(cfg api.ClusterProvider) bool {
 
 // ConfigurationContextsDefault returns the current context name
 // TODO: Should be moved to the Provider level ?
-func (k *Kubernetes) ConfigurationContextsDefault() (string, error) {
-	cfg, err := k.ToRawKubeConfigLoader().RawConfig()
+func (c *Core) ConfigurationContextsDefault() (string, error) {
+	cfg, err := c.ToRawKubeConfigLoader().RawConfig()
 	if err != nil {
 		return "", err
 	}
@@ -43,8 +43,8 @@ func (k *Kubernetes) ConfigurationContextsDefault() (string, error) {
 
 // ConfigurationContextsList returns the list of available context names
 // TODO: Should be moved to the Provider level ?
-func (k *Kubernetes) ConfigurationContextsList() (map[string]string, error) {
-	cfg, err := k.ToRawKubeConfigLoader().RawConfig()
+func (c *Core) ConfigurationContextsList() (map[string]string, error) {
+	cfg, err := c.ToRawKubeConfigLoader().RawConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -64,10 +64,10 @@ func (k *Kubernetes) ConfigurationContextsList() (map[string]string, error) {
 // If minify is true, keeps only the current-context and the relevant pieces of the configuration for that context.
 // If minify is false, all contexts, clusters, auth-infos, and users are returned in the configuration.
 // TODO: Should be moved to the Provider level ?
-func (k *Kubernetes) ConfigurationView(minify bool) (runtime.Object, error) {
+func (c *Core) ConfigurationView(minify bool) (runtime.Object, error) {
 	var cfg clientcmdapi.Config
 	var err error
-	if cfg, err = k.ToRawKubeConfigLoader().RawConfig(); err != nil {
+	if cfg, err = c.ToRawKubeConfigLoader().RawConfig(); err != nil {
 		return nil, err
 	}
 	if minify {

--- a/pkg/kubernetes/core.go
+++ b/pkg/kubernetes/core.go
@@ -1,0 +1,13 @@
+package kubernetes
+
+import "github.com/containers/kubernetes-mcp-server/pkg/api"
+
+type Core struct {
+	api.KubernetesClient
+}
+
+func NewCore(client api.KubernetesClient) *Core {
+	return &Core{
+		KubernetesClient: client,
+	}
+}

--- a/pkg/kubernetes/events.go
+++ b/pkg/kubernetes/events.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (k *Kubernetes) EventsList(ctx context.Context, namespace string) ([]map[string]any, error) {
+func (c *Core) EventsList(ctx context.Context, namespace string) ([]map[string]any, error) {
 	var eventMap []map[string]any
-	raw, err := k.ResourcesList(ctx, &schema.GroupVersionKind{
+	raw, err := c.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Event",
 	}, namespace, api.ListOptions{})
 	if err != nil {

--- a/pkg/kubernetes/namespaces.go
+++ b/pkg/kubernetes/namespaces.go
@@ -8,14 +8,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (k *Kubernetes) NamespacesList(ctx context.Context, options api.ListOptions) (runtime.Unstructured, error) {
-	return k.ResourcesList(ctx, &schema.GroupVersionKind{
+func (c *Core) NamespacesList(ctx context.Context, options api.ListOptions) (runtime.Unstructured, error) {
+	return c.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Namespace",
 	}, "", options)
 }
 
-func (k *Kubernetes) ProjectsList(ctx context.Context, options api.ListOptions) (runtime.Unstructured, error) {
-	return k.ResourcesList(ctx, &schema.GroupVersionKind{
+func (c *Core) ProjectsList(ctx context.Context, options api.ListOptions) (runtime.Unstructured, error) {
+	return c.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "project.openshift.io", Version: "v1", Kind: "Project",
 	}, "", options)
 }

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -11,7 +11,7 @@ import (
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
-func (k *Kubernetes) NodesLog(ctx context.Context, name string, query string, tailLines int64) (string, error) {
+func (c *Core) NodesLog(ctx context.Context, name string, query string, tailLines int64) (string, error) {
 	// Use the node proxy API to access logs from the kubelet
 	// https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#log-query
 	// Common log paths:
@@ -19,11 +19,11 @@ func (k *Kubernetes) NodesLog(ctx context.Context, name string, query string, ta
 	// - /var/log/kube-proxy.log - kube-proxy logs
 	// - /var/log/containers/ - container logs
 
-	if _, err := k.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{}); err != nil {
+	if _, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{}); err != nil {
 		return "", fmt.Errorf("failed to get node %s: %w", name, err)
 	}
 
-	req := k.CoreV1().RESTClient().
+	req := c.CoreV1().RESTClient().
 		Get().
 		AbsPath("api", "v1", "nodes", name, "proxy", "logs")
 	req.Param("query", query)
@@ -45,16 +45,16 @@ func (k *Kubernetes) NodesLog(ctx context.Context, name string, query string, ta
 	return string(rawData), nil
 }
 
-func (k *Kubernetes) NodesStatsSummary(ctx context.Context, name string) (string, error) {
+func (c *Core) NodesStatsSummary(ctx context.Context, name string) (string, error) {
 	// Use the node proxy API to access stats summary from the kubelet
 	// https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/
 	// This endpoint provides CPU, memory, filesystem, and network statistics
 
-	if _, err := k.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{}); err != nil {
+	if _, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{}); err != nil {
 		return "", fmt.Errorf("failed to get node %s: %w", name, err)
 	}
 
-	result := k.CoreV1().RESTClient().
+	result := c.CoreV1().RESTClient().
 		Get().
 		AbsPath("api", "v1", "nodes", name, "proxy", "stats", "summary").
 		Do(ctx)
@@ -70,21 +70,21 @@ func (k *Kubernetes) NodesStatsSummary(ctx context.Context, name string) (string
 	return string(rawData), nil
 }
 
-func (k *Kubernetes) NodesTop(ctx context.Context, options api.NodesTopOptions) (*metrics.NodeMetricsList, error) {
+func (c *Core) NodesTop(ctx context.Context, options api.NodesTopOptions) (*metrics.NodeMetricsList, error) {
 	// TODO, maybe move to mcp Tools setup and omit in case metrics aren't available in the target cluster
-	if !k.supportsGroupVersion(metrics.GroupName + "/" + metricsv1beta1api.SchemeGroupVersion.Version) {
+	if !c.supportsGroupVersion(metrics.GroupName + "/" + metricsv1beta1api.SchemeGroupVersion.Version) {
 		return nil, errors.New("metrics API is not available")
 	}
 	versionedMetrics := &metricsv1beta1api.NodeMetricsList{}
 	var err error
 	if options.Name != "" {
-		m, err := k.MetricsV1beta1Client().NodeMetricses().Get(ctx, options.Name, metav1.GetOptions{})
+		m, err := c.MetricsV1beta1Client().NodeMetricses().Get(ctx, options.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get metrics for node %s: %w", options.Name, err)
 		}
 		versionedMetrics.Items = []metricsv1beta1api.NodeMetrics{*m}
 	} else {
-		versionedMetrics, err = k.MetricsV1beta1Client().NodeMetricses().List(ctx, options.ListOptions)
+		versionedMetrics, err = c.MetricsV1beta1Client().NodeMetricses().List(ctx, options.ListOptions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list node metrics: %w", err)
 		}

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -27,27 +27,27 @@ import (
 // DefaultTailLines is the default number of lines to retrieve from the end of the logs
 const DefaultTailLines = int64(100)
 
-func (k *Kubernetes) PodsListInAllNamespaces(ctx context.Context, options api.ListOptions) (runtime.Unstructured, error) {
-	return k.ResourcesList(ctx, &schema.GroupVersionKind{
+func (c *Core) PodsListInAllNamespaces(ctx context.Context, options api.ListOptions) (runtime.Unstructured, error) {
+	return c.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
 	}, "", options)
 }
 
-func (k *Kubernetes) PodsListInNamespace(ctx context.Context, namespace string, options api.ListOptions) (runtime.Unstructured, error) {
-	return k.ResourcesList(ctx, &schema.GroupVersionKind{
+func (c *Core) PodsListInNamespace(ctx context.Context, namespace string, options api.ListOptions) (runtime.Unstructured, error) {
+	return c.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
 	}, namespace, options)
 }
 
-func (k *Kubernetes) PodsGet(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error) {
-	return k.ResourcesGet(ctx, &schema.GroupVersionKind{
+func (c *Core) PodsGet(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error) {
+	return c.ResourcesGet(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
-	}, k.NamespaceOrDefault(namespace), name)
+	}, c.NamespaceOrDefault(namespace), name)
 }
 
-func (k *Kubernetes) PodsDelete(ctx context.Context, namespace, name string) (string, error) {
-	namespace = k.NamespaceOrDefault(namespace)
-	pod, err := k.ResourcesGet(ctx, &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, namespace, name)
+func (c *Core) PodsDelete(ctx context.Context, namespace, name string) (string, error) {
+	namespace = c.NamespaceOrDefault(namespace)
+	pod, err := c.ResourcesGet(ctx, &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, namespace, name)
 	if err != nil {
 		return "", err
 	}
@@ -60,7 +60,7 @@ func (k *Kubernetes) PodsDelete(ctx context.Context, namespace, name string) (st
 
 	// Delete managed service
 	if isManaged {
-		services := k.CoreV1().Services(namespace)
+		services := c.CoreV1().Services(namespace)
 		if sl, _ := services.List(ctx, metav1.ListOptions{
 			LabelSelector: managedLabelSelector.String(),
 		}); sl != nil {
@@ -71,8 +71,8 @@ func (k *Kubernetes) PodsDelete(ctx context.Context, namespace, name string) (st
 	}
 
 	// Delete managed Route
-	if isManaged && k.supportsGroupVersion("route.openshift.io/v1") {
-		routeResources := k.DynamicClient().
+	if isManaged && c.supportsGroupVersion("route.openshift.io/v1") {
+		routeResources := c.DynamicClient().
 			Resource(schema.GroupVersionResource{Group: "route.openshift.io", Version: "v1", Resource: "routes"}).
 			Namespace(namespace)
 		if rl, _ := routeResources.List(ctx, metav1.ListOptions{
@@ -85,11 +85,11 @@ func (k *Kubernetes) PodsDelete(ctx context.Context, namespace, name string) (st
 
 	}
 	return "Pod deleted successfully",
-		k.ResourcesDelete(ctx, &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, namespace, name)
+		c.ResourcesDelete(ctx, &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, namespace, name)
 }
 
-func (k *Kubernetes) PodsLog(ctx context.Context, namespace, name, container string, previous bool, tail int64) (string, error) {
-	pods := k.CoreV1().Pods(k.NamespaceOrDefault(namespace))
+func (c *Core) PodsLog(ctx context.Context, namespace, name, container string, previous bool, tail int64) (string, error) {
+	pods := c.CoreV1().Pods(c.NamespaceOrDefault(namespace))
 
 	logOptions := &v1.PodLogOptions{
 		Container: container,
@@ -116,7 +116,7 @@ func (k *Kubernetes) PodsLog(ctx context.Context, namespace, name, container str
 	return string(rawData), nil
 }
 
-func (k *Kubernetes) PodsRun(ctx context.Context, namespace, name, image string, port int32) ([]*unstructured.Unstructured, error) {
+func (c *Core) PodsRun(ctx context.Context, namespace, name, image string, port int32) ([]*unstructured.Unstructured, error) {
 	if name == "" {
 		name = version.BinaryName + "-run-" + rand.String(5)
 	}
@@ -130,7 +130,7 @@ func (k *Kubernetes) PodsRun(ctx context.Context, namespace, name, image string,
 	var resources []any
 	pod := &v1.Pod{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: k.NamespaceOrDefault(namespace), Labels: labels},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: c.NamespaceOrDefault(namespace), Labels: labels},
 		Spec: v1.PodSpec{Containers: []v1.Container{{
 			Name:            name,
 			Image:           image,
@@ -142,7 +142,7 @@ func (k *Kubernetes) PodsRun(ctx context.Context, namespace, name, image string,
 		pod.Spec.Containers[0].Ports = []v1.ContainerPort{{ContainerPort: port}}
 		resources = append(resources, &v1.Service{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: k.NamespaceOrDefault(namespace), Labels: labels},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: c.NamespaceOrDefault(namespace), Labels: labels},
 			Spec: v1.ServiceSpec{
 				Selector: labels,
 				Type:     v1.ServiceTypeClusterIP,
@@ -150,14 +150,14 @@ func (k *Kubernetes) PodsRun(ctx context.Context, namespace, name, image string,
 			},
 		})
 	}
-	if port > 0 && k.supportsGroupVersion("route.openshift.io/v1") {
+	if port > 0 && c.supportsGroupVersion("route.openshift.io/v1") {
 		resources = append(resources, &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "route.openshift.io/v1",
 				"kind":       "Route",
 				"metadata": map[string]interface{}{
 					"name":      name,
-					"namespace": k.NamespaceOrDefault(namespace),
+					"namespace": c.NamespaceOrDefault(namespace),
 					"labels":    labels,
 				},
 				"spec": map[string]interface{}{
@@ -193,30 +193,30 @@ func (k *Kubernetes) PodsRun(ctx context.Context, namespace, name, image string,
 		}
 		toCreate = append(toCreate, u)
 	}
-	return k.resourcesCreateOrUpdate(ctx, toCreate)
+	return c.resourcesCreateOrUpdate(ctx, toCreate)
 }
 
-func (k *Kubernetes) PodsTop(ctx context.Context, options api.PodsTopOptions) (*metrics.PodMetricsList, error) {
+func (c *Core) PodsTop(ctx context.Context, options api.PodsTopOptions) (*metrics.PodMetricsList, error) {
 	// TODO, maybe move to mcp Tools setup and omit in case metrics aren't available in the target cluster
-	if !k.supportsGroupVersion(metrics.GroupName + "/" + metricsv1beta1api.SchemeGroupVersion.Version) {
+	if !c.supportsGroupVersion(metrics.GroupName + "/" + metricsv1beta1api.SchemeGroupVersion.Version) {
 		return nil, errors.New("metrics API is not available")
 	}
 	namespace := options.Namespace
 	if options.AllNamespaces && namespace == "" {
 		namespace = ""
 	} else {
-		namespace = k.NamespaceOrDefault(namespace)
+		namespace = c.NamespaceOrDefault(namespace)
 	}
 	var err error
 	versionedMetrics := &metricsv1beta1api.PodMetricsList{}
 	if options.Name != "" {
-		m, err := k.MetricsV1beta1Client().PodMetricses(namespace).Get(ctx, options.Name, metav1.GetOptions{})
+		m, err := c.MetricsV1beta1Client().PodMetricses(namespace).Get(ctx, options.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get metrics for pod %s/%s: %w", namespace, options.Name, err)
 		}
 		versionedMetrics.Items = []metricsv1beta1api.PodMetrics{*m}
 	} else {
-		versionedMetrics, err = k.MetricsV1beta1Client().PodMetricses(namespace).List(ctx, options.ListOptions)
+		versionedMetrics, err = c.MetricsV1beta1Client().PodMetricses(namespace).List(ctx, options.ListOptions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list pod metrics in namespace %s: %w", namespace, err)
 		}
@@ -225,9 +225,9 @@ func (k *Kubernetes) PodsTop(ctx context.Context, options api.PodsTopOptions) (*
 	return convertedMetrics, metricsv1beta1api.Convert_v1beta1_PodMetricsList_To_metrics_PodMetricsList(versionedMetrics, convertedMetrics, nil)
 }
 
-func (k *Kubernetes) PodsExec(ctx context.Context, namespace, name, container string, command []string) (string, error) {
-	namespace = k.NamespaceOrDefault(namespace)
-	pods := k.CoreV1().Pods(namespace)
+func (c *Core) PodsExec(ctx context.Context, namespace, name, container string, command []string) (string, error) {
+	namespace = c.NamespaceOrDefault(namespace)
+	pods := c.CoreV1().Pods(namespace)
 	pod, err := pods.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -247,14 +247,14 @@ func (k *Kubernetes) PodsExec(ctx context.Context, namespace, name, container st
 	}
 	// Compute URL
 	// https://github.com/kubernetes/kubectl/blob/5366de04e168bcbc11f5e340d131a9ca8b7d0df4/pkg/cmd/exec/exec.go#L382-L397
-	execRequest := k.CoreV1().RESTClient().
+	execRequest := c.CoreV1().RESTClient().
 		Post().
 		Resource("pods").
 		Namespace(namespace).
 		Name(name).
 		SubResource("exec")
 	execRequest.VersionedParams(podExecOptions, ParameterCodec)
-	restConfig, err := k.ToRESTConfig()
+	restConfig, err := c.ToRESTConfig()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -26,37 +26,37 @@ const (
 	AppKubernetesPartOf    = "app.kubernetes.io/part-of"
 )
 
-func (k *Kubernetes) ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, namespace string, options api.ListOptions) (runtime.Unstructured, error) {
-	gvr, err := k.resourceFor(gvk)
+func (c *Core) ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, namespace string, options api.ListOptions) (runtime.Unstructured, error) {
+	gvr, err := c.resourceFor(gvk)
 	if err != nil {
 		return nil, err
 	}
 
 	// Check if operation is allowed for all namespaces (applicable for namespaced resources)
-	isNamespaced, _ := k.isNamespaced(gvk)
-	if isNamespaced && !k.canIUse(ctx, gvr, namespace, "list") && namespace == "" {
-		namespace = k.NamespaceOrDefault("")
+	isNamespaced, _ := c.isNamespaced(gvk)
+	if isNamespaced && !c.canIUse(ctx, gvr, namespace, "list") && namespace == "" {
+		namespace = c.NamespaceOrDefault("")
 	}
 	if options.AsTable {
-		return k.resourcesListAsTable(ctx, gvk, gvr, namespace, options)
+		return c.resourcesListAsTable(ctx, gvk, gvr, namespace, options)
 	}
-	return k.DynamicClient().Resource(*gvr).Namespace(namespace).List(ctx, options.ListOptions)
+	return c.DynamicClient().Resource(*gvr).Namespace(namespace).List(ctx, options.ListOptions)
 }
 
-func (k *Kubernetes) ResourcesGet(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) (*unstructured.Unstructured, error) {
-	gvr, err := k.resourceFor(gvk)
+func (c *Core) ResourcesGet(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) (*unstructured.Unstructured, error) {
+	gvr, err := c.resourceFor(gvk)
 	if err != nil {
 		return nil, err
 	}
 
 	// If it's a namespaced resource and namespace wasn't provided, try to use the default configured one
-	if namespaced, nsErr := k.isNamespaced(gvk); nsErr == nil && namespaced {
-		namespace = k.NamespaceOrDefault(namespace)
+	if namespaced, nsErr := c.isNamespaced(gvk); nsErr == nil && namespaced {
+		namespace = c.NamespaceOrDefault(namespace)
 	}
-	return k.DynamicClient().Resource(*gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	return c.DynamicClient().Resource(*gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
-func (k *Kubernetes) ResourcesCreateOrUpdate(ctx context.Context, resource string) ([]*unstructured.Unstructured, error) {
+func (c *Core) ResourcesCreateOrUpdate(ctx context.Context, resource string) ([]*unstructured.Unstructured, error) {
 	separator := regexp.MustCompile(`\r?\n---\r?\n`)
 	resources := separator.Split(resource, -1)
 	var parsedResources []*unstructured.Unstructured
@@ -67,43 +67,43 @@ func (k *Kubernetes) ResourcesCreateOrUpdate(ctx context.Context, resource strin
 		}
 		parsedResources = append(parsedResources, &obj)
 	}
-	return k.resourcesCreateOrUpdate(ctx, parsedResources)
+	return c.resourcesCreateOrUpdate(ctx, parsedResources)
 }
 
-func (k *Kubernetes) ResourcesDelete(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) error {
-	gvr, err := k.resourceFor(gvk)
+func (c *Core) ResourcesDelete(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) error {
+	gvr, err := c.resourceFor(gvk)
 	if err != nil {
 		return err
 	}
 
 	// If it's a namespaced resource and namespace wasn't provided, try to use the default configured one
-	if namespaced, nsErr := k.isNamespaced(gvk); nsErr == nil && namespaced {
-		namespace = k.NamespaceOrDefault(namespace)
+	if namespaced, nsErr := c.isNamespaced(gvk); nsErr == nil && namespaced {
+		namespace = c.NamespaceOrDefault(namespace)
 	}
-	return k.DynamicClient().Resource(*gvr).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	return c.DynamicClient().Resource(*gvr).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
-func (k *Kubernetes) ResourcesScale(
+func (c *Core) ResourcesScale(
 	ctx context.Context,
 	gvk *schema.GroupVersionKind,
 	namespace, name string,
 	desiredScale int64,
 	shouldScale bool,
 ) (*unstructured.Unstructured, error) {
-	gvr, err := k.resourceFor(gvk)
+	gvr, err := c.resourceFor(gvk)
 	if err != nil {
 		return nil, err
 	}
 
 	var resourceClient dynamic.ResourceInterface
 
-	if namespaced, nsErr := k.isNamespaced(gvk); nsErr == nil && namespaced {
-		resourceClient = k.
+	if namespaced, nsErr := c.isNamespaced(gvk); nsErr == nil && namespaced {
+		resourceClient = c.
 			DynamicClient().
 			Resource(*gvr).
-			Namespace(k.NamespaceOrDefault(namespace))
+			Namespace(c.NamespaceOrDefault(namespace))
 	} else {
-		resourceClient = k.DynamicClient().Resource(*gvr)
+		resourceClient = c.DynamicClient().Resource(*gvr)
 	}
 
 	scale, err := resourceClient.Get(ctx, name, metav1.GetOptions{}, "scale")
@@ -128,7 +128,7 @@ func (k *Kubernetes) ResourcesScale(
 // resourcesListAsTable retrieves a list of resources in a table format.
 // It's almost identical to the dynamic.DynamicClient implementation, but it uses a specific Accept header to request the table format.
 // dynamic.DynamicClient does not provide a way to set the HTTP header (TODO: create an issue to request this feature)
-func (k *Kubernetes) resourcesListAsTable(ctx context.Context, gvk *schema.GroupVersionKind, gvr *schema.GroupVersionResource, namespace string, options api.ListOptions) (runtime.Unstructured, error) {
+func (c *Core) resourcesListAsTable(ctx context.Context, gvk *schema.GroupVersionKind, gvr *schema.GroupVersionResource, namespace string, options api.ListOptions) (runtime.Unstructured, error) {
 	var url []string
 	if len(gvr.Group) == 0 {
 		url = append(url, "api")
@@ -141,7 +141,7 @@ func (k *Kubernetes) resourcesListAsTable(ctx context.Context, gvk *schema.Group
 	}
 	url = append(url, gvr.Resource)
 	var table metav1.Table
-	err := k.CoreV1().RESTClient().
+	err := c.CoreV1().RESTClient().
 		Get().
 		SetHeader("Accept", strings.Join([]string{
 			fmt.Sprintf("application/json;as=Table;v=%s;g=%s", metav1.SchemeGroupVersion.Version, metav1.GroupName),
@@ -172,20 +172,20 @@ func (k *Kubernetes) resourcesListAsTable(ctx context.Context, gvk *schema.Group
 	return &unstructured.Unstructured{Object: unstructuredObject}, err
 }
 
-func (k *Kubernetes) resourcesCreateOrUpdate(ctx context.Context, resources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
+func (c *Core) resourcesCreateOrUpdate(ctx context.Context, resources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
 	for i, obj := range resources {
 		gvk := obj.GroupVersionKind()
-		gvr, rErr := k.resourceFor(&gvk)
+		gvr, rErr := c.resourceFor(&gvk)
 		if rErr != nil {
 			return nil, rErr
 		}
 
 		namespace := obj.GetNamespace()
 		// If it's a namespaced resource and namespace wasn't provided, try to use the default configured one
-		if namespaced, nsErr := k.isNamespaced(&gvk); nsErr == nil && namespaced {
-			namespace = k.NamespaceOrDefault(namespace)
+		if namespaced, nsErr := c.isNamespaced(&gvk); nsErr == nil && namespaced {
+			namespace = c.NamespaceOrDefault(namespace)
 		}
-		resources[i], rErr = k.DynamicClient().Resource(*gvr).Namespace(namespace).Apply(ctx, obj.GetName(), obj, metav1.ApplyOptions{
+		resources[i], rErr = c.DynamicClient().Resource(*gvr).Namespace(namespace).Apply(ctx, obj.GetName(), obj, metav1.ApplyOptions{
 			FieldManager: version.BinaryName,
 		})
 		if rErr != nil {
@@ -193,22 +193,22 @@ func (k *Kubernetes) resourcesCreateOrUpdate(ctx context.Context, resources []*u
 		}
 		// Clear the cache to ensure the next operation is performed on the latest exposed APIs (will change after the CRD creation)
 		if gvk.Kind == "CustomResourceDefinition" {
-			k.RESTMapper().Reset()
+			c.RESTMapper().Reset()
 		}
 	}
 	return resources, nil
 }
 
-func (k *Kubernetes) resourceFor(gvk *schema.GroupVersionKind) (*schema.GroupVersionResource, error) {
-	m, err := k.RESTMapper().RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
+func (c *Core) resourceFor(gvk *schema.GroupVersionKind) (*schema.GroupVersionResource, error) {
+	m, err := c.RESTMapper().RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
 	if err != nil {
 		return nil, err
 	}
 	return &m.Resource, nil
 }
 
-func (k *Kubernetes) isNamespaced(gvk *schema.GroupVersionKind) (bool, error) {
-	apiResourceList, err := k.DiscoveryClient().ServerResourcesForGroupVersion(gvk.GroupVersion().String())
+func (c *Core) isNamespaced(gvk *schema.GroupVersionKind) (bool, error) {
+	apiResourceList, err := c.DiscoveryClient().ServerResourcesForGroupVersion(gvk.GroupVersion().String())
 	if err != nil {
 		return false, err
 	}
@@ -220,15 +220,15 @@ func (k *Kubernetes) isNamespaced(gvk *schema.GroupVersionKind) (bool, error) {
 	return false, nil
 }
 
-func (k *Kubernetes) supportsGroupVersion(groupVersion string) bool {
-	if _, err := k.DiscoveryClient().ServerResourcesForGroupVersion(groupVersion); err != nil {
+func (c *Core) supportsGroupVersion(groupVersion string) bool {
+	if _, err := c.DiscoveryClient().ServerResourcesForGroupVersion(groupVersion); err != nil {
 		return false
 	}
 	return true
 }
 
-func (k *Kubernetes) canIUse(ctx context.Context, gvr *schema.GroupVersionResource, namespace, verb string) bool {
-	accessReviews := k.AuthorizationV1().SelfSubjectAccessReviews()
+func (c *Core) canIUse(ctx context.Context, gvr *schema.GroupVersionResource, namespace, verb string) bool {
+	accessReviews := c.AuthorizationV1().SelfSubjectAccessReviews()
 	response, err := accessReviews.Create(ctx, &authv1.SelfSubjectAccessReview{
 		Spec: authv1.SelfSubjectAccessReviewSpec{ResourceAttributes: &authv1.ResourceAttributes{
 			Namespace: namespace,

--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 )
 
@@ -62,7 +63,7 @@ func initConfiguration() []api.ServerTool {
 }
 
 func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	contexts, err := params.ConfigurationContextsList()
+	contexts, err := kubernetes.NewCore(params).ConfigurationContextsList()
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list contexts: %v", err)), nil
 	}
@@ -71,7 +72,7 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("No contexts found in kubeconfig", nil), nil
 	}
 
-	defaultContext, err := params.ConfigurationContextsDefault()
+	defaultContext, err := kubernetes.NewCore(params).ConfigurationContextsDefault()
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get default context: %v", err)), nil
 	}
@@ -102,7 +103,7 @@ func configurationView(params api.ToolHandlerParams) (*api.ToolCallResult, error
 	if _, ok := minified.(bool); ok {
 		minify = minified.(bool)
 	}
-	ret, err := params.ConfigurationView(minify)
+	ret, err := kubernetes.NewCore(params).ConfigurationView(minify)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get configuration: %v", err)), nil
 	}

--- a/pkg/toolsets/core/events.go
+++ b/pkg/toolsets/core/events.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 )
 
@@ -39,7 +40,7 @@ func eventsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if namespace == nil {
 		namespace = ""
 	}
-	eventMap, err := params.EventsList(params, namespace.(string))
+	eventMap, err := kubernetes.NewCore(params).EventsList(params, namespace.(string))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list events in all namespaces: %v", err)), nil
 	}

--- a/pkg/toolsets/core/namespaces.go
+++ b/pkg/toolsets/core/namespaces.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 )
 
 func initNamespaces(o api.Openshift) []api.ServerTool {
@@ -48,7 +49,7 @@ func initNamespaces(o api.Openshift) []api.ServerTool {
 }
 
 func namespacesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ret, err := params.NamespacesList(params, api.ListOptions{AsTable: params.ListOutput.AsTable()})
+	ret, err := kubernetes.NewCore(params).NamespacesList(params, api.ListOptions{AsTable: params.ListOutput.AsTable()})
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list namespaces: %v", err)), nil
 	}
@@ -56,7 +57,7 @@ func namespacesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func projectsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ret, err := params.ProjectsList(params, api.ListOptions{AsTable: params.ListOutput.AsTable()})
+	ret, err := kubernetes.NewCore(params).ProjectsList(params, api.ListOptions{AsTable: params.ListOutput.AsTable()})
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list projects: %v", err)), nil
 	}

--- a/pkg/toolsets/core/nodes.go
+++ b/pkg/toolsets/core/nodes.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 )
 
 func initNodes() []api.ServerTool {
@@ -113,7 +114,7 @@ func nodesLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 			return api.NewToolCallResult("", fmt.Errorf("failed to parse tailLines parameter: %w", err)), nil
 		}
 	}
-	ret, err := params.NodesLog(params, name, query, tailInt)
+	ret, err := kubernetes.NewCore(params).NodesLog(params, name, query, tailInt)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get node log for %s: %v", name, err)), nil
 	} else if ret == "" {
@@ -127,7 +128,7 @@ func nodesStatsSummary(params api.ToolHandlerParams) (*api.ToolCallResult, error
 	if !ok || name == "" {
 		return api.NewToolCallResult("", errors.New("failed to get node stats summary, missing argument name")), nil
 	}
-	ret, err := params.NodesStatsSummary(params, name)
+	ret, err := kubernetes.NewCore(params).NodesStatsSummary(params, name)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get node stats summary for %s: %v", name, err)), nil
 	}
@@ -143,7 +144,7 @@ func nodesTop(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		nodesTopOptions.LabelSelector = v
 	}
 
-	nodeMetrics, err := params.NodesTop(params, nodesTopOptions)
+	nodeMetrics, err := kubernetes.NewCore(params).NodesTop(params, nodesTopOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get nodes top: %v", err)), nil
 	}

--- a/pkg/toolsets/core/pods.go
+++ b/pkg/toolsets/core/pods.go
@@ -257,7 +257,7 @@ func podsListInAllNamespaces(params api.ToolHandlerParams) (*api.ToolCallResult,
 	if labelSelector != nil {
 		resourceListOptions.LabelSelector = labelSelector.(string)
 	}
-	ret, err := params.PodsListInAllNamespaces(params, resourceListOptions)
+	ret, err := kubernetes.NewCore(params).PodsListInAllNamespaces(params, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in all namespaces: %v", err)), nil
 	}
@@ -276,7 +276,7 @@ func podsListInNamespace(params api.ToolHandlerParams) (*api.ToolCallResult, err
 	if labelSelector != nil {
 		resourceListOptions.LabelSelector = labelSelector.(string)
 	}
-	ret, err := params.PodsListInNamespace(params, ns.(string), resourceListOptions)
+	ret, err := kubernetes.NewCore(params).PodsListInNamespace(params, ns.(string), resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace %s: %v", ns, err)), nil
 	}
@@ -292,7 +292,7 @@ func podsGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if name == nil {
 		return api.NewToolCallResult("", errors.New("failed to get pod, missing argument name")), nil
 	}
-	ret, err := params.PodsGet(params, ns.(string), name.(string))
+	ret, err := kubernetes.NewCore(params).PodsGet(params, ns.(string), name.(string))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod %s in namespace %s: %v", name, ns, err)), nil
 	}
@@ -308,7 +308,7 @@ func podsDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if name == nil {
 		return api.NewToolCallResult("", errors.New("failed to delete pod, missing argument name")), nil
 	}
-	ret, err := params.PodsDelete(params, ns.(string), name.(string))
+	ret, err := kubernetes.NewCore(params).PodsDelete(params, ns.(string), name.(string))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to delete pod %s in namespace %s: %v", name, ns, err)), nil
 	}
@@ -329,7 +329,7 @@ func podsTop(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if v, ok := params.GetArguments()["label_selector"].(string); ok {
 		podsTopOptions.LabelSelector = v
 	}
-	ret, err := params.PodsTop(params, podsTopOptions)
+	ret, err := kubernetes.NewCore(params).PodsTop(params, podsTopOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pods top: %v", err)), nil
 	}
@@ -366,7 +366,7 @@ func podsExec(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	} else {
 		return api.NewToolCallResult("", errors.New("failed to exec in pod, invalid command argument")), nil
 	}
-	ret, err := params.PodsExec(params, ns.(string), name.(string), container.(string), command)
+	ret, err := kubernetes.NewCore(params).PodsExec(params, ns.(string), name.(string), container.(string), command)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to exec in pod %s in namespace %s: %v", name, ns, err)), nil
 	} else if ret == "" {
@@ -404,7 +404,7 @@ func podsLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		}
 	}
 
-	ret, err := params.PodsLog(params.Context, ns.(string), name.(string), container.(string), previousBool, tailInt)
+	ret, err := kubernetes.NewCore(params).PodsLog(params.Context, ns.(string), name.(string), container.(string), previousBool, tailInt)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod %s log in namespace %s: %v", name, ns, err)), nil
 	} else if ret == "" {
@@ -430,7 +430,7 @@ func podsRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if port == nil {
 		port = float64(0)
 	}
-	resources, err := params.PodsRun(params, ns.(string), name.(string), image.(string), int32(port.(float64)))
+	resources, err := kubernetes.NewCore(params).PodsRun(params, ns.(string), name.(string), image.(string), int32(port.(float64)))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to run pod %s in namespace %s: %v", name, ns, err)), nil
 	}

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 )
 
@@ -203,7 +204,7 @@ func resourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("", fmt.Errorf("namespace is not a string")), nil
 	}
 
-	ret, err := params.ResourcesList(params, gvk, ns, resourceListOptions)
+	ret, err := kubernetes.NewCore(params).ResourcesList(params, gvk, ns, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list resources: %v", err)), nil
 	}
@@ -234,7 +235,7 @@ func resourcesGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("", fmt.Errorf("name is not a string")), nil
 	}
 
-	ret, err := params.ResourcesGet(params, gvk, ns, n)
+	ret, err := kubernetes.NewCore(params).ResourcesGet(params, gvk, ns, n)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get resource: %v", err)), nil
 	}
@@ -252,7 +253,7 @@ func resourcesCreateOrUpdate(params api.ToolHandlerParams) (*api.ToolCallResult,
 		return api.NewToolCallResult("", fmt.Errorf("resource is not a string")), nil
 	}
 
-	resources, err := params.ResourcesCreateOrUpdate(params, r)
+	resources, err := kubernetes.NewCore(params).ResourcesCreateOrUpdate(params, r)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to create or update resources: %v", err)), nil
 	}
@@ -287,7 +288,7 @@ func resourcesDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) 
 		return api.NewToolCallResult("", fmt.Errorf("name is not a string")), nil
 	}
 
-	err = params.ResourcesDelete(params, gvk, ns, n)
+	err = kubernetes.NewCore(params).ResourcesDelete(params, gvk, ns, n)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to delete resource: %v", err)), nil
 	}
@@ -315,8 +316,6 @@ func resourcesScale(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("", fmt.Errorf("namespace is not a string")), nil
 	}
 
-	ns = params.NamespaceOrDefault(ns)
-
 	n, ok := name.(string)
 	if !ok {
 		return api.NewToolCallResult("", fmt.Errorf("name is not a string")), nil
@@ -331,7 +330,7 @@ func resourcesScale(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		}
 	}
 
-	scale, err := params.ResourcesScale(params.Context, gvk, ns, n, desiredScale, shouldScale)
+	scale, err := kubernetes.NewCore(params).ResourcesScale(params.Context, gvk, ns, n, desiredScale, shouldScale)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get/update resource scale: %w", err)), nil
 	}

--- a/pkg/toolsets/kubevirt/vm/create/tool.go
+++ b/pkg/toolsets/kubevirt/vm/create/tool.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 	"github.com/google/jsonschema-go/jsonschema"
@@ -131,7 +132,7 @@ func create(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	}
 
 	// Create the VM in the cluster
-	resources, err := params.ResourcesCreateOrUpdate(params, vmYaml)
+	resources, err := kubernetes.NewCore(params).ResourcesCreateOrUpdate(params, vmYaml)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to create VirtualMachine: %w", err)), nil
 	}


### PR DESCRIPTION
Follows up on #578
Follows up on #585 
Last phase of and fixes #577

Move all operational methods (pods, nodes, namespaces, events, resources, and configuration) from the KubernetesClient interface to a separate Core struct in pkg/kubernetes. This slims down the KubernetesClient interface to only expose core client accessors while providing the operational methods through a composable wrapper.

Consumers now access operational methods via kubernetes.NewCore(client) instead of calling them directly on the KubernetesClient interface.