### PR TITLE
refactor(auth): remove unused tool-scoped authorization middleware

### DIFF
--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/utils/strings/slices"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
-	"github.com/containers/kubernetes-mcp-server/pkg/mcp"
 )
 
 // write401 sends a 401/Unauthorized response with WWW-Authenticate header.
@@ -87,12 +86,6 @@ func AuthorizationMiddleware(staticConfig *config.StaticConfig, oidcProvider *oi
 			// Online OIDC provider validation
 			if err == nil {
 				err = claims.ValidateWithProvider(r.Context(), staticConfig.OAuthAudience, oidcProvider)
-			}
-			// Scopes propagation, they are likely to be used for authorization.
-			if err == nil {
-				scopes := claims.GetScopes()
-				klog.V(2).Infof("JWT token validated - Scopes: %v", scopes)
-				r = r.WithContext(context.WithValue(r.Context(), mcp.TokenScopesContextKey, scopes))
 			}
 			if err != nil {
 				klog.V(1).Infof("Authentication failed - JWT validation error: %s %s from %s, error: %v", r.Method, r.URL.Path, r.RemoteAddr, err)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -21,10 +21,6 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/version"
 )
 
-type ContextKey string
-
-const TokenScopesContextKey = ContextKey("TokenScopesContextKey")
-
 type Configuration struct {
 	*config.StaticConfig
 	listOutput output.Output
@@ -97,9 +93,6 @@ func NewServer(configuration Configuration, oidcProvider *oidc.Provider, httpCli
 
 	s.server.AddReceivingMiddleware(authHeaderPropagationMiddleware)
 	s.server.AddReceivingMiddleware(toolCallLoggingMiddleware)
-	if configuration.RequireOAuth && false { // TODO: Disabled scope auth validation for now
-		s.server.AddReceivingMiddleware(toolScopedAuthorizationMiddleware)
-	}
 
 	var err error
 	s.p, err = internalk8s.NewProvider(s.configuration.StaticConfig)

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -3,8 +3,6 @@ package mcp
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"slices"
 
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -42,19 +40,6 @@ func toolCallLoggingMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 					klog.V(7).Infof("mcp tool call headers: %s", buffer)
 				}
 			}
-		}
-		return next(ctx, method, req)
-	}
-}
-
-func toolScopedAuthorizationMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
-	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
-		scopes, ok := ctx.Value(TokenScopesContextKey).([]string)
-		if !ok {
-			return NewTextResult("", fmt.Errorf("authorization failed: Access denied: Tool '%s' requires scope 'mcp:%s' but no scope is available", method, method)), nil
-		}
-		if !slices.Contains(scopes, "mcp:"+method) && !slices.Contains(scopes, method) {
-			return NewTextResult("", fmt.Errorf("authorization failed: Access denied: Tool '%s' requires scope 'mcp:%s' but only scopes %s are available", method, method, scopes)), nil
 		}
 		return next(ctx, method, req)
 	}


### PR DESCRIPTION
The toolScopedAuthorizationMiddleware was conceived for tool authorization but the feature was dropped in favor of implementing this in an MCP gateway. This removes:
- The middleware function and its registration
- TokenScopesContextKey constant and ContextKey type
- Scopes propagation code in authorization middleware

Relates to:
- https://github.com/containers/kubernetes-mcp-server/pull/176/changes#r2204920104
- #160 
- #161 
- #170 
- #172
- #176