### PR TITLE
feat(helm): add support for specifying RBAC

### DIFF
--- a/charts/kubernetes-mcp-server/templates/rbac.yaml
+++ b/charts/kubernetes-mcp-server/templates/rbac.yaml
@@ -1,0 +1,107 @@
+{{/*
+Generic RBAC resources template.
+This allows downstream forks and users to add custom RBAC resources without
+modifying upstream templates. Define your RBAC needs in values.yaml under:
+  - rbac.extraClusterRoles
+  - rbac.extraClusterRoleBindings
+  - rbac.extraRoles
+  - rbac.extraRoleBindings
+*/}}
+
+{{- range .Values.rbac.extraClusterRoles }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "kubernetes-mcp-server.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  {{- toYaml .rules | nindent 2 }}
+{{- end }}
+
+{{- range .Values.rbac.extraClusterRoleBindings }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "kubernetes-mcp-server.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ .roleRef.kind | default "ClusterRole" }}
+  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .roleRef.name }}
+subjects:
+  {{- if .subjects }}
+  {{- toYaml .subjects | nindent 2 }}
+  {{- else }}
+  - kind: ServiceAccount
+    name: {{ include "kubernetes-mcp-server.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+{{- end }}
+
+{{- range .Values.rbac.extraRoles }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .name }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "kubernetes-mcp-server.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  {{- toYaml .rules | nindent 2 }}
+{{- end }}
+
+{{- range .Values.rbac.extraRoleBindings }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .name }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "kubernetes-mcp-server.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ .roleRef.kind | default "Role" }}
+  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .roleRef.name }}
+subjects:
+  {{- if .subjects }}
+  {{- toYaml .subjects | nindent 2 }}
+  {{- else }}
+  - kind: ServiceAccount
+    name: {{ include "kubernetes-mcp-server.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+{{- end }}

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -29,6 +29,44 @@ serviceAccount:
   # -- If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- RBAC configuration for the MCP server.
+# -- Use these lists to add custom RBAC resources without modifying templates.
+# -- This is useful for downstream forks that need provider-specific permissions.
+rbac:
+  # -- Extra ClusterRoles to create. Each entry creates a ClusterRole named
+  # -- "<release-fullname>-<name>" with the specified rules.
+  extraClusterRoles: []
+  # - name: my-provider
+  #   rules:
+  #   - apiGroups: [""]
+  #     resources: ["pods"]
+  #     verbs: ["get", "list"]
+
+  # -- Extra ClusterRoleBindings to create. Each entry creates a ClusterRoleBinding
+  # -- that binds to the release's ServiceAccount by default.
+  extraClusterRoleBindings: []
+  # - name: my-provider
+  #   roleRef:
+  #     name: my-provider  # References "<release-fullname>-my-provider" ClusterRole
+
+  # -- Extra Roles to create (namespace-scoped). Each entry creates a Role named
+  # -- "<release-fullname>-<name>" in the specified namespace.
+  extraRoles: []
+  # - name: my-provider
+  #   namespace: some-namespace
+  #   rules:
+  #   - apiGroups: [""]
+  #     resources: ["services"]
+  #     verbs: ["get"]
+
+  # -- Extra RoleBindings to create. Each entry creates a RoleBinding
+  # -- that binds to the release's ServiceAccount by default.
+  extraRoleBindings: []
+  # - name: my-provider
+  #   namespace: some-namespace
+  #   roleRef:
+  #     name: my-provider  # References "<release-fullname>-my-provider" Role
+
 # -- This is for setting Kubernetes Annotations to a Pod.
 # -- For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}


### PR DESCRIPTION
As in some deployments the MCP server itself needs RBAC (beyond using the user's role when executing tool calls), this provides support in the helm chart for setting that RBAC