### PR TITLE
test(mcp): add notification capture helpers and error logging tests

### DIFF
--- a/internal/test/mcp.go
+++ b/internal/test/mcp.go
@@ -2,9 +2,12 @@ package test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
@@ -58,4 +61,119 @@ func (m *McpClient) CallTool(name string, args map[string]interface{}) (*mcp.Cal
 	callToolRequest.Params.Name = name
 	callToolRequest.Params.Arguments = args
 	return m.Client.CallTool(m.ctx, callToolRequest)
+}
+
+// NotificationCapture captures MCP notifications for testing.
+// Use StartCapturingNotifications to begin capturing, then RequireNotification to retrieve.
+type NotificationCapture struct {
+	mu            sync.RWMutex
+	notifications []*mcp.JSONRPCNotification
+	signal        chan struct{} // signals when new notifications arrive
+}
+
+// StartCapturingNotifications begins capturing all MCP notifications.
+// Must be called BEFORE the operation that triggers the notification.
+func (m *McpClient) StartCapturingNotifications() *NotificationCapture {
+	capture := &NotificationCapture{
+		notifications: make([]*mcp.JSONRPCNotification, 0),
+		signal:        make(chan struct{}, 1),
+	}
+	m.OnNotification(func(n mcp.JSONRPCNotification) {
+		capture.mu.Lock()
+		capture.notifications = append(capture.notifications, &n)
+		capture.mu.Unlock()
+		// Signal that a new notification arrived (non-blocking)
+		select {
+		case capture.signal <- struct{}{}:
+		default:
+		}
+	})
+	return capture
+}
+
+// RequireNotification waits for a notification matching the specified method and fails the test if not received.
+// Iterates through all captured notifications looking for a match, waiting for new ones if needed.
+// The method parameter specifies which notification method to wait for (e.g., "notifications/tools/list_changed").
+func (c *NotificationCapture) RequireNotification(t *testing.T, timeout time.Duration, method string) *mcp.JSONRPCNotification {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	checked := 0
+	for {
+		// Check all notifications we haven't checked yet
+		c.mu.RLock()
+		for i := checked; i < len(c.notifications); i++ {
+			if c.notifications[i].Method == method {
+				n := c.notifications[i]
+				c.mu.RUnlock()
+				return n
+			}
+		}
+		checked = len(c.notifications)
+		c.mu.RUnlock()
+
+		// Wait for new notifications or timeout
+		select {
+		case <-c.signal:
+			// New notification arrived, loop and check it
+		case <-ctx.Done():
+			require.Fail(t, "timeout waiting for MCP notification", "method: %s", method)
+			return nil
+		}
+	}
+}
+
+// LogNotification represents a parsed MCP logging notification.
+// Used for asserting log messages sent to MCP clients during error handling.
+type LogNotification struct {
+	// Level is the log severity level (debug, info, notice, warning, error, critical, alert, emergency)
+	Level string
+	// Logger is the name of the logger that generated the message
+	Logger string
+	// Data contains the log message content
+	Data string
+}
+
+// parseLogNotification extracts log information from an MCP notification.
+// Returns nil if the notification is not a valid logging notification.
+func parseLogNotification(notification *mcp.JSONRPCNotification) *LogNotification {
+	if notification == nil {
+		return nil
+	}
+	// The Params field contains the LoggingMessageParams via AdditionalFields
+	paramsBytes, err := json.Marshal(notification.Params)
+	if err != nil {
+		return nil
+	}
+	var logParams struct {
+		Level  string `json:"level"`
+		Logger string `json:"logger"`
+		Data   any    `json:"data"`
+	}
+	if err := json.Unmarshal(paramsBytes, &logParams); err != nil {
+		return nil
+	}
+	// Convert Data to string
+	var dataStr string
+	switch v := logParams.Data.(type) {
+	case string:
+		dataStr = v
+	default:
+		dataBytes, _ := json.Marshal(v)
+		dataStr = string(dataBytes)
+	}
+	return &LogNotification{
+		Level:  logParams.Level,
+		Logger: logParams.Logger,
+		Data:   dataStr,
+	}
+}
+
+// RequireLogNotification waits for a logging notification and returns it parsed.
+// Filters for "notifications/message" method and fails the test if not received within timeout.
+func (c *NotificationCapture) RequireLogNotification(t *testing.T, timeout time.Duration) *LogNotification {
+	notification := c.RequireNotification(t, timeout, "notifications/message")
+	logNotification := parseLogNotification(notification)
+	require.NotNil(t, logNotification, "failed to parse log notification")
+	return logNotification
 }

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -213,37 +212,23 @@ func (s *BaseMcpSuite) InitMcpClient(options ...transport.StreamableHTTPCOption)
 	s.McpClient = test.NewMcpClient(s.T(), s.mcpServer.ServeHTTP(), options...)
 }
 
