### PR TITLE
refactor(metrics)!: rename metrics from mcp_ to k8s_mcp_ prefix

### DIFF
--- a/charts/kubernetes-mcp-server/templates/prometheusrule.yaml
+++ b/charts/kubernetes-mcp-server/templates/prometheusrule.yaml
@@ -16,50 +16,51 @@ metadata:
 spec:
   groups:
     {{- if .Values.metrics.prometheusRule.defaultRules.enabled }}
-    # Default recording rules for MCP server metrics
+    # Default recording rules for Kubernetes MCP server metrics
     # These aggregate high-cardinality metrics for efficient querying and Telemeter compatibility
-    - name: mcp-server.rules
+    # Metrics use k8s_mcp_ prefix for clear identification in multi-MCP-server environments
+    - name: k8s-mcp-server.rules
       rules:
         # Cluster-level aggregations (for Telemeter - no namespace label)
-        # Aggregate tool calls across all tool names (removes tool.name label)
-        - record: cluster:mcp_tool_calls:sum
-          expr: sum(mcp_tool_calls_total)
+        # Aggregate tool calls across all tool names (removes tool_name label)
+        - record: cluster:k8s_mcp_tool_calls:sum
+          expr: sum(k8s_mcp_tool_calls_total)
 
         # Aggregate tool errors across all tool names
-        - record: cluster:mcp_tool_errors:sum
-          expr: sum(mcp_tool_errors_total)
+        - record: cluster:k8s_mcp_tool_errors:sum
+          expr: sum(k8s_mcp_tool_errors_total)
 
         # Calculate error rate (errors / total calls)
-        - record: cluster:mcp_tool_error_rate:ratio
+        - record: cluster:k8s_mcp_tool_error_rate:ratio
           expr: |
-            sum(mcp_tool_errors_total) / clamp_min(sum(mcp_tool_calls_total), 1)
+            sum(k8s_mcp_tool_errors_total) / clamp_min(sum(k8s_mcp_tool_calls_total), 1)
 
         # Aggregate HTTP requests by status class only (removes path, method labels)
-        - record: cluster:mcp_http_requests_by_status:sum
-          expr: sum by (http_response_status_class) (http_server_requests_total)
+        - record: cluster:k8s_mcp_http_requests_by_status:sum
+          expr: sum by (http_response_status_class) (k8s_mcp_http_requests_total)
 
         # Total HTTP requests
-        - record: cluster:mcp_http_requests:sum
-          expr: sum(http_server_requests_total)
+        - record: cluster:k8s_mcp_http_requests:sum
+          expr: sum(k8s_mcp_http_requests_total)
 
         # Server info (already low cardinality, just ensures it's available)
-        - record: cluster:mcp_server_info:count
-          expr: count(mcp_server_info)
+        - record: cluster:k8s_mcp_server_info:count
+          expr: count(k8s_mcp_server_info)
 
         # Namespace-level aggregations (for multi-tenant RBAC - preserves k8s_namespace_name label)
         # Note: OTel semantic convention k8s.namespace.name becomes k8s_namespace_name in Prometheus
-        - record: namespace:mcp_tool_calls:sum
-          expr: sum by (k8s_namespace_name) (mcp_tool_calls_total)
+        - record: namespace:k8s_mcp_tool_calls:sum
+          expr: sum by (k8s_namespace_name) (k8s_mcp_tool_calls_total)
 
-        - record: namespace:mcp_tool_errors:sum
-          expr: sum by (k8s_namespace_name) (mcp_tool_errors_total)
+        - record: namespace:k8s_mcp_tool_errors:sum
+          expr: sum by (k8s_namespace_name) (k8s_mcp_tool_errors_total)
 
-        - record: namespace:mcp_tool_error_rate:ratio
+        - record: namespace:k8s_mcp_tool_error_rate:ratio
           expr: |
-            sum by (k8s_namespace_name) (mcp_tool_errors_total) / clamp_min(sum by (k8s_namespace_name) (mcp_tool_calls_total), 1)
+            sum by (k8s_namespace_name) (k8s_mcp_tool_errors_total) / clamp_min(sum by (k8s_namespace_name) (k8s_mcp_tool_calls_total), 1)
 
-        - record: namespace:mcp_http_requests:sum
-          expr: sum by (k8s_namespace_name) (http_server_requests_total)
+        - record: namespace:k8s_mcp_http_requests:sum
+          expr: sum by (k8s_namespace_name) (k8s_mcp_http_requests_total)
     {{- end }}
     {{- with .Values.metrics.prometheusRule.additionalRules }}
     {{- toYaml . | nindent 4 }}

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -226,18 +226,18 @@ metrics:
       # These rules create aggregates at two levels:
       #
       # Cluster-level (for Telemeter):
