### PR TITLE
Add JSON output format and environment variable configuration

### DIFF
--- a/CHANGELOG_JSON_AND_ENV.md
+++ b/CHANGELOG_JSON_AND_ENV.md
@@ -1,0 +1,98 @@
+# JSON Output Format & Environment Variable Configuration
+
+## Summary
+
+Added JSON output format support and environment variable configuration to make the server compatible with agentic frameworks and container deployments.
+
+## Changes
+
+### 1. JSON Output Format
+
+**Added:** New `json` output format alongside existing `yaml` and `table` formats.
+
+**Files Modified:**
+- `pkg/output/output.go` - Added JSON marshaling with proper indentation
+- `pkg/output/output_test.go` - Added unit tests
+- `pkg/mcp/*_test.go` - Added integration tests for pods, namespaces, and resources
+
+**Usage:**
+```bash
+# Command line
+kubernetes-mcp-server --list-output=json
+
+# Environment variable
+export MCP_LIST_OUTPUT=json
+kubernetes-mcp-server
+
+# Docker
+docker run -e MCP_LIST_OUTPUT=json ...
+```
+
+### 2. Environment Variable Configuration
+
+**Added:** All configuration options now support environment variables with `MCP_` prefix.
+
+**Files Modified:**
+- `pkg/kubernetes-mcp-server/cmd/root.go` - Added `loadEnvironmentVariables()` function
+- `pkg/kubernetes-mcp-server/cmd/root_test.go` - Added environment variable tests
+
+**Supported Variables:**
+- `MCP_PORT` - Server port
+- `MCP_LIST_OUTPUT` - Output format (yaml/json/table)
+- `MCP_LOG_LEVEL` - Logging level
+- `MCP_KUBECONFIG` - Kubeconfig path
+- `MCP_READ_ONLY` - Read-only mode (true/false)
+- `MCP_DISABLE_DESTRUCTIVE` - Disable destructive operations
+- `MCP_STATELESS` - Stateless mode
+- `MCP_TOOLSETS` - Comma-separated toolsets
+- `MCP_DISABLE_MULTI_CLUSTER` - Disable multi-cluster
+- Plus OAuth and other configuration options
+
+**Configuration Precedence:**
+1. Command-line flags (highest)
+2. Environment variables
+3. Configuration file
+4. Default values (lowest)
+
+## Container Example
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-mcp-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: mcp-server
+        image: quay.io/containers/kubernetes_mcp_server:latest
+        env:
+        - name: MCP_PORT
+          value: "8080"
+        - name: MCP_LIST_OUTPUT
+          value: "json"
+        - name: MCP_STATELESS
+          value: "true"
+```
+
+## Documentation Updates
+
+- `README.md` - Updated `--list-output` description and added Environment Variables section
+
+## Testing
+
+All tests pass with no breaking changes:
+```bash
+go test ./pkg/output/... -v
+go test ./pkg/mcp/... -v -run "AsJson"
+go test ./pkg/kubernetes-mcp-server/cmd/... -v -run TestEnvironmentVariables
+```
+
+## How this change helps
+
+1. **JSON Format:** Compatible with agentic frameworks that prefer JSON over YAML
+2. **Environment Variables:** Standard configuration method for containers
+3. **No Breaking Changes:** All existing functionality preserved
+4. **Automatic Support:** All tools work with JSON without code changes
+

--- a/README.md
+++ b/README.md
@@ -192,12 +192,89 @@ uvx kubernetes-mcp-server@latest --help
 | `--config`                | (Optional) Path to the main TOML configuration file. See [Drop-in Configuration](#drop-in-configuration) section below for details.                                                                                                                                                          |
 | `--config-dir`            | (Optional) Path to drop-in configuration directory. Files are loaded in lexical (alphabetical) order. Defaults to `conf.d` relative to the main config file if `--config` is specified. See [Drop-in Configuration](#drop-in-configuration) section below for details.                       |
 | `--kubeconfig`            | Path to the Kubernetes configuration file. If not provided, it will try to resolve the configuration (in-cluster, default location, etc.).                                                                                                                                                    |
-| `--list-output`           | Output format for resource list operations (one of: yaml, table) (default "table")                                                                                                                                                                                                            |
+| `--list-output`           | Output format for resource list operations (one of: yaml, json, table) (default "table")                                                                                                                                                                                                      |
 | `--read-only`             | If set, the MCP server will run in read-only mode, meaning it will not allow any write operations (create, update, delete) on the Kubernetes cluster. This is useful for debugging or inspecting the cluster without making changes.                                                          |
 | `--disable-destructive`   | If set, the MCP server will disable all destructive operations (delete, update, etc.) on the Kubernetes cluster. This is useful for debugging or inspecting the cluster without accidentally making changes. This option has no effect when `--read-only` is used.                            |
 | `--stateless`             | If set, the MCP server will run in stateless mode, disabling tool and prompt change notifications. This is useful for container deployments, load balancing, and serverless environments where maintaining client state is not desired. |
 | `--toolsets`              | Comma-separated list of toolsets to enable. Check the [🛠️ Tools and Functionalities](#tools-and-functionalities) section for more information.                                                                                                                                               |
 | `--disable-multi-cluster` | If set, the MCP server will disable multi-cluster support and will only use the current context from the kubeconfig file. This is useful if you want to restrict the MCP server to a single cluster.                                                                                          |
+
+### Environment Variables
+
+All configuration options can also be set using environment variables. This is particularly useful for container deployments where environment variables are the preferred configuration method.
+
+Environment variables use the `MCP_` prefix and are named after the corresponding command-line flag in uppercase with hyphens replaced by underscores.
+
+**Configuration precedence (highest to lowest):**
+1. Command-line flags
+2. Environment variables
+3. Configuration file (TOML)
+4. Default values
+
+| Environment Variable           | Equivalent Flag             | Example Value          | Description                                                                 |
+|--------------------------------|-----------------------------|------------------------|-----------------------------------------------------------------------------|
+| `MCP_PORT`                     | `--port`                    | `8080`                 | Port for HTTP/SSE server                                                    |
+| `MCP_LOG_LEVEL`                | `--log-level`               | `5`                    | Logging level (0-9)                                                         |
+| `MCP_KUBECONFIG`               | `--kubeconfig`              | `/path/to/kubeconfig`  | Path to kubeconfig file                                                     |
+| `MCP_LIST_OUTPUT`              | `--list-output`             | `json`                 | Output format (yaml, json, or table)                                        |
+| `MCP_READ_ONLY`                | `--read-only`               | `true`                 | Enable read-only mode (true/false)                                          |
+| `MCP_DISABLE_DESTRUCTIVE`      | `--disable-destructive`     | `true`                 | Disable destructive operations (true/false)                                 |
+| `MCP_STATELESS`                | `--stateless`               | `true`                 | Enable stateless mode (true/false)                                          |
+| `MCP_TOOLSETS`                 | `--toolsets`                | `core,config,helm`     | Comma-separated list of toolsets                                            |
+| `MCP_DISABLE_MULTI_CLUSTER`    | `--disable-multi-cluster`   | `true`                 | Disable multi-cluster support (true/false)                                  |
+| `MCP_SSE_BASE_URL`             | `--sse-base-url`            | `https://example.com`  | Public base URL for SSE                                                     |
+| `MCP_REQUIRE_OAUTH`            | `--require-oauth`           | `true`                 | Require OAuth authentication (true/false)                                   |
+| `MCP_OAUTH_AUDIENCE`           | `--oauth-audience`          | `my-audience`          | OAuth token audience                                                        |
+| `MCP_AUTHORIZATION_URL`        | `--authorization-url`       | `https://auth.example` | OAuth authorization server URL                                              |
+| `MCP_SERVER_URL`               | `--server-url`              | `https://mcp.example`  | This server's URL                                                           |
+| `MCP_CERTIFICATE_AUTHORITY`    | `--certificate-authority`   | `/path/to/ca.crt`      | Path to CA certificate                                                      |
+
+**Example: Running in a Docker container with environment variables**
+
+```bash
+docker run -d \
+  -e MCP_PORT=8080 \
+  -e MCP_LIST_OUTPUT=json \
+  -e MCP_READ_ONLY=true \
+  -e MCP_TOOLSETS=core,config \
+  -v ~/.kube/config:/root/.kube/config:ro \
+  quay.io/containers/kubernetes_mcp_server:latest
+```
+
+**Example: Kubernetes Deployment with environment variables**
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubernetes-mcp-server
+  template:
+    metadata:
+      labels:
+        app: kubernetes-mcp-server
+    spec:
+      containers:
+      - name: mcp-server
+        image: quay.io/containers/kubernetes_mcp_server:latest
+        env:
+        - name: MCP_PORT
+          value: "8080"
+        - name: MCP_LIST_OUTPUT
+          value: "json"
+        - name: MCP_READ_ONLY
+          value: "true"
+        - name: MCP_STATELESS
+          value: "true"
+        - name: MCP_TOOLSETS
+          value: "core,config,helm"
+        ports:
+        - containerPort: 8080
+```
 
 ### Drop-in Configuration <a id="drop-in-configuration"></a>
 

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -167,6 +167,7 @@ func (m *MCPServerOptions) Complete(cmd *cobra.Command) error {
 		m.StaticConfig = cnf
 	}
 
+	m.loadEnvironmentVariables()
 	m.loadFlags(cmd)
 
 	m.initializeLogging()
@@ -179,7 +180,70 @@ func (m *MCPServerOptions) Complete(cmd *cobra.Command) error {
 	return nil
 }
 
+func (m *MCPServerOptions) loadEnvironmentVariables() {
+	// Load configuration from environment variables
+	// Environment variables take precedence over config file but not over command-line flags
+	if v := os.Getenv("MCP_LOG_LEVEL"); v != "" {
+		if level, err := strconv.Atoi(v); err == nil {
+			m.StaticConfig.LogLevel = level
+		}
+	}
+	if v := os.Getenv("MCP_PORT"); v != "" {
+		m.StaticConfig.Port = v
+	}
+	if v := os.Getenv("MCP_SSE_BASE_URL"); v != "" {
+		m.StaticConfig.SSEBaseURL = v
+	}
+	if v := os.Getenv("MCP_KUBECONFIG"); v != "" {
+		m.StaticConfig.KubeConfig = v
+	}
+	if v := os.Getenv("MCP_LIST_OUTPUT"); v != "" {
+		m.StaticConfig.ListOutput = v
+	}
+	if v := os.Getenv("MCP_READ_ONLY"); v != "" {
+		if readOnly, err := strconv.ParseBool(v); err == nil {
+			m.StaticConfig.ReadOnly = readOnly
+		}
+	}
+	if v := os.Getenv("MCP_DISABLE_DESTRUCTIVE"); v != "" {
+		if disableDestructive, err := strconv.ParseBool(v); err == nil {
+			m.StaticConfig.DisableDestructive = disableDestructive
+		}
+	}
+	if v := os.Getenv("MCP_STATELESS"); v != "" {
+		if stateless, err := strconv.ParseBool(v); err == nil {
+			m.StaticConfig.Stateless = stateless
+		}
+	}
+	if v := os.Getenv("MCP_TOOLSETS"); v != "" {
+		m.StaticConfig.Toolsets = strings.Split(v, ",")
+	}
+	if v := os.Getenv("MCP_REQUIRE_OAUTH"); v != "" {
+		if requireOAuth, err := strconv.ParseBool(v); err == nil {
+			m.StaticConfig.RequireOAuth = requireOAuth
+		}
+	}
+	if v := os.Getenv("MCP_OAUTH_AUDIENCE"); v != "" {
+		m.StaticConfig.OAuthAudience = v
+	}
+	if v := os.Getenv("MCP_AUTHORIZATION_URL"); v != "" {
+		m.StaticConfig.AuthorizationURL = v
+	}
+	if v := os.Getenv("MCP_SERVER_URL"); v != "" {
+		m.StaticConfig.ServerURL = v
+	}
+	if v := os.Getenv("MCP_CERTIFICATE_AUTHORITY"); v != "" {
+		m.StaticConfig.CertificateAuthority = v
+	}
+	if v := os.Getenv("MCP_DISABLE_MULTI_CLUSTER"); v != "" {
+		if disableMultiCluster, err := strconv.ParseBool(v); err == nil && disableMultiCluster {
+			m.StaticConfig.ClusterProviderStrategy = api.ClusterProviderDisabled
+		}
+	}
+}
+
 func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
+	// Command-line flags take precedence over environment variables
 	if cmd.Flag(flagLogLevel).Changed {
 		m.StaticConfig.LogLevel = m.LogLevel
 	}

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -27,6 +28,110 @@ func TestPlainTextUnstructuredList(t *testing.T) {
 		expectedHeaders := "NAME\\s+AGE\\s+LABELS"
 		if m, e := regexp.MatchString(expectedHeaders, out); !m || e != nil {
 			t.Errorf("Expected headers '%s' not found in output: %s", expectedHeaders, out)
+		}
+	})
+}
+
+func TestJsonUnstructuredList(t *testing.T) {
+	var podList unstructured.UnstructuredList
+	_ = json.Unmarshal([]byte(`
+			{ "apiVersion": "v1", "kind": "PodList", "items": [{ 
+			  "apiVersion": "v1", "kind": "Pod",
+			  "metadata": {
+			    "name": "pod-1", "namespace": "default", "creationTimestamp": "2023-10-01T00:00:00Z", "labels": { "app": "nginx" }
+			  },
+			  "spec": { "containers": [{ "name": "container-1", "image": "marcnuri/chuck-norris" }] } }
+			]}`), &podList)
+	out, err := Json.PrintObj(&podList)
+	t.Run("processes the list", func(t *testing.T) {
+		if err != nil {
+			t.Fatalf("Error printing pod list as JSON: %v", err)
+		}
+	})
+	t.Run("outputs valid JSON", func(t *testing.T) {
+		var result []map[string]any
+		if err := json.Unmarshal([]byte(out), &result); err != nil {
+			t.Errorf("Output is not valid JSON: %v\nOutput: %s", err, out)
+		}
+	})
+	t.Run("contains expected pod data", func(t *testing.T) {
+		if !strings.Contains(out, `"name": "pod-1"`) {
+			t.Errorf("Expected pod name 'pod-1' not found in JSON output: %s", out)
+		}
+		if !strings.Contains(out, `"namespace": "default"`) {
+			t.Errorf("Expected namespace 'default' not found in JSON output: %s", out)
+		}
+		if !strings.Contains(out, `"image": "marcnuri/chuck-norris"`) {
+			t.Errorf("Expected image 'marcnuri/chuck-norris' not found in JSON output: %s", out)
+		}
+	})
+	t.Run("does not contain managedFields", func(t *testing.T) {
+		if strings.Contains(out, "managedFields") {
+			t.Errorf("JSON output should not contain managedFields: %s", out)
+		}
+	})
+}
+
+func TestJsonUnstructured(t *testing.T) {
+	var pod unstructured.Unstructured
+	_ = json.Unmarshal([]byte(`
+			{ 
+			  "apiVersion": "v1", "kind": "Pod",
+			  "metadata": {
+			    "name": "pod-1", "namespace": "default", "creationTimestamp": "2023-10-01T00:00:00Z", "labels": { "app": "nginx" }
+			  },
+			  "spec": { "containers": [{ "name": "container-1", "image": "marcnuri/chuck-norris" }] } 
+			}`), &pod)
+	out, err := Json.PrintObj(&pod)
+	t.Run("processes single object", func(t *testing.T) {
+		if err != nil {
+			t.Fatalf("Error printing pod as JSON: %v", err)
+		}
+	})
+	t.Run("outputs valid JSON", func(t *testing.T) {
+		var result map[string]any
+		if err := json.Unmarshal([]byte(out), &result); err != nil {
+			t.Errorf("Output is not valid JSON: %v\nOutput: %s", err, out)
+		}
+	})
+	t.Run("contains expected pod data", func(t *testing.T) {
+		if !strings.Contains(out, `"name": "pod-1"`) {
+			t.Errorf("Expected pod name 'pod-1' not found in JSON output: %s", out)
+		}
+	})
+}
+
+func TestOutputFromString(t *testing.T) {
+	t.Run("returns yaml output", func(t *testing.T) {
+		out := FromString("yaml")
+		if out == nil || out.GetName() != "yaml" {
+			t.Errorf("Expected yaml output, got %v", out)
+		}
+	})
+	t.Run("returns table output", func(t *testing.T) {
+		out := FromString("table")
+		if out == nil || out.GetName() != "table" {
+			t.Errorf("Expected table output, got %v", out)
+		}
+	})
+	t.Run("returns json output", func(t *testing.T) {
+		out := FromString("json")
+		if out == nil || out.GetName() != "json" {
+			t.Errorf("Expected json output, got %v", out)
+		}
+	})
+	t.Run("returns nil for unknown format", func(t *testing.T) {
+		out := FromString("unknown")
+		if out != nil {
+			t.Errorf("Expected nil for unknown format, got %v", out)
+		}
+	})
+}
+
+func TestJsonAsTable(t *testing.T) {
+	t.Run("json output does not use table format", func(t *testing.T) {
+		if Json.AsTable() {
+			t.Error("JSON output should not use table format")
 		}
 	})
 }


### PR DESCRIPTION
- Add JSON output format alongside YAML and Table
- Add environment variable support for all config options (MCP_* prefix)
- Add comprehensive tests for both features
- Update documentation
- No breaking changes to existing functionality