### PR TITLE
cleanup(helm): improve RBAC configuration

### DIFF
--- a/charts/kubernetes-mcp-server/README.md
+++ b/charts/kubernetes-mcp-server/README.md
@@ -27,6 +27,21 @@ helm upgrade -i -n kubernetes-mcp-server --create-namespace kubernetes-mcp-serve
 
 Functionality has been added to the Chart to simplify the deployment to OpenShift Cluster.
 
+### RBAC Configuration
+
+The chart supports creating custom RBAC resources. Set `rbac.create: false` to disable all RBAC resource creation.
+
+To bind to an existing cluster role (e.g., `view`, `edit`, `admin`), use `roleRef.external: true`:
+
+```yaml
+rbac:
+  extraClusterRoleBindings:
+    - name: use-view-role
+      roleRef:
+        name: view
+        external: true
+```
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -51,6 +66,12 @@ Functionality has been added to the Chart to simplify the deployment to OpenShif
 | podAnnotations | object | `{}` | For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
 | podLabels | object | `{}` | For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
 | podSecurityContext | object | `{}` | Define the Security Context for the Pod |
+| rbac | object | `{"create":true,"extraClusterRoleBindings":[],"extraClusterRoles":[],"extraRoleBindings":[],"extraRoles":[]}` | When using long names, they will be automatically truncated. |
+| rbac.create | bool | `true` | contents of extraClusterRoles, extraClusterRoleBindings, extraRoles, and extraRoleBindings. |
+| rbac.extraClusterRoleBindings | list | `[]` | without prefixing the release fullname. |
+| rbac.extraClusterRoles | list | `[]` | "<release-fullname>-<name>" with the specified rules. |
+| rbac.extraRoleBindings | list | `[]` | Use roleRef.external: true to reference existing roles without prefixing the release fullname. |
+| rbac.extraRoles | list | `[]` | "<release-fullname>-<name>" in the specified namespace. |
 | readinessProbe.httpGet.path | string | `"/healthz"` |  |
 | readinessProbe.httpGet.port | string | `"http"` |  |
 | replicaCount | int | `1` | This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/ |

--- a/charts/kubernetes-mcp-server/README.md.gotmpl
+++ b/charts/kubernetes-mcp-server/README.md.gotmpl
@@ -27,6 +27,21 @@ helm upgrade -i -n kubernetes-mcp-server --create-namespace kubernetes-mcp-serve
 
 Functionality has been added to the Chart to simplify the deployment to OpenShift Cluster.
 
+### RBAC Configuration
+
+The chart supports creating custom RBAC resources. Set `rbac.create: false` to disable all RBAC resource creation.
+
+To bind to an existing cluster role (e.g., `view`, `edit`, `admin`), use `roleRef.external: true`:
+
+```yaml
+rbac:
+  extraClusterRoleBindings:
+    - name: use-view-role
+      roleRef:
+        name: view
+        external: true
+```
+
 {{ template "chart.valuesSection" . }}
 
 ## Updating the README

--- a/charts/kubernetes-mcp-server/templates/_helpers.tpl
+++ b/charts/kubernetes-mcp-server/templates/_helpers.tpl
@@ -71,3 +71,13 @@ Create the image path for the passed in image field
 {{- printf "%s/%s:%s" .registry .repository .version -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a suffixed resource name, ensuring the total length doesn't exceed 63 characters.
+Usage: {{ include "kubernetes-mcp-server.fullname.suffixed" (dict "root" $ "suffix" "my-suffix") }}
+*/}}
+{{- define "kubernetes-mcp-server.fullname.suffixed" -}}
+{{- $fullname := include "kubernetes-mcp-server.fullname" .root -}}
+{{- $suffix := .suffix -}}
+{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/kubernetes-mcp-server/templates/rbac.yaml
+++ b/charts/kubernetes-mcp-server/templates/rbac.yaml
@@ -8,12 +8,14 @@ modifying upstream templates. Define your RBAC needs in values.yaml under:
   - rbac.extraRoleBindings
 */}}
 
+{{- if .Values.rbac.create }}
+
 {{- range .Values.rbac.extraClusterRoles }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .name }}
+  name: {{ include "kubernetes-mcp-server.fullname.suffixed" (dict "root" $ "suffix" .name) }}
   labels:
     {{- include "kubernetes-mcp-server.labels" $ | nindent 4 }}
     {{- with .labels }}
@@ -21,7 +23,7 @@ metadata:
     {{- end }}
   {{- with .annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 rules:
   {{- toYaml .rules | nindent 2 }}
@@ -32,7 +34,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .name }}
+  name: {{ include "kubernetes-mcp-server.fullname.suffixed" (dict "root" $ "suffix" .name) }}
   labels:
     {{- include "kubernetes-mcp-server.labels" $ | nindent 4 }}
     {{- with .labels }}
