### PR TITLE
fix(mcp): update server.json to latest schema version

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.containers/kubernetes-mcp-server",
   "description": "A Model Context Protocol (MCP) server for Kubernetes and OpenShift",
-  "status": "active",
   "repository": {
     "url": "https://github.com/containers/kubernetes-mcp-server",
     "source": "github"


### PR DESCRIPTION
Follows up on #645 
Last step on #555 

- Update $schema from 2025-10-17 to 2025-12-11
- Remove deprecated status field (now registry-managed)