-      # - cluster:mcp_tool_calls:sum - Total tool calls across all tools
-      # - cluster:mcp_tool_errors:sum - Total tool errors across all tools
-      # - cluster:mcp_tool_error_rate:ratio - Error rate (errors/calls)
-      # - cluster:mcp_http_requests:sum - Total HTTP requests
-      # - cluster:mcp_http_requests_by_status:sum - HTTP requests by status class
-      # - cluster:mcp_server_info:count - Server instance count
+      # - cluster:k8s_mcp_tool_calls:sum - Total tool calls across all tools
+      # - cluster:k8s_mcp_tool_errors:sum - Total tool errors across all tools
+      # - cluster:k8s_mcp_tool_error_rate:ratio - Error rate (errors/calls) - local only
+      # - cluster:k8s_mcp_http_requests:sum - Total HTTP requests
+      # - cluster:k8s_mcp_http_requests_by_status:sum - HTTP requests by status class
+      # - cluster:k8s_mcp_server_info:count - Server instance count
       #
       # Namespace-level (for multi-tenant RBAC, grouped by k8s_namespace_name label):
-      # - namespace:mcp_tool_calls:sum - Tool calls by k8s_namespace_name
-      # - namespace:mcp_tool_errors:sum - Tool errors by k8s_namespace_name
-      # - namespace:mcp_tool_error_rate:ratio - Error rate by k8s_namespace_name
-      # - namespace:mcp_http_requests:sum - HTTP requests by k8s_namespace_name
+      # - namespace:k8s_mcp_tool_calls:sum - Tool calls by k8s_namespace_name
+      # - namespace:k8s_mcp_tool_errors:sum - Tool errors by k8s_namespace_name
+      # - namespace:k8s_mcp_tool_error_rate:ratio - Error rate by k8s_namespace_name
+      # - namespace:k8s_mcp_http_requests:sum - HTTP requests by k8s_namespace_name
       enabled: true
     # -- Additional custom recording rules (appended to default rules if enabled)
     # Example:

--- a/docs/OTEL.md
+++ b/docs/OTEL.md
@@ -431,11 +431,11 @@ This endpoint returns metrics in OpenMetrics/Prometheus text format, suitable fo
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `mcp_tool_calls_total` | Counter | Total MCP tool calls (labeled by `tool_name`) |
-| `mcp_tool_errors_total` | Counter | Total MCP tool errors (labeled by `tool_name`) |
-| `mcp_tool_duration_seconds` | Histogram | Tool call duration in seconds |
-| `http_server_requests_total` | Counter | HTTP requests (labeled by `http_request_method`, `url_path`, `http_response_status_class`) |
-| `mcp_server_info` | Gauge | Server info (labeled by `version`, `go_version`) |
+| `k8s_mcp_tool_calls_total` | Counter | Total MCP tool calls (labeled by `tool_name`) |
+| `k8s_mcp_tool_errors_total` | Counter | Total MCP tool errors (labeled by `tool_name`) |
+| `k8s_mcp_tool_duration_seconds` | Histogram | Tool call duration in seconds |
+| `k8s_mcp_http_requests_total` | Counter | HTTP requests (labeled by `http_request_method`, `url_path`, `http_response_status_class`) |
+| `k8s_mcp_server_info` | Gauge | Server info (labeled by `version`, `go_version`) |
 
 ### Prometheus Scrape Configuration
 

