### PR TITLE
fix(tests): adjust notification wait times for improved debounced notification handling

### DIFF
--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -213,14 +213,28 @@ func (s *BaseMcpSuite) InitMcpClient(options ...transport.StreamableHTTPCOption)
 	s.McpClient = test.NewMcpClient(s.T(), s.mcpServer.ServeHTTP(), options...)
 }
 
+// notificationDelay is the time to wait after receiving a notification before capturing it.
+// This accounts for multiple layers of async processing in tests:
+// - go-sdk debounce (10ms in mcp/server.go changeAndNotify)
+// - cluster state / kubeconfig debounce (CLUSTER_STATE_DEBOUNCE_WINDOW_MS, KUBECONFIG_DEBOUNCE_WINDOW_MS)
+// - async tool updates completing after notification is sent
+// We use 50ms to ensure all debouncing and async operations have settled.
+const notificationDelay = time.Millisecond * 50
+
 // WaitForNotification wait for a specific MCP notification method within the given timeout duration.
 func (s *BaseMcpSuite) WaitForNotification(timeout time.Duration, method string) *mcp.JSONRPCNotification {
 	withTimeout, cancel := context.WithTimeout(s.T().Context(), timeout)
 	defer cancel()
 	var notification *mcp.JSONRPCNotification
+	var timer *time.Timer
 	s.OnNotification(func(n mcp.JSONRPCNotification) {
 		if n.Method == method {
-			notification = &n
+			if timer != nil {
+				timer.Stop()
+			}
+			timer = time.AfterFunc(notificationDelay, func() {
+				notification = &n
+			})
 		}
 	})
 	for notification == nil {

--- a/pkg/mcp/mcp_watch_test.go
+++ b/pkg/mcp/mcp_watch_test.go
@@ -19,6 +19,7 @@ type WatchKubeConfigSuite struct {
 
 func (s *WatchKubeConfigSuite) SetupTest() {
 	s.BaseMcpSuite.SetupTest()
+	s.T().Setenv("KUBECONFIG_DEBOUNCE_WINDOW_MS", "10")
 	s.mockServer = test.NewMockServer()
 	s.Require().NoError(toml.Unmarshal([]byte(`
 		[[prompts]]
@@ -145,8 +146,8 @@ type WatchClusterStateSuite struct {
 func (s *WatchClusterStateSuite) SetupTest() {
 	s.BaseMcpSuite.SetupTest()
 	// Configure fast polling for tests
-	s.T().Setenv("CLUSTER_STATE_POLL_INTERVAL_MS", "100")
-	s.T().Setenv("CLUSTER_STATE_DEBOUNCE_WINDOW_MS", "50")
+	s.T().Setenv("CLUSTER_STATE_POLL_INTERVAL_MS", "50")
+	s.T().Setenv("CLUSTER_STATE_DEBOUNCE_WINDOW_MS", "10")
 	s.mockServer = test.NewMockServer()
 	s.handler = &test.DiscoveryClientHandler{}
 	s.mockServer.Handle(s.handler)


### PR DESCRIPTION
Fixes test for #609

In go-sdk 1.2.0 they've introduced a debounce mechanism to enable batch notifications.
Notifications are now only sent once per batch.

See:
- https://github.com/modelcontextprotocol/go-sdk/pull/717
- https://github.com/modelcontextprotocol/go-sdk/issues/649

The changes in this PR account for the introduced latency/delay of the batched notifications emitted by the server in the `WaitForNotification` test utility implementation.