### PR TITLE
test(mcp)!: remove mark3labs/mcp-go dependency from test infrastructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/logr v1.4.3
 	github.com/google/jsonschema-go v0.4.2
-	github.com/mark3labs/mcp-go v0.43.2
 	github.com/modelcontextprotocol/go-sdk v1.3.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/afero v1.15.0
@@ -53,10 +52,8 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
@@ -91,7 +88,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -132,7 +128,6 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,16 +24,12 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
-github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -164,8 +160,6 @@ github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
-github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -190,8 +184,6 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
-github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy/I=
-github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -299,8 +291,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
-github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/internal/test/mcp.go
+++ b/internal/test/mcp.go
@@ -9,9 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mark3labs/mcp-go/client"
-	"github.com/mark3labs/mcp-go/client/transport"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,22 +19,29 @@ type McpClientOption interface {
 }
 
 type mcpClientConfig struct {
-	transportOptions []transport.StreamableHTTPCOption
-	clientInfo       *mcp.Implementation
+	headers              map[string]string
+	clientInfo           *mcp.Implementation
+	endpoint             string
+	allowConnectionError bool
 }
 
-// transportOptionWrapper wraps transport.StreamableHTTPCOption
-type transportOptionWrapper struct {
-	opt transport.StreamableHTTPCOption
+// httpHeaderOption sets custom HTTP headers
+type httpHeaderOption struct {
+	headers map[string]string
 }
 
-func (t transportOptionWrapper) apply(c *mcpClientConfig) {
-	c.transportOptions = append(c.transportOptions, t.opt)
+func (o httpHeaderOption) apply(c *mcpClientConfig) {
+	if c.headers == nil {
+		c.headers = make(map[string]string)
+	}
+	for k, v := range o.headers {
+		c.headers[k] = v
+	}
 }
 
-// WithTransport wraps a transport.StreamableHTTPCOption for use with NewMcpClient
-func WithTransport(opt transport.StreamableHTTPCOption) McpClientOption {
-	return transportOptionWrapper{opt}
+// WithHTTPHeaders sets custom HTTP headers for the MCP client transport
+func WithHTTPHeaders(headers map[string]string) McpClientOption {
+	return httpHeaderOption{headers: headers}
 }
 
 // clientInfoOption sets custom client info
@@ -58,26 +63,77 @@ func WithEmptyClientInfo() McpClientOption {
 	return clientInfoOption{info: mcp.Implementation{}}
 }
 
-// McpInitRequest returns a default MCP initialization request for backward compatibility
-func McpInitRequest() mcp.InitializeRequest {
-	initRequest := mcp.InitializeRequest{
-		Request: mcp.Request{Method: "initialize"},
+// endpointOption sets a custom endpoint URL instead of using httptest.Server
+type endpointOption struct {
+	endpoint string
+}
+
+func (o endpointOption) apply(c *mcpClientConfig) {
+	c.endpoint = o.endpoint
+}
+
+// WithEndpoint sets a custom endpoint URL for the MCP client.
+// When set, no httptest.Server will be created and the provided URL will be used directly.
+// The URL should include the full path (e.g., "http://localhost:8080/mcp").
+func WithEndpoint(endpoint string) McpClientOption {
+	return endpointOption{endpoint: endpoint}
+}
+
+// allowConnectionErrorOption allows connection errors without failing the test
+type allowConnectionErrorOption struct{}
+
+func (o allowConnectionErrorOption) apply(c *mcpClientConfig) {
+	c.allowConnectionError = true
+}
+
+// WithAllowConnectionError allows connection errors without failing the test.
+// When set, connection failures will result in a nil Session instead of a test failure.
+// Useful for testing authentication/authorization scenarios where connection rejection is expected.
+func WithAllowConnectionError() McpClientOption {
+	return allowConnectionErrorOption{}
+}
+
+// headerRoundTripper injects HTTP headers into requests
+type headerRoundTripper struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
 	}
-	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
-	initRequest.Params.ClientInfo = mcp.Implementation{Name: "test", Version: "1.33.7"}
-	return initRequest
+	return h.base.RoundTrip(req)
+}
+
+// CapturedNotification represents a captured MCP notification for testing
+type CapturedNotification struct {
+	Method string
+	Params any
 }
 
 type McpClient struct {
-	ctx        context.Context
-	testServer *httptest.Server
-	*client.Client
+	ctx              context.Context
+	testServer       *httptest.Server
+	client           *mcp.Client
+	Session          *mcp.ClientSession
 	InitializeResult *mcp.InitializeResult
+	notifications    *NotificationCapture
 }
 
+// NewMcpClient creates a new MCP test client.
+//
+// When an http.Handler is provided, an httptest.Server is created automatically.
+// Alternatively, use WithEndpoint() option to connect to an existing server URL.
+//
+// Example with handler:
+//
+//	client := test.NewMcpClient(t, myHandler)
+//
+// Example with endpoint:
+//
+//	client := test.NewMcpClient(t, nil, test.WithEndpoint("http://localhost:8080/mcp"))
 func NewMcpClient(t *testing.T, mcpHttpServer http.Handler, options ...McpClientOption) *McpClient {
-	require.NotNil(t, mcpHttpServer, "McpHttpServer must be provided")
-
 	cfg := &mcpClientConfig{
 		clientInfo: &mcp.Implementation{Name: "test", Version: "1.33.7"},
 	}
@@ -85,29 +141,101 @@ func NewMcpClient(t *testing.T, mcpHttpServer http.Handler, options ...McpClient
 		opt.apply(cfg)
 	}
 
-	var err error
-	ret := &McpClient{ctx: t.Context()}
-	ret.testServer = httptest.NewServer(mcpHttpServer)
-	transportOpts := append(cfg.transportOptions, transport.WithContinuousListening())
-	ret.Client, err = client.NewStreamableHttpClient(ret.testServer.URL+"/mcp", transportOpts...)
-	require.NoError(t, err, "Expected no error creating MCP client")
-	err = ret.Start(t.Context())
-	require.NoError(t, err, "Expected no error starting MCP client")
-
-	initRequest := mcp.InitializeRequest{
-		Request: mcp.Request{Method: "initialize"},
+	// Validate configuration
+	if mcpHttpServer == nil && cfg.endpoint == "" {
+		require.Fail(t, "Either mcpHttpServer or WithEndpoint() option must be provided")
+		return nil
 	}
-	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
-	initRequest.Params.ClientInfo = *cfg.clientInfo
 
-	ret.InitializeResult, err = ret.Initialize(t.Context(), initRequest)
-	require.NoError(t, err, "Expected no error initializing MCP client")
+	// Initialize notification capture immediately. Notifications are always captured
+	// from the moment the client connects. Use StartCapturingNotifications() to get
+	// the capture object for waiting on specific notifications in tests.
+	ret := &McpClient{
+		ctx: t.Context(),
+		notifications: &NotificationCapture{
+			notifications: make([]*CapturedNotification, 0),
+			signal:        make(chan struct{}, 1),
+		},
+	}
+
+	// Determine the endpoint URL
+	var endpoint string
+	if cfg.endpoint != "" {
+		// Use provided endpoint directly
+		endpoint = cfg.endpoint
+	} else {
+		// Create httptest.Server from handler
+		ret.testServer = httptest.NewServer(mcpHttpServer)
+		endpoint = ret.testServer.URL + "/mcp"
+	}
+
+	// Create HTTP client with custom headers if provided
+	httpClient := http.DefaultClient
+	if len(cfg.headers) > 0 {
+		httpClient = &http.Client{
+			Transport: &headerRoundTripper{
+				base:    http.DefaultTransport,
+				headers: cfg.headers,
+			},
+		}
+	}
+
+	// Create go-sdk client with notification handlers
+	clientOptions := &mcp.ClientOptions{
+		ToolListChangedHandler: func(_ context.Context, req *mcp.ToolListChangedRequest) {
+			ret.notifications.capture(&CapturedNotification{
+				Method: "notifications/tools/list_changed",
+				Params: req.Params,
+			})
+		},
+		PromptListChangedHandler: func(_ context.Context, req *mcp.PromptListChangedRequest) {
+			ret.notifications.capture(&CapturedNotification{
+				Method: "notifications/prompts/list_changed",
+				Params: req.Params,
+			})
+		},
+		ResourceListChangedHandler: func(_ context.Context, req *mcp.ResourceListChangedRequest) {
+			ret.notifications.capture(&CapturedNotification{
+				Method: "notifications/resources/list_changed",
+				Params: req.Params,
+			})
+		},
+		LoggingMessageHandler: func(_ context.Context, req *mcp.LoggingMessageRequest) {
+			ret.notifications.capture(&CapturedNotification{
+				Method: "notifications/message",
+				Params: req.Params,
+			})
+		},
+	}
+
+	ret.client = mcp.NewClient(cfg.clientInfo, clientOptions)
+
+	// Create transport with StreamableClientTransport
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:   endpoint,
+		HTTPClient: httpClient,
+	}
+
+	var err error
+	ret.Session, err = ret.client.Connect(t.Context(), transport, nil)
+	if err != nil {
+		if cfg.allowConnectionError {
+			// Connection error is allowed, return client with nil session
+			ret.Session = nil
+			return ret
+		}
+		require.NoError(t, err, "Expected no error connecting MCP client")
+	}
+
+	if ret.Session != nil {
+		ret.InitializeResult = ret.Session.InitializeResult()
+	}
 	return ret
 }
 
 func (m *McpClient) Close() {
-	if m.Client != nil {
-		_ = m.Client.Close()
+	if m.Session != nil {
+		_ = m.Session.Close()
 	}
 	if m.testServer != nil {
 		m.testServer.Close()
@@ -116,38 +244,60 @@ func (m *McpClient) Close() {
 
 // CallTool helper function to call a tool by name with arguments
 func (m *McpClient) CallTool(name string, args map[string]any) (*mcp.CallToolResult, error) {
-	callToolRequest := mcp.CallToolRequest{}
-	callToolRequest.Params.Name = name
-	callToolRequest.Params.Arguments = args
-	return m.Client.CallTool(m.ctx, callToolRequest)
+	return m.Session.CallTool(m.ctx, &mcp.CallToolParams{
+		Name:      name,
+		Arguments: args,
+	})
+}
+
+// ListTools helper function to list available tools
+func (m *McpClient) ListTools() (*mcp.ListToolsResult, error) {
+	return m.Session.ListTools(m.ctx, &mcp.ListToolsParams{})
+}
+
+// ListPrompts helper function to list available prompts
+func (m *McpClient) ListPrompts() (*mcp.ListPromptsResult, error) {
+	return m.Session.ListPrompts(m.ctx, &mcp.ListPromptsParams{})
+}
+
+// GetPrompt helper function to get a prompt by name
+func (m *McpClient) GetPrompt(name string, arguments map[string]string) (*mcp.GetPromptResult, error) {
+	return m.Session.GetPrompt(m.ctx, &mcp.GetPromptParams{
+		Name:      name,
+		Arguments: arguments,
+	})
+}
+
+// SetLoggingLevel sets the logging level on the server
+func (m *McpClient) SetLoggingLevel(level mcp.LoggingLevel) error {
+	return m.Session.SetLoggingLevel(m.ctx, &mcp.SetLoggingLevelParams{
+		Level: level,
+	})
 }
 
 // NotificationCapture captures MCP notifications for testing.
 // Use StartCapturingNotifications to begin capturing, then RequireNotification to retrieve.
 type NotificationCapture struct {
 	mu            sync.RWMutex
-	notifications []*mcp.JSONRPCNotification
+	notifications []*CapturedNotification
 	signal        chan struct{} // signals when new notifications arrive
 }
 
-// StartCapturingNotifications begins capturing all MCP notifications.
-// Must be called BEFORE the operation that triggers the notification.
-func (m *McpClient) StartCapturingNotifications() *NotificationCapture {
-	capture := &NotificationCapture{
-		notifications: make([]*mcp.JSONRPCNotification, 0),
-		signal:        make(chan struct{}, 1),
+func (c *NotificationCapture) capture(n *CapturedNotification) {
+	c.mu.Lock()
+	c.notifications = append(c.notifications, n)
+	c.mu.Unlock()
+	// Signal that a new notification arrived (non-blocking)
+	select {
+	case c.signal <- struct{}{}:
+	default:
 	}
-	m.OnNotification(func(n mcp.JSONRPCNotification) {
-		capture.mu.Lock()
-		capture.notifications = append(capture.notifications, &n)
-		capture.mu.Unlock()
-		// Signal that a new notification arrived (non-blocking)
-		select {
-		case capture.signal <- struct{}{}:
-		default:
-		}
-	})
-	return capture
+}
+
+// StartCapturingNotifications returns the notification capture for waiting on notifications.
+// The notifications are always being captured; this just returns the capture object.
+func (m *McpClient) StartCapturingNotifications() *NotificationCapture {
+	return m.notifications
 }
 
 // RequireNotification waits for a notification matching the specified method and fails the test if not received.
@@ -157,7 +307,7 @@ func (m *McpClient) StartCapturingNotifications() *NotificationCapture {
 // Timeout recommendations:
 //   - 2 seconds: For immediate notifications like log messages after tool calls
 //   - 5 seconds: For notifications involving file system or cluster state changes (kubeconfig, API groups)
-func (c *NotificationCapture) RequireNotification(t *testing.T, timeout time.Duration, method string) *mcp.JSONRPCNotification {
+func (c *NotificationCapture) RequireNotification(t *testing.T, timeout time.Duration, method string) *CapturedNotification {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -197,39 +347,32 @@ type LogNotification struct {
 	Data string
 }
 
-// parseLogNotification extracts log information from an MCP notification.
+// parseLogNotification extracts log information from a CapturedNotification.
 // Returns nil if the notification is not a valid logging notification.
-func parseLogNotification(notification *mcp.JSONRPCNotification) *LogNotification {
+func parseLogNotification(notification *CapturedNotification) *LogNotification {
 	if notification == nil {
 		return nil
 	}
-	// The Params field contains the LoggingMessageParams via AdditionalFields
-	paramsBytes, err := json.Marshal(notification.Params)
-	if err != nil {
-		return nil
+
+	// The Params field should be *mcp.LoggingMessageParams
+	if params, ok := notification.Params.(*mcp.LoggingMessageParams); ok {
+		// Convert Data to string
+		var dataStr string
+		switch v := params.Data.(type) {
+		case string:
+			dataStr = v
+		default:
+			dataBytes, _ := json.Marshal(v)
+			dataStr = string(dataBytes)
+		}
+		return &LogNotification{
+			Level:  string(params.Level),
+			Logger: params.Logger,
+			Data:   dataStr,
+		}
 	}
-	var logParams struct {
-		Level  string `json:"level"`
-		Logger string `json:"logger"`
-		Data   any    `json:"data"`
-	}
-	if err := json.Unmarshal(paramsBytes, &logParams); err != nil {
-		return nil
-	}
-	// Convert Data to string
-	var dataStr string
-	switch v := logParams.Data.(type) {
-	case string:
-		dataStr = v
-	default:
-		dataBytes, _ := json.Marshal(v)
-		dataStr = string(dataBytes)
-	}
-	return &LogNotification{
-		Level:  logParams.Level,
-		Logger: logParams.Logger,
-		Data:   dataStr,
-	}
+
+	return nil
 }
 
 // RequireLogNotification waits for a logging notification and returns it parsed.

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
@@ -214,22 +214,12 @@ func (s *BaseMcpSuite) InitMcpClient(options ...test.McpClientOption) {
 	s.McpClient = test.NewMcpClient(s.T(), s.mcpServer.ServeHTTP(), options...)
 }
 
-// StartCapturingNotifications begins capturing all MCP notifications.
-// Must be called BEFORE the operation that triggers the notification.
-func (s *BaseMcpSuite) StartCapturingNotifications() *test.NotificationCapture {
-	return s.McpClient.StartCapturingNotifications()
-}
-
 // StartCapturingLogNotifications begins capturing log notifications.
 // Must be called BEFORE the tool call that triggers the notification.
 // This method sets the logging level to debug to ensure all log messages are received.
 func (s *BaseMcpSuite) StartCapturingLogNotifications() *test.NotificationCapture {
 	// Set logging level to debug to receive all log messages
-	err := s.SetLevel(s.T().Context(), mcp.SetLevelRequest{
-		Params: mcp.SetLevelParams{
-			Level: mcp.LoggingLevelDebug,
-		},
-	})
+	err := s.SetLoggingLevel(mcp.LoggingLevel("debug"))
 	s.Require().NoError(err, "failed to set logging level")
 
 	return s.StartCapturingNotifications()

--- a/pkg/mcp/configuration_test.go
+++ b/pkg/mcp/configuration_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -48,11 +48,11 @@ func (s *ConfigurationSuite) TestContextsList() {
 		s.Require().NotNil(toolResult, "Expected tool result from call")
 		s.Lenf(toolResult.Content, 1, "invalid tool result content length %v", len(toolResult.Content))
 		s.Run("contains context count", func() {
-			s.Regexpf(`^Available Kubernetes contexts \(11 total`, toolResult.Content[0].(mcp.TextContent).Text, "invalid tool count result content %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Regexpf(`^Available Kubernetes contexts \(11 total`, toolResult.Content[0].(*mcp.TextContent).Text, "invalid tool count result content %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("contains default context name", func() {
-			s.Regexpf(`^Available Kubernetes contexts \(\d+ total, default: fake-context\)`, toolResult.Content[0].(mcp.TextContent).Text, "invalid tool context default result content %v", toolResult.Content[0].(mcp.TextContent).Text)
-			s.Regexpf(`(?m)^\*fake-context -> http:\/\/127\.0\.0\.1:\d*$`, toolResult.Content[0].(mcp.TextContent).Text, "invalid tool context default result content %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Regexpf(`^Available Kubernetes contexts \(\d+ total, default: fake-context\)`, toolResult.Content[0].(*mcp.TextContent).Text, "invalid tool context default result content %v", toolResult.Content[0].(*mcp.TextContent).Text)
+			s.Regexpf(`(?m)^\*fake-context -> http:\/\/127\.0\.0\.1:\d*$`, toolResult.Content[0].(*mcp.TextContent).Text, "invalid tool context default result content %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 }
@@ -66,7 +66,7 @@ func (s *ConfigurationSuite) TestConfigurationView() {
 		})
 		s.Require().NotNil(toolResult, "Expected tool result from call")
 		var decoded *v1.Config
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -97,7 +97,7 @@ func (s *ConfigurationSuite) TestConfigurationView() {
 			s.Nilf(err, "call tool failed %v", err)
 		})
 		var decoded *v1.Config
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -140,7 +140,7 @@ func (s *ConfigurationSuite) TestConfigurationViewInCluster() {
 		})
 		s.Require().NotNil(toolResult, "Expected tool result from call")
 		var decoded *v1.Config
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})

--- a/pkg/mcp/events_test.go
+++ b/pkg/mcp/events_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +27,7 @@ func (s *EventsSuite) TestEventsList() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		s.Run("returns no events message", func() {
-			s.Equal("# No events found", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equal("# No events found", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("events_list (with events)", func() {
@@ -55,10 +55,10 @@ func (s *EventsSuite) TestEventsList() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			s.Run("has yaml comment indicating output format", func() {
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# The following events (YAML format) were found:\n"), "unexpected result %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# The following events (YAML format) were found:\n"), "unexpected result %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			})
 			var decoded []v1.Event
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 			s.Run("has yaml content", func() {
 				s.Nilf(err, "unmarshal failed %v", err)
 			})
@@ -82,8 +82,8 @@ func (s *EventsSuite) TestEventsList() {
 					"  Reason: \"\"\n"+
 					"  Timestamp: 0001-01-01 00:00:00 +0000 UTC\n"+
 					"  Type: Normal\n",
-					toolResult.Content[0].(mcp.TextContent).Text,
-					"unexpected result %v", toolResult.Content[0].(mcp.TextContent).Text)
+					toolResult.Content[0].(*mcp.TextContent).Text,
+					"unexpected result %v", toolResult.Content[0].(*mcp.TextContent).Text)
 
 			})
 		})
@@ -96,10 +96,10 @@ func (s *EventsSuite) TestEventsList() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			s.Run("has yaml comment indicating output format", func() {
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# The following events (YAML format) were found:\n"), "unexpected result %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# The following events (YAML format) were found:\n"), "unexpected result %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			})
 			var decoded []v1.Event
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 			s.Run("has yaml content", func() {
 				s.Nilf(err, "unmarshal failed %v", err)
 			})
@@ -114,8 +114,8 @@ func (s *EventsSuite) TestEventsList() {
 					"  Reason: \"\"\n"+
 					"  Timestamp: 0001-01-01 00:00:00 +0000 UTC\n"+
 					"  Type: Normal\n",
-					toolResult.Content[0].(mcp.TextContent).Text,
-					"unexpected result %v", toolResult.Content[0].(mcp.TextContent).Text)
+					toolResult.Content[0].(*mcp.TextContent).Text,
+					"unexpected result %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			})
 		})
 	})
@@ -134,7 +134,7 @@ func (s *EventsSuite) TestEventsListDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := toolResult.Content[0].(mcp.TextContent).Text
+			msg := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list events in all namespaces:(.+:)? resource not allowed: /v1, Kind=Event"
 			s.Regexpf(expectedMessage, msg,
@@ -155,7 +155,7 @@ func (s *EventsSuite) TestEventsListForbidden() {
 		toolResult, _ := s.CallTool("events_list", map[string]interface{}{})
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
-			s.Contains(toolResult.Content[0].(mcp.TextContent).Text, "forbidden",
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "forbidden",
 				"error message should indicate forbidden")
 		})
 		s.Run("sends log notification", func() {

--- a/pkg/mcp/helm_test.go
+++ b/pkg/mcp/helm_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -61,7 +61,7 @@ func (s *HelmSuite) TestHelmInstall() {
 		})
 		s.Run("returns installed chart", func() {
 			var decoded []map[string]interface{}
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 			s.Run("has yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
 			})
@@ -107,7 +107,7 @@ func (s *HelmSuite) TestHelmInstallDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := toolResult.Content[0].(mcp.TextContent).Text
+			msg := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			s.Truef(strings.HasPrefix(msg, "failed to install helm chart"), "expected descriptive error, got %v", msg)
 			expectedMessage := ": resource not allowed: /v1, Kind=Secret"
@@ -128,7 +128,7 @@ func (s *HelmSuite) TestHelmListNoReleases() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		s.Run("returns not found", func() {
-			s.Equalf("No Helm releases found", toolResult.Content[0].(mcp.TextContent).Text, "unexpected result %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf("No Helm releases found", toolResult.Content[0].(*mcp.TextContent).Text, "unexpected result %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 }
@@ -157,7 +157,7 @@ func (s *HelmSuite) TestHelmList() {
 		})
 		s.Run("returns release", func() {
 			var decoded []map[string]interface{}
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 			s.Run("has yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
 			})
@@ -179,7 +179,7 @@ func (s *HelmSuite) TestHelmList() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		s.Run("returns not found", func() {
-			s.Equalf("No Helm releases found", toolResult.Content[0].(mcp.TextContent).Text, "unexpected result %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf("No Helm releases found", toolResult.Content[0].(*mcp.TextContent).Text, "unexpected result %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("helm_list(namespace=ns-1, all_namespaces=true) with deployed release in all namespaces", func() {
@@ -190,7 +190,7 @@ func (s *HelmSuite) TestHelmList() {
 		})
 		s.Run("returns release", func() {
 			var decoded []map[string]interface{}
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 			s.Run("has yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
 			})
@@ -233,7 +233,7 @@ func (s *HelmSuite) TestHelmListDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := toolResult.Content[0].(mcp.TextContent).Text
+			msg := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			s.Truef(strings.HasPrefix(msg, "failed to list helm releases"), "expected descriptive error, got %v", msg)
 			expectedMessage := ": resource not allowed: /v1, Kind=Secret"
@@ -253,7 +253,7 @@ func (s *HelmSuite) TestHelmUninstallNoReleases() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		s.Run("returns not found", func() {
-			s.Equalf("Release release-to-uninstall not found", toolResult.Content[0].(mcp.TextContent).Text, "unexpected result %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf("Release release-to-uninstall not found", toolResult.Content[0].(*mcp.TextContent).Text, "unexpected result %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 }
@@ -283,7 +283,7 @@ func (s *HelmSuite) TestHelmUninstall() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		s.Run("returns uninstalled", func() {
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "Uninstalled release existent-release-to-uninstall"), "unexpected result %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "Uninstalled release existent-release-to-uninstall"), "unexpected result %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			_, err = kc.CoreV1().Secrets("default").Get(s.T().Context(), "sh.helm.release.v1.existent-release-to-uninstall.v0", metav1.GetOptions{})
 			s.Truef(errors.IsNotFound(err), "expected release to be deleted, but it still exists")
 		})
@@ -320,7 +320,7 @@ func (s *HelmSuite) TestHelmUninstallDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes failure to uninstall", func() {
-			s.Contains(toolResult.Content[0].(mcp.TextContent).Text,
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text,
 				"failed to uninstall helm chart 'existent-release-to-uninstall': failed to delete release: existent-release-to-uninstall")
 		})
 		s.Run("describes denial (in log)", func() {
@@ -344,7 +344,7 @@ func (s *HelmSuite) TestHelmListForbidden() {
 		toolResult, _ := s.CallTool("helm_list", map[string]interface{}{})
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
-			s.Contains(toolResult.Content[0].(mcp.TextContent).Text, "forbidden",
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "forbidden",
 				"error message should indicate forbidden")
 		})
 		s.Run("sends log notification", func() {

--- a/pkg/mcp/kiali_test.go
+++ b/pkg/mcp/kiali_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -61,7 +61,7 @@ func (s *KialiSuite) TestGetTraces() {
 			s.Equal("/api/traces/test-trace-123", capturedURL.Path, "Unexpected path")
 		})
 		s.Run("response contains trace ID", func() {
-			s.Contains(toolResult.Content[0].(mcp.TextContent).Text, traceId, "Response should contain trace ID")
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, traceId, "Response should contain trace ID")
 		})
 	})
 }

--- a/pkg/mcp/kubevirt_test.go
+++ b/pkg/mcp/kubevirt_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	kubevirttesting "github.com/containers/kubernetes-mcp-server/pkg/kubevirt/testing"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
@@ -78,7 +78,7 @@ func (s *KubevirtSuite) TestCreate() {
 				toolResult, err := s.CallTool("vm_create", params)
 				s.Require().Nilf(err, "call tool failed %v", err)
 				s.Truef(toolResult.IsError, "expected call tool to fail due to missing %s", param)
-				s.Equal(toolResult.Content[0].(mcp.TextContent).Text, param+" parameter required")
+				s.Equal(toolResult.Content[0].(*mcp.TextContent).Text, param+" parameter required")
 			})
 		}
 	})
@@ -92,11 +92,11 @@ func (s *KubevirtSuite) TestCreate() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-				"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+				"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			vm := &decodedResult[0]
 			s.Equal("test-vm", vm.GetName(), "invalid resource name")
@@ -118,11 +118,11 @@ func (s *KubevirtSuite) TestCreate() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-				"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+				"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			vm := &decodedResult[0]
 			s.Equal("test-vm-2", vm.GetName(), "invalid resource name")
@@ -146,11 +146,11 @@ func (s *KubevirtSuite) TestCreate() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-				"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+				"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			vm := &decodedResult[0]
 			s.Equal("test-vm-3", vm.GetName(), "invalid resource name")
@@ -173,11 +173,11 @@ func (s *KubevirtSuite) TestCreate() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-				"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+				"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			vm := &decodedResult[0]
 			s.Equal("test-vm-4", vm.GetName(), "invalid resource name")
@@ -220,11 +220,11 @@ func (s *KubevirtSuite) TestCreate() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			var decodedResult []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 			s.Run("returns yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-					"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+					"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 				s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 				vm := &decodedResult[0]
 				s.Equal("test-vm-5", vm.GetName(), "invalid resource name")
@@ -246,11 +246,11 @@ func (s *KubevirtSuite) TestCreate() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			var decodedResult []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 			s.Run("returns yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-					"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+					"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 				s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 				vm := &decodedResult[0]
 				s.Equal("test-vm-6", vm.GetName(), "invalid resource name")
@@ -271,11 +271,11 @@ func (s *KubevirtSuite) TestCreate() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			var decodedResult []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 			s.Run("returns yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-					"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+					"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 				s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 				vm := &decodedResult[0]
 				s.Equal("test-vm-7", vm.GetName(), "invalid resource name")
@@ -307,11 +307,11 @@ func (s *KubevirtSuite) TestCreate() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			var decodedResult []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 			s.Run("returns yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-					"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+					"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 				s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 				vm := &decodedResult[0]
 				s.Equal("test-vm-8", vm.GetName(), "invalid resource name")
@@ -344,11 +344,11 @@ func (s *KubevirtSuite) TestCreate() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			var decodedResult []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 			s.Run("returns yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-					"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+					"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 				s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 				vm := &decodedResult[0]
 				s.Equal("test-vm-9", vm.GetName(), "invalid resource name")
@@ -373,11 +373,11 @@ func (s *KubevirtSuite) TestCreate() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			var decodedResult []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 			s.Run("returns yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-					"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+					"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 				s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 				vm := &decodedResult[0]
 				s.Equal("test-vm-10", vm.GetName(), "invalid resource name")
@@ -412,11 +412,11 @@ func (s *KubevirtSuite) TestCreate() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			var decodedResult []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 			s.Run("returns yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-					"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+					"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 				s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 				vm := &decodedResult[0]
 				s.Equal("test-vm-11", vm.GetName(), "invalid resource name")
@@ -438,11 +438,11 @@ func (s *KubevirtSuite) TestCreate() {
 				s.Falsef(toolResult.IsError, "call tool failed")
 			})
 			var decodedResult []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+			err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 			s.Run("returns yaml content", func() {
 				s.Nilf(err, "invalid tool result content %v", err)
-				s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine created successfully"),
-					"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine created successfully"),
+					"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 				s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 				vm := &decodedResult[0]
 				s.Equal("test-vm-12", vm.GetName(), "invalid resource name")
@@ -489,7 +489,7 @@ func (s *KubevirtSuite) TestVMLifecycle() {
 				toolResult, err := s.CallTool("vm_lifecycle", params)
 				s.Require().Nilf(err, "call tool failed %v", err)
 				s.Truef(toolResult.IsError, "expected call tool to fail due to missing %s", param)
-				s.Equal(toolResult.Content[0].(mcp.TextContent).Text, param+" parameter required")
+				s.Equal(toolResult.Content[0].(*mcp.TextContent).Text, param+" parameter required")
 			})
 		}
 	})
@@ -502,8 +502,8 @@ func (s *KubevirtSuite) TestVMLifecycle() {
 		})
 		s.Require().Nilf(err, "call tool failed %v", err)
 		s.Truef(toolResult.IsError, "expected call tool to fail due to invalid action")
-		s.Truef(strings.Contains(toolResult.Content[0].(mcp.TextContent).Text, "invalid action"),
-			"Expected invalid action message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Truef(strings.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "invalid action"),
+			"Expected invalid action message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 
 	s.Run("vm_lifecycle action=start on halted VM", func() {
@@ -517,11 +517,11 @@ func (s *KubevirtSuite) TestVMLifecycle() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine started successfully"),
-				"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine started successfully"),
+				"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			s.Equal("test-vm-lifecycle", decodedResult[0].GetName(), "invalid resource name")
 			s.Equal("default", decodedResult[0].GetNamespace(), "invalid resource namespace")
@@ -542,12 +542,12 @@ func (s *KubevirtSuite) TestVMLifecycle() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content showing VM was already running", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 			expectedPrefix := fmt.Sprintf("# VirtualMachine '%s' in namespace '%s' is already running", "test-vm-lifecycle", "default")
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, expectedPrefix),
-				"Expected already running message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, expectedPrefix),
+				"Expected already running message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			s.Equal("Always",
 				decodedResult[0].Object["spec"].(map[string]interface{})["runStrategy"].(string),
@@ -566,11 +566,11 @@ func (s *KubevirtSuite) TestVMLifecycle() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine stopped successfully"),
-				"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine stopped successfully"),
+				"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			s.Equal("test-vm-lifecycle", decodedResult[0].GetName(), "invalid resource name")
 			s.Equal("default", decodedResult[0].GetNamespace(), "invalid resource namespace")
@@ -591,12 +591,12 @@ func (s *KubevirtSuite) TestVMLifecycle() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content showing VM was already stopped", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 			expectedPrefix := fmt.Sprintf("# VirtualMachine '%s' in namespace '%s' is already stopped", "test-vm-lifecycle", "default")
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, expectedPrefix),
-				"Expected already stopped message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, expectedPrefix),
+				"Expected already stopped message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			s.Equal("Halted",
 				decodedResult[0].Object["spec"].(map[string]interface{})["runStrategy"].(string),
@@ -615,11 +615,11 @@ func (s *KubevirtSuite) TestVMLifecycle() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content showing VM restarted from stopped state", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine restarted successfully"),
-				"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine restarted successfully"),
+				"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			s.Equal("Always",
 				decodedResult[0].Object["spec"].(map[string]interface{})["runStrategy"].(string),
@@ -638,11 +638,11 @@ func (s *KubevirtSuite) TestVMLifecycle() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachine restarted successfully"),
-				"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachine restarted successfully"),
+				"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			s.Equal("test-vm-lifecycle", decodedResult[0].GetName(), "invalid resource name")
 			s.Equal("default", decodedResult[0].GetNamespace(), "invalid resource namespace")
@@ -662,8 +662,8 @@ func (s *KubevirtSuite) TestVMLifecycle() {
 				})
 				s.Nilf(err, "call tool failed %v", err)
 				s.Truef(toolResult.IsError, "expected call tool to fail for non-existent VM")
-				s.Truef(strings.Contains(toolResult.Content[0].(mcp.TextContent).Text, "failed to get VirtualMachine"),
-					"Expected error message about VM not found, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				s.Truef(strings.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "failed to get VirtualMachine"),
+					"Expected error message about VM not found, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			})
 		}
 	})
@@ -683,7 +683,7 @@ func (s *KubevirtSuite) TestVMClone() {
 				toolResult, err := s.CallTool("vm_clone", params)
 				s.Require().Nilf(err, "call tool failed %v", err)
 				s.Truef(toolResult.IsError, "expected call tool to fail due to missing %s", param)
-				s.Equal(toolResult.Content[0].(mcp.TextContent).Text, param+" parameter required")
+				s.Equal(toolResult.Content[0].(*mcp.TextContent).Text, param+" parameter required")
 			})
 		}
 	})
@@ -720,11 +720,11 @@ func (s *KubevirtSuite) TestVMClone() {
 			s.Falsef(toolResult.IsError, "call tool failed: %v", toolResult.Content)
 		})
 		var decodedResult []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decodedResult)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decodedResult)
 		s.Run("returns yaml content with correct source and target", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(toolResult.Content[0].(mcp.TextContent).Text, "# VirtualMachineClone created successfully"),
-				"Expected success message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(toolResult.Content[0].(*mcp.TextContent).Text, "# VirtualMachineClone created successfully"),
+				"Expected success message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Require().Lenf(decodedResult, 1, "invalid resource count, expected 1, got %v", len(decodedResult))
 			clone := &decodedResult[0]
 			s.Equal("default", clone.GetNamespace(), "invalid resource namespace")
@@ -740,14 +740,9 @@ func (s *KubevirtSuite) TestVMClone() {
 
 func (s *KubevirtSuite) TestVMTroubleshootPrompt() {
 	s.Run("vm-troubleshoot prompt returns troubleshooting guide", func() {
-		result, err := s.GetPrompt(s.T().Context(), mcp.GetPromptRequest{
-			Params: mcp.GetPromptParams{
-				Name: "vm-troubleshoot",
-				Arguments: map[string]string{
-					"namespace": "default",
-					"name":      "test-vm",
-				},
-			},
+		result, err := s.GetPrompt("vm-troubleshoot", map[string]string{
+			"namespace": "default",
+			"name":      "test-vm",
 		})
 
 		s.Run("no error", func() {
@@ -759,7 +754,7 @@ func (s *KubevirtSuite) TestVMTroubleshootPrompt() {
 			s.Require().NotNil(result)
 			s.Require().Len(result.Messages, 2, "Expected 2 messages")
 
-			textContent, ok := result.Messages[0].Content.(mcp.TextContent)
+			textContent, ok := result.Messages[0].Content.(*mcp.TextContent)
 			s.Require().True(ok, "expected TextContent")
 			s.Contains(textContent.Text, "# VirtualMachine Troubleshooting Guide")
 			s.Contains(textContent.Text, "test-vm")
@@ -768,13 +763,8 @@ func (s *KubevirtSuite) TestVMTroubleshootPrompt() {
 	})
 
 	s.Run("vm-troubleshoot prompt returns error for missing namespace", func() {
-		result, err := s.GetPrompt(s.T().Context(), mcp.GetPromptRequest{
-			Params: mcp.GetPromptParams{
-				Name: "vm-troubleshoot",
-				Arguments: map[string]string{
-					"name": "test-vm",
-				},
-			},
+		result, err := s.GetPrompt("vm-troubleshoot", map[string]string{
+			"name": "test-vm",
 		})
 		s.Error(err, "expected error for missing namespace")
 		s.Nil(result)
@@ -782,13 +772,8 @@ func (s *KubevirtSuite) TestVMTroubleshootPrompt() {
 	})
 
 	s.Run("vm-troubleshoot prompt returns error for missing name", func() {
-		result, err := s.GetPrompt(s.T().Context(), mcp.GetPromptRequest{
-			Params: mcp.GetPromptParams{
-				Name: "vm-troubleshoot",
-				Arguments: map[string]string{
-					"namespace": "default",
-				},
-			},
+		result, err := s.GetPrompt("vm-troubleshoot", map[string]string{
+			"namespace": "default",
 		})
 		s.Error(err, "expected error for missing name")
 		s.Nil(result)

--- a/pkg/mcp/mcp_middleware_test.go
+++ b/pkg/mcp/mcp_middleware_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
-	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
@@ -60,12 +59,12 @@ func (s *McpLoggingSuite) TestLogsToolCall() {
 
 func (s *McpLoggingSuite) TestLogsToolCallHeaders() {
 	s.SetLogLevel(7)
-	s.InitMcpClient(test.WithTransport(transport.WithHTTPHeaders(map[string]string{
+	s.InitMcpClient(test.WithHTTPHeaders(map[string]string{
 		"Accept-Encoding":   "gzip",
 		"Authorization":     "Bearer should-not-be-logged",
 		"authorization":     "Bearer should-not-be-logged",
 		"a-loggable-header": "should-be-logged",
-	})))
+	}))
 	_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
 	s.Require().NoError(err, "call to tool configuration_view failed")
 

--- a/pkg/mcp/mcp_prompts_test.go
+++ b/pkg/mcp/mcp_prompts_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -32,7 +32,7 @@ func (s *McpPromptsSuite) TestListPrompts() {
 
 	s.InitMcpClient()
 
-	prompts, err := s.ListPrompts(s.T().Context(), mcp.ListPromptsRequest{})
+	prompts, err := s.ListPrompts()
 
 	s.Run("ListPrompts returns prompts", func() {
 		s.NoError(err, "call ListPrompts failed")
@@ -42,9 +42,9 @@ func (s *McpPromptsSuite) TestListPrompts() {
 	s.Run("config prompt is available with all metadata", func() {
 		s.Require().NotNil(prompts)
 		var testPrompt *mcp.Prompt
-		for _, prompt := range prompts.Prompts {
-			if prompt.Name == "test-prompt" {
-				testPrompt = &prompt
+		for _, p := range prompts.Prompts {
+			if p.Name == "test-prompt" {
+				testPrompt = p
 				break
 			}
 		}
@@ -78,13 +78,8 @@ func (s *McpPromptsSuite) TestGetPrompt() {
 
 	s.InitMcpClient()
 
-	result, err := s.GetPrompt(s.T().Context(), mcp.GetPromptRequest{
-		Params: mcp.GetPromptParams{
-			Name: "substitution-prompt",
-			Arguments: map[string]string{
-				"name": "World",
-			},
-		},
+	result, err := s.GetPrompt("substitution-prompt", map[string]string{
+		"name": "World",
 	})
 
 	s.Run("GetPrompt succeeds", func() {
@@ -97,9 +92,8 @@ func (s *McpPromptsSuite) TestGetPrompt() {
 		s.Equal("Test argument substitution", result.Description)
 		s.Require().Len(result.Messages, 1)
 		s.Equal("user", string(result.Messages[0].Role))
-		textContent, ok := result.Messages[0].Content.(mcp.TextContent)
+		textContent, ok := result.Messages[0].Content.(*mcp.TextContent)
 		s.Require().True(ok, "expected TextContent")
-		s.Equal("text", textContent.Type)
 		s.Equal("Hello World!", textContent.Text)
 	})
 }
@@ -122,12 +116,7 @@ func (s *McpPromptsSuite) TestGetPromptMissingRequiredArgument() {
 
 	s.InitMcpClient()
 
-	result, err := s.GetPrompt(s.T().Context(), mcp.GetPromptRequest{
-		Params: mcp.GetPromptParams{
-			Name:      "required-arg-prompt",
-			Arguments: map[string]string{},
-		},
-	})
+	result, err := s.GetPrompt("required-arg-prompt", map[string]string{})
 
 	s.Run("missing required argument returns error", func() {
 		s.Error(err, "expected error for missing required argument")

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
-	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -191,7 +190,7 @@ func (s *ConfigReloadSuite) TestReloadUpdatesToolsets() {
 
 	// Get initial tools
 	s.InitMcpClient()
-	initialTools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+	initialTools, err := s.ListTools()
 	s.Require().NoError(err)
 	s.Require().Greater(len(initialTools.Tools), 0)
 
@@ -205,7 +204,7 @@ func (s *ConfigReloadSuite) TestReloadUpdatesToolsets() {
 	s.Require().NoError(err)
 
 	// Verify helm tools are available
-	reloadedTools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+	reloadedTools, err := s.ListTools()
 	s.Require().NoError(err)
 
 	helmToolFound := false

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
-	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -57,7 +56,7 @@ func (s *McpHeadersSuite) TearDownTest() {
 func (s *McpHeadersSuite) TestAuthorizationHeaderPropagation() {
 	cases := []string{"kubernetes-authorization", "Authorization"}
 	for _, header := range cases {
-		s.InitMcpClient(test.WithTransport(transport.WithHTTPHeaders(map[string]string{header: "Bearer a-token-from-mcp-client"})))
+		s.InitMcpClient(test.WithHTTPHeaders(map[string]string{header: "Bearer a-token-from-mcp-client"}))
 		_, _ = s.CallTool("pods_list", map[string]interface{}{})
 		s.pathHeadersMux.Lock()
 		pathHeadersLen := len(s.pathHeaders)
@@ -165,9 +164,9 @@ func (s *UserAgentPropagationSuite) TearDownTest() {
 }
 
 func (s *UserAgentPropagationSuite) TestPropagatesExplicitUserAgentToKubeAPI() {
-	s.InitMcpClient(test.WithTransport(transport.WithHTTPHeaders(map[string]string{
+	s.InitMcpClient(test.WithHTTPHeaders(map[string]string{
 		"User-Agent": "custom-mcp-client/2.0",
-	})))
+	}))
 	_, _ = s.CallTool("pods_list", map[string]any{})
 
 	s.pathHeadersMux.Lock()
@@ -184,10 +183,10 @@ func (s *UserAgentPropagationSuite) TestPropagatesExplicitUserAgentToKubeAPI() {
 }
 
 func (s *UserAgentPropagationSuite) TestPropagatesExplicitUserAgentWithOAuthToKubeAPI() {
-	s.InitMcpClient(test.WithTransport(transport.WithHTTPHeaders(map[string]string{
+	s.InitMcpClient(test.WithHTTPHeaders(map[string]string{
 		"Authorization": "Bearer a-token-from-mcp-client",
 		"User-Agent":    "custom-mcp-client/2.0",
-	})))
+	}))
 	_, _ = s.CallTool("pods_list", map[string]any{})
 
 	s.pathHeadersMux.Lock()

--- a/pkg/mcp/mcp_toolset_prompts_test.go
+++ b/pkg/mcp/mcp_toolset_prompts_test.go
@@ -3,7 +3,7 @@ package mcp
 import (
 	"testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -67,7 +67,7 @@ func (s *McpToolsetPromptsSuite) TestToolsetReturningPrompts() {
 
 	s.InitMcpClient()
 
-	prompts, err := s.ListPrompts(s.T().Context(), mcp.ListPromptsRequest{})
+	prompts, err := s.ListPrompts()
 
 	s.Run("ListPrompts returns toolset prompts", func() {
 		s.NoError(err)
@@ -91,13 +91,8 @@ func (s *McpToolsetPromptsSuite) TestToolsetReturningPrompts() {
 	})
 
 	s.Run("toolset prompt handler executes correctly", func() {
-		result, err := s.GetPrompt(s.T().Context(), mcp.GetPromptRequest{
-			Params: mcp.GetPromptParams{
-				Name: "toolset-prompt",
-				Arguments: map[string]string{
-					"arg1": "test-value",
-				},
-			},
+		result, err := s.GetPrompt("toolset-prompt", map[string]string{
+			"arg1": "test-value",
 		})
 
 		s.NoError(err)
@@ -106,7 +101,7 @@ func (s *McpToolsetPromptsSuite) TestToolsetReturningPrompts() {
 		s.Require().Len(result.Messages, 1)
 		s.Equal("user", string(result.Messages[0].Role))
 
-		textContent, ok := result.Messages[0].Content.(mcp.TextContent)
+		textContent, ok := result.Messages[0].Content.(*mcp.TextContent)
 		s.Require().True(ok, "expected TextContent")
 		s.Equal("Toolset prompt with test-value", textContent.Text)
 	})
@@ -125,7 +120,7 @@ func (s *McpToolsetPromptsSuite) TestToolsetReturningNilPrompts() {
 
 	s.InitMcpClient()
 
-	prompts, err := s.ListPrompts(s.T().Context(), mcp.ListPromptsRequest{})
+	prompts, err := s.ListPrompts()
 
 	s.Run("ListPrompts succeeds with nil toolset prompts", func() {
 		s.NoError(err)
@@ -151,7 +146,7 @@ func (s *McpToolsetPromptsSuite) TestToolsetReturningEmptyPrompts() {
 
 	s.InitMcpClient()
 
-	prompts, err := s.ListPrompts(s.T().Context(), mcp.ListPromptsRequest{})
+	prompts, err := s.ListPrompts()
 
 	s.Run("ListPrompts succeeds with empty toolset prompts", func() {
 		s.NoError(err)
@@ -204,7 +199,7 @@ func (s *McpToolsetPromptsSuite) TestMultipleToolsetsPromptCollection() {
 
 	s.InitMcpClient()
 
-	prompts, err := s.ListPrompts(s.T().Context(), mcp.ListPromptsRequest{})
+	prompts, err := s.ListPrompts()
 
 	s.Run("ListPrompts collects from multiple toolsets", func() {
 		s.NoError(err)
@@ -270,7 +265,7 @@ content = "From config"
 
 	s.InitMcpClient()
 
-	prompts, err := s.ListPrompts(s.T().Context(), mcp.ListPromptsRequest{})
+	prompts, err := s.ListPrompts()
 
 	s.Run("ListPrompts returns prompts", func() {
 		s.NoError(err)
@@ -285,17 +280,13 @@ content = "From config"
 	})
 
 	s.Run("config prompt handler is used", func() {
-		result, err := s.GetPrompt(s.T().Context(), mcp.GetPromptRequest{
-			Params: mcp.GetPromptParams{
-				Name: "shared-prompt",
-			},
-		})
+		result, err := s.GetPrompt("shared-prompt", nil)
 
 		s.NoError(err)
 		s.Require().NotNil(result)
 		s.Require().Len(result.Messages, 1)
 
-		textContent, ok := result.Messages[0].Content.(mcp.TextContent)
+		textContent, ok := result.Messages[0].Content.(*mcp.TextContent)
 		s.Require().True(ok)
 		s.Equal("From config", textContent.Text)
 	})
@@ -342,7 +333,7 @@ func (s *McpToolsetPromptsSuite) TestPromptsNotExposedWhenToolsetDisabled() {
 
 	s.InitMcpClient()
 
-	prompts, err := s.ListPrompts(s.T().Context(), mcp.ListPromptsRequest{})
+	prompts, err := s.ListPrompts()
 
 	s.Run("ListPrompts returns prompts", func() {
 		s.NoError(err)

--- a/pkg/mcp/mcp_watch_test.go
+++ b/pkg/mcp/mcp_watch_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
-	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -112,7 +111,7 @@ func (s *WatchKubeConfigSuite) TestClearsNoLongerAvailableTools() {
 	s.InitMcpClient()
 
 	s.Run("OpenShift tool is available", func() {
-		tools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+		tools, err := s.ListTools()
 		s.Require().NoError(err, "call ListTools failed")
 		s.Require().NotNil(tools, "list tools failed")
 		var found bool
@@ -134,7 +133,7 @@ func (s *WatchKubeConfigSuite) TestClearsNoLongerAvailableTools() {
 		capture.RequireNotification(s.T(), 5*time.Second, "notifications/tools/list_changed")
 		time.Sleep(serverSettleDelay)
 
-		tools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+		tools, err := s.ListTools()
 		s.Require().NoError(err, "call ListTools failed")
 		s.Require().NotNil(tools, "list tools failed")
 		for _, tool := range tools.Tools {
@@ -206,7 +205,7 @@ func (s *WatchClusterStateSuite) TestDetectsOpenShiftClusterStateChange() {
 	s.InitMcpClient()
 
 	s.Run("OpenShift tool is not available initially", func() {
-		tools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+		tools, err := s.ListTools()
 		s.Require().NoError(err, "call ListTools failed")
 		s.Require().NotNil(tools, "list tools failed")
 		for _, tool := range tools.Tools {
@@ -224,7 +223,7 @@ func (s *WatchClusterStateSuite) TestDetectsOpenShiftClusterStateChange() {
 		capture.RequireNotification(s.T(), 5*time.Second, "notifications/tools/list_changed")
 		time.Sleep(serverSettleDelay)
 
-		tools, err := s.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+		tools, err := s.ListTools()
 		s.Require().NoError(err, "call ListTools failed")
 		s.Require().NotNil(tools, "list tools failed")
 

--- a/pkg/mcp/namespaces_test.go
+++ b/pkg/mcp/namespaces_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -31,7 +31,7 @@ func (s *NamespacesSuite) TestNamespacesList() {
 		})
 		s.Require().NotNil(toolResult, "Expected tool result from call")
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -58,7 +58,7 @@ func (s *NamespacesSuite) TestNamespacesListDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := toolResult.Content[0].(mcp.TextContent).Text
+			msg := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list namespaces:(.+:)? resource not allowed: /v1, Kind=Namespace"
 			s.Regexpf(expectedMessage, msg,
@@ -79,7 +79,7 @@ func (s *NamespacesSuite) TestNamespacesListForbidden() {
 		toolResult, _ := s.CallTool("namespaces_list", map[string]interface{}{})
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
-			s.Contains(toolResult.Content[0].(mcp.TextContent).Text, "forbidden",
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "forbidden",
 				"error message should indicate forbidden")
 		})
 		s.Run("sends log notification", func() {
@@ -100,7 +100,7 @@ func (s *NamespacesSuite) TestNamespacesListAsTable() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		s.Require().NotNil(toolResult, "Expected tool result from call")
-		out := toolResult.Content[0].(mcp.TextContent).Text
+		out := toolResult.Content[0].(*mcp.TextContent).Text
 		s.Run("returns column headers", func() {
 			expectedHeaders := "APIVERSION\\s+KIND\\s+NAME\\s+STATUS\\s+AGE\\s+LABELS"
 			m, e := regexp.MatchString(expectedHeaders, out)
@@ -155,7 +155,7 @@ func (s *NamespacesSuite) TestProjectsListInOpenShift() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -186,7 +186,7 @@ func (s *NamespacesSuite) TestProjectsListInOpenShiftDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := projectsList.Content[0].(mcp.TextContent).Text
+			msg := projectsList.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list projects:(.+:)? resource not allowed: project.openshift.io/v1, Kind=Project"
 			s.Regexpf(expectedMessage, msg,

--- a/pkg/mcp/nodes_test.go
+++ b/pkg/mcp/nodes_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -79,8 +79,8 @@ func (s *NodesSuite) TestNodesLog() {
 		})
 		s.Run("describes missing name", func() {
 			expectedMessage := "failed to get node log, missing argument name"
-			s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("nodes_log(name=existing-node, query=nil)", func() {
@@ -94,8 +94,8 @@ func (s *NodesSuite) TestNodesLog() {
 		})
 		s.Run("describes missing name", func() {
 			expectedMessage := "failed to get node log, missing argument query"
-			s.Regexpf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Regexpf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("nodes_log(name=inexistent-node, query=/kubelet.log)", func() {
@@ -110,8 +110,8 @@ func (s *NodesSuite) TestNodesLog() {
 		})
 		s.Run("describes missing node", func() {
 			expectedMessage := "failed to get node log for inexistent-node: failed to get node inexistent-node: the server could not find the requested resource (get nodes inexistent-node)"
-			s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("nodes_log(name=existing-node, query=/missing.log)", func() {
@@ -126,8 +126,8 @@ func (s *NodesSuite) TestNodesLog() {
 		})
 		s.Run("describes missing log file", func() {
 			expectedMessage := "failed to get node log for existing-node: failed to get node logs: the server could not find the requested resource"
-			s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("nodes_log(name=existing-node, query=/empty.log)", func() {
@@ -142,8 +142,8 @@ func (s *NodesSuite) TestNodesLog() {
 		})
 		s.Run("describes empty log", func() {
 			expectedMessage := "The node existing-node has not logged any message yet or the log file is empty"
-			s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-				"expected descriptive message '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+				"expected descriptive message '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("nodes_log(name=existing-node, query=/kubelet.log)", func() {
@@ -158,8 +158,8 @@ func (s *NodesSuite) TestNodesLog() {
 		})
 		s.Run("returns full log", func() {
 			expectedMessage := "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
-			s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-				"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+				"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	for _, tailCase := range []interface{}{2, int64(2), float64(2)} {
@@ -176,8 +176,8 @@ func (s *NodesSuite) TestNodesLog() {
 			})
 			s.Run("returns tail log", func() {
 				expectedMessage := "Line 4\nLine 5\n"
-				s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-					"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+				s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+					"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 			})
 		})
 		s.Run("nodes_log(name=existing-node, query=/kubelet.log, tailLines=-1)", func() {
@@ -193,8 +193,8 @@ func (s *NodesSuite) TestNodesLog() {
 			})
 			s.Run("returns full log", func() {
 				expectedMessage := "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
-				s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-					"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+				s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+					"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 			})
 		})
 	}
@@ -216,7 +216,7 @@ func (s *NodesSuite) TestNodesLogDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := toolResult.Content[0].(mcp.TextContent).Text
+			msg := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get node log for does-not-matter:(.+:)? resource not allowed: /v1, Kind=Node"
 			s.Regexpf(expectedMessage, msg,
@@ -275,8 +275,8 @@ func (s *NodesSuite) TestNodesStatsSummary() {
 		})
 		s.Run("describes missing name", func() {
 			expectedMessage := "failed to get node stats summary, missing argument name"
-			s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("nodes_stats_summary(name=inexistent-node)", func() {
@@ -290,8 +290,8 @@ func (s *NodesSuite) TestNodesStatsSummary() {
 		})
 		s.Run("describes missing node", func() {
 			expectedMessage := "failed to get node stats summary for inexistent-node: failed to get node inexistent-node: the server could not find the requested resource (get nodes inexistent-node)"
-			s.Equalf(expectedMessage, toolResult.Content[0].(mcp.TextContent).Text,
-				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+				"expected descriptive error '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("nodes_stats_summary(name=existing-node)", func() {
@@ -304,7 +304,7 @@ func (s *NodesSuite) TestNodesStatsSummary() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("returns stats summary", func() {
-			content := toolResult.Content[0].(mcp.TextContent).Text
+			content := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Containsf(content, "existing-node", "expected stats to contain node name, got %v", content)
 			s.Containsf(content, "usageNanoCores", "expected stats to contain CPU metrics, got %v", content)
 			s.Containsf(content, "usageBytes", "expected stats to contain memory metrics, got %v", content)
@@ -327,7 +327,7 @@ func (s *NodesSuite) TestNodesStatsSummaryDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := toolResult.Content[0].(mcp.TextContent).Text
+			msg := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get node stats summary for does-not-matter:(.+:)? resource not allowed: /v1, Kind=Node"
 			s.Regexpf(expectedMessage, msg,

--- a/pkg/mcp/nodes_top_test.go
+++ b/pkg/mcp/nodes_top_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -154,7 +154,7 @@ func (s *NodesTopSuite) TestNodesTop() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("returns metrics for all nodes", func() {
-			content := toolResult.Content[0].(mcp.TextContent).Text
+			content := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(content, "node-1", "expected metrics to contain node-1")
 			s.Contains(content, "node-2", "expected metrics to contain node-2")
 			s.Contains(content, "CPU(cores)", "expected header with CPU column")
@@ -172,7 +172,7 @@ func (s *NodesTopSuite) TestNodesTop() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("returns metrics for specific node", func() {
-			content := toolResult.Content[0].(mcp.TextContent).Text
+			content := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(content, "node-1", "expected metrics to contain node-1")
 			s.Contains(content, "500m", "expected CPU usage of 500m")
 			s.Contains(content, "2048Mi", "expected memory usage of 2048Mi")
@@ -189,7 +189,7 @@ func (s *NodesTopSuite) TestNodesTop() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("returns metrics for filtered nodes", func() {
-			content := toolResult.Content[0].(mcp.TextContent).Text
+			content := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(content, "node-1", "expected metrics to contain node-1")
 			s.Contains(content, "node-2", "expected metrics to contain node-2")
 		})
@@ -207,7 +207,7 @@ func (s *NodesTopSuite) TestNodesTopMetricsUnavailable() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes metrics unavailable", func() {
-			content := toolResult.Content[0].(mcp.TextContent).Text
+			content := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(content, "failed to get nodes top", "expected error message about failing to get nodes top")
 		})
 	})
@@ -227,7 +227,7 @@ func (s *NodesTopSuite) TestNodesTopDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := toolResult.Content[0].(mcp.TextContent).Text
+			msg := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get nodes top:(.+:)? resource not allowed: metrics.k8s.io/v1beta1, Kind=NodeMetrics"
 			s.Regexpf(expectedMessage, msg,

--- a/pkg/mcp/pods_exec_test.go
+++ b/pkg/mcp/pods_exec_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,7 +77,7 @@ func (s *PodsExecSuite) TestPodsExec() {
 		s.Run("returns command output", func() {
 			s.NoError(err, "call tool failed %v", err)
 			s.Falsef(result.IsError, "call tool failed: %v", result.Content)
-			s.Contains(result.Content[0].(mcp.TextContent).Text, "command:ls -l\n", "unexpected result %v", result.Content[0].(mcp.TextContent).Text)
+			s.Contains(result.Content[0].(*mcp.TextContent).Text, "command:ls -l\n", "unexpected result %v", result.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("pods_exec(name=pod-to-exec, namespace=default, command=[ls -l])", func() {
@@ -90,7 +90,7 @@ func (s *PodsExecSuite) TestPodsExec() {
 		s.Run("returns command output", func() {
 			s.NoError(err, "call tool failed %v", err)
 			s.Falsef(result.IsError, "call tool failed: %v", result.Content)
-			s.Contains(result.Content[0].(mcp.TextContent).Text, "command:ls -l\n", "unexpected result %v", result.Content[0].(mcp.TextContent).Text)
+			s.Contains(result.Content[0].(*mcp.TextContent).Text, "command:ls -l\n", "unexpected result %v", result.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 	s.Run("pods_exec(name=pod-to-exec, namespace=default, command=[ls -l], container=a-specific-container)", func() {
@@ -104,7 +104,7 @@ func (s *PodsExecSuite) TestPodsExec() {
 		s.Run("returns command output", func() {
 			s.NoError(err, "call tool failed %v", err)
 			s.Falsef(result.IsError, "call tool failed: %v", result.Content)
-			s.Contains(result.Content[0].(mcp.TextContent).Text, "command:ls -l\n", "unexpected result %v", result.Content[0].(mcp.TextContent).Text)
+			s.Contains(result.Content[0].(*mcp.TextContent).Text, "command:ls -l\n", "unexpected result %v", result.Content[0].(*mcp.TextContent).Text)
 		})
 	})
 }
@@ -127,7 +127,7 @@ func (s *PodsExecSuite) TestPodsExecDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := toolResult.Content[0].(mcp.TextContent).Text
+			msg := toolResult.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to exec in pod pod-to-exec in namespace default:(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,

--- a/pkg/mcp/pods_run_test.go
+++ b/pkg/mcp/pods_run_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
@@ -21,8 +21,8 @@ func (s *PodsRunSuite) TestPodsRun() {
 	s.Run("pods_run with nil image returns error", func() {
 		toolResult, _ := s.CallTool("pods_run", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to run pod, missing argument image", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to run pod, missing argument image", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_run(image=nginx, namespace=nil), uses configured namespace", func() {
 		podsRunNilNamespace, err := s.CallTool("pods_run", map[string]interface{}{"image": "nginx"})
@@ -31,7 +31,7 @@ func (s *PodsRunSuite) TestPodsRun() {
 			s.Falsef(podsRunNilNamespace.IsError, "call tool failed")
 		})
 		var decodedNilNamespace []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(podsRunNilNamespace.Content[0].(mcp.TextContent).Text), &decodedNilNamespace)
+		err = yaml.Unmarshal([]byte(podsRunNilNamespace.Content[0].(*mcp.TextContent).Text), &decodedNilNamespace)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -64,7 +64,7 @@ func (s *PodsRunSuite) TestPodsRun() {
 			s.Falsef(podsRunNamespaceAndPort.IsError, "call tool failed")
 		})
 		var decodedNamespaceAndPort []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(podsRunNamespaceAndPort.Content[0].(mcp.TextContent).Text), &decodedNamespaceAndPort)
+		err = yaml.Unmarshal([]byte(podsRunNamespaceAndPort.Content[0].(*mcp.TextContent).Text), &decodedNamespaceAndPort)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -101,7 +101,7 @@ func (s *PodsRunSuite) TestPodsRunDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := podsRun.Content[0].(mcp.TextContent).Text
+			msg := podsRun.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to run pod  in namespace :(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
@@ -124,7 +124,7 @@ func (s *PodsRunSuite) TestPodsRunInOpenShift() {
 			s.Falsef(podsRunInOpenShift.IsError, "call tool failed")
 		})
 		var decodedPodServiceRoute []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(podsRunInOpenShift.Content[0].(mcp.TextContent).Text), &decodedPodServiceRoute)
+		err = yaml.Unmarshal([]byte(podsRunInOpenShift.Content[0].(*mcp.TextContent).Text), &decodedPodServiceRoute)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})

--- a/pkg/mcp/pods_test.go
+++ b/pkg/mcp/pods_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +33,7 @@ func (s *PodsSuite) TestPodsListInAllNamespaces() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -92,7 +92,7 @@ func (s *PodsSuite) TestPodsListInAllNamespacesUnauthorized() {
 			s.Falsef(toolResult.IsError, "call tool failed %v", toolResult.Content)
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -122,8 +122,8 @@ func (s *PodsSuite) TestPodsListInNamespace() {
 	s.Run("pods_list_in_namespace with nil namespace returns error", func() {
 		toolResult, _ := s.CallTool("pods_list_in_namespace", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to list pods in namespace, missing argument namespace", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to list pods in namespace, missing argument namespace", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_list_in_namespace(namespace=ns-1) returns pods list", func() {
 		toolResult, err := s.CallTool("pods_list_in_namespace", map[string]interface{}{
@@ -134,7 +134,7 @@ func (s *PodsSuite) TestPodsListInNamespace() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -164,7 +164,7 @@ func (s *PodsSuite) TestPodsListDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := podsList.Content[0].(mcp.TextContent).Text
+			msg := podsList.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list pods in all namespaces:(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
@@ -182,7 +182,7 @@ func (s *PodsSuite) TestPodsListDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := podsListInNamespace.Content[0].(mcp.TextContent).Text
+			msg := podsListInNamespace.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list pods in namespace ns-1:(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
@@ -206,7 +206,7 @@ func (s *PodsSuite) TestPodsListForbidden() {
 		toolResult, _ := s.CallTool("pods_list", map[string]interface{}{})
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
-			s.Contains(toolResult.Content[0].(mcp.TextContent).Text, "forbidden",
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "forbidden",
 				"error message should indicate forbidden")
 		})
 		s.Run("sends log notification", func() {
@@ -227,7 +227,7 @@ func (s *PodsSuite) TestPodsListAsTable() {
 			s.Falsef(podsList.IsError, "call tool failed")
 		})
 		s.Require().NotNil(podsList, "Expected tool result from call")
-		outPodsList := podsList.Content[0].(mcp.TextContent).Text
+		outPodsList := podsList.Content[0].(*mcp.TextContent).Text
 		s.Run("returns table with header and rows", func() {
 			lines := strings.Count(outPodsList, "\n")
 			s.GreaterOrEqualf(lines, 3, "invalid line count, expected at least 3 (1 header, 2+ rows), got %v", lines)
@@ -284,7 +284,7 @@ func (s *PodsSuite) TestPodsListAsTable() {
 			s.Falsef(podsListInNamespace.IsError, "call tool failed")
 		})
 		s.Require().NotNil(podsListInNamespace, "Expected tool result from call")
-		outPodsListInNamespace := podsListInNamespace.Content[0].(mcp.TextContent).Text
+		outPodsListInNamespace := podsListInNamespace.Content[0].(*mcp.TextContent).Text
 		s.Run("returns table with header and row", func() {
 			lines := strings.Count(outPodsListInNamespace, "\n")
 			s.GreaterOrEqualf(lines, 1, "invalid line count, expected at least 1 (1 header, 1+ rows), got %v", lines)
@@ -321,14 +321,14 @@ func (s *PodsSuite) TestPodsGet() {
 	s.Run("pods_get with nil name returns error", func() {
 		toolResult, _ := s.CallTool("pods_get", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get pod, missing argument name", toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get pod, missing argument name", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_get(name=not-found) with not found name", func() {
 		capture := s.StartCapturingLogNotifications()
 		toolResult, _ := s.CallTool("pods_get", map[string]interface{}{"name": "not-found"})
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
-			s.Equalf("failed to get pod not-found in namespace : pods \"not-found\" not found", toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf("failed to get pod not-found in namespace : pods \"not-found\" not found", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("sends log notification", func() {
 			logNotification := capture.RequireLogNotification(s.T(), 2*time.Second)
@@ -345,7 +345,7 @@ func (s *PodsSuite) TestPodsGet() {
 			s.Falsef(podsGetNilNamespace.IsError, "call tool failed")
 		})
 		var decodedNilNamespace unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(podsGetNilNamespace.Content[0].(mcp.TextContent).Text), &decodedNilNamespace)
+		err = yaml.Unmarshal([]byte(podsGetNilNamespace.Content[0].(*mcp.TextContent).Text), &decodedNilNamespace)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -367,7 +367,7 @@ func (s *PodsSuite) TestPodsGet() {
 			s.Falsef(podsGetInNamespace.IsError, "call tool failed")
 		})
 		var decodedInNamespace unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(podsGetInNamespace.Content[0].(mcp.TextContent).Text), &decodedInNamespace)
+		err = yaml.Unmarshal([]byte(podsGetInNamespace.Content[0].(*mcp.TextContent).Text), &decodedInNamespace)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -390,7 +390,7 @@ func (s *PodsSuite) TestPodsGetDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := podsGet.Content[0].(mcp.TextContent).Text
+			msg := podsGet.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get pod a-pod-in-default in namespace :(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
@@ -404,14 +404,14 @@ func (s *PodsSuite) TestPodsDelete() {
 	s.Run("pods_delete with nil name returns error", func() {
 		toolResult, _ := s.CallTool("pods_delete", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to delete pod, missing argument name", toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to delete pod, missing argument name", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_delete(name=not-found) with not found name", func() {
 		capture := s.StartCapturingLogNotifications()
 		toolResult, _ := s.CallTool("pods_delete", map[string]interface{}{"name": "not-found"})
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
-			s.Equalf("failed to delete pod not-found in namespace : pods \"not-found\" not found", toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Equalf("failed to delete pod not-found in namespace : pods \"not-found\" not found", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("sends log notification", func() {
 			logNotification := capture.RequireLogNotification(s.T(), 2*time.Second)
@@ -431,7 +431,7 @@ func (s *PodsSuite) TestPodsDelete() {
 		s.Run("returns success", func() {
 			s.Nilf(err, "call tool failed %v", err)
 			s.Falsef(podsDeleteNilNamespace.IsError, "call tool failed")
-			s.Equalf("Pod deleted successfully", podsDeleteNilNamespace.Content[0].(mcp.TextContent).Text, "invalid tool result content, got %v", podsDeleteNilNamespace.Content[0].(mcp.TextContent).Text)
+			s.Equalf("Pod deleted successfully", podsDeleteNilNamespace.Content[0].(*mcp.TextContent).Text, "invalid tool result content, got %v", podsDeleteNilNamespace.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("deletes Pod", func() {
 			p, pErr := kc.CoreV1().Pods("default").Get(s.T().Context(), "a-pod-to-delete", metav1.GetOptions{})
@@ -451,7 +451,7 @@ func (s *PodsSuite) TestPodsDelete() {
 		s.Run("returns success", func() {
 			s.Nilf(err, "call tool failed %v", err)
 			s.Falsef(podsDeleteInNamespace.IsError, "call tool failed")
-			s.Equalf("Pod deleted successfully", podsDeleteInNamespace.Content[0].(mcp.TextContent).Text, "invalid tool result content, got %v", podsDeleteInNamespace.Content[0].(mcp.TextContent).Text)
+			s.Equalf("Pod deleted successfully", podsDeleteInNamespace.Content[0].(*mcp.TextContent).Text, "invalid tool result content, got %v", podsDeleteInNamespace.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("deletes Pod", func() {
 			p, pErr := kc.CoreV1().Pods("ns-1").Get(s.T().Context(), "a-pod-to-delete-in-ns-1", metav1.GetOptions{})
@@ -478,7 +478,7 @@ func (s *PodsSuite) TestPodsDelete() {
 		s.Run("returns success", func() {
 			s.Nilf(err, "call tool failed %v", err)
 			s.Falsef(podsDeleteManaged.IsError, "call tool failed")
-			s.Equalf("Pod deleted successfully", podsDeleteManaged.Content[0].(mcp.TextContent).Text, "invalid tool result content, got %v", podsDeleteManaged.Content[0].(mcp.TextContent).Text)
+			s.Equalf("Pod deleted successfully", podsDeleteManaged.Content[0].(*mcp.TextContent).Text, "invalid tool result content, got %v", podsDeleteManaged.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("deletes Pod and Service", func() {
 			p, pErr := kc.CoreV1().Pods("default").Get(s.T().Context(), "a-managed-pod-to-delete", metav1.GetOptions{})
@@ -501,7 +501,7 @@ func (s *PodsSuite) TestPodsDeleteDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := podsDelete.Content[0].(mcp.TextContent).Text
+			msg := podsDelete.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to delete pod a-pod-in-default in namespace :(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
@@ -543,8 +543,8 @@ func (s *PodsSuite) TestPodsDeleteInOpenShift() {
 		s.Run("returns success", func() {
 			s.Nilf(err, "call tool failed %v", err)
 			s.Falsef(podsDeleteManagedOpenShift.IsError, "call tool failed")
-			s.Equalf("Pod deleted successfully", podsDeleteManagedOpenShift.Content[0].(mcp.TextContent).Text,
-				"invalid tool result content, got %v", podsDeleteManagedOpenShift.Content[0].(mcp.TextContent).Text)
+			s.Equalf("Pod deleted successfully", podsDeleteManagedOpenShift.Content[0].(*mcp.TextContent).Text,
+				"invalid tool result content, got %v", podsDeleteManagedOpenShift.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("deletes Pod and Route", func() {
 			p, pErr := kc.CoreV1().Pods("default").Get(s.T().Context(), "a-managed-pod-to-delete-in-openshift", metav1.GetOptions{})
@@ -562,12 +562,12 @@ func (s *PodsSuite) TestPodsLog() {
 	s.Run("pods_log with nil name returns error", func() {
 		toolResult, _ := s.CallTool("pods_log", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get pod log, missing argument name", toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get pod log, missing argument name", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_log with not found name returns error", func() {
 		toolResult, _ := s.CallTool("pods_log", map[string]interface{}{"name": "not-found"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get pod not-found log in namespace : pods \"not-found\" not found", toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get pod not-found log in namespace : pods \"not-found\" not found", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_log(name=a-pod-in-default, namespace=nil), uses configured namespace", func() {
 		podsLogNilNamespace, err := s.CallTool("pods_log", map[string]interface{}{
@@ -601,7 +601,7 @@ func (s *PodsSuite) TestPodsLog() {
 		})
 		s.Nilf(err, "call tool should not return error object")
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get pod a-pod-in-ns-1 log in namespace ns-1: container a-not-existing-container is not valid for pod a-pod-in-ns-1", toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get pod a-pod-in-ns-1 log in namespace ns-1: container a-not-existing-container is not valid for pod a-pod-in-ns-1", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_log(previous=true) returns previous pod log", func() {
 		podsPreviousLogInNamespace, err := s.CallTool("pods_log", map[string]interface{}{
@@ -638,7 +638,7 @@ func (s *PodsSuite) TestPodsLog() {
 		})
 		s.Truef(podsInvalidTailLines.IsError, "call tool should fail")
 		expectedErrorMsg := "failed to parse tail parameter: expected integer"
-		errMsg := podsInvalidTailLines.Content[0].(mcp.TextContent).Text
+		errMsg := podsInvalidTailLines.Content[0].(*mcp.TextContent).Text
 		s.Containsf(errMsg, expectedErrorMsg, "unexpected error message, expected to contain '%s', got '%s'", expectedErrorMsg, errMsg)
 	})
 }
@@ -655,7 +655,7 @@ func (s *PodsSuite) TestPodsLogDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := podsLog.Content[0].(mcp.TextContent).Text
+			msg := podsLog.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get pod a-pod-in-default log in namespace :(.+:)? resource not allowed: /v1, Kind=Pod"
 			s.Regexpf(expectedMessage, msg,
@@ -692,7 +692,7 @@ func (s *PodsSuite) TestPodsListWithLabelSelector() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -711,7 +711,7 @@ func (s *PodsSuite) TestPodsListWithLabelSelector() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -732,7 +732,7 @@ func (s *PodsSuite) TestPodsListWithLabelSelector() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -771,7 +771,7 @@ func (s *PodsSuite) TestPodsListWithFieldSelector() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -798,7 +798,7 @@ func (s *PodsSuite) TestPodsListWithFieldSelector() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -841,7 +841,7 @@ func (s *PodsSuite) TestPodsListWithFieldSelector() {
 			s.Falsef(toolResult.IsError, "call tool failed")
 		})
 		var decoded []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(toolResult.Content[0].(mcp.TextContent).Text), &decoded)
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})

--- a/pkg/mcp/pods_top_test.go
+++ b/pkg/mcp/pods_top_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,8 +42,8 @@ func (s *PodsTopSuite) TestPodsTopMetricsUnavailable() {
 		s.NoError(err, "call tool failed %v", err)
 		s.Require().NoError(err)
 		s.True(result.IsError, "call tool should have returned an error")
-		s.Equalf("failed to get pods top: metrics API is not available", result.Content[0].(mcp.TextContent).Text,
-			"call tool returned unexpected content: %s", result.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get pods top: metrics API is not available", result.Content[0].(*mcp.TextContent).Text,
+			"call tool returned unexpected content: %s", result.Content[0].(*mcp.TextContent).Text)
 	})
 }
 
@@ -99,7 +99,7 @@ func (s *PodsTopSuite) TestPodsTopMetricsAvailable() {
 		result, err := s.CallTool("pods_top", map[string]interface{}{})
 		s.Require().NotNil(result)
 		s.NoErrorf(err, "call tool failed %v", err)
-		textContent := result.Content[0].(mcp.TextContent).Text
+		textContent := result.Content[0].(*mcp.TextContent).Text
 		s.Falsef(result.IsError, "call tool failed %v", textContent)
 
 		expectedHeaders := regexp.MustCompile(`(?m)^\s*NAMESPACE\s+POD\s+NAME\s+CPU\(cores\)\s+MEMORY\(bytes\)\s+SWAP\(bytes\)\s*$`)
@@ -124,7 +124,7 @@ func (s *PodsTopSuite) TestPodsTopMetricsAvailable() {
 		})
 		s.Require().NotNil(result)
 		s.NoErrorf(err, "call tool failed %v", err)
-		textContent := result.Content[0].(mcp.TextContent).Text
+		textContent := result.Content[0].(*mcp.TextContent).Text
 		s.Falsef(result.IsError, "call tool failed %v", textContent)
 
 		expectedRows := []string{
@@ -145,7 +145,7 @@ func (s *PodsTopSuite) TestPodsTopMetricsAvailable() {
 		})
 		s.Require().NotNil(result)
 		s.NoErrorf(err, "call tool failed %v", err)
-		textContent := result.Content[0].(mcp.TextContent).Text
+		textContent := result.Content[0].(*mcp.TextContent).Text
 		s.Falsef(result.IsError, "call tool failed %v", textContent)
 
 		expectedRow := regexp.MustCompile(`ns-5\s+pod-ns-5-1\s+container-1\s+10m\s+20Mi\s+42Mi`)
@@ -162,7 +162,7 @@ func (s *PodsTopSuite) TestPodsTopMetricsAvailable() {
 		})
 		s.Require().NotNil(result)
 		s.NoErrorf(err, "call tool failed %v", err)
-		textContent := result.Content[0].(mcp.TextContent).Text
+		textContent := result.Content[0].(*mcp.TextContent).Text
 		s.Falsef(result.IsError, "call tool failed %v", textContent)
 
 		expectedRow := regexp.MustCompile(`ns-5\s+pod-ns-5-5\s+container-1\s+13m\s+37Mi\s+42Mi`)
@@ -178,7 +178,7 @@ func (s *PodsTopSuite) TestPodsTopMetricsAvailable() {
 		})
 		s.Require().NotNil(result)
 		s.NoErrorf(err, "call tool failed %v", err)
-		textContent := result.Content[0].(mcp.TextContent).Text
+		textContent := result.Content[0].(*mcp.TextContent).Text
 		s.Falsef(result.IsError, "call tool failed %v", textContent)
 
 		expectedRow := regexp.MustCompile(`ns-5\s+pod-ns-5-42\s+container-1\s+42m\s+42Mi`)
@@ -209,7 +209,7 @@ func (s *PodsTopSuite) TestPodsTopDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := result.Content[0].(mcp.TextContent).Text
+			msg := result.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get pods top:(.+:)? resource not allowed: metrics.k8s.io/v1beta1, Kind=PodMetrics"
 			s.Regexpf(expectedMessage, msg,

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,26 +31,26 @@ func (s *ResourcesSuite) TestResourcesList() {
 	s.Run("resources_list with missing apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_list", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to list resources, missing argument apiVersion", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to list resources, missing argument apiVersion", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_list with missing kind returns error", func() {
 		toolResult, _ := s.CallTool("resources_list", map[string]interface{}{"apiVersion": "v1"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to list resources, missing argument kind", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to list resources, missing argument kind", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_list with invalid apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_list", map[string]interface{}{"apiVersion": "invalid/api/version", "kind": "Pod"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to list resources, invalid argument apiVersion", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to list resources, invalid argument apiVersion", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_list with nonexistent apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_list", map[string]interface{}{"apiVersion": "custom.non.existent.example.com/v1", "kind": "Custom"})
 		s.Truef(toolResult.IsError, "call tool should fail")
 		s.Equalf(`failed to list resources: no matches for kind "Custom" in version "custom.non.existent.example.com/v1"`,
-			toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_list(apiVersion=v1, kind=Namespace) returns namespaces", func() {
 		namespaces, err := s.CallTool("resources_list", map[string]interface{}{"apiVersion": "v1", "kind": "Namespace"})
@@ -59,7 +59,7 @@ func (s *ResourcesSuite) TestResourcesList() {
 			s.Falsef(namespaces.IsError, "call tool failed")
 		})
 		var decodedNamespaces []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(namespaces.Content[0].(mcp.TextContent).Text), &decodedNamespaces)
+		err = yaml.Unmarshal([]byte(namespaces.Content[0].(*mcp.TextContent).Text), &decodedNamespaces)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -79,7 +79,7 @@ func (s *ResourcesSuite) TestResourcesList() {
 			s.Falsef(result.IsError, "call tool failed")
 
 			var decodedPods []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &decodedPods)
+			err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedPods)
 			s.Nilf(err, "invalid tool result content %v", err)
 
 			s.Lenf(decodedPods, 1, "expected 1 pod, got %d", len(decodedPods))
@@ -96,7 +96,7 @@ func (s *ResourcesSuite) TestResourcesList() {
 			s.Falsef(result.IsError, "call tool failed")
 
 			var decodedPods []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &decodedPods)
+			err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedPods)
 			s.Nilf(err, "invalid tool result content %v", err)
 
 			s.Lenf(decodedPods, 0, "expected 0 pods, got %d", len(decodedPods))
@@ -124,7 +124,7 @@ func (s *ResourcesSuite) TestResourcesList() {
 			s.Falsef(result.IsError, "call tool failed")
 
 			var decodedPods []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &decodedPods)
+			err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedPods)
 			s.Nilf(err, "invalid tool result content %v", err)
 
 			s.Lenf(decodedPods, 1, "expected exactly 1 pod, got %d", len(decodedPods))
@@ -145,7 +145,7 @@ func (s *ResourcesSuite) TestResourcesList() {
 			s.Falsef(result.IsError, "call tool failed")
 
 			var decodedPods []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &decodedPods)
+			err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedPods)
 			s.Nilf(err, "invalid tool result content %v", err)
 
 			s.Lenf(decodedPods, 1, "expected exactly 1 pod, got %d", len(decodedPods))
@@ -172,7 +172,7 @@ func (s *ResourcesSuite) TestResourcesListDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByKind.Content[0].(mcp.TextContent).Text
+			msg := deniedByKind.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list resources:(.+:)? resource not allowed: /v1, Kind=Secret"
 			s.Regexpf(expectedMessage, msg,
@@ -186,7 +186,7 @@ func (s *ResourcesSuite) TestResourcesListDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByGroup.Content[0].(mcp.TextContent).Text
+			msg := deniedByGroup.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to list resources:(.+:)? resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			s.Regexpf(expectedMessage, msg,
@@ -211,7 +211,7 @@ func (s *ResourcesSuite) TestResourcesListForbidden() {
 		toolResult, _ := s.CallTool("resources_list", map[string]interface{}{"apiVersion": "v1", "kind": "ConfigMap"})
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
-			s.Contains(toolResult.Content[0].(mcp.TextContent).Text, "forbidden",
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "forbidden",
 				"error message should indicate forbidden")
 		})
 		s.Run("sends log notification", func() {
@@ -242,7 +242,7 @@ func (s *ResourcesSuite) TestResourcesListAsTable() {
 			s.Falsef(configMapList.IsError, "call tool failed")
 		})
 		s.Require().NotNil(configMapList, "Expected tool result from call")
-		outConfigMapList := configMapList.Content[0].(mcp.TextContent).Text
+		outConfigMapList := configMapList.Content[0].(*mcp.TextContent).Text
 		s.Run("returns column headers for ConfigMap list", func() {
 			expectedHeaders := "NAMESPACE\\s+APIVERSION\\s+KIND\\s+NAME\\s+DATA\\s+AGE\\s+LABELS"
 			m, e := regexp.MatchString(expectedHeaders, outConfigMapList)
@@ -280,7 +280,7 @@ func (s *ResourcesSuite) TestResourcesListAsTable() {
 			s.Falsef(routeList.IsError, "call tool failed")
 		})
 		s.Require().NotNil(routeList, "Expected tool result from call")
-		outRouteList := routeList.Content[0].(mcp.TextContent).Text
+		outRouteList := routeList.Content[0].(*mcp.TextContent).Text
 		s.Run("returns column headers for Route list", func() {
 			expectedHeaders := "NAMESPACE\\s+APIVERSION\\s+KIND\\s+NAME\\s+AGE\\s+LABELS"
 			m, e := regexp.MatchString(expectedHeaders, outRouteList)
@@ -306,32 +306,32 @@ func (s *ResourcesSuite) TestResourcesGet() {
 	s.Run("resources_get with missing apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_get", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get resource, missing argument apiVersion", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get resource, missing argument apiVersion", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_get with missing kind returns error", func() {
 		toolResult, _ := s.CallTool("resources_get", map[string]interface{}{"apiVersion": "v1"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get resource, missing argument kind", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get resource, missing argument kind", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_get with invalid apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_get", map[string]interface{}{"apiVersion": "invalid/api/version", "kind": "Pod", "name": "a-pod"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get resource, invalid argument apiVersion", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get resource, invalid argument apiVersion", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_get with nonexistent apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_get", map[string]interface{}{"apiVersion": "custom.non.existent.example.com/v1", "kind": "Custom", "name": "a-custom"})
 		s.Truef(toolResult.IsError, "call tool should fail")
 		s.Equalf(`failed to get resource: no matches for kind "Custom" in version "custom.non.existent.example.com/v1"`,
-			toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_get with missing name returns error", func() {
 		toolResult, _ := s.CallTool("resources_get", map[string]interface{}{"apiVersion": "v1", "kind": "Namespace"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get resource, missing argument name", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get resource, missing argument name", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_get with nonexistent resource", func() {
 		capture := s.StartCapturingLogNotifications()
@@ -339,7 +339,7 @@ func (s *ResourcesSuite) TestResourcesGet() {
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
 			s.Equalf(`failed to get resource: configmaps "nonexistent-configmap" not found`,
-				toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("sends log notification", func() {
 			logNotification := capture.RequireLogNotification(s.T(), 2*time.Second)
@@ -354,7 +354,7 @@ func (s *ResourcesSuite) TestResourcesGet() {
 			s.Falsef(namespace.IsError, "call tool failed")
 		})
 		var decodedNamespace unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(namespace.Content[0].(mcp.TextContent).Text), &decodedNamespace)
+		err = yaml.Unmarshal([]byte(namespace.Content[0].(*mcp.TextContent).Text), &decodedNamespace)
 		s.Run("has yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
@@ -386,7 +386,7 @@ func (s *ResourcesSuite) TestResourcesGetDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByKind.Content[0].(mcp.TextContent).Text
+			msg := deniedByKind.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get resource:(.+:)? resource not allowed: /v1, Kind=Secret"
 			s.Regexpf(expectedMessage, msg,
@@ -400,7 +400,7 @@ func (s *ResourcesSuite) TestResourcesGetDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByGroup.Content[0].(mcp.TextContent).Text
+			msg := deniedByGroup.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get resource:(.+:)? resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			s.Regexpf(expectedMessage, msg,
@@ -421,14 +421,14 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdate() {
 	s.Run("resources_create_or_update with nil resource returns error", func() {
 		toolResult, _ := s.CallTool("resources_create_or_update", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to create or update resources, missing argument resource", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to create or update resources, missing argument resource", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_create_or_update with empty resource returns error", func() {
 		toolResult, _ := s.CallTool("resources_create_or_update", map[string]interface{}{"resource": ""})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to create or update resources, missing argument resource", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to create or update resources, missing argument resource", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 
 	s.Run("resources_create_or_update with valid namespaced yaml resource", func() {
@@ -439,11 +439,11 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdate() {
 			s.Falsef(resourcesCreateOrUpdateCm1.IsError, "call tool failed")
 		})
 		var decodedCreateOrUpdateCm1 []unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(resourcesCreateOrUpdateCm1.Content[0].(mcp.TextContent).Text), &decodedCreateOrUpdateCm1)
+		err = yaml.Unmarshal([]byte(resourcesCreateOrUpdateCm1.Content[0].(*mcp.TextContent).Text), &decodedCreateOrUpdateCm1)
 		s.Run("returns yaml content", func() {
 			s.Nilf(err, "invalid tool result content %v", err)
-			s.Truef(strings.HasPrefix(resourcesCreateOrUpdateCm1.Content[0].(mcp.TextContent).Text, "# The following resources (YAML) have been created or updated successfully"),
-				"Expected success message, got %v", resourcesCreateOrUpdateCm1.Content[0].(mcp.TextContent).Text)
+			s.Truef(strings.HasPrefix(resourcesCreateOrUpdateCm1.Content[0].(*mcp.TextContent).Text, "# The following resources (YAML) have been created or updated successfully"),
+				"Expected success message, got %v", resourcesCreateOrUpdateCm1.Content[0].(*mcp.TextContent).Text)
 			s.Lenf(decodedCreateOrUpdateCm1, 1, "invalid resource count, expected 1, got %v", len(decodedCreateOrUpdateCm1))
 			s.Equalf("a-cm-created-or-updated", decodedCreateOrUpdateCm1[0].GetName(),
 				"invalid resource name, expected a-cm-created-or-updated, got %v", decodedCreateOrUpdateCm1[0].GetName())
@@ -543,7 +543,7 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdate() {
 		})
 		s.Run("created resource does not contain status", func() {
 			var decodedResources []unstructured.Unstructured
-			err = yaml.Unmarshal([]byte(result.Content[0].(mcp.TextContent).Text), &decodedResources)
+			err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedResources)
 			s.Nilf(err, "invalid tool result content %v", err)
 			s.Require().Lenf(decodedResources, 1, "expected 1 resource, got %d", len(decodedResources))
 			_, hasStatus := decodedResources[0].Object["status"]
@@ -624,7 +624,7 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdateDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByKind.Content[0].(mcp.TextContent).Text
+			msg := deniedByKind.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to create or update resources:(.+:)? resource not allowed: /v1, Kind=Secret"
 			s.Regexpf(expectedMessage, msg,
@@ -639,7 +639,7 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdateDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByGroup.Content[0].(mcp.TextContent).Text
+			msg := deniedByGroup.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to create or update resources:(.+:)? resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			s.Regexpf(expectedMessage, msg,
@@ -667,7 +667,7 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdateForbidden() {
 		toolResult, _ := s.CallTool("resources_create_or_update", map[string]interface{}{"resource": configMapYaml})
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
-			s.Contains(toolResult.Content[0].(mcp.TextContent).Text, "forbidden",
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "forbidden",
 				"error message should indicate forbidden")
 		})
 		s.Run("sends log notification", func() {
@@ -685,32 +685,32 @@ func (s *ResourcesSuite) TestResourcesDelete() {
 	s.Run("resources_delete with missing apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_delete", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to delete resource, missing argument apiVersion", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to delete resource, missing argument apiVersion", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_delete with missing kind returns error", func() {
 		toolResult, _ := s.CallTool("resources_delete", map[string]interface{}{"apiVersion": "v1"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to delete resource, missing argument kind", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to delete resource, missing argument kind", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_delete with invalid apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_delete", map[string]interface{}{"apiVersion": "invalid/api/version", "kind": "Pod", "name": "a-pod"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to delete resource, invalid argument apiVersion", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to delete resource, invalid argument apiVersion", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_delete with nonexistent apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_delete", map[string]interface{}{"apiVersion": "custom.non.existent.example.com/v1", "kind": "Custom", "name": "a-custom"})
 		s.Truef(toolResult.IsError, "call tool should fail")
 		s.Equalf(`failed to delete resource: no matches for kind "Custom" in version "custom.non.existent.example.com/v1"`,
-			toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_delete with missing name returns error", func() {
 		toolResult, _ := s.CallTool("resources_delete", map[string]interface{}{"apiVersion": "v1", "kind": "Namespace"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to delete resource, missing argument name", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to delete resource, missing argument name", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_delete with nonexistent resource", func() {
 		capture := s.StartCapturingLogNotifications()
@@ -718,7 +718,7 @@ func (s *ResourcesSuite) TestResourcesDelete() {
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
 			s.Equalf(`failed to delete resource: configmaps "nonexistent-configmap" not found`,
-				toolResult.Content[0].(mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+				toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("sends log notification", func() {
 			logNotification := capture.RequireLogNotification(s.T(), 2*time.Second)
@@ -729,8 +729,8 @@ func (s *ResourcesSuite) TestResourcesDelete() {
 	s.Run("resources_delete with invalid gracePeriodSeconds returns error", func() {
 		toolResult, _ := s.CallTool("resources_delete", map[string]interface{}{"apiVersion": "v1", "kind": "ConfigMap", "name": "a-configmap", "gracePeriodSeconds": "-5"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to delete resource, invalid argument gracePeriodSeconds", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to delete resource, invalid argument gracePeriodSeconds", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 
 	s.Run("resources_delete with valid namespaced resource", func() {
@@ -738,8 +738,8 @@ func (s *ResourcesSuite) TestResourcesDelete() {
 		s.Run("returns success", func() {
 			s.Nilf(err, "call tool failed %v", err)
 			s.Falsef(resourcesDeleteCm.IsError, "call tool failed")
-			s.Equalf("Resource deleted successfully", resourcesDeleteCm.Content[0].(mcp.TextContent).Text,
-				"invalid tool result content got: %v", resourcesDeleteCm.Content[0].(mcp.TextContent).Text)
+			s.Equalf("Resource deleted successfully", resourcesDeleteCm.Content[0].(*mcp.TextContent).Text,
+				"invalid tool result content got: %v", resourcesDeleteCm.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("deletes ConfigMap", func() {
 			_, err := client.CoreV1().ConfigMaps("default").Get(s.T().Context(), "a-configmap-to-delete", metav1.GetOptions{})
@@ -752,8 +752,8 @@ func (s *ResourcesSuite) TestResourcesDelete() {
 		s.Run("returns success", func() {
 			s.Nilf(err, "call tool failed %v", err)
 			s.Falsef(resourcesDeleteNamespace.IsError, "call tool failed")
-			s.Equalf("Resource deleted successfully", resourcesDeleteNamespace.Content[0].(mcp.TextContent).Text,
-				"invalid tool result content got: %v", resourcesDeleteNamespace.Content[0].(mcp.TextContent).Text)
+			s.Equalf("Resource deleted successfully", resourcesDeleteNamespace.Content[0].(*mcp.TextContent).Text,
+				"invalid tool result content got: %v", resourcesDeleteNamespace.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run(" deletes Namespace", func() {
 			ns, err := client.CoreV1().Namespaces().Get(s.T().Context(), "ns-to-delete", metav1.GetOptions{})
@@ -789,7 +789,7 @@ func (s *ResourcesSuite) TestResourcesDeleteDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByKind.Content[0].(mcp.TextContent).Text
+			msg := deniedByKind.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to delete resource:(.+:)? resource not allowed: /v1, Kind=Secret"
 			s.Regexpf(expectedMessage, msg,
@@ -803,7 +803,7 @@ func (s *ResourcesSuite) TestResourcesDeleteDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByGroup.Content[0].(mcp.TextContent).Text
+			msg := deniedByGroup.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to delete resource:(.+:)? resource not allowed: rbac.authorization.k8s.io/v1, Kind=Role"
 			s.Regexpf(expectedMessage, msg,
@@ -840,20 +840,20 @@ func (s *ResourcesSuite) TestResourcesScale() {
 	s.Run("resources_scale with missing apiVersion returns error", func() {
 		toolResult, _ := s.CallTool("resources_scale", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get/update resource scale, missing argument apiVersion", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get/update resource scale, missing argument apiVersion", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_scale with missing kind returns error", func() {
 		toolResult, _ := s.CallTool("resources_scale", map[string]interface{}{"apiVersion": "apps/v1"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get/update resource scale, missing argument kind", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get/update resource scale, missing argument kind", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_scale with missing name returns error", func() {
 		toolResult, _ := s.CallTool("resources_scale", map[string]interface{}{"apiVersion": "apps/v1", "kind": "Deployment"})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get/update resource scale, missing argument name", toolResult.Content[0].(mcp.TextContent).Text,
-			"invalid error message, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Equalf("failed to get/update resource scale, missing argument name", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("resources_scale get returns current scale", func() {
 		result, err := s.CallTool("resources_scale", map[string]interface{}{
@@ -867,7 +867,7 @@ func (s *ResourcesSuite) TestResourcesScale() {
 			s.Falsef(result.IsError, "call tool failed: %v", result.Content)
 		})
 		s.Run("returns scale yaml", func() {
-			content := result.Content[0].(mcp.TextContent).Text
+			content := result.Content[0].(*mcp.TextContent).Text
 			s.Truef(strings.HasPrefix(content, "# Current resource scale (YAML) is below"),
 				"Expected success message, got %v", content)
 			var decodedScale unstructured.Unstructured
@@ -891,7 +891,7 @@ func (s *ResourcesSuite) TestResourcesScale() {
 			s.Falsef(result.IsError, "call tool failed: %v", result.Content)
 		})
 		s.Run("returns updated scale yaml", func() {
-			content := result.Content[0].(mcp.TextContent).Text
+			content := result.Content[0].(*mcp.TextContent).Text
 			var decodedScale unstructured.Unstructured
 			err = yaml.Unmarshal([]byte(strings.TrimPrefix(content, "# Current resource scale (YAML) is below\n")), &decodedScale)
 			s.Nilf(err, "invalid tool result content %v", err)
@@ -914,8 +914,8 @@ func (s *ResourcesSuite) TestResourcesScale() {
 		})
 		s.Run("returns error", func() {
 			s.Truef(toolResult.IsError, "call tool should fail")
-			s.Containsf(toolResult.Content[0].(mcp.TextContent).Text, "not found",
-				"expected not found error, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+			s.Containsf(toolResult.Content[0].(*mcp.TextContent).Text, "not found",
+				"expected not found error, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("sends log notification", func() {
 			logNotification := capture.RequireLogNotification(s.T(), 2*time.Second)
@@ -936,8 +936,8 @@ func (s *ResourcesSuite) TestResourcesScale() {
 			"name":       configMapName,
 		})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Containsf(toolResult.Content[0].(mcp.TextContent).Text, "the server could not find the requested resource",
-			"expected scale subresource not found error, got %v", toolResult.Content[0].(mcp.TextContent).Text)
+		s.Containsf(toolResult.Content[0].(*mcp.TextContent).Text, "the server could not find the requested resource",
+			"expected scale subresource not found error, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 }
 
@@ -961,7 +961,7 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByKind.Content[0].(mcp.TextContent).Text
+			msg := deniedByKind.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get/update resource scale:(.+:)? resource not allowed: /v1, Kind=ReplicationController"
 			s.Regexpf(expectedMessage, msg,
@@ -981,7 +981,7 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByKind.Content[0].(mcp.TextContent).Text
+			msg := deniedByKind.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get/update resource scale:(.+:)? resource not allowed: /v1, Kind=ReplicationController"
 			s.Regexpf(expectedMessage, msg,
@@ -1000,7 +1000,7 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByGroup.Content[0].(mcp.TextContent).Text
+			msg := deniedByGroup.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get/update resource scale:(.+:)? resource not allowed: apps/v1, Kind=StatefulSet"
 			s.Regexpf(expectedMessage, msg,
@@ -1020,7 +1020,7 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 			s.Nilf(err, "call tool should not return error object")
 		})
 		s.Run("describes denial", func() {
-			msg := deniedByGroup.Content[0].(mcp.TextContent).Text
+			msg := deniedByGroup.Content[0].(*mcp.TextContent).Text
 			s.Contains(msg, "resource not allowed:")
 			expectedMessage := "failed to get/update resource scale:(.+:)? resource not allowed: apps/v1, Kind=StatefulSet"
 			s.Regexpf(expectedMessage, msg,

--- a/pkg/mcp/testdata/toolsets-config-tools.json
+++ b/pkg/mcp/testdata/toolsets-config-tools.json
@@ -1,21 +1,22 @@
 [
   {
     "annotations": {
-      "title": "Configuration: View",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Configuration: View"
     },
     "description": "Get the current Kubernetes configuration content as a kubeconfig YAML",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "minified": {
           "description": "Return a minified version of the configuration. If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. (Optional, default true)",
           "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "configuration_view"
+    "name": "configuration_view",
+    "title": "Configuration: View"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -1,46 +1,48 @@
 [
   {
     "annotations": {
-      "title": "Events: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Events: List"
     },
     "description": "List Kubernetes events (warnings, errors, state changes) for debugging and troubleshooting in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "namespace": {
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "events_list"
+    "name": "events_list",
+    "title": "Events: List"
   },
   {
     "annotations": {
-      "title": "Namespaces: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Namespaces: List"
     },
     "description": "List all the Kubernetes namespaces in the current cluster",
     "inputSchema": {
+      "properties": {},
       "type": "object"
     },
-    "name": "namespaces_list"
+    "name": "namespaces_list",
+    "title": "Namespaces: List"
   },
   {
     "annotations": {
-      "title": "Node: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Log"
     },
     "description": "Get logs from a Kubernetes node (kubelet, kube-proxy, or other system logs). This accesses node logs through the Kubernetes API proxy to the kubelet",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the node to get logs from",
@@ -60,20 +62,21 @@
       "required": [
         "name",
         "query"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_log"
+    "name": "nodes_log",
+    "title": "Node: Log"
   },
   {
     "annotations": {
-      "title": "Node: Stats Summary",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Stats Summary"
     },
     "description": "Get detailed resource usage statistics from a Kubernetes node via the kubelet's Summary API. Provides comprehensive metrics including CPU, memory, filesystem, and network usage at the node, pod, and container levels. On systems with cgroup v2 and kernel 4.20+, also includes PSI (Pressure Stall Information) metrics that show resource pressure for CPU, memory, and I/O. See https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/ for details on PSI metrics",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the node to get stats from",
@@ -82,21 +85,22 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_stats_summary"
+    "name": "nodes_stats_summary",
+    "title": "Node: Stats Summary"
   },
   {
     "annotations": {
-      "title": "Nodes: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Nodes: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Nodes or all nodes in the cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "label_selector": {
           "description": "Kubernetes label selector (e.g. 'node-role.kubernetes.io/worker=') to filter nodes by label (Optional, only applicable when name is not provided)",
@@ -107,20 +111,21 @@
           "description": "Name of the Node to get the resource consumption from (Optional, all Nodes if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "nodes_top"
+    "name": "nodes_top",
+    "title": "Nodes: Top"
   },
   {
     "annotations": {
-      "title": "Pods: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Delete"
     },
     "description": "Delete a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the Pod to delete",
@@ -133,19 +138,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_delete"
+    "name": "pods_delete",
+    "title": "Pods: Delete"
   },
   {
     "annotations": {
-      "title": "Pods: Exec",
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Exec"
     },
     "description": "Execute a command in a Kubernetes Pod (shell access, run commands in container) in the current or provided namespace with the provided name and command",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "command": {
           "description": "Command to execute in the Pod container. The first item is the command to be run, and the rest are the arguments to that command. Example: [\"ls\", \"-l\", \"/tmp\"]",
@@ -170,20 +176,21 @@
       "required": [
         "name",
         "command"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_exec"
+    "name": "pods_exec",
+    "title": "Pods: Exec"
   },
   {
     "annotations": {
-      "title": "Pods: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Get"
     },
     "description": "Get a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the Pod",
@@ -196,20 +203,21 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_get"
+    "name": "pods_get",
+    "title": "Pods: Get"
   },
   {
     "annotations": {
-      "title": "Pods: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List"
     },
     "description": "List all the Kubernetes pods in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter pods by field values (e.g. 'status.phase=Running', 'spec.nodeName=node1'). Supported fields: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. Note: CrashLoopBackOff is a container state, not a pod phase, so it cannot be filtered directly. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
@@ -221,20 +229,21 @@
           "pattern": "^([/_.\\-A-Za-z0-9=, ()!])+$",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_list"
+    "name": "pods_list",
+    "title": "Pods: List"
   },
   {
     "annotations": {
-      "title": "Pods: List in Namespace",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List in Namespace"
     },
     "description": "List all the Kubernetes pods in the specified namespace in the current cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter pods by field values (e.g. 'status.phase=Running', 'spec.nodeName=node1'). Supported fields: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. Note: CrashLoopBackOff is a container state, not a pod phase, so it cannot be filtered directly. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
@@ -253,20 +262,21 @@
       },
       "required": [
         "namespace"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_list_in_namespace"
+    "name": "pods_list_in_namespace",
+    "title": "Pods: List in Namespace"
   },
   {
     "annotations": {
-      "title": "Pods: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Log"
     },
     "description": "Get the logs of a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
@@ -293,19 +303,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_log"
+    "name": "pods_log",
+    "title": "Pods: Log"
   },
   {
     "annotations": {
-      "title": "Pods: Run",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Run"
     },
     "description": "Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "image": {
           "description": "Container Image to run in the Pod",
@@ -326,21 +337,22 @@
       },
       "required": [
         "image"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_run"
+    "name": "pods_run",
+    "title": "Pods: Run"
   },
   {
     "annotations": {
-      "title": "Pods: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Pods in the all namespaces, the provided namespace, or the current namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "default": true,
@@ -360,20 +372,21 @@
           "description": "Namespace to get the Pods resource consumption from (Optional, current namespace if not provided and all_namespaces is false)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_top"
+    "name": "pods_top",
+    "title": "Pods: Top"
   },
   {
     "annotations": {
-      "title": "Resources: Create or Update",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Create or Update"
     },
     "description": "Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
@@ -382,20 +395,21 @@
       },
       "required": [
         "resource"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_create_or_update"
+    "name": "resources_create_or_update",
+    "title": "Resources: Create or Update"
   },
   {
     "annotations": {
-      "title": "Resources: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Delete"
     },
     "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -422,20 +436,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_delete"
+    "name": "resources_delete",
+    "title": "Resources: Delete"
   },
   {
     "annotations": {
-      "title": "Resources: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: Get"
     },
     "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -458,20 +473,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_get"
+    "name": "resources_get",
+    "title": "Resources: Get"
   },
   {
     "annotations": {
-      "title": "Resources: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: List"
     },
     "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -499,20 +515,21 @@
       "required": [
         "apiVersion",
         "kind"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_list"
+    "name": "resources_list",
+    "title": "Resources: List"
   },
   {
     "annotations": {
-      "title": "Resources: Scale",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Scale"
     },
     "description": "Get or update the scale of a Kubernetes resource in the current cluster by providing its apiVersion, kind, name, and optionally the namespace. If the scale is set in the tool call, the scale will be updated to that value. Always returns the current scale of the resource",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are apps/v1)",
@@ -539,8 +556,10 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_scale"
+    "name": "resources_scale",
+    "title": "Resources: Scale"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
@@ -1,47 +1,49 @@
 [
   {
     "annotations": {
-      "title": "Configuration: Contexts List",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": false
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Configuration: Contexts List"
     },
     "description": "List all available context names and associated server urls from the kubeconfig file",
     "inputSchema": {
+      "properties": {},
       "type": "object"
     },
-    "name": "configuration_contexts_list"
+    "name": "configuration_contexts_list",
+    "title": "Configuration: Contexts List"
   },
   {
     "annotations": {
-      "title": "Configuration: View",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Configuration: View"
     },
     "description": "Get the current Kubernetes configuration content as a kubeconfig YAML",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "minified": {
           "description": "Return a minified version of the configuration. If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. (Optional, default true)",
           "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "configuration_view"
+    "name": "configuration_view",
+    "title": "Configuration: View"
   },
   {
     "annotations": {
-      "title": "Events: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Events: List"
     },
     "description": "List Kubernetes events (warnings, errors, state changes) for debugging and troubleshooting in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -55,19 +57,20 @@
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "events_list"
+    "name": "events_list",
+    "title": "Events: List"
   },
   {
     "annotations": {
-      "title": "Helm: Install",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Install"
     },
     "description": "Install (deploy) a Helm chart to create a release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
@@ -97,20 +100,21 @@
       },
       "required": [
         "chart"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_install"
+    "name": "helm_install",
+    "title": "Helm: Install"
   },
   {
     "annotations": {
-      "title": "Helm: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Helm: List"
     },
     "description": "List all the Helm releases in the current or provided namespace (or in all namespaces if specified)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
@@ -128,20 +132,21 @@
           "description": "Namespace to list Helm releases from (Optional, all namespaces if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "helm_list"
+    "name": "helm_list",
+    "title": "Helm: List"
   },
   {
     "annotations": {
-      "title": "Helm: Uninstall",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Uninstall"
     },
     "description": "Uninstall a Helm release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -162,20 +167,21 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_uninstall"
+    "name": "helm_uninstall",
+    "title": "Helm: Uninstall"
   },
   {
     "annotations": {
-      "title": "Namespaces: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Namespaces: List"
     },
     "description": "List all the Kubernetes namespaces in the current cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -185,20 +191,21 @@
           ],
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "namespaces_list"
+    "name": "namespaces_list",
+    "title": "Namespaces: List"
   },
   {
     "annotations": {
-      "title": "Node: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Log"
     },
     "description": "Get logs from a Kubernetes node (kubelet, kube-proxy, or other system logs). This accesses node logs through the Kubernetes API proxy to the kubelet",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -226,20 +233,21 @@
       "required": [
         "name",
         "query"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_log"
+    "name": "nodes_log",
+    "title": "Node: Log"
   },
   {
     "annotations": {
-      "title": "Node: Stats Summary",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Stats Summary"
     },
     "description": "Get detailed resource usage statistics from a Kubernetes node via the kubelet's Summary API. Provides comprehensive metrics including CPU, memory, filesystem, and network usage at the node, pod, and container levels. On systems with cgroup v2 and kernel 4.20+, also includes PSI (Pressure Stall Information) metrics that show resource pressure for CPU, memory, and I/O. See https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/ for details on PSI metrics",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -256,21 +264,22 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_stats_summary"
+    "name": "nodes_stats_summary",
+    "title": "Node: Stats Summary"
   },
   {
     "annotations": {
-      "title": "Nodes: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Nodes: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Nodes or all nodes in the cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -289,20 +298,21 @@
           "description": "Name of the Node to get the resource consumption from (Optional, all Nodes if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "nodes_top"
+    "name": "nodes_top",
+    "title": "Nodes: Top"
   },
   {
     "annotations": {
-      "title": "Pods: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Delete"
     },
     "description": "Delete a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -323,19 +333,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_delete"
+    "name": "pods_delete",
+    "title": "Pods: Delete"
   },
   {
     "annotations": {
-      "title": "Pods: Exec",
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Exec"
     },
     "description": "Execute a command in a Kubernetes Pod (shell access, run commands in container) in the current or provided namespace with the provided name and command",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "command": {
           "description": "Command to execute in the Pod container. The first item is the command to be run, and the rest are the arguments to that command. Example: [\"ls\", \"-l\", \"/tmp\"]",
@@ -368,20 +379,21 @@
       "required": [
         "name",
         "command"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_exec"
+    "name": "pods_exec",
+    "title": "Pods: Exec"
   },
   {
     "annotations": {
-      "title": "Pods: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Get"
     },
     "description": "Get a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -402,20 +414,21 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_get"
+    "name": "pods_get",
+    "title": "Pods: Get"
   },
   {
     "annotations": {
-      "title": "Pods: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List"
     },
     "description": "List all the Kubernetes pods in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -435,20 +448,21 @@
           "pattern": "^([/_.\\-A-Za-z0-9=, ()!])+$",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_list"
+    "name": "pods_list",
+    "title": "Pods: List"
   },
   {
     "annotations": {
-      "title": "Pods: List in Namespace",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List in Namespace"
     },
     "description": "List all the Kubernetes pods in the specified namespace in the current cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -475,20 +489,21 @@
       },
       "required": [
         "namespace"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_list_in_namespace"
+    "name": "pods_list_in_namespace",
+    "title": "Pods: List in Namespace"
   },
   {
     "annotations": {
-      "title": "Pods: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Log"
     },
     "description": "Get the logs of a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
@@ -523,19 +538,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_log"
+    "name": "pods_log",
+    "title": "Pods: Log"
   },
   {
     "annotations": {
-      "title": "Pods: Run",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Run"
     },
     "description": "Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -564,21 +580,22 @@
       },
       "required": [
         "image"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_run"
+    "name": "pods_run",
+    "title": "Pods: Run"
   },
   {
     "annotations": {
-      "title": "Pods: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Pods in the all namespaces, the provided namespace, or the current namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "default": true,
@@ -606,20 +623,21 @@
           "description": "Namespace to get the Pods resource consumption from (Optional, current namespace if not provided and all_namespaces is false)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_top"
+    "name": "pods_top",
+    "title": "Pods: Top"
   },
   {
     "annotations": {
-      "title": "Resources: Create or Update",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Create or Update"
     },
     "description": "Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -636,20 +654,21 @@
       },
       "required": [
         "resource"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_create_or_update"
+    "name": "resources_create_or_update",
+    "title": "Resources: Create or Update"
   },
   {
     "annotations": {
-      "title": "Resources: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Delete"
     },
     "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -684,20 +703,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_delete"
+    "name": "resources_delete",
+    "title": "Resources: Delete"
   },
   {
     "annotations": {
-      "title": "Resources: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: Get"
     },
     "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -728,20 +748,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_get"
+    "name": "resources_get",
+    "title": "Resources: Get"
   },
   {
     "annotations": {
-      "title": "Resources: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: List"
     },
     "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -777,20 +798,21 @@
       "required": [
         "apiVersion",
         "kind"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_list"
+    "name": "resources_list",
+    "title": "Resources: List"
   },
   {
     "annotations": {
-      "title": "Resources: Scale",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Scale"
     },
     "description": "Get or update the scale of a Kubernetes resource in the current cluster by providing its apiVersion, kind, name, and optionally the namespace. If the scale is set in the tool call, the scale will be updated to that value. Always returns the current scale of the resource",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are apps/v1)",
@@ -825,8 +847,10 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_scale"
+    "name": "resources_scale",
+    "title": "Resources: Scale"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -1,47 +1,49 @@
 [
   {
     "annotations": {
-      "title": "Configuration: Contexts List",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": false
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Configuration: Contexts List"
     },
     "description": "List all available context names and associated server urls from the kubeconfig file",
     "inputSchema": {
+      "properties": {},
       "type": "object"
     },
-    "name": "configuration_contexts_list"
+    "name": "configuration_contexts_list",
+    "title": "Configuration: Contexts List"
   },
   {
     "annotations": {
-      "title": "Configuration: View",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Configuration: View"
     },
     "description": "Get the current Kubernetes configuration content as a kubeconfig YAML",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "minified": {
           "description": "Return a minified version of the configuration. If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. (Optional, default true)",
           "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "configuration_view"
+    "name": "configuration_view",
+    "title": "Configuration: View"
   },
   {
     "annotations": {
-      "title": "Events: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Events: List"
     },
     "description": "List Kubernetes events (warnings, errors, state changes) for debugging and troubleshooting in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -51,19 +53,20 @@
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "events_list"
+    "name": "events_list",
+    "title": "Events: List"
   },
   {
     "annotations": {
-      "title": "Helm: Install",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Install"
     },
     "description": "Install (deploy) a Helm chart to create a release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
@@ -89,20 +92,21 @@
       },
       "required": [
         "chart"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_install"
+    "name": "helm_install",
+    "title": "Helm: Install"
   },
   {
     "annotations": {
-      "title": "Helm: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Helm: List"
     },
     "description": "List all the Helm releases in the current or provided namespace (or in all namespaces if specified)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
@@ -116,20 +120,21 @@
           "description": "Namespace to list Helm releases from (Optional, all namespaces if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "helm_list"
+    "name": "helm_list",
+    "title": "Helm: List"
   },
   {
     "annotations": {
-      "title": "Helm: Uninstall",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Uninstall"
     },
     "description": "Uninstall a Helm release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -146,39 +151,41 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_uninstall"
+    "name": "helm_uninstall",
+    "title": "Helm: Uninstall"
   },
   {
     "annotations": {
-      "title": "Namespaces: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Namespaces: List"
     },
     "description": "List all the Kubernetes namespaces in the current cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "namespaces_list"
+    "name": "namespaces_list",
+    "title": "Namespaces: List"
   },
   {
     "annotations": {
-      "title": "Node: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Log"
     },
     "description": "Get logs from a Kubernetes node (kubelet, kube-proxy, or other system logs). This accesses node logs through the Kubernetes API proxy to the kubelet",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -202,20 +209,21 @@
       "required": [
         "name",
         "query"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_log"
+    "name": "nodes_log",
+    "title": "Node: Log"
   },
   {
     "annotations": {
-      "title": "Node: Stats Summary",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Stats Summary"
     },
     "description": "Get detailed resource usage statistics from a Kubernetes node via the kubelet's Summary API. Provides comprehensive metrics including CPU, memory, filesystem, and network usage at the node, pod, and container levels. On systems with cgroup v2 and kernel 4.20+, also includes PSI (Pressure Stall Information) metrics that show resource pressure for CPU, memory, and I/O. See https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/ for details on PSI metrics",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -228,21 +236,22 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_stats_summary"
+    "name": "nodes_stats_summary",
+    "title": "Node: Stats Summary"
   },
   {
     "annotations": {
-      "title": "Nodes: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Nodes: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Nodes or all nodes in the cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -257,20 +266,21 @@
           "description": "Name of the Node to get the resource consumption from (Optional, all Nodes if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "nodes_top"
+    "name": "nodes_top",
+    "title": "Nodes: Top"
   },
   {
     "annotations": {
-      "title": "Pods: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Delete"
     },
     "description": "Delete a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -287,19 +297,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_delete"
+    "name": "pods_delete",
+    "title": "Pods: Delete"
   },
   {
     "annotations": {
-      "title": "Pods: Exec",
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Exec"
     },
     "description": "Execute a command in a Kubernetes Pod (shell access, run commands in container) in the current or provided namespace with the provided name and command",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "command": {
           "description": "Command to execute in the Pod container. The first item is the command to be run, and the rest are the arguments to that command. Example: [\"ls\", \"-l\", \"/tmp\"]",
@@ -328,20 +339,21 @@
       "required": [
         "name",
         "command"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_exec"
+    "name": "pods_exec",
+    "title": "Pods: Exec"
   },
   {
     "annotations": {
-      "title": "Pods: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Get"
     },
     "description": "Get a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -358,20 +370,21 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_get"
+    "name": "pods_get",
+    "title": "Pods: Get"
   },
   {
     "annotations": {
-      "title": "Pods: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List"
     },
     "description": "List all the Kubernetes pods in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -387,20 +400,21 @@
           "pattern": "^([/_.\\-A-Za-z0-9=, ()!])+$",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_list"
+    "name": "pods_list",
+    "title": "Pods: List"
   },
   {
     "annotations": {
-      "title": "Pods: List in Namespace",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List in Namespace"
     },
     "description": "List all the Kubernetes pods in the specified namespace in the current cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -423,20 +437,21 @@
       },
       "required": [
         "namespace"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_list_in_namespace"
+    "name": "pods_list_in_namespace",
+    "title": "Pods: List in Namespace"
   },
   {
     "annotations": {
-      "title": "Pods: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Log"
     },
     "description": "Get the logs of a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
@@ -467,19 +482,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_log"
+    "name": "pods_log",
+    "title": "Pods: Log"
   },
   {
     "annotations": {
-      "title": "Pods: Run",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Run"
     },
     "description": "Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -504,21 +520,22 @@
       },
       "required": [
         "image"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_run"
+    "name": "pods_run",
+    "title": "Pods: Run"
   },
   {
     "annotations": {
-      "title": "Pods: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Pods in the all namespaces, the provided namespace, or the current namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "default": true,
@@ -542,20 +559,21 @@
           "description": "Namespace to get the Pods resource consumption from (Optional, current namespace if not provided and all_namespaces is false)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_top"
+    "name": "pods_top",
+    "title": "Pods: Top"
   },
   {
     "annotations": {
-      "title": "Resources: Create or Update",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Create or Update"
     },
     "description": "Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
@@ -568,20 +586,21 @@
       },
       "required": [
         "resource"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_create_or_update"
+    "name": "resources_create_or_update",
+    "title": "Resources: Create or Update"
   },
   {
     "annotations": {
-      "title": "Resources: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Delete"
     },
     "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -612,20 +631,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_delete"
+    "name": "resources_delete",
+    "title": "Resources: Delete"
   },
   {
     "annotations": {
-      "title": "Resources: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: Get"
     },
     "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -652,20 +672,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_get"
+    "name": "resources_get",
+    "title": "Resources: Get"
   },
   {
     "annotations": {
-      "title": "Resources: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: List"
     },
     "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -697,20 +718,21 @@
       "required": [
         "apiVersion",
         "kind"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_list"
+    "name": "resources_list",
+    "title": "Resources: List"
   },
   {
     "annotations": {
-      "title": "Resources: Scale",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Scale"
     },
     "description": "Get or update the scale of a Kubernetes resource in the current cluster by providing its apiVersion, kind, name, and optionally the namespace. If the scale is set in the tool call, the scale will be updated to that value. Always returns the current scale of the resource",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are apps/v1)",
@@ -741,8 +763,10 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_scale"
+    "name": "resources_scale",
+    "title": "Resources: Scale"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -1,51 +1,52 @@
 [
   {
     "annotations": {
-      "title": "Configuration: View",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Configuration: View"
     },
     "description": "Get the current Kubernetes configuration content as a kubeconfig YAML",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "minified": {
           "description": "Return a minified version of the configuration. If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. (Optional, default true)",
           "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "configuration_view"
+    "name": "configuration_view",
+    "title": "Configuration: View"
   },
   {
     "annotations": {
-      "title": "Events: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Events: List"
     },
     "description": "List Kubernetes events (warnings, errors, state changes) for debugging and troubleshooting in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "namespace": {
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "events_list"
+    "name": "events_list",
+    "title": "Events: List"
   },
   {
     "annotations": {
-      "title": "Helm: Install",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Install"
     },
     "description": "Install (deploy) a Helm chart to create a release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
@@ -67,20 +68,21 @@
       },
       "required": [
         "chart"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_install"
+    "name": "helm_install",
+    "title": "Helm: Install"
   },
   {
     "annotations": {
-      "title": "Helm: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Helm: List"
     },
     "description": "List all the Helm releases in the current or provided namespace (or in all namespaces if specified)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
@@ -90,20 +92,21 @@
           "description": "Namespace to list Helm releases from (Optional, all namespaces if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "helm_list"
+    "name": "helm_list",
+    "title": "Helm: List"
   },
   {
     "annotations": {
-      "title": "Helm: Uninstall",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Uninstall"
     },
     "description": "Uninstall a Helm release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the Helm release to uninstall",
@@ -116,33 +119,36 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_uninstall"
+    "name": "helm_uninstall",
+    "title": "Helm: Uninstall"
   },
   {
     "annotations": {
-      "title": "Namespaces: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Namespaces: List"
     },
     "description": "List all the Kubernetes namespaces in the current cluster",
     "inputSchema": {
+      "properties": {},
       "type": "object"
     },
-    "name": "namespaces_list"
+    "name": "namespaces_list",
+    "title": "Namespaces: List"
   },
   {
     "annotations": {
-      "title": "Node: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Log"
     },
     "description": "Get logs from a Kubernetes node (kubelet, kube-proxy, or other system logs). This accesses node logs through the Kubernetes API proxy to the kubelet",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the node to get logs from",
@@ -162,20 +168,21 @@
       "required": [
         "name",
         "query"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_log"
+    "name": "nodes_log",
+    "title": "Node: Log"
   },
   {
     "annotations": {
-      "title": "Node: Stats Summary",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Stats Summary"
     },
     "description": "Get detailed resource usage statistics from a Kubernetes node via the kubelet's Summary API. Provides comprehensive metrics including CPU, memory, filesystem, and network usage at the node, pod, and container levels. On systems with cgroup v2 and kernel 4.20+, also includes PSI (Pressure Stall Information) metrics that show resource pressure for CPU, memory, and I/O. See https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/ for details on PSI metrics",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the node to get stats from",
@@ -184,21 +191,22 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_stats_summary"
+    "name": "nodes_stats_summary",
+    "title": "Node: Stats Summary"
   },
   {
     "annotations": {
-      "title": "Nodes: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Nodes: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Nodes or all nodes in the cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "label_selector": {
           "description": "Kubernetes label selector (e.g. 'node-role.kubernetes.io/worker=') to filter nodes by label (Optional, only applicable when name is not provided)",
@@ -209,20 +217,21 @@
           "description": "Name of the Node to get the resource consumption from (Optional, all Nodes if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "nodes_top"
+    "name": "nodes_top",
+    "title": "Nodes: Top"
   },
   {
     "annotations": {
-      "title": "Pods: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Delete"
     },
     "description": "Delete a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the Pod to delete",
@@ -235,19 +244,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_delete"
+    "name": "pods_delete",
+    "title": "Pods: Delete"
   },
   {
     "annotations": {
-      "title": "Pods: Exec",
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Exec"
     },
     "description": "Execute a command in a Kubernetes Pod (shell access, run commands in container) in the current or provided namespace with the provided name and command",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "command": {
           "description": "Command to execute in the Pod container. The first item is the command to be run, and the rest are the arguments to that command. Example: [\"ls\", \"-l\", \"/tmp\"]",
@@ -272,20 +282,21 @@
       "required": [
         "name",
         "command"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_exec"
+    "name": "pods_exec",
+    "title": "Pods: Exec"
   },
   {
     "annotations": {
-      "title": "Pods: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Get"
     },
     "description": "Get a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the Pod",
@@ -298,20 +309,21 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_get"
+    "name": "pods_get",
+    "title": "Pods: Get"
   },
   {
     "annotations": {
-      "title": "Pods: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List"
     },
     "description": "List all the Kubernetes pods in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter pods by field values (e.g. 'status.phase=Running', 'spec.nodeName=node1'). Supported fields: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. Note: CrashLoopBackOff is a container state, not a pod phase, so it cannot be filtered directly. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
@@ -323,20 +335,21 @@
           "pattern": "^([/_.\\-A-Za-z0-9=, ()!])+$",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_list"
+    "name": "pods_list",
+    "title": "Pods: List"
   },
   {
     "annotations": {
-      "title": "Pods: List in Namespace",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List in Namespace"
     },
     "description": "List all the Kubernetes pods in the specified namespace in the current cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter pods by field values (e.g. 'status.phase=Running', 'spec.nodeName=node1'). Supported fields: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. Note: CrashLoopBackOff is a container state, not a pod phase, so it cannot be filtered directly. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
@@ -355,20 +368,21 @@
       },
       "required": [
         "namespace"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_list_in_namespace"
+    "name": "pods_list_in_namespace",
+    "title": "Pods: List in Namespace"
   },
   {
     "annotations": {
-      "title": "Pods: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Log"
     },
     "description": "Get the logs of a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
@@ -395,19 +409,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_log"
+    "name": "pods_log",
+    "title": "Pods: Log"
   },
   {
     "annotations": {
-      "title": "Pods: Run",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Run"
     },
     "description": "Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "image": {
           "description": "Container Image to run in the Pod",
@@ -428,21 +443,22 @@
       },
       "required": [
         "image"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_run"
+    "name": "pods_run",
+    "title": "Pods: Run"
   },
   {
     "annotations": {
-      "title": "Pods: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Pods in the all namespaces, the provided namespace, or the current namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "default": true,
@@ -462,33 +478,36 @@
           "description": "Namespace to get the Pods resource consumption from (Optional, current namespace if not provided and all_namespaces is false)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_top"
+    "name": "pods_top",
+    "title": "Pods: Top"
   },
   {
     "annotations": {
-      "title": "Projects: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Projects: List"
     },
     "description": "List all the OpenShift projects in the current cluster",
     "inputSchema": {
+      "properties": {},
       "type": "object"
     },
-    "name": "projects_list"
+    "name": "projects_list",
+    "title": "Projects: List"
   },
   {
     "annotations": {
-      "title": "Resources: Create or Update",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Create or Update"
     },
     "description": "Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
@@ -497,20 +516,21 @@
       },
       "required": [
         "resource"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_create_or_update"
+    "name": "resources_create_or_update",
+    "title": "Resources: Create or Update"
   },
   {
     "annotations": {
-      "title": "Resources: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Delete"
     },
     "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -537,20 +557,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_delete"
+    "name": "resources_delete",
+    "title": "Resources: Delete"
   },
   {
     "annotations": {
-      "title": "Resources: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: Get"
     },
     "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -573,20 +594,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_get"
+    "name": "resources_get",
+    "title": "Resources: Get"
   },
   {
     "annotations": {
-      "title": "Resources: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: List"
     },
     "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -614,20 +636,21 @@
       "required": [
         "apiVersion",
         "kind"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_list"
+    "name": "resources_list",
+    "title": "Resources: List"
   },
   {
     "annotations": {
-      "title": "Resources: Scale",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Scale"
     },
     "description": "Get or update the scale of a Kubernetes resource in the current cluster by providing its apiVersion, kind, name, and optionally the namespace. If the scale is set in the tool call, the scale will be updated to that value. Always returns the current scale of the resource",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are apps/v1)",
@@ -654,8 +677,10 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_scale"
+    "name": "resources_scale",
+    "title": "Resources: Scale"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -1,51 +1,52 @@
 [
   {
     "annotations": {
-      "title": "Configuration: View",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Configuration: View"
     },
     "description": "Get the current Kubernetes configuration content as a kubeconfig YAML",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "minified": {
           "description": "Return a minified version of the configuration. If set to true, keeps only the current-context and the relevant pieces of the configuration for that context. If set to false, all contexts, clusters, auth-infos, and users are returned in the configuration. (Optional, default true)",
           "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "configuration_view"
+    "name": "configuration_view",
+    "title": "Configuration: View"
   },
   {
     "annotations": {
-      "title": "Events: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Events: List"
     },
     "description": "List Kubernetes events (warnings, errors, state changes) for debugging and troubleshooting in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "namespace": {
           "description": "Optional Namespace to retrieve the events from. If not provided, will list events from all namespaces",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "events_list"
+    "name": "events_list",
+    "title": "Events: List"
   },
   {
     "annotations": {
-      "title": "Helm: Install",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Install"
     },
     "description": "Install (deploy) a Helm chart to create a release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
@@ -67,20 +68,21 @@
       },
       "required": [
         "chart"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_install"
+    "name": "helm_install",
+    "title": "Helm: Install"
   },
   {
     "annotations": {
-      "title": "Helm: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Helm: List"
     },
     "description": "List all the Helm releases in the current or provided namespace (or in all namespaces if specified)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
@@ -90,20 +92,21 @@
           "description": "Namespace to list Helm releases from (Optional, all namespaces if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "helm_list"
+    "name": "helm_list",
+    "title": "Helm: List"
   },
   {
     "annotations": {
-      "title": "Helm: Uninstall",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Uninstall"
     },
     "description": "Uninstall a Helm release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the Helm release to uninstall",
@@ -116,33 +119,36 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_uninstall"
+    "name": "helm_uninstall",
+    "title": "Helm: Uninstall"
   },
   {
     "annotations": {
-      "title": "Namespaces: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Namespaces: List"
     },
     "description": "List all the Kubernetes namespaces in the current cluster",
     "inputSchema": {
+      "properties": {},
       "type": "object"
     },
-    "name": "namespaces_list"
+    "name": "namespaces_list",
+    "title": "Namespaces: List"
   },
   {
     "annotations": {
-      "title": "Node: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Log"
     },
     "description": "Get logs from a Kubernetes node (kubelet, kube-proxy, or other system logs). This accesses node logs through the Kubernetes API proxy to the kubelet",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the node to get logs from",
@@ -162,20 +168,21 @@
       "required": [
         "name",
         "query"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_log"
+    "name": "nodes_log",
+    "title": "Node: Log"
   },
   {
     "annotations": {
-      "title": "Node: Stats Summary",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Node: Stats Summary"
     },
     "description": "Get detailed resource usage statistics from a Kubernetes node via the kubelet's Summary API. Provides comprehensive metrics including CPU, memory, filesystem, and network usage at the node, pod, and container levels. On systems with cgroup v2 and kernel 4.20+, also includes PSI (Pressure Stall Information) metrics that show resource pressure for CPU, memory, and I/O. See https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/ for details on PSI metrics",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the node to get stats from",
@@ -184,21 +191,22 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "nodes_stats_summary"
+    "name": "nodes_stats_summary",
+    "title": "Node: Stats Summary"
   },
   {
     "annotations": {
-      "title": "Nodes: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Nodes: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Nodes or all nodes in the cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "label_selector": {
           "description": "Kubernetes label selector (e.g. 'node-role.kubernetes.io/worker=') to filter nodes by label (Optional, only applicable when name is not provided)",
@@ -209,20 +217,21 @@
           "description": "Name of the Node to get the resource consumption from (Optional, all Nodes if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "nodes_top"
+    "name": "nodes_top",
+    "title": "Nodes: Top"
   },
   {
     "annotations": {
-      "title": "Pods: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Delete"
     },
     "description": "Delete a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the Pod to delete",
@@ -235,19 +244,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_delete"
+    "name": "pods_delete",
+    "title": "Pods: Delete"
   },
   {
     "annotations": {
-      "title": "Pods: Exec",
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Exec"
     },
     "description": "Execute a command in a Kubernetes Pod (shell access, run commands in container) in the current or provided namespace with the provided name and command",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "command": {
           "description": "Command to execute in the Pod container. The first item is the command to be run, and the rest are the arguments to that command. Example: [\"ls\", \"-l\", \"/tmp\"]",
@@ -272,20 +282,21 @@
       "required": [
         "name",
         "command"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_exec"
+    "name": "pods_exec",
+    "title": "Pods: Exec"
   },
   {
     "annotations": {
-      "title": "Pods: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Get"
     },
     "description": "Get a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the Pod",
@@ -298,20 +309,21 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_get"
+    "name": "pods_get",
+    "title": "Pods: Get"
   },
   {
     "annotations": {
-      "title": "Pods: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List"
     },
     "description": "List all the Kubernetes pods in the current cluster from all namespaces",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter pods by field values (e.g. 'status.phase=Running', 'spec.nodeName=node1'). Supported fields: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. Note: CrashLoopBackOff is a container state, not a pod phase, so it cannot be filtered directly. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
@@ -323,20 +335,21 @@
           "pattern": "^([/_.\\-A-Za-z0-9=, ()!])+$",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_list"
+    "name": "pods_list",
+    "title": "Pods: List"
   },
   {
     "annotations": {
-      "title": "Pods: List in Namespace",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: List in Namespace"
     },
     "description": "List all the Kubernetes pods in the specified namespace in the current cluster",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter pods by field values (e.g. 'status.phase=Running', 'spec.nodeName=node1'). Supported fields: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. Note: CrashLoopBackOff is a container state, not a pod phase, so it cannot be filtered directly. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
@@ -355,20 +368,21 @@
       },
       "required": [
         "namespace"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_list_in_namespace"
+    "name": "pods_list_in_namespace",
+    "title": "Pods: List in Namespace"
   },
   {
     "annotations": {
-      "title": "Pods: Log",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Log"
     },
     "description": "Get the logs of a Kubernetes Pod in the current or provided namespace with the provided name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "container": {
           "description": "Name of the Pod container to get the logs from (Optional)",
@@ -395,19 +409,20 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_log"
+    "name": "pods_log",
+    "title": "Pods: Log"
   },
   {
     "annotations": {
-      "title": "Pods: Run",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pods: Run"
     },
     "description": "Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "image": {
           "description": "Container Image to run in the Pod",
@@ -428,21 +443,22 @@
       },
       "required": [
         "image"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "pods_run"
+    "name": "pods_run",
+    "title": "Pods: Run"
   },
   {
     "annotations": {
-      "title": "Pods: Top",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Top"
     },
     "description": "List the resource consumption (CPU and memory) as recorded by the Kubernetes Metrics Server for the specified Kubernetes Pods in the all namespaces, the provided namespace, or the current namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "default": true,
@@ -462,20 +478,21 @@
           "description": "Namespace to get the Pods resource consumption from (Optional, current namespace if not provided and all_namespaces is false)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "pods_top"
+    "name": "pods_top",
+    "title": "Pods: Top"
   },
   {
     "annotations": {
-      "title": "Resources: Create or Update",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Create or Update"
     },
     "description": "Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "resource": {
           "description": "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
@@ -484,20 +501,21 @@
       },
       "required": [
         "resource"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_create_or_update"
+    "name": "resources_create_or_update",
+    "title": "Resources: Create or Update"
   },
   {
     "annotations": {
-      "title": "Resources: Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Delete"
     },
     "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -524,20 +542,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_delete"
+    "name": "resources_delete",
+    "title": "Resources: Delete"
   },
   {
     "annotations": {
-      "title": "Resources: Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: Get"
     },
     "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -560,20 +579,21 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_get"
+    "name": "resources_get",
+    "title": "Resources: Get"
   },
   {
     "annotations": {
-      "title": "Resources: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Resources: List"
     },
     "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
@@ -601,20 +621,21 @@
       "required": [
         "apiVersion",
         "kind"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_list"
+    "name": "resources_list",
+    "title": "Resources: List"
   },
   {
     "annotations": {
-      "title": "Resources: Scale",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Resources: Scale"
     },
     "description": "Get or update the scale of a Kubernetes resource in the current cluster by providing its apiVersion, kind, name, and optionally the namespace. If the scale is set in the tool call, the scale will be updated to that value. Always returns the current scale of the resource",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are apps/v1)",
@@ -641,8 +662,10 @@
         "apiVersion",
         "kind",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "resources_scale"
+    "name": "resources_scale",
+    "title": "Resources: Scale"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-helm-tools.json
+++ b/pkg/mcp/testdata/toolsets-helm-tools.json
@@ -1,13 +1,12 @@
 [
   {
     "annotations": {
-      "title": "Helm: Install",
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Install"
     },
     "description": "Install (deploy) a Helm chart to create a release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "chart": {
           "description": "Chart reference to install (for example: stable/grafana, oci://ghcr.io/nginxinc/charts/nginx-ingress)",
@@ -29,20 +28,21 @@
       },
       "required": [
         "chart"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_install"
+    "name": "helm_install",
+    "title": "Helm: Install"
   },
   {
     "annotations": {
-      "title": "Helm: List",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Helm: List"
     },
     "description": "List all the Helm releases in the current or provided namespace (or in all namespaces if specified)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "all_namespaces": {
           "description": "If true, lists all Helm releases in all namespaces ignoring the namespace argument (Optional)",
@@ -52,20 +52,21 @@
           "description": "Namespace to list Helm releases from (Optional, all namespaces if not provided)",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "helm_list"
+    "name": "helm_list",
+    "title": "Helm: List"
   },
   {
     "annotations": {
-      "title": "Helm: Uninstall",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Helm: Uninstall"
     },
     "description": "Uninstall a Helm release in the current or provided namespace",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "Name of the Helm release to uninstall",
@@ -78,8 +79,10 @@
       },
       "required": [
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "helm_uninstall"
+    "name": "helm_uninstall",
+    "title": "Helm: Uninstall"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-kiali-tools.json
+++ b/pkg/mcp/testdata/toolsets-kiali-tools.json
@@ -1,15 +1,14 @@
 [
   {
     "annotations": {
-      "title": "Get Metrics for a Resource",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Get Metrics for a Resource"
     },
     "description": "Gets lists or detailed info for Kubernetes resources (services, workloads) within the mesh",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "byLabels": {
           "description": "Comma-separated list of labels to group metrics by (e.g., 'source_workload,destination_service'). Optional",
@@ -70,21 +69,22 @@
         "resource_type",
         "namespace",
         "resource_name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "kiali_get_metrics"
+    "name": "kiali_get_metrics",
+    "title": "Get Metrics for a Resource"
   },
   {
     "annotations": {
-      "title": "List or Resource Details",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "List or Resource Details"
     },
     "description": "Gets lists or detailed info for Kubernetes resources (services, workloads) within the mesh",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "namespaces": {
           "description": "Comma-separated list of namespaces to get services from (e.g. 'bookinfo' or 'bookinfo,default'). If not provided, will list services from all accessible namespaces",
@@ -102,21 +102,22 @@
           ],
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "kiali_get_resource_details"
+    "name": "kiali_get_resource_details",
+    "title": "List or Resource Details"
   },
   {
     "annotations": {
-      "title": "Get Traces for a Resource or Trace Details",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Get Traces for a Resource or Trace Details"
     },
     "description": "Gets traces for a specific resource (app, service, workload) in a namespace, or gets detailed information for a specific trace by its ID. If traceId is provided, it returns detailed trace information and other parameters are not required.",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "clusterName": {
           "description": "Cluster name for multi-cluster environments (optional, only used when traceId is not provided)",
@@ -166,20 +167,21 @@
           "description": "Unique identifier of the trace to retrieve detailed information for. If provided, this will return detailed trace information and other parameters (resource_type, namespace, resource_name) are not required.",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "kiali_get_traces"
+    "name": "kiali_get_traces",
+    "title": "Get Traces for a Resource or Trace Details"
   },
   {
     "annotations": {
-      "title": "Manage Istio Config: Create, Patch, Delete",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Manage Istio Config: Create, Patch, Delete"
     },
     "description": "Creates, patches, or deletes Istio configuration objects (Gateways, VirtualServices, etc.)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "action": {
           "description": "Action to perform: create, patch, or delete",
@@ -212,21 +214,22 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "kiali_manage_istio_config"
+    "name": "kiali_manage_istio_config",
+    "title": "Manage Istio Config: Create, Patch, Delete"
   },
   {
     "annotations": {
-      "title": "Manage Istio Config: List or Get",
-      "readOnlyHint": true,
       "destructiveHint": false,
       "idempotentHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Manage Istio Config: List or Get"
     },
     "description": "Lists or gets Istio configuration objects (Gateways, VirtualServices, etc.)",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "action": {
           "description": "Action to perform: list or get",
@@ -255,20 +258,21 @@
       },
       "required": [
         "action"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "kiali_manage_istio_config_read"
+    "name": "kiali_manage_istio_config_read",
+    "title": "Manage Istio Config: List or Get"
   },
   {
     "annotations": {
-      "title": "Topology: Mesh, Graph, Health, and Status",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Topology: Mesh, Graph, Health, and Status"
     },
     "description": "Returns the topology of a specific namespaces, health, status of the mesh and namespaces. Includes a mesh health summary overview with aggregated counts of healthy, degraded, and failing apps, workloads, and services. Use this for high-level overviews",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "graphType": {
           "default": "versionedApp",
@@ -288,20 +292,21 @@
           "description": "Optional rate interval for fetching (e.g., '10m', '5m', '1h').",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "name": "kiali_mesh_graph"
+    "name": "kiali_mesh_graph",
+    "title": "Topology: Mesh, Graph, Health, and Status"
   },
   {
     "annotations": {
-      "title": "Workload: Logs",
-      "readOnlyHint": true,
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Workload: Logs"
     },
     "description": "Get logs for a specific workload's pods in a namespace. Only requires namespace and workload name - automatically discovers pods and containers. Optionally filter by container name, time range, and other parameters. Container is auto-detected if not specified.",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "container": {
           "description": "Optional container name to filter logs. If not provided, automatically detects and uses the main application container (excludes istio-proxy and istio-init)",
@@ -328,8 +333,10 @@
       "required": [
         "namespace",
         "workload"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "kiali_workload_logs"
+    "name": "kiali_workload_logs",
+    "title": "Workload: Logs"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -1,14 +1,13 @@
 [
   {
     "annotations": {
-      "title": "Virtual Machine: Clone",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": false
+      "openWorldHint": false,
+      "title": "Virtual Machine: Clone"
     },
     "description": "Clone a KubeVirt VirtualMachine by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the KubeVirt Clone API",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "name": {
           "description": "The name of the source virtual machine to clone",
@@ -27,20 +26,21 @@
         "namespace",
         "name",
         "targetName"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "vm_clone"
+    "name": "vm_clone",
+    "title": "Virtual Machine: Clone"
   },
   {
     "annotations": {
-      "title": "Virtual Machine: Create",
       "destructiveHint": true,
       "idempotentHint": true,
-      "openWorldHint": false
+      "openWorldHint": false,
+      "title": "Virtual Machine: Create"
     },
     "description": "Create a VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "autostart": {
           "description": "Optional flag to automatically start the VM after creation (sets runStrategy to Always instead of Halted). Defaults to false.",
@@ -150,19 +150,20 @@
       "required": [
         "namespace",
         "name"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "vm_create"
+    "name": "vm_create",
+    "title": "Virtual Machine: Create"
   },
   {
     "annotations": {
-      "title": "Virtual Machine: Lifecycle",
       "destructiveHint": true,
-      "openWorldHint": false
+      "openWorldHint": false,
+      "title": "Virtual Machine: Lifecycle"
     },
     "description": "Manage VirtualMachine lifecycle: start, stop, or restart a VM",
     "inputSchema": {
-      "type": "object",
       "properties": {
         "action": {
           "description": "The lifecycle action to perform: 'start' (changes runStrategy to Always), 'stop' (changes runStrategy to Halted), or 'restart' (stops then starts the VM)",
@@ -186,8 +187,10 @@
         "namespace",
         "name",
         "action"
-      ]
+      ],
+      "type": "object"
     },
-    "name": "vm_lifecycle"
+    "name": "vm_lifecycle",
+    "title": "Virtual Machine: Lifecycle"
   }
 ]


### PR DESCRIPTION
> [!IMPORTANT]
> If we merge this, we should do a downstream just before merging and after.
> This introduces several minor breaking changes into the tests, and it can be the cause of multiple conflics.
> In addition, if the downstream uses the test infrastructure, tests will need some refactoring too.

Complete the migration from github.com/mark3labs/mcp-go to github.com/modelcontextprotocol/go-sdk in test code.

The mark3labs/mcp-go library was retained in test infrastructure after the production code migration to ensure behavioral consistency while go-sdk matured. PR #781 highlighted compatibility issues with newer mark3labs versions, making it a maintenance burden.

Changes:
- Rewrite internal/test/mcp.go using go-sdk's StreamableClientTransport
- Add extensible options: WithEndpoint, WithHTTPHeaders, WithAllowConnectionError, WithClientInfo
- Update all test files with pointer type assertions (*mcp.TextContent)
- Refactor authorization tests to reuse shared test client infrastructure
- Update snapshot test data for go-sdk's schema format

BREAKING CHANGE: Test infrastructure now uses go-sdk exclusively. Type assertions in tests must use pointer types (e.g., *mcp.TextContent instead of mcp.TextContent).

Supersedes closes #781 