### PR TITLE
refactor(auth): remove unused tool-scoped authorization middleware

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -109,9 +109,6 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 	s.server.AddReceivingMiddleware(authHeaderPropagationMiddleware)
 	s.server.AddReceivingMiddleware(toolCallLoggingMiddleware)
 	s.server.AddReceivingMiddleware(s.metricsMiddleware())
-	if configuration.RequireOAuth && false { // TODO: Disabled scope auth validation for now
-		s.server.AddReceivingMiddleware(toolScopedAuthorizationMiddleware)
-	}
 	err = s.reloadToolsets()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change was accidentally reverted in PR #590 and is now being re-applied (originally from PR #633).

The toolScopedAuthorizationMiddleware was conceived for tool authorization but the feature was dropped in favor of implementing this in an MCP gateway.

This removes:
- The middleware function and its registration
- TokenScopesContextKey constant and tokenScopesContextKeyType type
- Unused imports (fmt, slices) in middleware.go
