### PR TITLE
chore(ci): add helm chart validation to CI pipeline

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,0 +1,38 @@
+name: Helm Chart Validation
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'charts/**'
+      - 'build/helm.mk'
+      - '.github/workflows/helm.yaml'
+  pull_request:
+    paths:
+      - 'charts/**'
+      - 'build/helm.mk'
+      - '.github/workflows/helm.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.19.2'
+
+      - name: Lint chart
+        run: make helm-lint
+
+      - name: Validate chart templates
+        run: make helm-validate

--- a/build/helm.mk
+++ b/build/helm.mk
@@ -36,7 +36,11 @@ kubeconform:
 
 .PHONY: helm-validate
 helm-validate: kubeconform ## Validate Helm chart manifests with kubeconform
-	helm template test-release $(HELM_CHART_DIR) --set ingress.host=localhost | $(KUBECONFORM) -strict -summary -ignore-missing-schemas
+	@echo "Validating with default values..."
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) --set ingress.host=localhost | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
+	@echo ""
+	@echo "Validating with tpl-exercising values..."
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/tpl-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
 
 .PHONY: helm-package
 helm-package: helm-lint helm-template ## Package the Helm chart (supports HELM_CHART_VERSION override)

--- a/charts/kubernetes-mcp-server/ci/tpl-test-values.yaml
+++ b/charts/kubernetes-mcp-server/ci/tpl-test-values.yaml
@@ -1,0 +1,60 @@
+# Test values that exercise tpl function paths in templates.
+# These values contain template expressions that require the correct context
+# to be passed to the tpl function.
+#
+# This file is used by helm-validate to catch bugs like:
+# https://github.com/containers/kubernetes-mcp-server/issues/743
+
+ingress:
+  host: localhost
+
+# Test tpl in imagePullSecrets (array inside with block)
+imagePullSecrets:
+  - name: "{{ .Release.Name }}-pull-secret"
+
+# Test tpl in podAnnotations (map inside with block)
+podAnnotations:
+  release-name: "{{ .Release.Name }}"
+  release-namespace: "{{ .Release.Namespace }}"
+
+# Test tpl in podLabels (map inside with block)
+podLabels:
+  custom-label: "{{ .Release.Name }}-label"
+
+# Test tpl in nodeSelector (map inside with block)
+nodeSelector:
+  kubernetes.io/os: linux
+
+# Test tpl in tolerations (array inside with block)
+tolerations:
+  - key: "{{ .Release.Name }}-toleration"
+    operator: "Exists"
+    effect: "NoSchedule"
+
+# Test tpl in affinity (object inside with block)
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+            - key: "node-label"
+              operator: "In"
+              values:
+                - "{{ .Release.Name }}"
+
+# Test tpl in extraVolumes (array inside with block)
+extraVolumes:
+  - name: "{{ .Release.Name }}-extra-volume"
+    emptyDir: {}
+
+# Test tpl in extraVolumeMounts (array inside with block)
+extraVolumeMounts:
+  - name: "{{ .Release.Name }}-extra-volume"
+    mountPath: /extra
+
+# Test tpl in extraContainers (array inside with block)
+extraContainers:
+  - name: "{{ .Release.Name }}-sidecar"
+    image: busybox:latest
+    command: ["sh", "-c", "sleep infinity"]


### PR DESCRIPTION
Add GitHub Actions workflow to validate Helm chart on PRs/pushes affecting chart files. Enhance helm-validate target to test with both default values and tpl-exercising values to catch template context bugs.

Refs #743
Should go in before #744 to verify the fix