### PR TITLE
chore(ci): restrict release workflows to version tags only

### DIFF
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -3,7 +3,7 @@ name: Release Helm Chart
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - 'v*'
 
 env:
   IMAGE_NAME: quay.io/containers/kubernetes_mcp_server

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.


### PR DESCRIPTION
Change tag filter from '*' to 'v*' so release workflows only trigger for semantic version tags (e.g., v1.0.0) and ignore other tags.