### PR TITLE
chore(doc): Align AGENTS.md w/ actual Go version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,7 +293,7 @@ When introducing new modules run `make tidy` so that `go.mod` and `go.sum` remai
 
 ## Coding style
 
-- Go modules target Go **1.24** (see `go.mod`).
+- Go modules target Go **1.25** (see `go.mod`).
 - Tests are written with the standard library `testing` package.
 - Build, test and lint steps are defined in the Makefile—keep them working.
 


### PR DESCRIPTION
reflecting the golang version bump, introduced in https://github.com/containers/kubernetes-mcp-server/pull/592 