### PR TITLE
feat(kcp): Add kcp provider

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -4,6 +4,7 @@ const (
 	ClusterProviderKubeConfig = "kubeconfig"
 	ClusterProviderInCluster  = "in-cluster"
 	ClusterProviderDisabled   = "disabled"
+	ClusterProviderKcp        = "kcp"
 )
 
 type AuthProvider interface {

--- a/pkg/kcp/workspace.go
+++ b/pkg/kcp/workspace.go
@@ -1,0 +1,134 @@
+package kcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+// WorkspaceGVR is the GroupVersionResource for kcp workspaces.
+var WorkspaceGVR = schema.GroupVersionResource{
+	Group:    "tenancy.kcp.io",
+	Version:  "v1alpha1",
+	Resource: "workspaces",
+}
+
+// ParseServerURL extracts the base server URL and workspace path from a kcp server URL.
+// Example: "https://10.95.33.40:6443/clusters/root" -> ("https://10.95.33.40:6443", "root")
+func ParseServerURL(serverURL string) (baseURL, workspace string) {
+	clustersIndex := strings.Index(serverURL, "/clusters/")
+	if clustersIndex == -1 {
+		return serverURL, ""
+	}
+
+	baseURL = serverURL[:clustersIndex]
+	workspacePath := serverURL[clustersIndex+len("/clusters/"):]
+	workspace = strings.TrimSuffix(workspacePath, "/")
+
+	return baseURL, workspace
+}
+
+// ExtractWorkspaceFromURL returns the workspace name from a full kcp URL.
+func ExtractWorkspaceFromURL(serverURL string) string {
+	_, workspace := ParseServerURL(serverURL)
+	return workspace
+}
+
+// ConstructWorkspaceURL builds a full kcp server URL for a workspace.
+func ConstructWorkspaceURL(baseURL, workspace string) string {
+	return fmt.Sprintf("%s/clusters/%s", baseURL, workspace)
+}
+
+// DiscoverWorkspacesRecursive recursively discovers child workspaces starting from a parent workspace.
+// It populates the discovered map with all found workspace paths.
+// The function creates dynamic clients for each workspace and queries the kcp tenancy API.
+func DiscoverWorkspacesRecursive(
+	ctx context.Context,
+	baseRestConfig *rest.Config,
+	parentWorkspace string,
+	discovered map[string]bool,
+) error {
+	// Parse base URL from the config
+	baseURL, _ := ParseServerURL(baseRestConfig.Host)
+
+	// Create a client for the parent workspace
+	workspaceRestConfig := rest.CopyConfig(baseRestConfig)
+	workspaceRestConfig.Host = ConstructWorkspaceURL(baseURL, parentWorkspace)
+
+	dynamicClient, err := dynamic.NewForConfig(workspaceRestConfig)
+	if err != nil {
+		klog.V(3).Infof("Failed to create client for workspace %s: %v", parentWorkspace, err)
+		return nil // Don't fail entirely, just skip this workspace
+	}
+
+	// List child workspaces
+	workspaceList, err := dynamicClient.Resource(WorkspaceGVR).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.V(3).Infof("Failed to list workspaces in %s: %v", parentWorkspace, err)
+		return nil // Don't fail entirely, just skip
+	}
+
+	// Process each child workspace
+	for _, item := range workspaceList.Items {
+		childName := item.GetName()
+		if childName == "" {
+			continue
+		}
+
+		// Construct full workspace path
+		// Child workspace names are local to their parent, so we need to prepend the parent path
+		fullPath := parentWorkspace + ":" + childName
+
+		// Skip if already discovered
+		if discovered[fullPath] {
+			continue
+		}
+
+		discovered[fullPath] = true
+		klog.V(3).Infof("Discovered workspace: %s", fullPath)
+
+		// Recursively discover children of this workspace
+		err = DiscoverWorkspacesRecursive(ctx, baseRestConfig, fullPath, discovered)
+		if err != nil {
+			klog.V(3).Infof("Failed to recurse into workspace %s: %v", fullPath, err)
+			// Continue with other workspaces
+		}
+	}
+
+	return nil
+}
+
+// DiscoverAllWorkspaces discovers all workspaces starting from a root workspace.
+// It returns a slice of all discovered workspace paths.
+func DiscoverAllWorkspaces(
+	ctx context.Context,
+	baseRestConfig *rest.Config,
+	rootWorkspace string,
+) ([]string, error) {
+	// Start with the root workspace
+	allWorkspaces := map[string]bool{
+		rootWorkspace: true,
+	}
+
+	// Recursively discover workspaces starting from the root workspace
+	err := DiscoverWorkspacesRecursive(ctx, baseRestConfig, rootWorkspace, allWorkspaces)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover workspaces: %w", err)
+	}
+
+	// Convert map to slice
+	workspaces := make([]string, 0, len(allWorkspaces))
+	for ws := range allWorkspaces {
+		workspaces = append(workspaces, ws)
+	}
+
+	klog.V(2).Infof("Discovered %d workspaces via kcp API (including nested)", len(workspaces))
+	return workspaces, nil
+}

