### PR TITLE
fix(evals): reduce PVC size in resize-pvc task for constrained environments

### DIFF
--- a/evals/tasks/kubernetes/resize-pvc/artifacts/storage-pvc.yaml
+++ b/evals/tasks/kubernetes/resize-pvc/artifacts/storage-pvc.yaml
@@ -8,5 +8,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 1Gi
   storageClassName: standard

--- a/evals/tasks/kubernetes/resize-pvc/resize-pvc.yaml
+++ b/evals/tasks/kubernetes/resize-pvc/resize-pvc.yaml
@@ -10,4 +10,4 @@ steps:
   cleanup:
     file: cleanup.sh
   prompt:
-    inline: "resize the storage volume to 15Gi for the storage-pod in `resize-pv` namespace"
+    inline: "resize the storage volume to 3Gi for the storage-pod in `resize-pv` namespace"

--- a/evals/tasks/kubernetes/resize-pvc/verify.sh
+++ b/evals/tasks/kubernetes/resize-pvc/verify.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Configuration
-PVC_NAME="storage-pvc" 
-EXPECTED_SIZE="15Gi"
+PVC_NAME="storage-pvc"
+EXPECTED_SIZE="3Gi"
 TIMEOUT="120s"
 
 echo "Attempting to get PV name from PVC: $PVC_NAME"
@@ -15,9 +15,9 @@ if [ -z "$PV_NAME" ]; then
   exit 1
 fi
 
-if ! kubectl wait --for=jsonpath='{.spec.capacity.storage}'='15Gi' pv/$PV_NAME --timeout=$TIMEOUT; then
+if ! kubectl wait --for=jsonpath='{.spec.capacity.storage}'="$EXPECTED_SIZE" pv/$PV_NAME --timeout=$TIMEOUT; then
   echo "FAILURE: PersistentVolume '$PV_NAME' did not reach the expected capacity of $EXPECTED_SIZE."
-  exit 1 
-else 
+  exit 1
+else
   echo "SUCCESS: PersistentVolume '$PV_NAME' reached the expected capacity of $EXPECTED_SIZE."
 fi


### PR DESCRIPTION
- Reduce initial PVC size from 10Gi to 1Gi
- Reduce target resize from 15Gi to 3Gi
- Use EXPECTED_SIZE variable instead of hardcoded value in verify.sh