### PR TITLE
fix(test): resolve race conditions in tests and MCP server

### DIFF
--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"net/http"
@@ -25,7 +24,7 @@ type AuthorizationSuite struct {
 	BaseHttpSuite
 	mcpClient *client.Client
 	klogState klog.State
-	logBuffer bytes.Buffer
+	logBuffer test.SyncBuffer
 }
 
 func (s *AuthorizationSuite) SetupTest() {

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -84,7 +83,7 @@ func (s *BaseHttpSuite) TearDownTest() {
 type httpContext struct {
 	klogState       klog.State
 	mockServer      *test.MockServer
-	LogBuffer       bytes.Buffer
+	LogBuffer       test.SyncBuffer
 	HttpAddress     string             // HTTP server address
 	timeoutCancel   context.CancelFunc // Release resources if test completes before the timeout
 	StopServer      context.CancelFunc

--- a/pkg/mcp/helm_test.go
+++ b/pkg/mcp/helm_test.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"flag"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +27,7 @@ import (
 type HelmSuite struct {
 	BaseMcpSuite
 	klogState klog.State
-	logBuffer bytes.Buffer
+	logBuffer test.SyncBuffer
 }
 
 func (s *HelmSuite) SetupTest() {

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -61,6 +62,7 @@ func (c *Configuration) isToolApplicable(tool api.ServerTool) bool {
 }
 
 type Server struct {
+	mu             sync.RWMutex
 	configuration  *Configuration
 	server         *mcp.Server
 	enabledTools   []string
@@ -134,9 +136,15 @@ func (s *Server) reloadToolsets() error {
 	applicableTools := s.collectApplicableTools(targets)
 	applicablePrompts := s.collectApplicablePrompts()
 
-	// Reload tools, and track the newly enabled tools so that we can diff on reload to figure out which to remove (if any)
-	s.enabledTools, err = reloadItems(
-		s.enabledTools,
+	// Read the previous state with read lock - don't hold lock while calling external code
+	s.mu.RLock()
+	previousTools := s.enabledTools
+	previousPrompts := s.enabledPrompts
+	s.mu.RUnlock()
+
+	// Reload tools (calls s.server.AddTool/RemoveTools - external code, no lock held)
+	newTools, err := reloadItems(
+		previousTools,
 		applicableTools,
 		func(t api.ServerTool) string { return t.Tool.Name },
 		s.server.RemoveTools,
@@ -146,9 +154,9 @@ func (s *Server) reloadToolsets() error {
 		return err
 	}
 
-	// Reload prompts, and track the newly enabled prompts so that we can diff on reload to figure out which to remove (if any)
-	s.enabledPrompts, err = reloadItems(
-		s.enabledPrompts,
+	// Reload prompts (calls s.server.AddPrompt/RemovePrompts - external code, no lock held)
+	newPrompts, err := reloadItems(
+		previousPrompts,
 		applicablePrompts,
 		func(p api.ServerPrompt) string { return p.Prompt.Name },
 		s.server.RemovePrompts,
@@ -157,6 +165,12 @@ func (s *Server) reloadToolsets() error {
 	if err != nil {
 		return err
 	}
+
+	// Only hold write lock for the final assignment
+	s.mu.Lock()
+	s.enabledTools = newTools
+	s.enabledPrompts = newPrompts
+	s.mu.Unlock()
 
 	// Start new watch
 	s.p.WatchTargets(s.reloadToolsets)
@@ -315,11 +329,15 @@ func (s *Server) GetTargetParameterName() string {
 }
 
 func (s *Server) GetEnabledTools() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.enabledTools
 }
 
 // GetEnabledPrompts returns the names of the currently enabled prompts
 func (s *Server) GetEnabledPrompts() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.enabledPrompts
 }
 

--- a/pkg/mcp/mcp_middleware_test.go
+++ b/pkg/mcp/mcp_middleware_test.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"regexp"
@@ -22,7 +21,7 @@ import (
 type McpLoggingSuite struct {
 	BaseMcpSuite
 	klogState klog.State
-	logBuffer bytes.Buffer
+	logBuffer test.SyncBuffer
 }
 
 func (s *McpLoggingSuite) SetupTest() {


### PR DESCRIPTION
Fixes: #763 

- Add mutex protection to shared state accessed by concurrent goroutines
- Fix SIGHUP handler goroutine leak by returning a stop function that properly cleans up signal notification and waits for goroutine exit