--- a/pkg/kcp/workspace_test.go
+++ b/pkg/kcp/workspace_test.go
@@ -1,0 +1,86 @@
+package kcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type WorkspaceSuite struct {
+	suite.Suite
+}
+
+func TestWorkspaceSuite(t *testing.T) {
+	suite.Run(t, new(WorkspaceSuite))
+}
+
+func (s *WorkspaceSuite) TestParseServerURL() {
+	s.Run("valid kcp server URL with root workspace", func() {
+		baseURL, workspace := ParseServerURL("https://10.95.33.40:6443/clusters/root")
+		s.Equal("https://10.95.33.40:6443", baseURL)
+		s.Equal("root", workspace)
+	})
+
+	s.Run("valid kcp server URL with nested workspace", func() {
+		baseURL, workspace := ParseServerURL("https://kcp.example.com:6443/clusters/root:org:team")
+		s.Equal("https://kcp.example.com:6443", baseURL)
+		s.Equal("root:org:team", workspace)
+	})
+
+	s.Run("valid kcp server URL with trailing slash", func() {
+		baseURL, workspace := ParseServerURL("https://kcp.example.com:6443/clusters/root/")
+		s.Equal("https://kcp.example.com:6443", baseURL)
+		s.Equal("root", workspace)
+	})
+
+	s.Run("URL without clusters path returns empty workspace", func() {
+		baseURL, workspace := ParseServerURL("https://kubernetes.example.com:6443")
+		s.Equal("https://kubernetes.example.com:6443", baseURL)
+		s.Equal("", workspace)
+	})
+
+	s.Run("empty URL", func() {
+		baseURL, workspace := ParseServerURL("")
+		s.Equal("", baseURL)
+		s.Equal("", workspace)
+	})
+}
+
+func (s *WorkspaceSuite) TestExtractWorkspaceFromURL() {
+	s.Run("extracts workspace from valid URL", func() {
+		workspace := ExtractWorkspaceFromURL("https://10.95.33.40:6443/clusters/root")
+		s.Equal("root", workspace)
+	})
+
+	s.Run("extracts nested workspace from valid URL", func() {
+		workspace := ExtractWorkspaceFromURL("https://kcp.example.com:6443/clusters/root:org:team")
+		s.Equal("root:org:team", workspace)
+	})
+
+	s.Run("returns empty string for URL without clusters path", func() {
+		workspace := ExtractWorkspaceFromURL("https://kubernetes.example.com:6443")
+		s.Equal("", workspace)
+	})
+
+	s.Run("returns empty string for empty URL", func() {
+		workspace := ExtractWorkspaceFromURL("")
+		s.Equal("", workspace)
+	})
+}
+
+func (s *WorkspaceSuite) TestConstructWorkspaceURL() {
+	s.Run("constructs URL for root workspace", func() {
+		url := ConstructWorkspaceURL("https://10.95.33.40:6443", "root")
+		s.Equal("https://10.95.33.40:6443/clusters/root", url)
+	})
+
+	s.Run("constructs URL for nested workspace", func() {
+		url := ConstructWorkspaceURL("https://kcp.example.com:6443", "root:org:team")
+		s.Equal("https://kcp.example.com:6443/clusters/root:org:team", url)
+	})
+
+	s.Run("constructs URL with empty workspace", func() {
+		url := ConstructWorkspaceURL("https://kcp.example.com:6443", "")
+		s.Equal("https://kcp.example.com:6443/clusters/", url)
+	})
+}

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -291,7 +291,7 @@ func TestToolsets(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--help"})
 		o, err := captureOutput(rootCmd.Execute) // --help doesn't use logger/klog, cobra prints directly to stdout
-		if !strings.Contains(o, "Comma-separated list of MCP toolsets to use (available toolsets: config, core, helm, kiali, kubevirt).") {
+		if !strings.Contains(o, "Comma-separated list of MCP toolsets to use (available toolsets: config, core, helm, kcp, kiali, kubevirt).") {
 			t.Fatalf("Expected all available toolsets, got %s %v", o, err)
 		}
 	})

