### PR TITLE
test(config): add stateless mode CLI tests and refactor HTTP transport tests

### DIFF
--- a/pkg/http/http_mcp_test.go
+++ b/pkg/http/http_mcp_test.go
@@ -17,7 +17,7 @@ type McpTransportSuite struct {
 
 func (s *McpTransportSuite) SetupTest() {
 	s.BaseHttpSuite.SetupTest()
-	s.StartServer()
+	s.StaticConfig.Stateless = false
 }
 
 func (s *McpTransportSuite) TearDownTest() {
@@ -25,6 +25,7 @@ func (s *McpTransportSuite) TearDownTest() {
 }
 
 func (s *McpTransportSuite) TestSseTransport() {
+	s.StartServer()
 	sseClient, sseClientErr := client.NewSSEMCPClient(fmt.Sprintf("http://127.0.0.1:%s/sse", s.StaticConfig.Port))
 	s.Require().NoError(sseClientErr, "Expected no error creating SSE MCP client")
 	startErr := sseClient.Start(s.T().Context())
@@ -44,85 +45,33 @@ func (s *McpTransportSuite) TestSseTransport() {
 }
 
 func (s *McpTransportSuite) TestStreamableHttpTransport() {
-	httpClient, httpClientErr := client.NewStreamableHttpClient(fmt.Sprintf("http://127.0.0.1:%s/mcp", s.StaticConfig.Port), transport.WithContinuousListening())
-	s.Require().NoError(httpClientErr, "Expected no error creating Streamable HTTP MCP client")
-	startErr := httpClient.Start(s.T().Context())
-	s.Require().NoError(startErr, "Expected no error starting Streamable HTTP MCP client")
-	s.Run("Can Initialize Session", func() {
-		_, err := httpClient.Initialize(s.T().Context(), test.McpInitRequest())
-		s.Require().NoError(err, "Expected no error initializing Streamable HTTP MCP client")
-	})
-	s.Run("Can List Tools", func() {
-		tools, err := httpClient.ListTools(s.T().Context(), mcp.ListToolsRequest{})
-		s.Require().NoError(err, "Expected no error listing tools from Streamable HTTP MCP client")
-		s.Greater(len(tools.Tools), 0, "Expected at least one tool from Streamable HTTP MCP client")
-	})
-	s.Run("Can close Streamable HTTP client", func() {
-		s.Require().NoError(httpClient.Close(), "Expected no error closing Streamable HTTP MCP client")
-	})
-}
-
-func (s *McpTransportSuite) TestStatelessConfiguration() {
-	s.Run("stateful mode by default", func() {
-		// Default configuration should be stateful (false)
-		s.False(s.StaticConfig.Stateless, "Expected default configuration to be stateful")
-
-		// Test that the HTTP handler is created (we can't directly test the Stateless field
-		// of StreamableHTTPOptions as it's not exposed, but we can verify the server works)
-		httpClient, err := client.NewStreamableHttpClient(fmt.Sprintf("http://127.0.0.1:%s/mcp", s.StaticConfig.Port), transport.WithContinuousListening())
-		s.Require().NoError(err, "Expected no error creating Streamable HTTP MCP client")
-		defer func() { _ = httpClient.Close() }()
-
-		startErr := httpClient.Start(s.T().Context())
-		s.Require().NoError(startErr, "Expected no error starting Streamable HTTP MCP client")
-
-		_, initErr := httpClient.Initialize(s.T().Context(), test.McpInitRequest())
-		s.Require().NoError(initErr, "Expected no error initializing MCP client in stateful mode")
-	})
-}
-
-type StatelessMcpTransportSuite struct {
-	BaseHttpSuite
-}
-
-func (s *StatelessMcpTransportSuite) SetupTest() {
-	s.BaseHttpSuite.SetupTest()
-	// Configure for stateless mode
-	s.StaticConfig.Stateless = true
-	s.StartServer()
-}
-
-func (s *StatelessMcpTransportSuite) TearDownTest() {
-	s.BaseHttpSuite.TearDownTest()
-}
-
-func (s *StatelessMcpTransportSuite) TestStatelessMode() {
-	s.Run("stateless mode configuration", func() {
-		// Verify configuration is set to stateless
-		s.True(s.StaticConfig.Stateless, "Expected configuration to be stateless")
-
-		// Test that the HTTP handler works in stateless mode
-		httpClient, err := client.NewStreamableHttpClient(fmt.Sprintf("http://127.0.0.1:%s/mcp", s.StaticConfig.Port), transport.WithContinuousListening())
-		s.Require().NoError(err, "Expected no error creating Streamable HTTP MCP client")
-		defer func() { _ = httpClient.Close() }()
-
-		startErr := httpClient.Start(s.T().Context())
-		s.Require().NoError(startErr, "Expected no error starting Streamable HTTP MCP client")
-
-		_, initErr := httpClient.Initialize(s.T().Context(), test.McpInitRequest())
-		s.Require().NoError(initErr, "Expected no error initializing MCP client in stateless mode")
-
-		// Basic functionality should still work
-		tools, err := httpClient.ListTools(s.T().Context(), mcp.ListToolsRequest{})
-		s.Require().NoError(err, "Expected no error listing tools in stateless mode")
-		s.Greater(len(tools.Tools), 0, "Expected at least one tool in stateless mode")
-	})
+	testCases := []bool{true, false}
+	for _, stateless := range testCases {
+		s.Run(fmt.Sprintf("Streamable HTTP transport with server stateless=%v", stateless), func() {
+			s.StaticConfig.Stateless = stateless
+			s.StartServer()
+			httpClient, httpClientErr := client.NewStreamableHttpClient(fmt.Sprintf("http://127.0.0.1:%s/mcp", s.StaticConfig.Port), transport.WithContinuousListening())
+			s.Require().NoError(httpClientErr, "Expected no error creating Streamable HTTP MCP client")
+			startErr := httpClient.Start(s.T().Context())
+			s.Require().NoError(startErr, "Expected no error starting Streamable HTTP MCP client")
+			s.Run("Can Initialize Session", func() {
+				_, err := httpClient.Initialize(s.T().Context(), test.McpInitRequest())
+				s.Require().NoError(err, "Expected no error initializing Streamable HTTP MCP client")
+			})
+			s.Run("Can List Tools", func() {
+				tools, err := httpClient.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+				s.Require().NoError(err, "Expected no error listing tools from Streamable HTTP MCP client")
+				s.Greater(len(tools.Tools), 0, "Expected at least one tool from Streamable HTTP MCP client")
+			})
+			s.Run("Can close Streamable HTTP client", func() {
+				s.Require().NoError(httpClient.Close(), "Expected no error closing Streamable HTTP MCP client")
+			})
+			s.StopServer()
+			s.Require().NoError(s.WaitForShutdown())
+		})
+	}
 }
 
 func TestMcpTransport(t *testing.T) {
 	suite.Run(t, new(McpTransportSuite))
-}
-
-func TestStatelessMcpTransport(t *testing.T) {
-	suite.Run(t, new(StatelessMcpTransportSuite))
 }

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -451,3 +451,24 @@ func TestDisableMultiCluster(t *testing.T) {
 		}
 	})
 }
+
+func TestStateless(t *testing.T) {
+	t.Run("defaults to false", func(t *testing.T) {
+		ioStreams, out := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
+		if err := rootCmd.Execute(); !strings.Contains(out.String(), " - Stateless mode: false") {
+			t.Fatalf("Expected stateless mode false, got %s %v", out, err)
+		}
+	})
+	t.Run("set with --stateless", func(t *testing.T) {
+		ioStreams, out := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--stateless"})
+		_ = rootCmd.Execute()
+		expected := `(?m)\" - Stateless mode\: true\"`
+		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
+			t.Fatalf("Expected stateless mode to be %s, got %s %v", expected, out.String(), err)
+		}
+	})
+}


### PR DESCRIPTION
Follows up on #603

- Add tests for --stateless CLI flag in root_test.go
- Consolidate stateless/stateful HTTP transport tests into parameterized loop
- Remove duplicate StatelessMcpTransportSuite in favor of table-driven tests