### PR TITLE
feat: Allow Toolset-specific instructions to be added to server instructions

### DIFF
--- a/internal/test/mock_toolset.go
+++ b/internal/test/mock_toolset.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
+)
+
+// MockToolset is a test helper for testing toolset functionality
+type MockToolset struct {
+	Name         string
+	Description  string
+	Instructions string
+	Tools        []api.ServerTool
+	Prompts      []api.ServerPrompt
+}
+
+var _ api.Toolset = (*MockToolset)(nil)
+
+func (m *MockToolset) GetName() string {
+	return m.Name
+}
+
+func (m *MockToolset) GetDescription() string {
+	return m.Description
+}
+
+func (m *MockToolset) GetToolsetInstructions() string {
+	return m.Instructions
+}
+
+func (m *MockToolset) GetTools(_ api.Openshift) []api.ServerTool {
+	if m.Tools == nil {
+		return []api.ServerTool{}
+	}
+	return m.Tools
+}
+
+func (m *MockToolset) GetPrompts() []api.ServerPrompt {
+	return m.Prompts
+}
+
+// RegisterMockToolset registers a mock toolset for testing
+func RegisterMockToolset(mockToolset *MockToolset) {
+	toolsets.Register(mockToolset)
+}
+
+// UnregisterMockToolset removes a mock toolset from the registry
+func UnregisterMockToolset(name string) {
+	// Get all toolsets and rebuild the list without the mock
+	allToolsets := toolsets.Toolsets()
+	toolsets.Clear()
+	for _, ts := range allToolsets {
+		if ts.GetName() != name {
+			toolsets.Register(ts)
+		}
+	}
+}

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -46,6 +46,11 @@ type Toolset interface {
 	// GetPrompts returns the prompts provided by this toolset.
 	// Returns nil if the toolset doesn't provide any prompts.
 	GetPrompts() []ServerPrompt
+	// GetToolsetInstructions returns instructions for using the tools in this toolset.
+	// These instructions will be included in the MCP server's initialize response
+	// to help LLMs understand how to effectively use the toolset.
+	// Returns an empty string if no specific instructions are needed.
+	GetToolsetInstructions() string
 }
 
 type ToolCallRequest interface {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,6 +86,10 @@ type StaticConfig struct {
 	// This can be used to provide specific instructions on how the client should use the server
 	ServerInstructions string `toml:"server_instructions,omitempty"`
 
+	// DisableToolsetInstructions indicates whether toolset instructions are to be excluded
+	// from being provided by the MCP server to the MCP client in the initialize response.
+	DisableToolsetInstructions bool `toml:"disable_toolset_instructions,omitempty"`
+
 	// Telemetry contains OpenTelemetry configuration options.
 	// These can also be configured via OTEL_* environment variables.
 	Telemetry TelemetryConfig `toml:"telemetry,omitempty"`

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -71,9 +71,9 @@ type Server struct {
 }
 
 func NewServer(configuration Configuration, targetProvider internalk8s.Provider) (*Server, error) {
-	instructions := buildServerInstructions(configuration.ServerInstructions, configuration.Toolsets())
-	if configuration.DisableToolsetInstructions {
-		instructions = configuration.ServerInstructions
+	instructions := configuration.ServerInstructions
+	if !configuration.DisableToolsetInstructions {
+		instructions = buildServerInstructions(configuration.ServerInstructions, configuration.Toolsets())
 	}
 
 	s := &Server{

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -135,7 +135,9 @@ func buildServerInstructions(serverInstructions string, toolsets []api.Toolset) 
 
 	for _, toolset := range toolsets {
 		if toolsetInstructions := toolset.GetToolsetInstructions(); toolsetInstructions != "" {
-			instructions = append(instructions, toolsetInstructions)
+			// Add markdown h2 header with toolset name
+			header := fmt.Sprintf("## %s", toolset.GetName())
+			instructions = append(instructions, header, toolsetInstructions)
 		}
 	}
 

--- a/pkg/mcp/mcp_toolset_prompts_test.go
+++ b/pkg/mcp/mcp_toolset_prompts_test.go
@@ -386,6 +386,10 @@ func (m *mockToolsetWithPrompts) GetPrompts() []api.ServerPrompt {
 	return m.prompts
 }
 
+func (m *mockToolsetWithPrompts) GetToolsetInstructions() string {
+	return ""
+}
+
 func TestMcpToolsetPromptsSuite(t *testing.T) {
 	suite.Run(t, new(McpToolsetPromptsSuite))
 }

--- a/pkg/toolsets/config/toolset.go
+++ b/pkg/toolsets/config/toolset.go
@@ -30,6 +30,10 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (t *Toolset) GetToolsetInstructions() string {
+	return ""
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/core/toolset.go
+++ b/pkg/toolsets/core/toolset.go
@@ -35,6 +35,10 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	)
 }
 
+func (t *Toolset) GetToolsetInstructions() string {
+	return ""
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/helm/toolset.go
+++ b/pkg/toolsets/helm/toolset.go
@@ -30,6 +30,10 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (t *Toolset) GetToolsetInstructions() string {
+	return ""
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kcp/toolset.go
+++ b/pkg/toolsets/kcp/toolset.go
@@ -29,6 +29,10 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (t *Toolset) GetToolsetInstructions() string {
+	return ""
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -38,6 +38,10 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (t *Toolset) GetToolsetInstructions() string {
+	return ""
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -32,6 +32,10 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return initVMTroubleshoot()
 }
 
+func (t *Toolset) GetToolsetInstructions() string {
+	return ""
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -36,6 +36,8 @@ func (t *TestToolset) GetTools(_ api.Openshift) []api.ServerTool { return nil }
 
 func (t *TestToolset) GetPrompts() []api.ServerPrompt { return nil }
 
+func (t *TestToolset) GetToolsetInstructions() string { return "" }
+
 var _ api.Toolset = (*TestToolset)(nil)
 
 func (s *ToolsetsSuite) TestToolsetNames() {


### PR DESCRIPTION
This commit adds a new method GetToolsetInstructions to Toolset interface, to allow Toolsets to specify their own custom instructions (LLM-friendly text describing how tools within a particular toolset can be used in tandem).

This is then bubbled up to MCP server initialize response and appended to the provided server prompt. Also added a config option to disable this behavior.