### PR TITLE
docs: add cross-cluster deployment guide and improve in-cluster error UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,8 +307,8 @@ The `docs/` directory contains user-facing documentation:
 - `docs/logging.md` – MCP Logging guide (automatic K8s error logging, secret redaction)
 - `docs/OTEL.md` – OpenTelemetry observability setup
 - `docs/KIALI.md` – Kiali toolset configuration
-- `docs/GETTING_STARTED_KUBERNETES.md` – Kubernetes ServiceAccount setup
-- `docs/GETTING_STARTED_CLAUDE_CODE.md` – Claude Code CLI integration
+- `docs/getting-started-kubernetes.md` – Kubernetes ServiceAccount setup
+- `docs/getting-started-claude-code.md` – Claude Code CLI integration
 - `docs/KEYCLOAK_OIDC_SETUP.md` – OAuth/OIDC developer setup
 
 ### Documentation conventions

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ If you're using the native binaries you don't need to have Node or Python instal
 <details>
 <summary><b>Claude Code</b></summary>
 
-Follow the [dedicated Claude Code getting started guide](docs/GETTING_STARTED_CLAUDE_CODE.md) in our [user documentation](docs/).
+Follow the [dedicated Claude Code getting started guide](docs/getting-started-claude-code.md) in our [user documentation](docs/).
 
-For a secure production setup with dedicated ServiceAccount and read-only access, also review the [Kubernetes setup guide](docs/GETTING_STARTED_KUBERNETES.md).
+For a secure production setup with dedicated ServiceAccount and read-only access, also review the [Kubernetes setup guide](docs/getting-started-kubernetes.md).
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,13 @@ Choose the guide that matches your needs:
 
 | Guide | Description | Best For |
 |-------|-------------|----------|
-| **[Getting Started with Kubernetes](GETTING_STARTED_KUBERNETES.md)** | Base setup: Create ServiceAccount, token, and kubeconfig | Everyone - **start here first** |
-| **[Using with Claude Code CLI](GETTING_STARTED_CLAUDE_CODE.md)** | Configure MCP server with Claude Code CLI | Claude Code CLI users |
+| **[Getting Started with Kubernetes](getting-started-kubernetes.md)** | Base setup: Create ServiceAccount, token, and kubeconfig | Everyone - **start here first** |
+| **[Using with Claude Code CLI](getting-started-claude-code.md)** | Configure MCP server with Claude Code CLI | Claude Code CLI users |
 
 ## Recommended Workflow
 
