### PR TITLE
test(auth): restore token exchange integration tests

### DIFF
--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -74,8 +74,10 @@ func stsExchangeTokenInContext(
 		TokenType:   "Bearer",
 	})
 	if err != nil {
+		klog.Errorf("token exchange failed: %v", err)
 		return ctx
 	}
 
+	klog.V(4).Info("token exchanged successfully")
 	return context.WithValue(ctx, OAuthAuthorizationHeader, "Bearer "+exchangedToken.AccessToken)
 }


### PR DESCRIPTION
After the changes in:
- #604 
- #602 

The token exchange functionality was extracted to a separate package and its invocation moved to the mcp layer.

These changes also removed some tests that asserted our current authorization stack for token exchange.

While restoring the tests I noticed a change in the behavior that we should probably address

In the previous state, whenever the token exchange failed, the server returned a failure (through the HTTP layer).
Now, these failures are silently omitted, while the kubernetes layer will interact with the target server using the original token. I understand that eventually this will end up in an error for the user, but we might want to pick it up earlier.


There was also an open discussion about moving the exchange logic to the MCP layer:
https://github.com/containers/kubernetes-mcp-server/pull/604/changes#r2645800581

I believe this can be handled from the DerivedClient logic directly (isolating/decoupling the mcp layer from any auth-related stuff)  but will probably mean some breaking changes.