--- a/pkg/metrics/otel_stats_collector.go
+++ b/pkg/metrics/otel_stats_collector.go
@@ -197,9 +197,10 @@ func NewOtelStatsCollectorWithConfig(cfg CollectorConfig) (*OtelStatsCollector, 
 
 	meter := provider.Meter(cfg.MeterName)
 
-	// Create metric instruments following OTel semantic conventions
+	// Create metric instruments with k8s_mcp prefix for clear identification
+	// in multi-MCP-server environments.
 	toolCallCounter, err := meter.Int64Counter(
-		"mcp.tool.calls",
+		"k8s_mcp.tool.calls",
 		metric.WithDescription("Total number of MCP tool calls"),
 	)
 	if err != nil {
@@ -207,7 +208,7 @@ func NewOtelStatsCollectorWithConfig(cfg CollectorConfig) (*OtelStatsCollector, 
 	}
 
 	toolCallErrorCounter, err := meter.Int64Counter(
-		"mcp.tool.errors",
+		"k8s_mcp.tool.errors",
 		metric.WithDescription("Total number of MCP tool call errors"),
 	)
 	if err != nil {
@@ -215,7 +216,7 @@ func NewOtelStatsCollectorWithConfig(cfg CollectorConfig) (*OtelStatsCollector, 
 	}
 
 	toolDurationHistogram, err := meter.Float64Histogram(
-		"mcp.tool.duration",
+		"k8s_mcp.tool.duration",
 		metric.WithDescription("Duration of MCP tool calls in seconds"),
 		metric.WithUnit("s"),
 	)
@@ -224,16 +225,16 @@ func NewOtelStatsCollectorWithConfig(cfg CollectorConfig) (*OtelStatsCollector, 
 	}
 
 	httpRequestCounter, err := meter.Int64Counter(
-		"http.server.requests",
-		metric.WithDescription("Total number of HTTP requests"),
+		"k8s_mcp.http.requests",
+		metric.WithDescription("Total number of HTTP requests to the MCP server"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request counter: %w", err)
 	}
 
 	serverInfoGauge, err := meter.Int64Gauge(
-		"mcp.server.info",
-		metric.WithDescription("MCP server version information"),
+		"k8s_mcp.server.info",
+		metric.WithDescription("Kubernetes MCP server version information"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create server info gauge: %w", err)
@@ -354,7 +355,7 @@ func (c *OtelStatsCollector) GetStats() *Statistics {
 // processMetric extracts data from a single metric and updates the statistics.
 func (c *OtelStatsCollector) processMetric(m metricdata.Metrics, stats *Statistics) {
 	switch m.Name {
-	case "mcp.tool.calls":
+	case "k8s_mcp.tool.calls":
 		if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
 			for _, dp := range sum.DataPoints {
 				value := dp.Value
@@ -368,7 +369,7 @@ func (c *OtelStatsCollector) processMetric(m metricdata.Metrics, stats *Statisti
 			}
 		}
 
-	case "mcp.tool.errors":
+	case "k8s_mcp.tool.errors":
 		if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
 			for _, dp := range sum.DataPoints {
 				value := dp.Value
@@ -382,7 +383,7 @@ func (c *OtelStatsCollector) processMetric(m metricdata.Metrics, stats *Statisti
 			}
 		}
 
-	case "http.server.requests":
+	case "k8s_mcp.http.requests":
 		if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
 			for _, dp := range sum.DataPoints {
 				value := dp.Value

--- a/pkg/metrics/otel_stats_collector_test.go
+++ b/pkg/metrics/otel_stats_collector_test.go
@@ -142,10 +142,10 @@ func (s *OtelStatsCollectorSuite) TestToolDurationHistogram() {
 		var foundHistogram bool
 		for _, scopeMetrics := range rm.ScopeMetrics {
 			for _, m := range scopeMetrics.Metrics {
-				if m.Name == "mcp.tool.duration" {
+				if m.Name == "k8s_mcp.tool.duration" {
 					foundHistogram = true
 					histogram, ok := m.Data.(metricdata.Histogram[float64])
-					s.True(ok, "mcp.tool.duration should be a float64 histogram")
+					s.True(ok, "k8s_mcp.tool.duration should be a float64 histogram")
 					s.Len(histogram.DataPoints, 2, "Should have 2 data points (one per tool)")
 
 					// Verify data points have recorded values
@@ -156,7 +156,7 @@ func (s *OtelStatsCollectorSuite) TestToolDurationHistogram() {
 				}
 			}
 		}
-		s.True(foundHistogram, "mcp.tool.duration histogram should exist")
+		s.True(foundHistogram, "k8s_mcp.tool.duration histogram should exist")
 	})
 }
 
@@ -180,10 +180,10 @@ func (s *OtelStatsCollectorSuite) TestServerInfoGauge() {
 		var foundGauge bool
 		for _, scopeMetrics := range rm.ScopeMetrics {
 			for _, m := range scopeMetrics.Metrics {
-				if m.Name == "mcp.server.info" {
+				if m.Name == "k8s_mcp.server.info" {
 					foundGauge = true
 					gauge, ok := m.Data.(metricdata.Gauge[int64])
-					s.True(ok, "mcp.server.info should be an int64 gauge")
+					s.True(ok, "k8s_mcp.server.info should be an int64 gauge")
 					s.Len(gauge.DataPoints, 1, "Should have 1 data point")
 
 					if len(gauge.DataPoints) > 0 {
@@ -203,7 +203,7 @@ func (s *OtelStatsCollectorSuite) TestServerInfoGauge() {
 				}
 			}
 		}
-		s.True(foundGauge, "mcp.server.info gauge should exist")
+		s.True(foundGauge, "k8s_mcp.server.info gauge should exist")
 	})
 }
 
@@ -245,10 +245,10 @@ func (s *OtelStatsCollectorSuite) TestPrometheusHandler() {
 		s.Equal(http.StatusOK, rec.Code, "Should return 200 OK")
 
 		body := rec.Body.String()
-		s.Contains(body, "mcp_tool_calls", "Should contain mcp_tool_calls metric")
-		s.Contains(body, "mcp_tool_duration", "Should contain mcp_tool_duration metric")
-		s.Contains(body, "http_server_requests", "Should contain http_server_requests metric")
-		s.Contains(body, "mcp_server_info", "Should contain mcp_server_info metric")
+		s.Contains(body, "k8s_mcp_tool_calls", "Should contain k8s_mcp_tool_calls metric")
+		s.Contains(body, "k8s_mcp_tool_duration", "Should contain k8s_mcp_tool_duration metric")
+		s.Contains(body, "k8s_mcp_http_requests", "Should contain k8s_mcp_http_requests metric")
+		s.Contains(body, "k8s_mcp_server_info", "Should contain k8s_mcp_server_info metric")
 	})
 }
 


### PR DESCRIPTION
Add `k8s_mcp_` prefix to all metrics for clear identification in multi-MCP-server environments. This prevents naming collisions with other MCP servers that may be deployed in the same cluster.

Changes:

 - Rename OTel metrics (k8s_mcp.tool.calls, k8s_mcp.http.requests, etc.)
 - Update PrometheusRule recording rules with new metric names
 - Update documentation and tests