-1. **Complete the base setup**: Start with [Getting Started with Kubernetes](GETTING_STARTED_KUBERNETES.md) to create a ServiceAccount and kubeconfig file
-2. **Configure Claude Code**: Then follow the [Claude Code CLI guide](GETTING_STARTED_CLAUDE_CODE.md)
+1. **Complete the base setup**: Start with [Getting Started with Kubernetes](getting-started-kubernetes.md) to create a ServiceAccount and kubeconfig file
+2. **Configure Claude Code**: Then follow the [Claude Code CLI guide](getting-started-claude-code.md)
 
 ## Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ This reference focuses on TOML file configuration. For CLI arguments, see the [C
 - [Configuration Reference](#configuration-reference-1)
   - [Server Settings](#server-settings)
   - [Kubernetes Connection](#kubernetes-connection)
+    - [Cross-Cluster Access from a Pod](#cross-cluster-access-from-a-pod)
   - [Access Control](#access-control)
   - [Toolsets](#toolsets)
   - [Tool Filtering](#tool-filtering)
@@ -151,6 +152,75 @@ stateless = true
 kubeconfig = "/home/user/.kube/config"
 cluster_provider_strategy = "kubeconfig"
 ```
+
+#### Cross-Cluster Access from a Pod
+
+When the MCP server runs inside a Kubernetes pod, it automatically detects the in-cluster environment and uses the `in-cluster` provider strategy to connect to the **local** cluster's API server.
+
+If you need the server to connect to a **different** cluster instead, you must explicitly provide both `kubeconfig` and `cluster_provider_strategy`. This overrides the automatic in-cluster detection.
+
+**Required configuration:**
+
+```toml
+kubeconfig = "/etc/kubernetes-mcp-server/external-kubeconfig"
+cluster_provider_strategy = "kubeconfig"
+```
+
+Or via CLI flags:
+
+```bash
+kubernetes-mcp-server --kubeconfig /etc/kubernetes-mcp-server/external-kubeconfig --cluster-provider kubeconfig
+```
+
+> **Important:** Both settings are required. Setting `--cluster-provider kubeconfig` alone (without `--kubeconfig`) will fail because the server still detects the in-cluster environment. The explicit `--kubeconfig` path overrides this detection.
+
+**Mounting the kubeconfig in a pod:**
+
+To make an external kubeconfig available inside a pod, mount it from a Secret or ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-kubeconfig
+  namespace: mcp
+type: Opaque
+data:
+  kubeconfig: <base64-encoded-kubeconfig>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-mcp-server
+  namespace: mcp
+spec:
+  template:
+    spec:
+      containers:
+        - name: kubernetes-mcp-server
+          args:
+            - --kubeconfig
+            - /etc/kubernetes-mcp-server/kubeconfig
+            - --cluster-provider
+            - kubeconfig
+          volumeMounts:
+            - name: external-kubeconfig
+              mountPath: /etc/kubernetes-mcp-server
+              readOnly: true
+      volumes:
+        - name: external-kubeconfig
+          secret:
+            secretName: external-kubeconfig
+```
+
+**Troubleshooting cross-cluster access:**
+
+If the server starts but operations fail (e.g., `failed to list namespaces: unknown`), verify:
+
+1. **Network connectivity** — The pod must be able to reach the external cluster's API server. Check network policies, firewalls, and DNS resolution.
+2. **Kubeconfig validity** — Ensure the kubeconfig contains valid credentials (token, client certificate, etc.) and points to the correct API server address.
+3. **Permissions** — The credentials in the kubeconfig must have sufficient RBAC permissions on the target cluster.
+4. **TLS certificates** — If the external cluster uses a private CA, the CA certificate must be included in the kubeconfig or mounted separately.
 
 ### Access Control
 
@@ -503,4 +573,4 @@ url = "https://kiali.example.com"
 - [OTEL.md](OTEL.md) - OpenTelemetry observability
 - [KIALI.md](KIALI.md) - Kiali toolset configuration
 - [KEYCLOAK_OIDC_SETUP.md](KEYCLOAK_OIDC_SETUP.md) - OAuth/OIDC setup guide
-- [GETTING_STARTED_KUBERNETES.md](GETTING_STARTED_KUBERNETES.md) - Kubernetes setup guide
+- [getting-started-kubernetes.md](getting-started-kubernetes.md) - Kubernetes setup guide

--- a/docs/getting-started-claude-code.md
+++ b/docs/getting-started-claude-code.md
@@ -2,7 +2,7 @@
 
 This guide shows you how to configure the Kubernetes MCP Server with Claude Code CLI.
 
-> **Prerequisites:** Complete the [Getting Started with Kubernetes](GETTING_STARTED_KUBERNETES.md) guide first to create a ServiceAccount and kubeconfig file.
+> **Prerequisites:** Complete the [Getting Started with Kubernetes](getting-started-kubernetes.md) guide first to create a ServiceAccount and kubeconfig file.
 
 ## Quick Setup
 
@@ -102,5 +102,5 @@ You can configure `server_instructions` to help Claude know when to use this ser
 
 ## Next Steps
 
-- Review the [Getting Started with Kubernetes](GETTING_STARTED_KUBERNETES.md) guide for more details on ServiceAccount setup
+- Review the [Getting Started with Kubernetes](getting-started-kubernetes.md) guide for more details on ServiceAccount setup
 - Explore the [main README](../README.md) for more MCP server capabilities

--- a/docs/getting-started-kubernetes.md
+++ b/docs/getting-started-kubernetes.md
@@ -1,10 +1,10 @@
-# Getting Started with Kubernetes MCP Server
+# Deploying Kubernetes MCP Server in a Kubernetes Cluster
 
-This guide walks you through the foundational setup for using the Kubernetes MCP Server with your Kubernetes cluster. You'll create a dedicated, read-only ServiceAccount and generate a secure kubeconfig file that can be used with various MCP clients.
+This guide walks you through setting up the Kubernetes MCP Server for deployment in a Kubernetes cluster. You'll create a dedicated, read-only ServiceAccount and generate a secure kubeconfig file that can be used with various MCP clients.
 
 > **Note:** This setup is **recommended for production use** but not strictly required. The MCP Server can use your existing kubeconfig file (e.g., `~/.kube/config`), but using a dedicated ServiceAccount with limited permissions follows the principle of least privilege and is more secure.
 
-> **Next:** After completing this guide, continue with the [Claude Code CLI guide](GETTING_STARTED_CLAUDE_CODE.md). See the [docs README](README.md) for all available guides.
+> **Next:** After completing this guide, continue with the [Claude Code CLI guide](getting-started-claude-code.md). See the [docs README](README.md) for all available guides.
 
 ## What You'll Create
 
@@ -236,7 +236,7 @@ kubectl auth can-i list pods --as=system:serviceaccount:mcp:mcp-viewer --all-nam
 
 Now that you have a working kubeconfig with read-only access, configure Claude Code CLI:
 
-- **[Using with Claude Code CLI](GETTING_STARTED_CLAUDE_CODE.md)** - Configure the MCP server with Claude Code CLI
+- **[Using with Claude Code CLI](getting-started-claude-code.md)** - Configure the MCP server with Claude Code CLI
 
 You can also:
 - Explore the [main README](../README.md) for more MCP server capabilities

--- a/pkg/kubernetes/provider_kubeconfig.go
+++ b/pkg/kubernetes/provider_kubeconfig.go
@@ -47,7 +47,14 @@ func (p *kubeConfigClusterProvider) reset() error {
 	m, err := NewKubeconfigManager(p.config, "")
 	if err != nil {
 		if errors.Is(err, ErrorKubeconfigInClusterNotAllowed) {
-			return fmt.Errorf("kubeconfig ClusterProviderStrategy is invalid for in-cluster deployments: %w", err)
+			return fmt.Errorf( //nolint:ST1005 // user-facing error with actionable multi-line guidance
+				"kubeconfig ClusterProviderStrategy is invalid for in-cluster deployments: %w\n\n"+
+					"If you intend to connect to a different cluster from within a pod, provide the kubeconfig path explicitly:\n"+
+					"  --kubeconfig /path/to/kubeconfig --cluster-provider kubeconfig\n\n"+
+					"This overrides the in-cluster detection and uses the specified kubeconfig file instead.\n"+
+					"See https://github.com/containers/kubernetes-mcp-server/blob/main/docs/configuration.md#cross-cluster-access-from-a-pod",
+				err,
+			)
 		}
 		return err
 	}

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -82,6 +82,8 @@ func (s *ProviderTestSuite) TestNewProviderInCluster() {
 		provider, err := NewProvider(cfg)
 		s.Require().Error(err, "Expected error for kubeconfig strategy")
 		s.ErrorContains(err, "kubeconfig ClusterProviderStrategy is invalid for in-cluster deployments")
+		s.ErrorContains(err, "--kubeconfig /path/to/kubeconfig --cluster-provider kubeconfig")
+		s.ErrorContains(err, "docs/configuration.md#cross-cluster-access-from-a-pod")
 		s.Nilf(provider, "Expected no provider instance, got %v", provider)
 	})
 	s.Run("With cluster_provider_strategy=kubeconfig and kubeconfig set to valid path, returns kubeconfig provider", func() {


### PR DESCRIPTION
Relates to #794

When running inside a pod with `--cluster-provider kubeconfig` but without an explicit `--kubeconfig` path, the error message now includes actionable guidance pointing users to provide both flags and links to the new documentation section.

- Rename GETTING_STARTED docs to lowercase per naming convention
- Update getting-started-kubernetes.md title to reflect deployment focus
- Add "Cross-Cluster Access from a Pod" section to configuration.md
- Improve error message in provider_kubeconfig.go with fix instructions
- Add test assertions for the actionable error message content