@@ -40,12 +42,16 @@ metadata:
     {{- end }}
   {{- with .annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ .roleRef.kind | default "ClusterRole" }}
-  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .roleRef.name }}
+  {{- if .roleRef.external }}
+  name: {{ .roleRef.name }}
+  {{- else }}
+  name: {{ include "kubernetes-mcp-server.fullname.suffixed" (dict "root" $ "suffix" .roleRef.name) }}
+  {{- end }}
 subjects:
   {{- if .subjects }}
   {{- toYaml .subjects | nindent 2 }}
@@ -61,7 +67,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .name }}
+  name: {{ include "kubernetes-mcp-server.fullname.suffixed" (dict "root" $ "suffix" .name) }}
   namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
     {{- include "kubernetes-mcp-server.labels" $ | nindent 4 }}
@@ -70,7 +76,7 @@ metadata:
     {{- end }}
   {{- with .annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 rules:
   {{- toYaml .rules | nindent 2 }}
@@ -81,7 +87,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .name }}
+  name: {{ include "kubernetes-mcp-server.fullname.suffixed" (dict "root" $ "suffix" .name) }}
   namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
     {{- include "kubernetes-mcp-server.labels" $ | nindent 4 }}
@@ -90,12 +96,16 @@ metadata:
     {{- end }}
   {{- with .annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ .roleRef.kind | default "Role" }}
-  name: {{ include "kubernetes-mcp-server.fullname" $ }}-{{ .roleRef.name }}
+  {{- if .roleRef.external }}
+  name: {{ .roleRef.name }}
+  {{- else }}
+  name: {{ include "kubernetes-mcp-server.fullname.suffixed" (dict "root" $ "suffix" .roleRef.name) }}
+  {{- end }}
 subjects:
   {{- if .subjects }}
   {{- toYaml .subjects | nindent 2 }}
@@ -104,4 +114,6 @@ subjects:
     name: {{ include "kubernetes-mcp-server.serviceAccountName" $ }}
     namespace: {{ $.Release.Namespace }}
   {{- end }}
+{{- end }}
+
 {{- end }}

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -32,7 +32,14 @@ serviceAccount:
 # -- RBAC configuration for the MCP server.
 # -- Use these lists to add custom RBAC resources without modifying templates.
 # -- This is useful for downstream forks that need provider-specific permissions.
+# -- Note: Resource names are limited to 63 characters (Kubernetes DNS naming spec).
+# -- When using long names, they will be automatically truncated.
 rbac:
+  # -- Specifies whether RBAC resources should be created.
+  # -- When set to false, no RBAC resources will be created regardless of the
+  # -- contents of extraClusterRoles, extraClusterRoleBindings, extraRoles, and extraRoleBindings.
+  create: true
+
   # -- Extra ClusterRoles to create. Each entry creates a ClusterRole named
   # -- "<release-fullname>-<name>" with the specified rules.
   extraClusterRoles: []
@@ -44,10 +51,16 @@ rbac:
 
   # -- Extra ClusterRoleBindings to create. Each entry creates a ClusterRoleBinding
   # -- that binds to the release's ServiceAccount by default.
+  # -- Use roleRef.external: true to reference existing cluster roles (e.g., "view", "edit", "admin")
+  # -- without prefixing the release fullname.
   extraClusterRoleBindings: []
   # - name: my-provider
   #   roleRef:
   #     name: my-provider  # References "<release-fullname>-my-provider" ClusterRole
+  # - name: use-view-role
+  #   roleRef:
+  #     name: view
+  #     external: true  # References the existing "view" ClusterRole directly
 
   # -- Extra Roles to create (namespace-scoped). Each entry creates a Role named
   # -- "<release-fullname>-<name>" in the specified namespace.
@@ -61,11 +74,17 @@ rbac:
 
   # -- Extra RoleBindings to create. Each entry creates a RoleBinding
   # -- that binds to the release's ServiceAccount by default.
+  # -- Use roleRef.external: true to reference existing roles without prefixing the release fullname.
   extraRoleBindings: []
   # - name: my-provider
   #   namespace: some-namespace
   #   roleRef:
   #     name: my-provider  # References "<release-fullname>-my-provider" Role
+  # - name: use-existing-role
+  #   namespace: some-namespace
+  #   roleRef:
+  #     name: some-existing-role
+  #     external: true  # References the existing "some-existing-role" Role directly
 
 # -- This is for setting Kubernetes Annotations to a Pod.
 # -- For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
This PR addresses some feedback left on the initial RBAC helm PR after it was merged.

In particular, it introduces:
1. Name length truncation
2. Consistent use of `tpl`
3. Support for binding to existing roles/clusterroles