-// notificationDelay is the time to wait after receiving a notification before capturing it.
-// This accounts for multiple layers of async processing in tests:
-// - go-sdk debounce (10ms in mcp/server.go changeAndNotify)
-// - cluster state / kubeconfig debounce (CLUSTER_STATE_DEBOUNCE_WINDOW_MS, KUBECONFIG_DEBOUNCE_WINDOW_MS)
-// - async tool updates completing after notification is sent
-// We use 50ms to ensure all debouncing and async operations have settled.
-const notificationDelay = time.Millisecond * 50
+// StartCapturingNotifications begins capturing all MCP notifications.
+// Must be called BEFORE the operation that triggers the notification.
+func (s *BaseMcpSuite) StartCapturingNotifications() *test.NotificationCapture {
+	return s.McpClient.StartCapturingNotifications()
+}
 
-// WaitForNotification wait for a specific MCP notification method within the given timeout duration.
-func (s *BaseMcpSuite) WaitForNotification(timeout time.Duration, method string) *mcp.JSONRPCNotification {
-	withTimeout, cancel := context.WithTimeout(s.T().Context(), timeout)
-	defer cancel()
-	var notification *mcp.JSONRPCNotification
-	var timer *time.Timer
-	s.OnNotification(func(n mcp.JSONRPCNotification) {
-		if n.Method == method {
-			if timer != nil {
-				timer.Stop()
-			}
-			timer = time.AfterFunc(notificationDelay, func() {
-				notification = &n
-			})
-		}
+// StartCapturingLogNotifications begins capturing log notifications.
+// Must be called BEFORE the tool call that triggers the notification.
+// This method sets the logging level to debug to ensure all log messages are received.
+func (s *BaseMcpSuite) StartCapturingLogNotifications() *test.NotificationCapture {
+	// Set logging level to debug to receive all log messages
+	err := s.SetLevel(s.T().Context(), mcp.SetLevelRequest{
+		Params: mcp.SetLevelParams{
+			Level: mcp.LoggingLevelDebug,
+		},
 	})
-	for notification == nil {
-		select {
-		case <-withTimeout.Done():
-			s.FailNow("timeout waiting for MCP notification")
-		default:
-			time.Sleep(100 * time.Millisecond)
-		}
-	}
-	return notification
+	s.Require().NoError(err, "failed to set logging level")
+
+	return s.StartCapturingNotifications()
 }

--- a/pkg/toolsets/core/pods.go
+++ b/pkg/toolsets/core/pods.go
@@ -274,6 +274,7 @@ func podsListInAllNamespaces(params api.ToolHandlerParams) (*api.ToolCallResult,
 	}
 	ret, err := kubernetes.NewCore(params).PodsListInAllNamespaces(params, resourceListOptions)
 	if err != nil {
+		mcplog.HandleK8sError(params.Context, err, "pod listing")
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in all namespaces: %w", err)), nil
 	}
 	return api.NewToolCallResult(params.ListOutput.PrintObj(ret)), nil
@@ -297,6 +298,7 @@ func podsListInNamespace(params api.ToolHandlerParams) (*api.ToolCallResult, err
 	}
 	ret, err := kubernetes.NewCore(params).PodsListInNamespace(params, ns.(string), resourceListOptions)
 	if err != nil {
+		mcplog.HandleK8sError(params.Context, err, "pod listing")
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace %s: %w", ns, err)), nil
 	}
 	return api.NewToolCallResult(params.ListOutput.PrintObj(ret)), nil


### PR DESCRIPTION
Fixes #655 

- Add NotificationCapture helper for reliable async notification testing
- Replace polling-based WaitForNotification with capture-based approach
- Add tests for log notifications on forbidden and not-found errors
- Fix missing error logging in pods_list tool handlers