### PR TITLE
ci(release): fix checkout ref and prevent script injection

### DIFF
--- a/.github/workflows/release-mcp-registry.yaml
+++ b/.github/workflows/release-mcp-registry.yaml
@@ -28,22 +28,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag || github.event.workflow_run.head_branch }}
+          # Use head_sha (not head_branch) to checkout the exact commit that Release validated
+          ref: ${{ inputs.tag || github.event.workflow_run.head_sha }}
 
       - name: Get version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.event.workflow_run.head_branch }}"
+            TAG="$HEAD_BRANCH"
           fi
           # Strip the v prefix
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
       - name: Update server.json version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          jq --arg v "${{ steps.version.outputs.version }}" \
+          jq --arg v "$VERSION" \
             '.version = $v | .packages[].version = $v | .packages[] |= if .registryType == "oci" then .identifier = (.identifier | sub(":[^:]+$"; ":" + $v)) else . end' \
             server.json > server.json.tmp && mv server.json.tmp server.json
           echo "Updated server.json:"


### PR DESCRIPTION
Changes to make workflow more secure:
- Use head_sha instead of head_branch to checkout the exact validated commit.
- Move GitHub context expressions to env vars to prevent untrusted input from being interpreted as shell commands.