### PR TITLE
chore(docs): add GitHub Copilot configuration for local MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,27 @@ extensions:
 
 ```
 
+### GitHub Copilot
+
+This configuration is for the IntelliJ GitHub Copilot plugin using a local Docker container. Add the following configuration to the `mcp.json` point Copilot to the local MCP server:
+
+```json
+{
+  "servers": {
+    "kubernetes-mcp": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp",
+      "requestInit": {
+        "method": "GET",
+        "headers": {
+          "Accept": "text/event-stream"
+        }
+      }
+    }
+  }
+}
+```
+
 ## 🎥 Demos <a id="demos"></a>
 
 ### Diagnosing and automatically fixing an OpenShift Deployment


### PR DESCRIPTION
This PR inserts a new "GitHub Copilot" subsection in README.md. The subsection documents how to configure the IntelliJ GitHub Copilot plugin to use a local Docker-hosted MCP server and includes a ready-to-use mcp.json snippet pointing Copilot at http://localhost:8080/mcp with SSE headers. It took me a while to figure out the correct way to configure it, so it might as well be in the official docs.