### PR TITLE
refactor(helm-charts): simplify PrometheusRule by removing redundant recording rules

### DIFF
--- a/charts/kubernetes-mcp-server/templates/prometheusrule.yaml
+++ b/charts/kubernetes-mcp-server/templates/prometheusrule.yaml
@@ -30,22 +30,9 @@ spec:
         - record: cluster:k8s_mcp_tool_errors:sum
           expr: sum(k8s_mcp_tool_errors_total)
 
-        # Calculate error rate (errors / total calls)
-        - record: cluster:k8s_mcp_tool_error_rate:ratio
-          expr: |
-            sum(k8s_mcp_tool_errors_total) / clamp_min(sum(k8s_mcp_tool_calls_total), 1)
-
-        # Aggregate HTTP requests by status class only (removes path, method labels)
-        - record: cluster:k8s_mcp_http_requests_by_status:sum
-          expr: sum by (http_response_status_class) (k8s_mcp_http_requests_total)
-
         # Total HTTP requests
         - record: cluster:k8s_mcp_http_requests:sum
           expr: sum(k8s_mcp_http_requests_total)
-
-        # Server info (already low cardinality, just ensures it's available)
-        - record: cluster:k8s_mcp_server_info:count
-          expr: count(k8s_mcp_server_info)
 
         # Namespace-level aggregations (for multi-tenant RBAC)
         - record: namespace:k8s_mcp_tool_calls:sum
@@ -53,10 +40,6 @@ spec:
 
         - record: namespace:k8s_mcp_tool_errors:sum
           expr: sum by (namespace) (k8s_mcp_tool_errors_total)
-
-        - record: namespace:k8s_mcp_tool_error_rate:ratio
-          expr: |
-            sum by (namespace) (k8s_mcp_tool_errors_total) / clamp_min(sum by (namespace) (k8s_mcp_tool_calls_total), 1)
 
         - record: namespace:k8s_mcp_http_requests:sum
           expr: sum by (namespace) (k8s_mcp_http_requests_total)

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -230,15 +230,11 @@ metrics:
       # Cluster-level (for Telemeter):
       # - cluster:k8s_mcp_tool_calls:sum - Total tool calls across all tools
       # - cluster:k8s_mcp_tool_errors:sum - Total tool errors across all tools
-      # - cluster:k8s_mcp_tool_error_rate:ratio - Error rate (errors/calls)
       # - cluster:k8s_mcp_http_requests:sum - Total HTTP requests
-      # - cluster:k8s_mcp_http_requests_by_status:sum - HTTP requests by status class
-      # - cluster:k8s_mcp_server_info:count - Server instance count
       #
       # Namespace-level (for multi-tenant RBAC, grouped by namespace label):
       # - namespace:k8s_mcp_tool_calls:sum - Tool calls by namespace
       # - namespace:k8s_mcp_tool_errors:sum - Tool errors by namespace
-      # - namespace:k8s_mcp_tool_error_rate:ratio - Error rate by namespace
       # - namespace:k8s_mcp_http_requests:sum - HTTP requests by namespace
       enabled: true
     # -- Additional custom recording rules (appended to default rules if enabled)


### PR DESCRIPTION
Remove derived and low-value recording rules that can be computed at query time:
- cluster:k8s_mcp_tool_error_rate:ratio (derived from errors/calls)
- cluster:k8s_mcp_http_requests_by_status:sum (status breakdown)
- cluster:k8s_mcp_server_info:count (source already low cardinality)
- namespace:k8s_mcp_tool_error_rate:ratio (derived metric)