### PR TITLE
refactor(api): simplify structured content API with auto-serialization

### DIFF
--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -63,6 +63,8 @@ type ToolCallResult struct {
 	Error error
 }
 
+// NewToolCallResult creates a ToolCallResult with text content only.
+// Use this for tools that return human-readable text output.
 func NewToolCallResult(content string, err error) *ToolCallResult {
 	return &ToolCallResult{
 		Content: content,
@@ -70,7 +72,24 @@ func NewToolCallResult(content string, err error) *ToolCallResult {
 	}
 }
 
-func NewToolCallResultWithStructuredContent(content string, structured any, err error) *ToolCallResult {
+// NewToolCallResultStructured creates a ToolCallResult with structured content.
+// The structured value is automatically JSON-serialized into the Content field
+// for backward compatibility with MCP clients that don't support structuredContent.
+//
+// Per the MCP specification:
+// "For backwards compatibility, a tool that returns structured content SHOULD
+// also return the serialized JSON in a TextContent block."
+// https://modelcontextprotocol.io/specification/2025-11-25/server/tools#structured-content
+//
+// Use this for tools that return typed/structured data (maps, slices, structs)
+// that MCP clients can parse programmatically.
+func NewToolCallResultStructured(structured any, err error) *ToolCallResult {
+	content := ""
+	if structured != nil {
+		if b, jsonErr := json.Marshal(structured); jsonErr == nil {
+			content = string(b)
+		}
+	}
 	return &ToolCallResult{
 		Content:           content,
 		StructuredContent: structured,

--- a/pkg/api/toolsets_test.go
+++ b/pkg/api/toolsets_test.go
@@ -63,26 +63,42 @@ func (s *ToolsetsSuite) TestNewToolCallResult() {
 	})
 }
 
-func (s *ToolsetsSuite) TestNewToolCallResultWithStructuredContent() {
-	s.Run("sets content and structured content", func() {
-		structured := map[string]any{"pods": []string{"pod-1"}}
-		result := NewToolCallResultWithStructuredContent("text output", structured, nil)
-		s.Equal("text output", result.Content)
-		s.Nil(result.Error)
-		s.Equal(structured, result.StructuredContent)
-	})
-	s.Run("allows nil structured content", func() {
-		result := NewToolCallResultWithStructuredContent("text output", nil, nil)
-		s.Equal("text output", result.Content)
+func (s *ToolsetsSuite) TestNewToolCallResultStructured() {
+	s.Run("sets empty content when structured is nil", func() {
+		result := NewToolCallResultStructured(nil, nil)
+		s.Equal("", result.Content)
 		s.Nil(result.StructuredContent)
 	})
-	s.Run("sets error alongside structured content", func() {
+	s.Run("sets error and structured content", func() {
 		err := errors.New("partial failure")
 		structured := map[string]any{"key": "value"}
-		result := NewToolCallResultWithStructuredContent("output", structured, err)
-		s.Equal("output", result.Content)
+		result := NewToolCallResultStructured(structured, err)
+		s.Equal(`{"key":"value"}`, result.Content)
 		s.Equal(err, result.Error)
 		s.Equal(structured, result.StructuredContent)
+	})
+	s.Run("handles complex nested structures", func() {
+		structured := map[string]any{
+			"metadata": map[string]any{"name": "test-pod"},
+			"items":    []int{1, 2, 3},
+		}
+		result := NewToolCallResultStructured(structured, nil)
+		s.Contains(result.Content, `"metadata"`)
+		s.Contains(result.Content, `"name":"test-pod"`)
+		s.Equal(structured, result.StructuredContent)
+	})
+	// Per MCP spec: "For backwards compatibility, a tool that returns structured content
+	// SHOULD also return the serialized JSON in a TextContent block."
+	// https://modelcontextprotocol.io/specification/2025-11-25/server/tools#structured-content
+	s.Run("Content field contains JSON serialization of StructuredContent for MCP backward compatibility", func() {
+		structured := map[string]any{"pods": []string{"pod-1", "pod-2"}, "count": 2}
+		result := NewToolCallResultStructured(structured, nil)
+
+		// Content should be valid JSON that represents the same data as StructuredContent
+		s.JSONEq(`{"pods":["pod-1","pod-2"],"count":2}`, result.Content)
+		// StructuredContent should be the original value
+		s.Equal(structured, result.StructuredContent)
+		s.Nil(result.Error)
 	})
 }
 

--- a/pkg/mcp/gosdk.go
+++ b/pkg/mcp/gosdk.go
@@ -54,7 +54,7 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 		if err != nil {
 			return nil, err
 		}
-		return NewTextResultWithStructuredContent(result.Content, result.StructuredContent, result.Error), nil
+		return NewStructuredResult(result.Content, result.StructuredContent, result.Error), nil
 	}
 	return goSdkTool, goSdkHandler, nil
 }

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -361,11 +361,40 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+// NewTextResult creates an MCP CallToolResult with text content only.
+// Use this for tools that return human-readable text output.
 func NewTextResult(content string, err error) *mcp.CallToolResult {
-	return NewTextResultWithStructuredContent(content, nil, err)
+	if err != nil {
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: err.Error(),
+				},
+			},
+		}
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{
+				Text: content,
+			},
+		},
+	}
 }
 
-func NewTextResultWithStructuredContent(content string, structuredContent any, err error) *mcp.CallToolResult {
+// NewStructuredResult creates an MCP CallToolResult with structured content.
+// The Content field contains the JSON-serialized form of structuredContent
+// for backward compatibility with MCP clients that don't support structuredContent.
+//
+// Per the MCP specification:
+// "For backwards compatibility, a tool that returns structured content SHOULD
+// also return the serialized JSON in a TextContent block."
+// https://modelcontextprotocol.io/specification/2025-11-25/server/tools#structured-content
+//
+// Use this for tools that return typed/structured data that MCP clients can
+// parse programmatically.
+func NewStructuredResult(content string, structuredContent any, err error) *mcp.CallToolResult {
 	if err != nil {
 		return &mcp.CallToolResult{
 			IsError: true,

--- a/pkg/mcp/text_result_test.go
+++ b/pkg/mcp/text_result_test.go
@@ -37,19 +37,19 @@ func (s *TextResultSuite) TestNewTextResult() {
 	})
 }
 
-func (s *TextResultSuite) TestNewTextResultWithStructuredContent() {
+func (s *TextResultSuite) TestNewStructuredResult() {
 	s.Run("returns text and structured content for successful result", func() {
 		structured := map[string]any{"pods": []string{"pod-1", "pod-2"}}
-		result := NewTextResultWithStructuredContent("text output", structured, nil)
+		result := NewStructuredResult(`{"pods":["pod-1","pod-2"]}`, structured, nil)
 		s.False(result.IsError)
 		s.Require().Len(result.Content, 1)
 		tc, ok := result.Content[0].(*mcp.TextContent)
 		s.Require().True(ok, "expected TextContent")
-		s.Equal("text output", tc.Text)
+		s.Equal(`{"pods":["pod-1","pod-2"]}`, tc.Text)
 		s.Equal(structured, result.StructuredContent)
 	})
 	s.Run("omits structured content when nil", func() {
-		result := NewTextResultWithStructuredContent("text output", nil, nil)
+		result := NewStructuredResult("text output", nil, nil)
 		s.False(result.IsError)
 		s.Require().Len(result.Content, 1)
 		tc, ok := result.Content[0].(*mcp.TextContent)
@@ -60,7 +60,7 @@ func (s *TextResultSuite) TestNewTextResultWithStructuredContent() {
 	s.Run("returns error result and ignores structured content", func() {
 		err := errors.New("metrics unavailable")
 		structured := map[string]any{"should": "be ignored"}
-		result := NewTextResultWithStructuredContent("", structured, err)
+		result := NewStructuredResult("", structured, err)
 		s.True(result.IsError)
 		s.Require().Len(result.Content, 1)
 		tc, ok := result.Content[0].(*mcp.TextContent)


### PR DESCRIPTION
Refactor the structured content API to automatically serialize the structured value to JSON in the Content field. This follows the MCP specification recommendation for backward compatibility:

"For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block." https://modelcontextprotocol.io/specification/2025-11-25/server/tools#structured-content

Changes:
- Replace NewToolCallResultWithStructuredContent with NewToolCallResultStructured
- NewToolCallResultStructured now only takes structured content and auto-serializes to JSON
- Rename NewTextResultWithStructuredContent to NewStructuredResult in MCP layer
- Update tests to verify JSON serialization behavior

Follows up on #777