### PR TITLE
build: Add Podman support for local development

### DIFF
--- a/dev/config/ingress/nginx-ingress.yaml
+++ b/dev/config/ingress/nginx-ingress.yaml
@@ -28,6 +28,7 @@ metadata:
   namespace: ingress-nginx
 data:
   allow-snippet-annotations: "true"
+  worker-processes: "2"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -282,7 +283,8 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/component: controller
     spec:
-      dnsPolicy: ClusterFirst
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       containers:
         - name: controller
           image: registry.k8s.io/ingress-nginx/controller:v1.11.1
@@ -345,15 +347,9 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-              hostPort: 80
             - name: https
               containerPort: 443
               protocol: TCP
-              hostPort: 443
-            - name: https-alt
-              containerPort: 443
-              protocol: TCP
-              hostPort: 8443
             - name: webhook
               containerPort: 8443
               protocol: TCP


### PR DESCRIPTION
Enhance the local development environment to fully support Podman as an alternative to Docker, with improved container engine detection and fixes for Kind cluster networking.

Container Engine Detection:
- Verify that docker or podman are actually running before selecting them by checking `docker info` / `podman info`
- Prevents errors when a container engine is installed but not active
- Consistently use CONTAINER_ENGINE variable throughout makefiles

Keycloak Connectivity:
- Add curl --resolve flag to bypass DNS and connect directly to localhost
- Ensures reliable connectivity to Keycloak running in the Kind cluster
- Prevents DNS-related connection failures

Kind Cluster Management:
- Set KIND_EXPERIMENTAL_PROVIDER inline when using podman on Linux
- Simplify cluster creation and deletion logic
- Consistently use CONTAINER_ENGINE for all container operations

Ingress Controller Fixes:
- Enable hostNetwork mode for nginx ingress controller
- Required for proper port binding with Podman in Kind clusters
- Limit nginx worker processes to 2 to avoid pthread resource exhaustion
- Remove redundant hostPort bindings (not needed with hostNetwork)
- Set dnsPolicy to ClusterFirstWithHostNet for proper name resolution

These changes enable seamless use of Podman for local Kubernetes development with Kind, Keycloak, and the MCP server.