### PR TITLE
fix: strip http forwarded headers from requests to kc

### DIFF
--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -57,6 +57,13 @@ func (w WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 		return
 	}
 	for key, values := range request.Header {
+		// Skip headers that would cause Keycloak to use the proxy's hostname in URLs
+		lowerKey := strings.ToLower(key)
+		if lowerKey == "host" ||
+			strings.HasPrefix(lowerKey, "x-forwarded-") ||
+			lowerKey == "forwarded" {
+			continue
+		}
 		for _, value := range values {
 			req.Header.Add(key, value)
 		}


### PR DESCRIPTION
While testing the server deployed in an openshift cluster, the wellknown proxy to keycloak was not working correctly, as all the various forwarded headers led keycloak to set the base url to the url to the MCP server, not the keycloak server.

This PR just strips those forwarded headers before passing requests to the keycloak server.