### PR TITLE
fix(test): On test suites always assume a certain default configuration to be executed

### DIFF
--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -192,6 +192,9 @@ type BaseMcpSuite struct {
 
 func (s *BaseMcpSuite) SetupTest() {
 	s.Cfg = config.Default()
+	// Reset to upstream defaults for testing (ignore downstream build-time overrides)
+	s.Cfg.ReadOnly = false
+	s.Cfg.Toolsets = []string{"core", "config", "helm"}
 	s.Cfg.ListOutput = "yaml"
 	s.Cfg.KubeConfig = filepath.Join(s.T().TempDir(), "config")
 	s.Require().NoError(os.WriteFile(s.Cfg.KubeConfig, envTest.KubeConfig, 0600), "Expected to write kubeconfig")

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -40,6 +40,9 @@ func (s *ToolsetsSuite) SetupTest() {
 	s.originalToolsets = toolsets.Toolsets()
 	s.MockServer = test.NewMockServer()
 	s.Cfg = configuration.Default()
+	// Reset to upstream defaults for testing (ignore downstream build-time overrides)
+	s.Cfg.ReadOnly = false
+	s.Cfg.Toolsets = []string{"core", "config", "helm"}
 	s.Cfg.KubeConfig = s.KubeconfigFile(s.T())
 	s.updateJson = os.Getenv(updateJsonEnvVar) != ""
 }


### PR DESCRIPTION
Following up on https://github.com/containers/kubernetes-mcp-server/pull/738

For now test suites should set configuration for toolsets' intended behavior (or default configuration). Just that downstream repos can disable some options (or toolsets) does not mean those should not be tested. Users can always re-enable any config.

As discussed in the other PR a larger refactor for a more modular approach is the ultimate goal