--- a/pkg/kubernetes/provider_kcp.go
+++ b/pkg/kubernetes/provider_kcp.go
@@ -1,0 +1,283 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kcppkg "github.com/containers/kubernetes-mcp-server/pkg/kcp"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes/watcher"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
+)
+
+// kcpTargetParameterName is the parameter name used to specify
+// the workspace when using the kcp cluster provider strategy.
+const kcpTargetParameterName = "workspace"
+
+// kcpClusterProvider implements Provider for managing multiple
+// kcp workspaces as separate cluster targets.
+// It discovers workspaces via the kcp tenancy API and creates
+// managers for each workspace on-demand.
+type kcpClusterProvider struct {
+	config              api.BaseConfig
+	baseServerURL       string
+	restConfig          *rest.Config
+	clientCmdConfig     clientcmd.ClientConfig
+	defaultWorkspace    string
+	managers            map[string]*Manager
+	workspaceWatcher    *watcher.Workspace
+	clusterStateWatcher *watcher.ClusterState
+}
+
+var _ Provider = &kcpClusterProvider{}
+
+func init() {
+	RegisterProvider(api.ClusterProviderKcp, newKcpClusterProvider)
+}
+
+// newKcpClusterProvider creates a provider that manages multiple kcp workspaces.
+// Each workspace is treated as a separate cluster target.
+func newKcpClusterProvider(cfg api.BaseConfig) (Provider, error) {
+	ret := &kcpClusterProvider{config: cfg}
+	if err := ret.reset(); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (p *kcpClusterProvider) reset() error {
+	// Load kubeconfig
+	pathOptions := clientcmd.NewDefaultPathOptions()
+	if p.config.GetKubeConfigPath() != "" {
+		pathOptions.LoadingRules.ExplicitPath = p.config.GetKubeConfigPath()
+	}
+
+	p.clientCmdConfig = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		pathOptions.LoadingRules,
+		&clientcmd.ConfigOverrides{})
+
+	rawConfig, err := p.clientCmdConfig.RawConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	// Get current context
+	currentContext := rawConfig.Contexts[rawConfig.CurrentContext]
+	if currentContext == nil {
+		return errors.New("no current context in kubeconfig")
+	}
+
+	currentCluster := rawConfig.Clusters[currentContext.Cluster]
+	if currentCluster == nil {
+		return errors.New("current context's cluster not found in kubeconfig")
+	}
+
+	// Parse kcp server URL to extract base URL and workspace
+	p.baseServerURL, p.defaultWorkspace = kcppkg.ParseServerURL(currentCluster.Server)
+	if p.defaultWorkspace == "" {
+		return errors.New("failed to parse workspace from kubeconfig cluster URL")
+	}
+
+	// Create REST config
+	p.restConfig, err = p.clientCmdConfig.ClientConfig()
+	if err != nil {
+		return fmt.Errorf("failed to create rest config: %w", err)
+	}
+
+	// Create base manager for workspace discovery
+	baseManager, err := NewKubeconfigManager(p.config, rawConfig.CurrentContext)
+	if err != nil {
+		return fmt.Errorf("failed to create base manager: %w", err)
+	}
+
+	// Discover workspaces
+	workspaceList, err := p.discoverWorkspaces(baseManager)
+	if err != nil {
+		klog.Warningf("Failed to discover workspaces via API, falling back to kubeconfig: %v", err)
+		workspaceList, err = p.workspacesFromKubeconfig()
+		if err != nil {
+			return fmt.Errorf("failed to discover workspaces: %w", err)
+		}
+	}
+
+	// Initialize workspace managers (lazily, set to nil first)
+	p.managers = make(map[string]*Manager, len(workspaceList))
+	for _, ws := range workspaceList {
+		p.managers[ws] = nil
+	}
+	// Store the base manager for the default workspace
+	p.managers[p.defaultWorkspace] = baseManager
+
+	// Setup watchers
+	p.Close()
+	p.workspaceWatcher = watcher.NewWorkspace(baseManager.kubernetes.DynamicClient(), p.defaultWorkspace)
+	p.clusterStateWatcher = watcher.NewClusterState(baseManager.kubernetes.DiscoveryClient())
+
+	return nil
+}
+
+// discoverWorkspaces queries the kcp tenancy API to discover available workspaces.
+// It recursively discovers nested workspaces in the workspace hierarchy.
+func (p *kcpClusterProvider) discoverWorkspaces(_ *Manager) ([]string, error) {
+	return kcppkg.DiscoverAllWorkspaces(context.TODO(), p.restConfig, p.defaultWorkspace)
+}
+
+// workspacesFromKubeconfig extracts workspace names from kubeconfig cluster URLs as a fallback.
+func (p *kcpClusterProvider) workspacesFromKubeconfig() ([]string, error) {
+	rawConfig, err := p.clientCmdConfig.RawConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	workspaces := make(map[string]bool)
+	for _, cluster := range rawConfig.Clusters {
+		if ws := kcppkg.ExtractWorkspaceFromURL(cluster.Server); ws != "" {
+			workspaces[ws] = true
+		}
+	}
+
+	result := make([]string, 0, len(workspaces))
+	for ws := range workspaces {
+		result = append(result, ws)
+	}
+
+	klog.V(2).Infof("Discovered %d workspaces from kubeconfig", len(result))
+	return result, nil
+}
+
+// managerForWorkspace returns or creates a Manager for the specified workspace.
+func (p *kcpClusterProvider) managerForWorkspace(workspace string) (*Manager, error) {
+	m, ok := p.managers[workspace]
+	if ok && m != nil {
+		return m, nil
+	}
+
+	if _, exists := p.managers[workspace]; !exists {
+		return nil, fmt.Errorf("workspace %s not found", workspace)
+	}
+
+	// Create REST config for this workspace
+	workspaceRestConfig := rest.CopyConfig(p.restConfig)
+	workspaceRestConfig.Host = kcppkg.ConstructWorkspaceURL(p.baseServerURL, workspace)
+
+	// Get raw config for context creation
+	rawConfig, err := p.clientCmdConfig.RawConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	// Find or create context for this workspace
+	contextName := p.findOrCreateWorkspaceContext(&rawConfig, workspace)
+
+	clientCmdConfig := clientcmd.NewDefaultClientConfig(rawConfig,
+		&clientcmd.ConfigOverrides{CurrentContext: contextName})
+
+	m, err = NewManager(p.config, workspaceRestConfig, clientCmdConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manager for workspace %s: %w", workspace, err)
+	}
+
+	p.managers[workspace] = m
+	return m, nil
+}
+
+// findOrCreateWorkspaceContext finds an existing context for a workspace or creates a virtual one.
+func (p *kcpClusterProvider) findOrCreateWorkspaceContext(
+	rawConfig *clientcmdapi.Config,
+	workspace string,
+) string {
+	// Look for existing context pointing to this workspace
+	for ctxName, ctx := range rawConfig.Contexts {
+		cluster := rawConfig.Clusters[ctx.Cluster]
+		if kcppkg.ExtractWorkspaceFromURL(cluster.Server) == workspace {
+			return ctxName
+		}
+	}
+
+	// Create new virtual context entry (in-memory only, not persisted)
+	contextName := fmt.Sprintf("kcp-%s", workspace)
+	clusterName := fmt.Sprintf("kcp-cluster-%s", workspace)
+
+	// Get current context's cluster for copying TLS settings
+	currentContext := rawConfig.Contexts[rawConfig.CurrentContext]
+	currentCluster := rawConfig.Clusters[currentContext.Cluster]
+
+	rawConfig.Clusters[clusterName] = &clientcmdapi.Cluster{
+		Server:                   kcppkg.ConstructWorkspaceURL(p.baseServerURL, workspace),
+		CertificateAuthorityData: currentCluster.CertificateAuthorityData,
+		CertificateAuthority:     currentCluster.CertificateAuthority,
+		InsecureSkipTLSVerify:    currentCluster.InsecureSkipTLSVerify,
+	}
+
+	rawConfig.Contexts[contextName] = &clientcmdapi.Context{
+		Cluster:  clusterName,
+		AuthInfo: currentContext.AuthInfo,
+	}
+
+	return contextName
+}
+
+func (p *kcpClusterProvider) IsOpenShift(ctx context.Context) bool {
+	// Use default workspace manager
+	if m, ok := p.managers[p.defaultWorkspace]; ok && m != nil {
+		return m.IsOpenShift(ctx)
+	}
+	return false
+}
+
+func (p *kcpClusterProvider) GetTargets(_ context.Context) ([]string, error) {
+	workspaces := make([]string, 0, len(p.managers))
+	for ws := range p.managers {
+		workspaces = append(workspaces, ws)
+	}
+	sort.Strings(workspaces)
+	return workspaces, nil
+}
+
+func (p *kcpClusterProvider) GetTargetParameterName() string {
+	return kcpTargetParameterName
+}
+
+func (p *kcpClusterProvider) GetDerivedKubernetes(ctx context.Context, workspace string) (*Kubernetes, error) {
+	if workspace == "" {
+		workspace = p.defaultWorkspace
+	}
+
+	m, err := p.managerForWorkspace(workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.Derived(ctx)
+}
+
+func (p *kcpClusterProvider) GetDefaultTarget() string {
+	return p.defaultWorkspace
+}
+
+func (p *kcpClusterProvider) WatchTargets(reload McpReload) {
+	reloadWithReset := func() error {
+		if err := p.reset(); err != nil {
+			return err
+		}
+		p.WatchTargets(reload)
+		return reload()
+	}
+
+	p.workspaceWatcher.Watch(reloadWithReset)
+	p.clusterStateWatcher.Watch(reload)
+}
+
+func (p *kcpClusterProvider) Close() {
+	for _, w := range []watcher.Watcher{p.workspaceWatcher, p.clusterStateWatcher} {
+		if w != nil && !reflect.ValueOf(w).IsNil() {
+			w.Close()
+		}
+	}
+}

--- a/pkg/kubernetes/watcher/workspace.go
+++ b/pkg/kubernetes/watcher/workspace.go
@@ -1,0 +1,200 @@
+package watcher
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// DefaultWorkspacePollInterval is the default interval for polling kcp workspaces
+	DefaultWorkspacePollInterval = 60 * time.Second
+	// DefaultWorkspaceDebounceWindow is the default debounce window for workspace changes
+	DefaultWorkspaceDebounceWindow = 5 * time.Second
+)
+
+type workspaceState struct {
+	workspaces []string
+}
+
+// Workspace watches for changes in kcp workspaces by polling the tenancy API.
+type Workspace struct {
+	dynamicClient  dynamic.Interface
+	rootWorkspace  string
+	pollInterval   time.Duration
+	debounceWindow time.Duration
+	lastKnownState workspaceState
+	debounceTimer  *time.Timer
+	mu             sync.Mutex
+	stopCh         chan struct{}
+	stoppedCh      chan struct{}
+	started        bool
+}
+
+var _ Watcher = (*Workspace)(nil)
+
+// NewWorkspace creates a new workspace watcher that polls the kcp tenancy API
+// for workspace changes.
+func NewWorkspace(dynamicClient dynamic.Interface, rootWorkspace string) *Workspace {
+	pollInterval := DefaultWorkspacePollInterval
+	debounceWindow := DefaultWorkspaceDebounceWindow
+
+	// Allow override via environment variable for testing
+	if envInterval := os.Getenv("WORKSPACE_POLL_INTERVAL_MS"); envInterval != "" {
+		if ms, err := strconv.Atoi(envInterval); err == nil && ms > 0 {
+			pollInterval = time.Duration(ms) * time.Millisecond
+			klog.V(2).Infof("Using custom workspace poll interval: %v", pollInterval)
+		}
+	}
+	if envDebounce := os.Getenv("WORKSPACE_DEBOUNCE_WINDOW_MS"); envDebounce != "" {
+		if ms, err := strconv.Atoi(envDebounce); err == nil && ms > 0 {
+			debounceWindow = time.Duration(ms) * time.Millisecond
+			klog.V(2).Infof("Using custom workspace debounce window: %v", debounceWindow)
+		}
+	}
+
+	return &Workspace{
+		dynamicClient:  dynamicClient,
+		rootWorkspace:  rootWorkspace,
+		pollInterval:   pollInterval,
+		debounceWindow: debounceWindow,
+		stopCh:         make(chan struct{}),
+		stoppedCh:      make(chan struct{}),
+	}
+}
+
+// Watch starts watching for workspace changes. The onChange callback is called
+// when workspace changes are detected after debouncing.
+// This can only be called once per Workspace instance.
+func (w *Workspace) Watch(onChange func() error) {
+	w.mu.Lock()
+	if w.started {
+		w.mu.Unlock()
+		return
+	}
+	w.started = true
+	w.lastKnownState = w.captureState()
+	w.mu.Unlock()
+
+	go func() {
+		defer close(w.stoppedCh)
+		ticker := time.NewTicker(w.pollInterval)
+		defer ticker.Stop()
+
+		klog.V(2).Infof("Started workspace watcher (poll interval: %v, debounce: %v)",
+			w.pollInterval, w.debounceWindow)
+
+		for {
+			select {
+			case <-w.stopCh:
+				klog.V(2).Info("Stopping workspace watcher")
+				return
+			case <-ticker.C:
+				w.mu.Lock()
+				current := w.captureState()
+				klog.V(3).Infof("Polled workspaces: %d total", len(current.workspaces))
+
+				changed := len(current.workspaces) != len(w.lastKnownState.workspaces)
+				if !changed {
+					for i := range current.workspaces {
+						if current.workspaces[i] != w.lastKnownState.workspaces[i] {
+							changed = true
+							break
+						}
+					}
+				}
+
+				if changed {
+					klog.V(2).Info("Workspace state changed, scheduling debounced reload")
+					if w.debounceTimer != nil {
+						w.debounceTimer.Stop()
+					}
+					w.debounceTimer = time.AfterFunc(w.debounceWindow, func() {
+						klog.V(2).Info("Workspace debounce window expired, triggering reload")
+						if err := onChange(); err != nil {
+							klog.Errorf("Failed to reload: %v", err)
+						} else {
+							w.mu.Lock()
+							w.lastKnownState = w.captureState()
+							w.mu.Unlock()
+							klog.V(2).Info("Reload completed")
+						}
+					})
+				}
+				w.mu.Unlock()
+			}
+		}
+	}()
+}
+
+// Close stops the workspace watcher and cleans up resources.
+func (w *Workspace) Close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.debounceTimer != nil {
+		w.debounceTimer.Stop()
+	}
+
+	if w.stopCh == nil || w.stoppedCh == nil {
+		return
+	}
+
+	if !w.started {
+		return
+	}
+
+	select {
+	case <-w.stopCh:
+		return
+	default:
+		close(w.stopCh)
+		w.mu.Unlock()
+		<-w.stoppedCh
+		w.mu.Lock()
+		w.started = false
+		w.stopCh = make(chan struct{})
+		w.stoppedCh = make(chan struct{})
+	}
+}
+
+// captureState queries the current workspace list from the kcp tenancy API.
+func (w *Workspace) captureState() workspaceState {
+	state := workspaceState{workspaces: []string{}}
+
+	// This is to avoid vendoring kcp client libraries; we can use dynamic client
+	// to query the tenancy API directly.
+	workspaceGVR := schema.GroupVersionResource{
+		Group:    "tenancy.kcp.io",
+		Version:  "v1alpha1",
+		Resource: "workspaces",
+	}
+
+	list, err := w.dynamicClient.Resource(workspaceGVR).
+		List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		klog.V(2).Infof("Unable to list workspaces from kcp API (this is expected if tenancy API is not available): %v", err)
+		// Return empty state - this means workspace watching won't work,
+		// but the provider will still function using kubeconfig-based discovery
+		return state
+	}
+
+	for _, item := range list.Items {
+		// Extract workspace name
+		name := item.GetName()
+		if name != "" {
+			state.workspaces = append(state.workspaces, name)
+		}
+	}
+
+	sort.Strings(state.workspaces)
+	return state
+}

