### PR TITLE
feat(docs): add prompt documentation generation to update-readme-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,8 +549,16 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `namespaces` (`string`) - Optional comma-separated list of namespaces to include in the graph
   - `rateInterval` (`string`) - Optional rate interval for fetching (e.g., '10m', '5m', '1h').
 
-- **kiali_manage_istio_config** - Manages Istio configuration objects (Gateways, VirtualServices, etc.). Can list (objects and validations), get, create, patch, or delete objects
-  - `action` (`string`) **(required)** - Action to perform: list, get, create, patch, or delete
+- **kiali_manage_istio_config_read** - Lists or gets Istio configuration objects (Gateways, VirtualServices, etc.)
+  - `action` (`string`) **(required)** - Action to perform: list or get
+  - `group` (`string`) - API group of the Istio object (e.g., 'networking.istio.io', 'gateway.networking.k8s.io')
+  - `kind` (`string`) - Kind of the Istio object (e.g., 'DestinationRule', 'VirtualService', 'HTTPRoute', 'Gateway')
+  - `name` (`string`) - Name of the Istio object
+  - `namespace` (`string`) - Namespace containing the Istio object
+  - `version` (`string`) - API version of the Istio object (e.g., 'v1', 'v1beta1')
+
+- **kiali_manage_istio_config** - Creates, patches, or deletes Istio configuration objects (Gateways, VirtualServices, etc.)
+  - `action` (`string`) **(required)** - Action to perform: create, patch, or delete
   - `group` (`string`) - API group of the Istio object (e.g., 'networking.istio.io', 'gateway.networking.k8s.io')
   - `json_data` (`string`) - JSON data to apply or create the object
   - `kind` (`string`) - Kind of the Istio object (e.g., 'DestinationRule', 'VirtualService', 'HTTPRoute', 'Gateway')
@@ -641,6 +649,23 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 
 <!-- AVAILABLE-TOOLSETS-TOOLS-END -->
+
+### Prompts
+
+<!-- AVAILABLE-TOOLSETS-PROMPTS-START -->
+
+<details>
+
+<summary>core</summary>
+
+- **cluster-health-check** - Perform comprehensive health assessment of Kubernetes/OpenShift cluster
+  - `namespace` (`string`) - Optional namespace to limit health check scope (default: all namespaces)
+  - `check_events` (`string`) - Include recent warning/error events (true/false, default: true)
+
+</details>
+
+
+<!-- AVAILABLE-TOOLSETS-PROMPTS-END -->
 
 ## Helm Chart
 

--- a/internal/tools/update-readme/main.go
+++ b/internal/tools/update-readme/main.go
@@ -106,6 +106,34 @@ func main() {
 		toolsetTools.String(),
 	)
 
+	// Available Toolset Prompts
+	toolsetPrompts := strings.Builder{}
+	for _, toolset := range toolsetsList {
+		prompts := toolset.GetPrompts()
+		if len(prompts) == 0 {
+			continue
+		}
+		toolsetPrompts.WriteString("<details>\n\n<summary>" + toolset.GetName() + "</summary>\n\n")
+		for _, prompt := range prompts {
+			toolsetPrompts.WriteString(fmt.Sprintf("- **%s** - %s\n", prompt.Prompt.Name, prompt.Prompt.Description))
+			for _, arg := range prompt.Prompt.Arguments {
+				toolsetPrompts.WriteString(fmt.Sprintf("  - `%s` (`string`)", arg.Name))
+				if arg.Required {
+					toolsetPrompts.WriteString(" **(required)**")
+				}
+				toolsetPrompts.WriteString(fmt.Sprintf(" - %s\n", arg.Description))
+			}
+			toolsetPrompts.WriteString("\n")
+		}
+		toolsetPrompts.WriteString("</details>\n\n")
+	}
+	updated = replaceBetweenMarkers(
+		updated,
+		"<!-- AVAILABLE-TOOLSETS-PROMPTS-START -->",
+		"<!-- AVAILABLE-TOOLSETS-PROMPTS-END -->",
+		toolsetPrompts.String(),
+	)
+
 	if err := os.WriteFile(localReadmePath, []byte(updated), 0o644); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes #698

The update-readme tool now generates a separate "### Prompts" section with collapsible toolset blocks, mirroring the structure of the existing "### Tools" section.

Only toolsets that have prompts are included.