### PR TITLE
feat(mcp): add grace period seconds to delete options

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ In case multi-cluster support is enabled (default) and you have access to multip
 - **resources_delete** - Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name
 (common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)
   - `apiVersion` (`string`) **(required)** - apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)
+  - `gracePeriodSeconds` (`integer`) - Optional duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used
   - `kind` (`string`) **(required)** - kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)
   - `name` (`string`) **(required)** - Name of the resource
   - `namespace` (`string`) - Optional Namespace to delete the namespaced resource from (ignored in case of cluster scoped resources). If not provided, will delete resource from configured namespace

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -85,7 +85,7 @@ func (c *Core) PodsDelete(ctx context.Context, namespace, name string) (string, 
 
 	}
 	return "Pod deleted successfully",
-		c.ResourcesDelete(ctx, &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, namespace, name)
+		c.ResourcesDelete(ctx, &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, namespace, name, nil)
 }
 
 func (c *Core) PodsLog(ctx context.Context, namespace, name, container string, previous bool, tail int64) (string, error) {

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -70,7 +70,7 @@ func (c *Core) ResourcesCreateOrUpdate(ctx context.Context, resource string) ([]
 	return c.resourcesCreateOrUpdate(ctx, parsedResources)
 }
 
-func (c *Core) ResourcesDelete(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) error {
+func (c *Core) ResourcesDelete(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string, gracePeriodSeconds *int64) error {
 	gvr, err := c.resourceFor(gvk)
 	if err != nil {
 		return err
@@ -80,7 +80,9 @@ func (c *Core) ResourcesDelete(ctx context.Context, gvk *schema.GroupVersionKind
 	if namespaced, nsErr := c.isNamespaced(gvk); nsErr == nil && namespaced {
 		namespace = c.NamespaceOrDefault(namespace)
 	}
-	return c.DynamicClient().Resource(*gvr).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	return c.DynamicClient().Resource(*gvr).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{
+		GracePeriodSeconds: gracePeriodSeconds,
+	})
 }
 
 func (c *Core) ResourcesScale(

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -583,6 +583,12 @@ func (s *ResourcesSuite) TestResourcesDelete() {
 		s.Equalf(`failed to delete resource: configmaps "nonexistent-configmap" not found`,
 			toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
 	})
+	s.Run("resources_delete with invalid gracePeriodSeconds returns error", func() {
+		toolResult, _ := s.CallTool("resources_delete", map[string]interface{}{"apiVersion": "v1", "kind": "ConfigMap", "name": "a-configmap", "gracePeriodSeconds": "-5"})
+		s.Truef(toolResult.IsError, "call tool should fail")
+		s.Equalf("failed to delete resource, invalid argument gracePeriodSeconds", toolResult.Content[0].(mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+	})
 
 	s.Run("resources_delete with valid namespaced resource", func() {
 		resourcesDeleteCm, err := s.CallTool("resources_delete", map[string]interface{}{"apiVersion": "v1", "kind": "ConfigMap", "name": "a-configmap-to-delete"})
@@ -610,6 +616,14 @@ func (s *ResourcesSuite) TestResourcesDelete() {
 			ns, err := client.CoreV1().Namespaces().Get(s.T().Context(), "ns-to-delete", metav1.GetOptions{})
 			s.Truef(err != nil || (ns != nil && ns.DeletionTimestamp != nil), "Namespace not deleted")
 		})
+	})
+
+	s.Run("resources_delete with valid gracePeriodSeconds", func() {
+		_, _ = client.CoreV1().ConfigMaps("default").Create(s.T().Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "a-configmap-with-grace-period"},
+		}, metav1.CreateOptions{})
+		toolResult, _ := s.CallTool("resources_delete", map[string]interface{}{"apiVersion": "v1", "kind": "ConfigMap", "name": "a-configmap-with-grace-period", "gracePeriodSeconds": int64(5)})
+		s.Falsef(toolResult.IsError, "call tool should not fail")
 	})
 }
 

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -401,6 +401,10 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "gracePeriodSeconds": {
+          "description": "Optional duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used",
+          "type": "integer"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
@@ -663,6 +663,10 @@
           ],
           "type": "string"
         },
+        "gracePeriodSeconds": {
+          "description": "Optional duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used",
+          "type": "integer"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -591,6 +591,10 @@
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "type": "string"
         },
+        "gracePeriodSeconds": {
+          "description": "Optional duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used",
+          "type": "integer"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -516,6 +516,10 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "gracePeriodSeconds": {
+          "description": "Optional duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used",
+          "type": "integer"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -503,6 +503,10 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "gracePeriodSeconds": {
+          "description": "Optional duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used",
+          "type": "integer"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"


### PR DESCRIPTION
Allow configuring grace period seconds
to enable immediate VM deletion when required.

This may be needed when a VM is stuck or
cannot shut down gracefully (e.g. Windows VMs).

Assisted-By: Claude <noreply@anthropic.com>