### PR TITLE
test(kubevirt): Add eval and agent configs directly to kubevirt tasks

### DIFF
--- a/evals/tasks/kubevirt/claude-code/eval.yaml
+++ b/evals/tasks/kubevirt/claude-code/eval.yaml
@@ -1,0 +1,15 @@
+kind: Eval
+metadata:
+  name: "kubevirt-basic-operations"
+config:
+  agent:
+    type: "builtin.claude-code"
+  mcpConfigFile: ../../../mcp-config.yaml
+  taskSets:
+    - glob: ../*/task.yaml
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/evals/tasks/kubevirt/openai-agent/eval.yaml
+++ b/evals/tasks/kubevirt/openai-agent/eval.yaml
@@ -1,0 +1,16 @@
+kind: Eval
+metadata:
+  name: "kubevirt-basic-operations"
+config:
+  agent:
+    type: "builtin.openai-agent"
+    model: "gemini-2.0-flash"
+  mcpConfigFile: ../../../mcp-config.yaml
+  taskSets:
+    - glob: ../*/task.yaml
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 20


### PR DESCRIPTION
Provide some basic Evals for use with the KubeVirt tasks. Eventually gevals should allow agent and taskset configuration to be provided separately.