### PR TITLE
feat(http): implement tls serving certs for server

### DIFF
--- a/charts/kubernetes-mcp-server/README.md
+++ b/charts/kubernetes-mcp-server/README.md
@@ -76,6 +76,7 @@ Each container accepts any valid Kubernetes container field including `image`, `
 | configFilePath | string | `"/etc/kubernetes-mcp-server/config.toml"` |  |
 | defaultPodSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Default Security Context for the Pod when one is not provided |
 | defaultSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true}` | Default Security Context for the Container when one is not provided |
+| extraArgs | list | `[]` | Note: For TLS configuration, use the tls section above instead of extraArgs. |
 | extraContainers | list | `[]` | Each container is defined as a complete container spec. |
 | extraVolumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
 | extraVolumes | list | `[]` | Additional volumes on the output Deployment definition. |
@@ -122,14 +123,21 @@ Each container accepts any valid Kubernetes container field including `image`, `
 | replicaCount | int | `1` | This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/ |
 | resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource requests and limits for the container. |
 | securityContext | object | `{}` | Define the Security Context for the Container |
-| service | object | `{"port":8080,"targetPort":"http","type":"ClusterIP"}` | This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/ |
+| service | object | `{"annotations":{},"port":8080,"targetPort":"http","type":"ClusterIP"}` | This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/ |
+| service.annotations | object | `{}` | Annotations to add to the service |
 | service.port | int | `8080` | This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports |
-| service.targetPort | string | `"http"` | Target port for the service. Useful when deploying with an proxy sidecar. Set this to the sidecar's port to route traffic through the proxy before reaching the main container. |
+| service.targetPort | string | `"http"` | Target port for the service. Useful when deploying with an proxy sidecar or exposing a different port. Set this to the sidecar's port to route traffic through the proxy before reaching the main container. |
 | service.type | string | `"ClusterIP"` | This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types |
 | serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/ |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
+| tls | object | `{"certFile":"tls.crt","enabled":false,"keyFile":"tls.key","mountPath":"/etc/tls","secretName":""}` | This is the recommended way to enable TLS instead of using extraArgs. |
+| tls.certFile | string | `"tls.crt"` | Name of the certificate file within the secret (default: tls.crt) |
+| tls.enabled | bool | `false` | Enable TLS for the MCP server |
+| tls.keyFile | string | `"tls.key"` | Name of the key file within the secret (default: tls.key) |
+| tls.mountPath | string | `"/etc/tls"` | Path where the TLS secret will be mounted inside the container |
+| tls.secretName | string | `""` | The secret should be of type kubernetes.io/tls with tls.crt and tls.key. |
 | tolerations | list | `[]` |  |
 
 ## Updating the README

--- a/charts/kubernetes-mcp-server/templates/deployment.yaml
+++ b/charts/kubernetes-mcp-server/templates/deployment.yaml
@@ -47,6 +47,13 @@ spec:
           args:
             - "--config"
             - "{{ .Values.configFilePath }}"
+          {{- if .Values.tls.enabled }}
+            - "--tls-cert={{ .Values.tls.mountPath }}/{{ .Values.tls.certFile }}"
+            - "--tls-key={{ .Values.tls.mountPath }}/{{ .Values.tls.keyFile }}"
+          {{- end }}
+          {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -54,11 +61,19 @@ spec:
                   fieldPath: metadata.namespace
           {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- $probe := . | deepCopy }}
+            {{- if and $.Values.tls.enabled (hasKey $probe "httpGet") }}
+            {{- $_ := set $probe.httpGet "scheme" "HTTPS" }}
+            {{- end }}
+            {{- tpl (toYaml $probe) $ | nindent 12 }}
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
-            {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- $probe := . | deepCopy }}
+            {{- if and $.Values.tls.enabled (hasKey $probe "httpGet") }}
+            {{- $_ := set $probe.httpGet "scheme" "HTTPS" }}
+            {{- end }}
+            {{- tpl (toYaml $probe) $ | nindent 12 }}
           {{- end }}
           {{- with .Values.resources }}
           resources:
@@ -67,6 +82,11 @@ spec:
           volumeMounts:
             - name: config
               mountPath: {{ .Values.configFilePath | dir }}
+          {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: {{ .Values.tls.mountPath }}
+              readOnly: true
+          {{- end }}
           {{- with .Values.extraVolumeMounts }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
@@ -77,6 +97,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "kubernetes-mcp-server.fullname" . }}
+      {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ required "tls.secretName is required when tls.enabled is true" .Values.tls.secretName }}
+      {{- end }}
       {{- with .Values.extraVolumes }}
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/charts/kubernetes-mcp-server/templates/service.yaml
+++ b/charts/kubernetes-mcp-server/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes-mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/kubernetes-mcp-server/templates/servicemonitor.yaml
+++ b/charts/kubernetes-mcp-server/templates/servicemonitor.yaml
@@ -24,8 +24,10 @@ spec:
       {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
-      {{- with .Values.metrics.serviceMonitor.scheme }}
-      scheme: {{ . }}
+      {{- if .Values.metrics.serviceMonitor.scheme }}
+      scheme: {{ .Values.metrics.serviceMonitor.scheme }}
+      {{- else if .Values.tls.enabled }}
+      scheme: https
       {{- end }}
       {{- with .Values.metrics.serviceMonitor.tlsConfig }}
       tlsConfig:

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -118,8 +118,11 @@ service:
   type: ClusterIP
   # -- This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8080
-  # -- Target port for the service. Useful when deploying with an proxy sidecar. Set this to the sidecar's port to route traffic through the proxy before reaching the main container.
+  # -- This sets the target port on the pod. Defaults to "http" (the container port name).
+  # -- Target port for the service. Useful when deploying with an proxy sidecar or exposing a different port. Set this to the sidecar's port to route traffic through the proxy before reaching the main container.
   targetPort: http
+  # -- Annotations to add to the service
+  annotations: {}
 
 # -- This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
@@ -174,6 +177,27 @@ initContainers: []
 #   volumeMounts:
 #     - name: config-volume
 #       mountPath: /config
+
+# -- TLS configuration for the MCP server.
+# -- When enabled, the server will serve HTTPS and health probes will use the HTTPS scheme.
+# -- This is the recommended way to enable TLS instead of using extraArgs.
+tls:
+  # -- Enable TLS for the MCP server
+  enabled: false
+  # -- Name of the Kubernetes Secret containing TLS certificate and key.
+  # -- The secret should be of type kubernetes.io/tls with tls.crt and tls.key.
+  secretName: ""
+  # -- Path where the TLS secret will be mounted inside the container
+  mountPath: /etc/tls
+  # -- Name of the certificate file within the secret (default: tls.crt)
+  certFile: tls.crt
+  # -- Name of the key file within the secret (default: tls.key)
+  keyFile: tls.key
+
+# -- Extra arguments to pass to the kubernetes-mcp-server command line.
+# -- Useful for passing additional configuration options. It can also be configured using ConfigMap.
+# -- Note: For TLS configuration, use the tls section above instead of extraArgs.
+extraArgs: []
 
 # -- Additional containers to add to the pod (sidecars).
 # -- Each container is defined as a complete container spec.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,8 @@ The server will:
 | `sse_base_url` | string | `""` | Base URL for Server-Sent Events (SSE) connections. Used when the server is behind a reverse proxy. |
 | `list_output` | string | `"table"` | Output format for resource list operations. Valid values: `yaml`, `table`. |
 | `stateless` | boolean | `false` | When `true`, disables tool and prompt change notifications. Useful for container deployments, load balancing, and serverless environments. |
+| `tls_cert` | string | `""` | Path to TLS certificate file for HTTPS. When set along with `tls_key`, the server serves HTTPS instead of HTTP. |
+| `tls_key` | string | `""` | Path to TLS private key file for HTTPS. Must be set together with `tls_cert`. |
 
 **Example:**
 ```toml
