### PR TITLE
test(cli): skip CLI tests if there is an override

### DIFF
--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -299,6 +300,9 @@ func TestToolsets(t *testing.T) {
 		}
 	})
 	t.Run("default", func(t *testing.T) {
+		if config.HasDefaultOverrides() {
+			t.Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
+		}
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
@@ -350,6 +354,9 @@ func TestListOutput(t *testing.T) {
 
 func TestReadOnly(t *testing.T) {
 	t.Run("defaults to false", func(t *testing.T) {
+		if config.HasDefaultOverrides() {
+			t.Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
+		}
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})


### PR DESCRIPTION
When doing `toolset` override (E.g. to `core`, `helm`) or changing to `read-Only: true`, some tests fail.

One of those is the one on the CLI tests. In #517 some tests were skipped (due to downstream) if there are some overrides. 

I think this works to some degree.  IMO regardless of what the actual downstream (compile time) override of defaults is, is that test for "disabled" parts should be still tested, since they can be enabled by users

