### PR TITLE
chore(build): updating to more recent version of golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LD_FLAGS = -s -w \
 COMMON_BUILD_ARGS = -ldflags "$(LD_FLAGS)"
 
 GOLANGCI_LINT = $(shell pwd)/_output/tools/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.6.1
+GOLANGCI_LINT_VERSION ?= v2.8.0
 
 # NPM version should not append the -dirty flag
 GIT_TAG_VERSION ?= $(shell echo $(shell git describe --tags --always) | sed 's/^v//')


### PR DESCRIPTION
Updated `golangci-lint` to latest 