### PR TITLE
build(deps): bump golangci-lint from v2.8.0 to v2.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LD_FLAGS = -s -w \
 COMMON_BUILD_ARGS = -ldflags "$(LD_FLAGS)"
 
 GOLANGCI_LINT = $(shell pwd)/_output/tools/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.8.0
+GOLANGCI_LINT_VERSION ?= v2.9.0
 
 # NPM version should not append the -dirty flag
 GIT_TAG_VERSION ?= $(shell echo $(shell git describe --tags --always) | sed 's/^v//')


### PR DESCRIPTION
Fixes panic when linting dependencies with //go:build go1.26 constraints (e.g., golang.org/x/net, golang.org/x/crypto).