### PR TITLE
fix(tokenexchange): register exchanger impls

### DIFF
--- a/pkg/tokenexchange/exchanger.go
+++ b/pkg/tokenexchange/exchanger.go
@@ -38,6 +38,11 @@ const (
 	ContentTypeXWWWFormUrlEncoded = "application/x-www-form-urlencoded"
 )
 
+const (
+	StrategyKeycloakV1 = "keycloak-v1"
+	StrategyRFC8693    = "rfc8693"
+)
+
 type TokenExchanger interface {
 	Exchange(ctx context.Context, cfg *TargetTokenExchangeConfig, subjectToken string) (*oauth2.Token, error)
 }

--- a/pkg/tokenexchange/registry.go
+++ b/pkg/tokenexchange/registry.go
@@ -4,6 +4,11 @@ var (
 	exchangerRegistry = &tokenExchangerRegistry{exchangers: map[string]TokenExchanger{}}
 )
 
+func init() {
+	RegisterTokenExchanger(StrategyKeycloakV1, &keycloakV1Exchanger{})
+	RegisterTokenExchanger(StrategyRFC8693, &rfc8693Exchanger{})
+}
+
 func RegisterTokenExchanger(strategy string, exchanger TokenExchanger) {
 	exchangerRegistry.register(strategy, exchanger)
 }


### PR DESCRIPTION
I realized that in the initial TokenExchange PR (#604) I missed actually registering the `TokenExchanger` impls to the runtime registry.