### PR TITLE
fix(helm-charts): use name helper for container name to respect nameOverride

### DIFF
--- a/charts/kubernetes-mcp-server/templates/deployment.yaml
+++ b/charts/kubernetes-mcp-server/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       securityContext:
         {{- tpl (toYaml (default .Values.defaultPodSecurityContext .Values.podSecurityContext)) . | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "kubernetes-mcp-server.name" . }}
           securityContext:
             {{- tpl (toYaml (default .Values.defaultSecurityContext .Values.securityContext)) . | nindent 12 }}
           image: "{{ template "kubernetes-mcp-server.image" .Values.image }}"


### PR DESCRIPTION
The container name was hardcoded to .Chart.Name, ignoring the nameOverride value. Use the kubernetes-mcp-server.name helper instead.

Fixes #787