### PR TITLE
chore(ci): disable kiali eval tasks temporarily

### DIFF
--- a/evals/claude-code/eval-inline.yaml
+++ b/evals/claude-code/eval-inline.yaml
@@ -12,7 +12,8 @@ config:
       apiKeyKey: JUDGE_API_KEY
       modelNameKey: JUDGE_MODEL_NAME
   taskSets:
-    - glob: ../tasks/*/*/*.yaml
+    # TODO: Re-enable kiali tasks once https://github.com/containers/kubernetes-mcp-server/issues/642 is resolved
+    - glob: ../tasks/kubernetes/*/*.yaml
       assertions:
         toolsUsed:
           - server: kubernetes

--- a/evals/claude-code/eval.yaml
+++ b/evals/claude-code/eval.yaml
@@ -12,7 +12,8 @@ config:
       apiKeyKey: JUDGE_API_KEY
       modelNameKey: JUDGE_MODEL_NAME
   taskSets:
-    - glob: ../tasks/*/*/*.yaml
+    # TODO: Re-enable kiali tasks once https://github.com/containers/kubernetes-mcp-server/issues/642 is resolved
+    - glob: ../tasks/kubernetes/*/*.yaml
       assertions:
         toolsUsed:
           - server: kubernetes

--- a/evals/openai-agent/eval-inline.yaml
+++ b/evals/openai-agent/eval-inline.yaml
@@ -16,7 +16,8 @@ config:
       apiKeyKey: JUDGE_API_KEY
       modelNameKey: JUDGE_MODEL_NAME
   taskSets:
-    - glob: ../tasks/*/*/*.yaml
+    # TODO: Re-enable kiali tasks once https://github.com/containers/kubernetes-mcp-server/issues/642 is resolved
+    - glob: ../tasks/kubernetes/*/*.yaml
       assertions:
         toolsUsed:
           - server: kubernetes

--- a/evals/openai-agent/eval.yaml
+++ b/evals/openai-agent/eval.yaml
@@ -12,7 +12,8 @@ config:
       apiKeyKey: JUDGE_API_KEY
       modelNameKey: JUDGE_MODEL_NAME
   taskSets:
-    - glob: ../tasks/*/*/*.yaml
+    # TODO: Re-enable kiali tasks once https://github.com/containers/kubernetes-mcp-server/issues/642 is resolved
+    - glob: ../tasks/kubernetes/*/*.yaml
       assertions:
         toolsUsed:
           - server: kubernetes


### PR DESCRIPTION
The kiali tasks are excluded from eval runs until the kiali MCP server integration is properly set up.

Relates to #642