--- a/pkg/mcp/modules.go
+++ b/pkg/mcp/modules.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/config"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/core"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/helm"
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kcp"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali"
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
 )

--- a/pkg/toolsets/kcp/toolset.go
+++ b/pkg/toolsets/kcp/toolset.go
@@ -1,0 +1,34 @@
+package kcp
+
+import (
+	"slices"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
+)
+
+type Toolset struct{}
+
+var _ api.Toolset = (*Toolset)(nil)
+
+func (t *Toolset) GetName() string {
+	return "kcp"
+}
+
+func (t *Toolset) GetDescription() string {
+	return "Manage kcp workspaces and multi-tenancy features"
+}
+
+func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
+	return slices.Concat(
+		initWorkspaceTools(),
+	)
+}
+
+func (t *Toolset) GetPrompts() []api.ServerPrompt {
+	return nil
+}
+
+func init() {
+	toolsets.Register(&Toolset{})
+}

--- a/pkg/toolsets/kcp/workspaces.go
+++ b/pkg/toolsets/kcp/workspaces.go
@@ -1,0 +1,115 @@
+package kcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kcppkg "github.com/containers/kubernetes-mcp-server/pkg/kcp"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+)
+
+func initWorkspaceTools() []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "kcp_workspaces_list",
+				Description: "List all available kcp workspaces in the current cluster ",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "kcp: Workspaces List",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(false),
+				},
+			},
+			ClusterAware:       ptr.To(false),
+			TargetListProvider: ptr.To(false),
+			Handler:            workspacesList,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "kcp_workspace_describe",
+				Description: "Get detailed information about a specific kcp workspace",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"workspace": {
+							Type:        "string",
+							Description: "Name or path of the workspace to describe",
+						},
+					},
+					Required: []string{"workspace"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "kcp: Workspace Describe",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			ClusterAware: ptr.To(false),
+			Handler:      workspaceDescribe,
+		},
+	}
+}
+
+func workspacesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	// Recursively discover all workspaces
+	core := kubernetes.NewCore(params)
+	restConfig := core.RESTConfig()
+
+	// Determine current workspace from server URL
+	currentWorkspace := kcppkg.ExtractWorkspaceFromURL(restConfig.Host)
+	if currentWorkspace == "" {
+		currentWorkspace = "root"
+	}
+
+	// Discover all workspaces recursively
+	workspaces, err := kcppkg.DiscoverAllWorkspaces(params.Context, restConfig, currentWorkspace)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to discover workspaces: %v", err)), nil
+	}
+
+	if len(workspaces) == 0 {
+		return api.NewToolCallResult("No workspaces found", nil), nil
+	}
+
+	result := fmt.Sprintf("Available kcp workspaces (%d total):\n\n", len(workspaces))
+	for _, ws := range workspaces {
+		result += fmt.Sprintf("- %s\n", ws)
+	}
+
+	return api.NewToolCallResult(result, nil), nil
+}
+
+func workspaceDescribe(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	workspaceName, ok := params.GetArguments()["workspace"].(string)
+	if !ok {
+		return api.NewToolCallResult("", fmt.Errorf("workspace parameter is required")), nil
+	}
+
+	dynamicClient := kubernetes.NewCore(params).DynamicClient()
+
+	workspace, err := dynamicClient.Resource(kcppkg.WorkspaceGVR).
+		Get(context.TODO(), workspaceName, metav1.GetOptions{})
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get workspace: %v", err)), nil
+	}
+
+	// Format workspace details as YAML
+	yamlData, err := output.MarshalYaml(workspace.Object)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to marshal workspace: %v", err)), nil
+	}
+
+	return api.NewToolCallResult(yamlData, nil), nil
+}


### PR DESCRIPTION
This adds tooling to treat kcp (kcp.io) workspaces as clusters.

This PR is primarily to measure temperature and gauge community interest; if so, what changes are needed (design by PR). 
Let me know if this is something we could merge :) 


Testing in real life:

```
# start kcp 
kcp start 
# repeat a few times
kubectl ws create foo --enter # repeat few times
# mcp works on relative path so move to start in workspace tree
k ws use :root

# run mcp with kcp toolset
npx @modelcontextprotocol/inspector@latest \
    ./kubernetes-mcp-server \
    --kubeconfig=.kcp/admin.kubeconfig \
    --toolsets=core,helm,kcp \
    --log-level=3                                      
```
connect with STDIO and test

and see some results.
<img width="1294" height="636" alt="Screenshot 2026-01-16 at 10 06 34" src="https://github.com/user-attachments/assets/557bd45d-16b3-48e7-b6c5-087a9e0b861d" />

<img width="1630" height="760" alt="Screenshot 2026-01-16 at 10 06 13" src="https://github.com/user-attachments/assets/34fde777-e53b-461c-bff0-2dde60150cf6" />


