### PR TITLE
refactor(http): improve user agent handling and test infrastructure

### DIFF
--- a/pkg/kubernetes/useragent_roundtripper.go
+++ b/pkg/kubernetes/useragent_roundtripper.go
@@ -9,13 +9,7 @@ type UserAgentRoundTripper struct {
 var _ http.RoundTripper = &UserAgentRoundTripper{}
 
 func (u *UserAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	userAgent := req.Context().Value(UserAgentHeader)
-
-	if userAgent == nil {
-		return u.delegate.RoundTrip(req)
-	}
-
-	userAgentHeader, ok := userAgent.(string)
+	userAgentHeader, ok := req.Context().Value(UserAgentHeader).(string)
 	if !ok || userAgentHeader == "" {
 		return u.delegate.RoundTrip(req)
 	}

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
@@ -206,7 +205,7 @@ func (s *BaseMcpSuite) TearDownTest() {
 	}
 }
 
-func (s *BaseMcpSuite) InitMcpClient(options ...transport.StreamableHTTPCOption) {
+func (s *BaseMcpSuite) InitMcpClient(options ...test.McpClientOption) {
 	provider, err := internalk8s.NewProvider(s.Cfg)
 	s.Require().NoError(err, "Expected no error creating k8s provider")
 	s.mcpServer, err = NewServer(Configuration{StaticConfig: s.Cfg}, provider)

--- a/pkg/mcp/mcp_middleware_test.go
+++ b/pkg/mcp/mcp_middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
@@ -60,12 +61,12 @@ func (s *McpLoggingSuite) TestLogsToolCall() {
 
 func (s *McpLoggingSuite) TestLogsToolCallHeaders() {
 	s.SetLogLevel(7)
-	s.InitMcpClient(transport.WithHTTPHeaders(map[string]string{
+	s.InitMcpClient(test.WithTransport(transport.WithHTTPHeaders(map[string]string{
 		"Accept-Encoding":   "gzip",
 		"Authorization":     "Bearer should-not-be-logged",
 		"authorization":     "Bearer should-not-be-logged",
 		"a-loggable-header": "should-be-logged",
-	}))
+	})))
 	_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
 	s.Require().NoError(err, "call to tool configuration_view failed")
 


### PR DESCRIPTION
- Fix trailing space in user agent when client info is unavailable
- Simplify UserAgentRoundTripper type assertion
- Add McpClientOption interface for extensible test client configuration
- Simplify BaseMcpSuite.InitMcpClient to use new options API
- Add test coverage for empty client info edge case