### PR TITLE
fix(ci): use gevals action from main branch

### DIFF
--- a/.github/workflows/gevals.yaml
+++ b/.github/workflows/gevals.yaml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Run gevals evaluation
         id: gevals
-        uses: genmcp/gevals/.github/actions/gevals-action@v0.0.1
+        uses: genmcp/gevals/.github/actions/gevals-action@main
         with:
           eval-config: 'evals/openai-agent/eval.yaml'
           gevals-version: 'latest'


### PR DESCRIPTION
Update gevals action reference from v0.0.1 tag to main branch to pick up the Go 1.25.x compatibility fix.
Relates to https://github.com/genmcp/gevals/pull/80