### PR TITLE
fix(helm): use namespace label in recording rules for multi-tenant RBAC

### DIFF
--- a/charts/kubernetes-mcp-server/templates/prometheusrule.yaml
+++ b/charts/kubernetes-mcp-server/templates/prometheusrule.yaml
@@ -47,20 +47,19 @@ spec:
         - record: cluster:k8s_mcp_server_info:count
           expr: count(k8s_mcp_server_info)
 
-        # Namespace-level aggregations (for multi-tenant RBAC - preserves k8s_namespace_name label)
-        # Note: OTel semantic convention k8s.namespace.name becomes k8s_namespace_name in Prometheus
+        # Namespace-level aggregations (for multi-tenant RBAC)
         - record: namespace:k8s_mcp_tool_calls:sum
-          expr: sum by (k8s_namespace_name) (k8s_mcp_tool_calls_total)
+          expr: sum by (namespace) (k8s_mcp_tool_calls_total)
 
         - record: namespace:k8s_mcp_tool_errors:sum
-          expr: sum by (k8s_namespace_name) (k8s_mcp_tool_errors_total)
+          expr: sum by (namespace) (k8s_mcp_tool_errors_total)
 
         - record: namespace:k8s_mcp_tool_error_rate:ratio
           expr: |
-            sum by (k8s_namespace_name) (k8s_mcp_tool_errors_total) / clamp_min(sum by (k8s_namespace_name) (k8s_mcp_tool_calls_total), 1)
+            sum by (namespace) (k8s_mcp_tool_errors_total) / clamp_min(sum by (namespace) (k8s_mcp_tool_calls_total), 1)
 
         - record: namespace:k8s_mcp_http_requests:sum
-          expr: sum by (k8s_namespace_name) (k8s_mcp_http_requests_total)
+          expr: sum by (namespace) (k8s_mcp_http_requests_total)
     {{- end }}
     {{- with .Values.metrics.prometheusRule.additionalRules }}
     {{- toYaml . | nindent 4 }}

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -228,16 +228,16 @@ metrics:
       # Cluster-level (for Telemeter):
       # - cluster:k8s_mcp_tool_calls:sum - Total tool calls across all tools
       # - cluster:k8s_mcp_tool_errors:sum - Total tool errors across all tools
-      # - cluster:k8s_mcp_tool_error_rate:ratio - Error rate (errors/calls) - local only
+      # - cluster:k8s_mcp_tool_error_rate:ratio - Error rate (errors/calls)
       # - cluster:k8s_mcp_http_requests:sum - Total HTTP requests
       # - cluster:k8s_mcp_http_requests_by_status:sum - HTTP requests by status class
       # - cluster:k8s_mcp_server_info:count - Server instance count
       #
-      # Namespace-level (for multi-tenant RBAC, grouped by k8s_namespace_name label):
-      # - namespace:k8s_mcp_tool_calls:sum - Tool calls by k8s_namespace_name
-      # - namespace:k8s_mcp_tool_errors:sum - Tool errors by k8s_namespace_name
-      # - namespace:k8s_mcp_tool_error_rate:ratio - Error rate by k8s_namespace_name
-      # - namespace:k8s_mcp_http_requests:sum - HTTP requests by k8s_namespace_name
+      # Namespace-level (for multi-tenant RBAC, grouped by namespace label):
+      # - namespace:k8s_mcp_tool_calls:sum - Tool calls by namespace
+      # - namespace:k8s_mcp_tool_errors:sum - Tool errors by namespace
+      # - namespace:k8s_mcp_tool_error_rate:ratio - Error rate by namespace
+      # - namespace:k8s_mcp_http_requests:sum - HTTP requests by namespace
       enabled: true
     # -- Additional custom recording rules (appended to default rules if enabled)
     # Example:


### PR DESCRIPTION
Update PrometheusRule recording rules to use the 'namespace' label
(provided by ServiceMonitor discovery) instead of 'k8s_namespace_name'.
This enables namespace-scoped metric queries for multi-tenant RBAC.