@@ -138,6 +140,10 @@ log_level = 2
 port = "8080"
 list_output = "yaml"
 stateless = true
+
+# Enable TLS for HTTPS
+tls_cert = "/etc/tls/tls.crt"
+tls_key = "/etc/tls/tls.key"
 ```
 
 ### Kubernetes Connection
@@ -504,6 +510,8 @@ The following options can be set via command-line arguments. CLI arguments overr
 | `--toolsets` | Comma-separated list of toolsets to enable |
 | `--disable-multi-cluster` | Disable multi-cluster support |
 | `--cluster-provider` | Cluster provider strategy (`kubeconfig`, `in-cluster`, `kcp`, `disabled`) |
+| `--tls-cert` | Path to TLS certificate file for HTTPS (must be used with `--tls-key`) |
+| `--tls-key` | Path to TLS private key file for HTTPS (must be used with `--tls-cert`) |
 
 ## Complete Example
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,6 +69,13 @@ type StaticConfig struct {
 	StsScopes            []string `toml:"sts_scopes,omitempty"`
 	CertificateAuthority string   `toml:"certificate_authority,omitempty"`
 	ServerURL            string   `toml:"server_url,omitempty"`
+
+	// TLS configuration for the HTTP server
+	// TLSCert is the path to the TLS certificate file for HTTPS
+	TLSCert string `toml:"tls_cert,omitempty"`
+	// TLSKey is the path to the TLS private key file for HTTPS
+	TLSKey string `toml:"tls_key,omitempty"`
+
 	// ClusterProviderStrategy is how the server finds clusters.
 	// If set to "kubeconfig", the clusters will be loaded from those in the kubeconfig.
 	// If set to "in-cluster", the server will use the in cluster config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -115,6 +115,10 @@ func (s *ConfigSuite) TestReadConfigValid() {
 			{group = "rbac.authorization.k8s.io", version = "v1", kind = "Role"}
 		]
 
+		# TLS configuration
+		tls_cert = "/path/to/cert.pem"
+		tls_key = "/path/to/key.pem"
+
 		[[prompts]]
 		name = "k8s-troubleshoot"
 		title = "Troubleshoot Kubernetes"
@@ -158,6 +162,12 @@ func (s *ConfigSuite) TestReadConfigValid() {
 	})
 	s.Run("stateless parsed correctly", func() {
 		s.Truef(config.Stateless, "Expected Stateless to be true, got %v", config.Stateless)
+	})
+	s.Run("tls_cert parsed correctly", func() {
+		s.Equalf("/path/to/cert.pem", config.TLSCert, "Expected TLSCert to be /path/to/cert.pem, got %s", config.TLSCert)
+	})
+	s.Run("tls_key parsed correctly", func() {
+		s.Equalf("/path/to/key.pem", config.TLSKey, "Expected TLSKey to be /path/to/key.pem, got %s", config.TLSKey)
 	})
 	s.Run("toolsets", func() {
 		s.Require().Lenf(config.Toolsets, 4, "Expected 4 toolsets, got %d", len(config.Toolsets))

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -17,6 +20,24 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcp"
 )
+
+// tlsErrorFilterWriter filters out noisy TLS handshake errors from health checks
+type tlsErrorFilterWriter struct {
+	underlying io.Writer
+}
+
+func (w *tlsErrorFilterWriter) Write(p []byte) (n int, err error) {
+	msg := string(p)
+	// Filter TLS handshake EOF errors - these are typically from
+	// load balancer health checks that just do TCP connects.
+	// Log at V(4) instead of discarding silently so they can still be seen
+	// when debugging with higher verbosity.
+	if strings.Contains(msg, "TLS handshake error") && strings.Contains(msg, "EOF") {
+		klog.V(4).Infof("TLS handshake error (likely health check): %s", strings.TrimSpace(msg))
+		return len(p), nil
+	}
+	return w.underlying.Write(p)
+}
 
 const (
 	healthEndpoint     = "/healthz"
@@ -92,6 +113,12 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.Stat
 		Handler: instrumentedHandler,
 	}
 
+	// Only set up custom error logger for TLS mode to filter noisy TLS handshake errors
+	// from load balancer health checks
+	if staticConfig.TLSCert != "" && staticConfig.TLSKey != "" {
+		httpServer.ErrorLog = log.New(&tlsErrorFilterWriter{underlying: os.Stderr}, "", 0)
+	}
+
 	sseServer := mcpServer.ServeSse()
 	streamableHttpServer := mcpServer.ServeHTTP()
 	mux.Handle(sseEndpoint, sseServer)
@@ -112,8 +139,15 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.Stat
 
 	serverErr := make(chan error, 1)
 	go func() {
-		klog.V(0).Infof("HTTP server starting on port %s (endpoints: /mcp, /sse, /message, /healthz, /stats, /metrics)", staticConfig.Port)
-		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		var err error
+		if staticConfig.TLSCert != "" && staticConfig.TLSKey != "" {
+			klog.V(0).Infof("HTTPS server starting on port %s (endpoints: /mcp, /sse, /message, /healthz, /stats, /metrics)", staticConfig.Port)
+			err = httpServer.ListenAndServeTLS(staticConfig.TLSCert, staticConfig.TLSKey)
+		} else {
+			klog.V(0).Infof("HTTP server starting on port %s (endpoints: /mcp, /sse, /message, /healthz, /stats, /metrics)", staticConfig.Port)
+			err = httpServer.ListenAndServe()
+		}
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErr <- err
 		}
 	}()

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -86,6 +86,8 @@ const (
 	flagCertificateAuthority = "certificate-authority"
 	flagDisableMultiCluster  = "disable-multi-cluster"
 	flagClusterProvider      = "cluster-provider"
+	flagTLSCert              = "tls-cert"
+	flagTLSKey               = "tls-key"
 )
 
 type MCPServerOptions struct {
@@ -106,6 +108,8 @@ type MCPServerOptions struct {
 	ServerURL            string
 	DisableMultiCluster  bool
 	ClusterProvider      string
+	TLSCert              string
+	TLSKey               string
 
 	ConfigPath   string
 	ConfigDir    string
@@ -167,6 +171,8 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	_ = cmd.Flags().MarkHidden(flagCertificateAuthority)
 	cmd.Flags().BoolVar(&o.DisableMultiCluster, flagDisableMultiCluster, o.DisableMultiCluster, "Disable multi cluster tools. Optional. If true, all tools will be run against the default cluster/context.")
 	cmd.Flags().StringVar(&o.ClusterProvider, flagClusterProvider, o.ClusterProvider, "Cluster provider strategy to use (one of: kubeconfig, in-cluster, kcp, disabled). If not set, the server will auto-detect based on the environment.")
+	cmd.Flags().StringVar(&o.TLSCert, flagTLSCert, o.TLSCert, "Path to TLS certificate file for HTTPS. Must be used together with --tls-key.")
+	cmd.Flags().StringVar(&o.TLSKey, flagTLSKey, o.TLSKey, "Path to TLS private key file for HTTPS. Must be used together with --tls-cert.")
 
 	return cmd
 }
@@ -241,6 +247,12 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	if cmd.Flag(flagDisableMultiCluster).Changed && m.DisableMultiCluster {
 		m.StaticConfig.ClusterProviderStrategy = api.ClusterProviderDisabled
 	}
+	if cmd.Flag(flagTLSCert).Changed {
+		m.StaticConfig.TLSCert = m.TLSCert
+	}
+	if cmd.Flag(flagTLSKey).Changed {
+		m.StaticConfig.TLSKey = m.TLSKey
+	}
 }
 
 func (m *MCPServerOptions) initializeLogging() {
@@ -294,6 +306,25 @@ func (m *MCPServerOptions) Validate() error {
 	if caValue := strings.TrimSpace(m.StaticConfig.CertificateAuthority); caValue != "" {
 		if _, err := os.Stat(caValue); err != nil {
 			return fmt.Errorf("certificate-authority must be a valid file path: %w", err)
+		}
+	}
+	// Validate TLS configuration
+	tlsCert := strings.TrimSpace(m.StaticConfig.TLSCert)
+	tlsKey := strings.TrimSpace(m.StaticConfig.TLSKey)
+	if (tlsCert != "" && tlsKey == "") || (tlsCert == "" && tlsKey != "") {
+		return fmt.Errorf("both --tls-cert and --tls-key must be provided together")
+	}
+	if tlsCert != "" && m.StaticConfig.Port == "" {
+		return fmt.Errorf("--tls-cert and --tls-key require --port to be set (TLS is only supported in HTTP mode)")
+	}
+	if tlsCert != "" {
+		if _, err := os.Stat(tlsCert); err != nil {
+			return fmt.Errorf("tls-cert must be a valid file path: %w", err)
+		}
+	}
+	if tlsKey != "" {
+		if _, err := os.Stat(tlsKey); err != nil {
+			return fmt.Errorf("tls-key must be a valid file path: %w", err)
 		}
 	}
 	return nil

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -484,3 +484,86 @@ func TestStateless(t *testing.T) {
 		}
 	})
 }
+
+func TestTLSValidation(t *testing.T) {
+	t.Run("tls-cert without tls-key returns error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certPath := filepath.Join(tempDir, "cert.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--port=8080", "--tls-cert", certPath})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "both --tls-cert and --tls-key must be provided together")
+	})
+
+	t.Run("tls-key without tls-cert returns error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		keyPath := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(keyPath, []byte("key content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--port=8080", "--tls-key", keyPath})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "both --tls-cert and --tls-key must be provided together")
+	})
+
+	t.Run("invalid tls-cert path returns error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		keyPath := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(keyPath, []byte("key content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--port=8080", "--tls-cert", "/nonexistent/cert.pem", "--tls-key", keyPath})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tls-cert must be a valid file path")
+	})
+
+	t.Run("invalid tls-key path returns error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certPath := filepath.Join(tempDir, "cert.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--port=8080", "--tls-cert", certPath, "--tls-key", "/nonexistent/key.pem"})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tls-key must be a valid file path")
+	})
+
+	t.Run("valid tls-cert and tls-key paths succeed", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certPath := filepath.Join(tempDir, "cert.pem")
+		keyPath := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert content"), 0644))
+		require.NoError(t, os.WriteFile(keyPath, []byte("key content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--port=8080", "--tls-cert", certPath, "--tls-key", keyPath})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("tls-cert without port returns error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certPath := filepath.Join(tempDir, "cert.pem")
+		keyPath := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert content"), 0644))
+		require.NoError(t, os.WriteFile(keyPath, []byte("key content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--tls-cert", certPath, "--tls-key", keyPath})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--tls-cert and --tls-key require --port to be set")
+	})
+}


### PR DESCRIPTION
Add tls service certs, allowing to provide TLS certificates to the server itself.

This allows usages:
* serviceType: Loadbalancer + external certs
* certmagic as side container

In general simplified configuration when neither ingress or gateway is available 