### PR TITLE
fix(ci): remove version field from OCI package for MCP registry compliance

### DIFF
--- a/.github/workflows/release-mcp-registry.yaml
+++ b/.github/workflows/release-mcp-registry.yaml
@@ -53,7 +53,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           jq --arg v "$VERSION" \
-            '.version = $v | .packages[].version = $v | .packages[] |= if .registryType == "oci" then .identifier = (.identifier | sub(":[^:]+$"; ":" + $v)) else . end' \
+            '.version = $v | .packages[] |= if .registryType == "oci" then .identifier = (.identifier | sub(":[^:]+$"; ":" + $v)) else .version = $v end' \
             server.json > server.json.tmp && mv server.json.tmp server.json
           echo "Updated server.json:"
           cat server.json

--- a/server.json
+++ b/server.json
@@ -30,7 +30,6 @@
     {
       "registryType": "oci",
       "identifier": "quay.io/containers/kubernetes_mcp_server:0.0.0",
-      "version": "0.0.0",
       "runtimeHint": "docker",
       "runtimeArguments": [
         {


### PR DESCRIPTION
Part of #555

The MCP registry now requires OCI packages to not have a separate 'version' field - the version should only be in the 'identifier' (e.g., image:1.0.0).

https://github.com/containers/kubernetes-mcp-server/actions/runs/21391968827/job/61580817303