### PR TITLE
fix(test): update SIGHUP prompt reload test for built-in prompts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ type StaticConfig struct {
 	// maintaining client state is not desired or possible. However, this disables dynamic tool
 	// and prompt updates, requiring clients to manually refresh their tool/prompt lists.
 	// Defaults to false (stateful mode with notifications enabled).
-	Stateless     bool     `toml:"stateless,omitempty"`
+	Stateless bool `toml:"stateless,omitempty"`
 	// When true, expose only tools annotated with readOnlyHint=true
 	ReadOnly bool `toml:"read_only,omitempty"`
 	// When true, disable tools annotated with destructiveHint=true

--- a/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
@@ -218,9 +218,9 @@ func (s *SIGHUPSuite) TestSIGHUPReloadsPrompts() {
     `), 0644))
 	s.InitServer(configPath, "")
 
-	prompts := s.server.GetEnabledPrompts()
-	s.Len(prompts, 1)
-	s.Equal("initial-prompt", prompts[0])
+	enabledPrompts := s.server.GetEnabledPrompts()
+	s.GreaterOrEqual(len(enabledPrompts), 1)
+	s.Contains(enabledPrompts, "initial-prompt")
 
 	// Update config with new prompt
 	s.Require().NoError(os.WriteFile(configPath, []byte(`
@@ -238,8 +238,8 @@ func (s *SIGHUPSuite) TestSIGHUPReloadsPrompts() {
 
 	// Verify prompts were reloaded
 	s.Require().Eventually(func() bool {
-		prompts := s.server.GetEnabledPrompts()
-		return len(prompts) == 1 && prompts[0] == "updated-prompt"
+		enabledPrompts = s.server.GetEnabledPrompts()
+		return len(enabledPrompts) >= 1 && slices.Contains(enabledPrompts, "updated-prompt") && !slices.Contains(enabledPrompts, "initial-prompt")
 	}, 2*time.Second, 50*time.Millisecond)
 }
 


### PR DESCRIPTION
The test was failing because it expected exactly 1 prompt, but the server now includes built-in prompts.