### PR TITLE
chore(ci): add MCP Registry publishing workflow

### DIFF
--- a/.github/workflows/release-mcp-registry.yaml
+++ b/.github/workflows/release-mcp-registry.yaml
@@ -1,0 +1,60 @@
+name: Publish to MCP Registry
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g., v0.0.51)'
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write  # Required for OIDC authentication
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to MCP Registry
+    if: github.repository == 'containers/kubernetes-mcp-server' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.event.workflow_run.head_branch }}
+
+      - name: Get version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
+          # Strip the v prefix
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Update server.json version
+        run: |
+          jq --arg v "${{ steps.version.outputs.version }}" \
+            '.version = $v | .packages[].version = $v | .packages[] |= if .registryType == "oci" then .identifier = (.identifier | sub(":[^:]+$"; ":" + $v)) else . end' \
+            server.json > server.json.tmp && mv server.json.tmp server.json
+          echo "Updated server.json:"
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
Adds GitHub Actions workflow to publish kubernetes-mcp-server to the official Model Context Protocol registry after releases.

- Triggers automatically after Release workflow completes
- Supports manual dispatch with tag input
- Updates server.json version fields including OCI identifier
- Uses GitHub OIDC for secure authentication

Last step in #555