### PR TITLE
feat(kubevirt): add tool for QEMU guest agent access

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,13 @@ For a secure production setup with dedicated ServiceAccount and read-only access
 If you have npm installed, this is the fastest way to get started with `kubernetes-mcp-server` on Claude Desktop.
 
 Open your `claude_desktop_config.json` and add the mcp server to the list of `mcpServers`:
-``` json
+
+```json
 {
   "mcpServers": {
     "kubernetes": {
       "command": "npx",
-      "args": [
-        "-y",
-        "kubernetes-mcp-server@latest"
-      ]
+      "args": ["-y", "kubernetes-mcp-server@latest"]
     }
   }
 }
@@ -135,6 +133,7 @@ Alternatively, you can install the extension manually by editing the `mcp.json` 
 If you have npm installed, this is the fastest way to get started with `kubernetes-mcp-server`.
 
 Open your goose `config.yaml` and add the mcp server to the list of `mcpServers`:
+
 ```yaml
 extensions:
   kubernetes:
@@ -142,7 +141,6 @@ extensions:
     args:
       - -y
       - kubernetes-mcp-server@latest
-
 ```
 
 ## 🎥 Demos <a id="demos"></a>
@@ -193,11 +191,11 @@ uvx kubernetes-mcp-server@latest --help
 ### Configuration Options
 
 | Option                    | Description                                                                                                                                                                                                                                                                                   |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--port`                  | Starts the MCP server in Streamable HTTP mode (path /mcp) and Server-Sent Event (SSE) (path /sse) mode and listens on the specified port .                                                                                                                                                    |
 | `--log-level`             | Sets the logging level (values [from 0-9](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md)). Similar to [kubectl logging levels](https://kubernetes.io/docs/reference/kubectl/quick-reference/#kubectl-output-verbosity-and-debugging). |
 | `--config`                | (Optional) Path to the main TOML configuration file. See [Configuration Reference](docs/configuration.md) for details.                                                                                                                                                                        |
-| `--config-dir`            | (Optional) Path to drop-in configuration directory. Files are loaded in lexical (alphabetical) order. Defaults to `conf.d` relative to the main config file if `--config` is specified. See [Configuration Reference](docs/configuration.md) for details.                                    |
+| `--config-dir`            | (Optional) Path to drop-in configuration directory. Files are loaded in lexical (alphabetical) order. Defaults to `conf.d` relative to the main config file if `--config` is specified. See [Configuration Reference](docs/configuration.md) for details.                                     |
 | `--kubeconfig`            | Path to the Kubernetes configuration file. If not provided, it will try to resolve the configuration (in-cluster, default location, etc.).                                                                                                                                                    |
 | `--list-output`           | Output format for resource list operations (one of: yaml, table) (default "table")                                                                                                                                                                                                            |
 | `--read-only`             | If set, the MCP server will run in read-only mode, meaning it will not allow any write operations (create, update, delete) on the Kubernetes cluster. This is useful for debugging or inspecting the cluster without making changes.                                                          |
@@ -235,6 +233,7 @@ endpoint = "http://localhost:4317"
 ```
 
 For comprehensive TOML configuration documentation, including:
+
 - All configuration options and their defaults
 - Drop-in configuration files for modular settings
 - Dynamic configuration reload via SIGHUP
@@ -530,6 +529,11 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `size` (`string`) - Optional workload size hint for the VM (e.g., 'small', 'medium', 'large', 'xlarge'). Used to auto-select an appropriate instance type if not explicitly specified.
   - `storage` (`string`) - Optional storage size for the VM's root disk when using DataSources (e.g., '30Gi', '50Gi', '100Gi'). Defaults to 30Gi. Ignored when using container disks.
   - `workload` (`string`) - The workload for the VM. Accepts OS names (e.g., 'fedora' (default), 'ubuntu', 'centos', 'centos-stream', 'debian', 'rhel', 'opensuse', 'opensuse-tumbleweed', 'opensuse-leap') or full container disk image URLs
+
+- **vm_guest_info** - Get guest operating system information from a VirtualMachine's QEMU guest agent. Requires the guest agent to be installed and running inside the VM. Provides detailed information about the OS, filesystems, network interfaces, and logged-in users.
+  - `info_type` (`string`) - Type of information to retrieve: 'all' (default - all available info), 'os' (operating system details), 'filesystem' (disk and filesystem info), 'users' (logged-in users), 'network' (network interfaces and IPs)
+  - `name` (`string`) **(required)** - The name of the virtual machine
+  - `namespace` (`string`) **(required)** - The namespace of the virtual machine
 
 - **vm_lifecycle** - Manage KubeVirt VirtualMachine lifecycle: start, stop, or restart a VM
   - `action` (`string`) **(required)** - The lifecycle action to perform: 'start' (changes runStrategy to Always), 'stop' (changes runStrategy to Halted), or 'restart' (stops then starts the VM)

--- a/evals/tasks/kubevirt/get-vm-filesystems/task.yaml
+++ b/evals/tasks/kubevirt/get-vm-filesystems/task.yaml
@@ -1,0 +1,93 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "get-vm-filesystems"
+  difficulty: easy
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-filesystems
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-filesystems
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-filesystems
+        spec:
+          runStrategy: Always
+          template:
+            spec:
+              domain:
+                devices:
+                  disks:
+                  - name: containerdisk
+                    disk:
+                      bus: virtio
+                  - name: cloudinitdisk
+                    disk:
+                      bus: virtio
+                resources:
+                  requests:
+                    memory: 2Gi
+              volumes:
+              - name: containerdisk
+                containerDisk:
+                  image: quay.io/containerdisks/fedora:latest
+              - name: cloudinitdisk
+                cloudInitNoCloud:
+                  userData: |
+                    #cloud-config
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl wait --for=create vm/test-vm -n vm-test-filesystems --timeout=30s
+          kubectl wait --for=condition=Ready vm/test-vm -n vm-test-filesystems --timeout=30s
+          kubectl wait --for=condition=AgentConnected --timeout=30s vmi/test-vm -n vm-test-filesystems
+          echo "VM created with guest agent connected."
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          if ! kubectl get vm test-vm -n vm-test-filesystems &>/dev/null; then
+            echo "ERROR: VirtualMachine 'test-vm' not found"
+            exit 1
+          fi
+          echo "Verification passed: VM exists"
+          exit 0
+    - llmJudge:
+        contains: "/"
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-filesystems
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-filesystems
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      Get the filesystem information from the VirtualMachine "test-vm" in the vm-test-filesystems namespace.
+
+      Report the mounted filesystems you find.

--- a/evals/tasks/kubevirt/get-vm-ip-address/task.yaml
+++ b/evals/tasks/kubevirt/get-vm-ip-address/task.yaml
@@ -1,0 +1,95 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "get-vm-ip-address"
+  difficulty: easy
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-ip-address
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-ip-address
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-ip-address
+        spec:
+          runStrategy: Always
+          template:
+            spec:
+              domain:
+                devices:
+                  disks:
+                  - name: containerdisk
+                    disk:
+                      bus: virtio
+                  - name: cloudinitdisk
+                    disk:
+                      bus: virtio
+                resources:
+                  requests:
+                    memory: 2Gi
+              volumes:
+              - name: containerdisk
+                containerDisk:
+                  image: quay.io/containerdisks/fedora:latest
+              - name: cloudinitdisk
+                cloudInitNoCloud:
+                  userData: |
+                    #cloud-config
+                    password: fedora
+                    chpasswd: { expire: False }
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl wait --for=create vm/test-vm -n vm-test-ip-address --timeout=30s
+          kubectl wait --for=condition=Ready vm/test-vm -n vm-test-ip-address --timeout=30s
+          kubectl wait --for=condition=AgentConnected --timeout=30s vmi/test-vm -n vm-test-ip-address
+          echo "VM created with guest agent connected."
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          if ! kubectl get vm test-vm -n vm-test-ip-address &>/dev/null; then
+            echo "ERROR: VirtualMachine 'test-vm' not found"
+            exit 1
+          fi
+          echo "Verification passed: VM exists"
+          exit 0
+    - llmJudge:
+        contains: "10."
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-ip-address
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-ip-address
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      Get the IP address of the VirtualMachine "test-vm" in the vm-test-ip-address namespace from inside the guest OS.
+
+      Report the IP address you find.

--- a/evals/tasks/kubevirt/get-vm-os-info/task.yaml
+++ b/evals/tasks/kubevirt/get-vm-os-info/task.yaml
@@ -1,0 +1,94 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "get-vm-os-info"
+  difficulty: easy
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-os-info
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-os-info
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-os-info
+        spec:
+          runStrategy: Always
+          template:
+            spec:
+              domain:
+                devices:
+                  disks:
+                  - name: containerdisk
+                    disk:
+                      bus: virtio
+                  - name: cloudinitdisk
+                    disk:
+                      bus: virtio
+                resources:
+                  requests:
+                    memory: 2Gi
+              volumes:
+              - name: containerdisk
+                containerDisk:
+                  image: quay.io/containerdisks/fedora:latest
+              - name: cloudinitdisk
+                cloudInitNoCloud:
+                  userData: |
+                    #cloud-config
+                    hostname: test-vm
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl wait --for=create vm/test-vm -n vm-test-os-info --timeout=30s
+          kubectl wait --for=condition=Ready vm/test-vm -n vm-test-os-info --timeout=30s
+          kubectl wait --for=condition=AgentConnected --timeout=30s vmi/test-vm -n vm-test-os-info
+          echo "VM created with guest agent connected."
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          if ! kubectl get vm test-vm -n vm-test-os-info &>/dev/null; then
+            echo "ERROR: VirtualMachine 'test-vm' not found"
+            exit 1
+          fi
+          echo "Verification passed: VM exists"
+          exit 0
+    - llmJudge:
+        contains: "Fedora"
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-os-info
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-os-info
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      Get the OS information from the VirtualMachine "test-vm" in the vm-test-os-info namespace.
+
+      Report the OS name and version you find.

--- a/evals/tasks/kubevirt/list-vm-users/task.yaml
+++ b/evals/tasks/kubevirt/list-vm-users/task.yaml
@@ -1,0 +1,98 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "list-vm-users"
+  difficulty: easy
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-users
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-users
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-users
+        spec:
+          runStrategy: Always
+          template:
+            spec:
+              domain:
+                devices:
+                  disks:
+                  - name: containerdisk
+                    disk:
+                      bus: virtio
+                  - name: cloudinitdisk
+                    disk:
+                      bus: virtio
+                resources:
+                  requests:
+                    memory: 2Gi
+              volumes:
+              - name: containerdisk
+                containerDisk:
+                  image: quay.io/containerdisks/fedora:latest
+              - name: cloudinitdisk
+                cloudInitNoCloud:
+                  userData: |
+                    #cloud-config
+                    users:
+                      - name: admin
+                        sudo: ALL=(ALL) NOPASSWD:ALL
+                      - name: developer
+                        groups: developers
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl wait --for=create vm/test-vm -n vm-test-users --timeout=30s
+          kubectl wait --for=condition=Ready vm/test-vm -n vm-test-users --timeout=30s
+          kubectl wait --for=condition=AgentConnected --timeout=30s vmi/test-vm -n vm-test-users
+          echo "VM created with guest agent connected."
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          if ! kubectl get vm test-vm -n vm-test-users &>/dev/null; then
+            echo "ERROR: VirtualMachine 'test-vm' not found"
+            exit 1
+          fi
+          echo "Verification passed: VM exists"
+          exit 0
+    - llmJudge:
+        contains: "admin"
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-users
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-users
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      Get the list of currently logged-in users from the VirtualMachine "test-vm" in the vm-test-users namespace.
+
+      Report the usernames you find.

--- a/evals/tasks/kubevirt/vm-guest-info/task.yaml
+++ b/evals/tasks/kubevirt/vm-guest-info/task.yaml
@@ -1,0 +1,111 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "vm-guest-info"
+  difficulty: medium
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-guest-info
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-guest-info
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm-with-agent
+          namespace: vm-test-guest-info
+        spec:
+          runStrategy: Always
+          template:
+            spec:
+              domain:
+                devices:
+                  disks:
+                  - name: containerdisk
+                    disk:
+                      bus: virtio
+                  - name: cloudinitdisk
+                    disk:
+                      bus: virtio
+                resources:
+                  requests:
+                    memory: 2Gi
+              volumes:
+              - name: containerdisk
+                containerDisk:
+                  image: quay.io/containerdisks/fedora:latest
+              - name: cloudinitdisk
+                cloudInitNoCloud:
+                  userData: |
+                    #cloud-config
+                    password: fedora
+                    chpasswd: { expire: False }
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          echo "Waiting for VM to be created..."
+          kubectl wait --for=create vm/test-vm-with-agent -n vm-test-guest-info --timeout=30s
+
+          echo "Waiting for VM to be ready..."
+          kubectl wait --for=condition=Ready vm/test-vm-with-agent -n vm-test-guest-info --timeout=30s
+
+          echo "Waiting for guest agent to connect..."
+          kubectl wait --for=condition=AgentConnected --timeout=30s vmi/test-vm-with-agent -n vm-test-guest-info
+
+          echo "VM created with guest agent connected."
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+
+          # Verify VMI exists and is running
+          if ! kubectl get vmi test-vm-with-agent -n vm-test-guest-info &>/dev/null; then
+            echo "ERROR: VirtualMachineInstance 'test-vm-with-agent' not found"
+            exit 1
+          fi
+
+          PHASE=$(kubectl get vmi test-vm-with-agent -n vm-test-guest-info -o jsonpath='{.status.phase}')
+          if [ "$PHASE" != "Running" ]; then
+            echo "ERROR: VMI is not running (phase: $PHASE)"
+            exit 1
+          fi
+
+          echo "Verification passed: VM is running"
+          echo "NOTE: Guest agent info availability depends on whether qemu-guest-agent started successfully in the VM"
+          exit 0
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm-with-agent
+          namespace: vm-test-guest-info
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-guest-info
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      A VirtualMachine named test-vm-with-agent is running in the vm-test-guest-info namespace with QEMU guest agent installed.
+
+      Please retrieve guest agent information from this VM. Get all available information (OS, filesystems, network interfaces, and users).
+
+      Note: If the guest agent is not yet available, it may indicate that cloud-init is still running or the guest agent service hasn't started. In that case, provide information about what guest agent data would typically include.

--- a/pkg/kubevirt/guestagent.go
+++ b/pkg/kubevirt/guestagent.go
@@ -1,0 +1,233 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// VMI subresource names for guest agent queries
+	subresourceGuestOSInfo    = "guestosinfo"
+	subresourceFilesystemList = "filesystemlist"
+	subresourceUserList       = "userlist"
+	subresourceInterfaceList  = "interfacelist"
+)
+
+var (
+	// subresourcesScheme is the scheme for subresources API
+	subresourcesScheme = Scheme
+	// subresourcesCodec is the codec for encoding/decoding subresources
+	subresourcesCodec = serializer.NewCodecFactory(subresourcesScheme)
+)
+
+// AllGuestInfo holds all guest agent information with error tracking
+type AllGuestInfo struct {
+	GuestOSInfo            any    `json:"guestOSInfo,omitempty" yaml:"guestOSInfo,omitempty"`
+	GuestOSInfoError       string `json:"guestOSInfoError,omitempty" yaml:"guestOSInfoError,omitempty"`
+	Filesystems            any    `json:"filesystems,omitempty" yaml:"filesystems,omitempty"`
+	FilesystemsError       string `json:"filesystemsError,omitempty" yaml:"filesystemsError,omitempty"`
+	Users                  any    `json:"users,omitempty" yaml:"users,omitempty"`
+	UsersError             string `json:"usersError,omitempty" yaml:"usersError,omitempty"`
+	NetworkInterfaces      any    `json:"networkInterfaces,omitempty" yaml:"networkInterfaces,omitempty"`
+	NetworkInterfacesError string `json:"networkInterfacesError,omitempty" yaml:"networkInterfacesError,omitempty"`
+}
+
+// getVMISubresource retrieves a VMI subresource using the REST client
+func getVMISubresource(ctx context.Context, restConfig *rest.Config, namespace, vmiName, subresource string) (map[string]any, error) {
+	// Create a copy to avoid mutating the original config
+	config := rest.CopyConfig(restConfig)
+
+	// Create a REST client configured for the subresources.kubevirt.io API group
+	gv := schema.GroupVersion{Group: "subresources.kubevirt.io", Version: "v1"}
+	config.GroupVersion = &gv
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = subresourcesCodec.WithoutConversion()
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create REST client for subresources: %w", err)
+	}
+
+	// Make the request using SubResource() to properly construct the URL
+	result := &unstructured.Unstructured{}
+	err = restClient.Get().
+		Namespace(namespace).
+		Resource("virtualmachineinstances").
+		Name(vmiName).
+		SubResource(subresource).
+		Do(ctx).
+		Into(result)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Object, nil
+}
+
+// GetGuestOSInfo retrieves operating system information from the guest agent
+func GetGuestOSInfo(ctx context.Context, restConfig *rest.Config, namespace, name string) (map[string]any, error) {
+	result, err := getVMISubresource(ctx, restConfig, namespace, name, subresourceGuestOSInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get guest OS info - guest agent may not be installed or running: %w", err)
+	}
+
+	return map[string]any{
+		"guestOSInfo": result,
+	}, nil
+}
+
+// GetFilesystemInfo retrieves filesystem and disk information from the guest agent
+func GetFilesystemInfo(ctx context.Context, restConfig *rest.Config, namespace, name string) (map[string]any, error) {
+	result, err := getVMISubresource(ctx, restConfig, namespace, name, subresourceFilesystemList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get filesystem info - guest agent may not be installed or running: %w", err)
+	}
+
+	return map[string]any{
+		"filesystems": result,
+	}, nil
+}
+
+// GetUserInfo retrieves logged-in user information from the guest agent
+func GetUserInfo(ctx context.Context, restConfig *rest.Config, namespace, name string) (map[string]any, error) {
+	result, err := getVMISubresource(ctx, restConfig, namespace, name, subresourceUserList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user info - guest agent may not be installed or running: %w", err)
+	}
+
+	return map[string]any{
+		"users": result,
+	}, nil
+}
+
+// GetNetworkInfo retrieves network interface information from the guest agent
+func GetNetworkInfo(ctx context.Context, restConfig *rest.Config, namespace, name string) (map[string]any, error) {
+	result, err := getVMISubresource(ctx, restConfig, namespace, name, subresourceInterfaceList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get network interface info - guest agent may not be installed or running: %w", err)
+	}
+
+	return map[string]any{
+		"networkInterfaces": result,
+	}, nil
+}
+
+// collectGuestOSInfo collects OS information and updates the result struct
+func collectGuestOSInfo(ctx context.Context, restConfig *rest.Config, namespace, name string, result *AllGuestInfo) (bool, error) {
+	osInfo, err := GetGuestOSInfo(ctx, restConfig, namespace, name)
+	if err != nil {
+		result.GuestOSInfoError = err.Error()
+		return false, fmt.Errorf("guestOSInfo: %v", err)
+	}
+	result.GuestOSInfo = osInfo["guestOSInfo"]
+	return true, nil
+}
+
+// collectFilesystemInfo collects filesystem information and updates the result struct
+func collectFilesystemInfo(ctx context.Context, restConfig *rest.Config, namespace, name string, result *AllGuestInfo) (bool, error) {
+	fsInfo, err := GetFilesystemInfo(ctx, restConfig, namespace, name)
+	if err != nil {
+		result.FilesystemsError = err.Error()
+		return false, fmt.Errorf("filesystems: %v", err)
+	}
+	result.Filesystems = fsInfo["filesystems"]
+	return true, nil
+}
+
+// collectUserInfo collects user information and updates the result struct
+func collectUserInfo(ctx context.Context, restConfig *rest.Config, namespace, name string, result *AllGuestInfo) (bool, error) {
+	userInfo, err := GetUserInfo(ctx, restConfig, namespace, name)
+	if err != nil {
+		result.UsersError = err.Error()
+		return false, fmt.Errorf("users: %v", err)
+	}
+	result.Users = userInfo["users"]
+	return true, nil
+}
+
+// collectNetworkInfo collects network information and updates the result struct
+func collectNetworkInfo(ctx context.Context, restConfig *rest.Config, namespace, name string, result *AllGuestInfo) (bool, error) {
+	netInfo, err := GetNetworkInfo(ctx, restConfig, namespace, name)
+	if err != nil {
+		result.NetworkInterfacesError = err.Error()
+		return false, fmt.Errorf("networkInterfaces: %v", err)
+	}
+	result.NetworkInterfaces = netInfo["networkInterfaces"]
+	return true, nil
+}
+
+// convertToMap converts AllGuestInfo struct to a map for consistent return type
+func convertToMap(result *AllGuestInfo) map[string]any {
+	resultMap := make(map[string]any)
+
+	if result.GuestOSInfo != nil {
+		resultMap["guestOSInfo"] = result.GuestOSInfo
+	} else if result.GuestOSInfoError != "" {
+		resultMap["guestOSInfoError"] = result.GuestOSInfoError
+	}
+
+	if result.Filesystems != nil {
+		resultMap["filesystems"] = result.Filesystems
+	} else if result.FilesystemsError != "" {
+		resultMap["filesystemsError"] = result.FilesystemsError
+	}
+
+	if result.Users != nil {
+		resultMap["users"] = result.Users
+	} else if result.UsersError != "" {
+		resultMap["usersError"] = result.UsersError
+	}
+
+	if result.NetworkInterfaces != nil {
+		resultMap["networkInterfaces"] = result.NetworkInterfaces
+	} else if result.NetworkInterfacesError != "" {
+		resultMap["networkInterfacesError"] = result.NetworkInterfacesError
+	}
+
+	return resultMap
+}
+
+// GetAllGuestInfo retrieves all available guest agent information
+func GetAllGuestInfo(ctx context.Context, restConfig *rest.Config, namespace, name string) (map[string]any, error) {
+	result := &AllGuestInfo{}
+	var errors []error
+	successCount := 0
+
+	// Collect all info types, but don't fail if one is unavailable
+	if success, err := collectGuestOSInfo(ctx, restConfig, namespace, name, result); success {
+		successCount++
+	} else if err != nil {
+		errors = append(errors, err)
+	}
+
+	if success, err := collectFilesystemInfo(ctx, restConfig, namespace, name, result); success {
+		successCount++
+	} else if err != nil {
+		errors = append(errors, err)
+	}
+
+	if success, err := collectUserInfo(ctx, restConfig, namespace, name, result); success {
+		successCount++
+	} else if err != nil {
+		errors = append(errors, err)
+	}
+
+	if success, err := collectNetworkInfo(ctx, restConfig, namespace, name, result); success {
+		successCount++
+	} else if err != nil {
+		errors = append(errors, err)
+	}
+
+	// If all failed, return an aggregated error
+	if successCount == 0 {
+		return nil, fmt.Errorf("guest agent is not responding - all queries failed: %v - ensure QEMU guest agent is installed and running in the VM", errors)
+	}
+
+	return convertToMap(result), nil
+}

--- a/pkg/kubevirt/guestagent_test.go
+++ b/pkg/kubevirt/guestagent_test.go
@@ -1,0 +1,410 @@
+package kubevirt
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+)
+
+// createTestRESTConfig creates a REST config pointing to a test HTTP server
+func createTestRESTConfig(server *httptest.Server) *rest.Config {
+	return &rest.Config{
+		Host: server.URL,
+	}
+}
+
+// createGuestOSInfoResponse creates a fake guest OS info response
+func createGuestOSInfoResponse() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "subresources.kubevirt.io/v1",
+		"kind":       "VirtualMachineInstanceGuestOSInfo",
+		"guestOSInfo": map[string]interface{}{
+			"name":          "Fedora Linux",
+			"version":       "40",
+			"id":            "fedora",
+			"kernelRelease": "6.8.5-301.fc40.x86_64",
+		},
+	}
+}
+
+// createFilesystemListResponse creates a fake filesystem list response
+func createFilesystemListResponse() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "subresources.kubevirt.io/v1",
+		"kind":       "VirtualMachineInstanceFilesystemList",
+		"items": []interface{}{
+			map[string]interface{}{
+				"diskName":       "vda",
+				"mountPoint":     "/",
+				"fileSystemType": "ext4",
+				"usedBytes":      1073741824,
+				"totalBytes":     10737418240,
+			},
+		},
+	}
+}
+
+// createUserListResponse creates a fake user list response
+func createUserListResponse() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "subresources.kubevirt.io/v1",
+		"kind":       "VirtualMachineInstanceGuestOSUserList",
+		"items": []interface{}{
+			map[string]interface{}{
+				"userName":  "fedora",
+				"loginTime": 1234567890.0,
+			},
+		},
+	}
+}
+
+// createInterfaceListResponse creates a fake network interface list response
+func createInterfaceListResponse() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "subresources.kubevirt.io/v1",
+		"kind":       "VirtualMachineInstanceGuestOSInterfaceList",
+		"items": []interface{}{
+			map[string]interface{}{
+				"interfaceName": "eth0",
+				"ipAddresses":   []interface{}{"10.0.2.15", "fe80::5054:ff:fe12:3456"},
+				"mac":           "52:54:00:12:34:56",
+			},
+		},
+	}
+}
+
+func TestGetGuestOSInfo(t *testing.T) {
+	testGuestInfoFunction(
+		t,
+		GetGuestOSInfo,
+		"/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/guestosinfo",
+		createGuestOSInfoResponse,
+		"guestOSInfo",
+		"failed to get guest OS info",
+	)
+}
+
+func TestGetFilesystemInfo(t *testing.T) {
+	testGuestInfoFunction(
+		t,
+		GetFilesystemInfo,
+		"/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/filesystemlist",
+		createFilesystemListResponse,
+		"filesystems",
+		"failed to get filesystem info",
+	)
+}
+
+func TestGetUserInfo(t *testing.T) {
+	testGuestInfoFunction(
+		t,
+		GetUserInfo,
+		"/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/userlist",
+		createUserListResponse,
+		"users",
+		"failed to get user info",
+	)
+}
+
+func TestGetNetworkInfo(t *testing.T) {
+	testGuestInfoFunction(
+		t,
+		GetNetworkInfo,
+		"/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/interfacelist",
+		createInterfaceListResponse,
+		"networkInterfaces",
+		"failed to get network interface info",
+	)
+}
+
+func TestGetAllGuestInfo(t *testing.T) {
+	tests := []struct {
+		name          string
+		namespace     string
+		vmName        string
+		setupServer   func() *httptest.Server
+		wantError     bool
+		errorContains string
+		wantKeys      []string
+		wantErrorKeys []string
+	}{
+		{
+			name:      "successfully retrieves all guest info",
+			namespace: "default",
+			vmName:    "test-vm",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					switch r.URL.Path {
+					case "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/guestosinfo":
+						_ = json.NewEncoder(w).Encode(createGuestOSInfoResponse())
+					case "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/filesystemlist":
+						_ = json.NewEncoder(w).Encode(createFilesystemListResponse())
+					case "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/userlist":
+						_ = json.NewEncoder(w).Encode(createUserListResponse())
+					case "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/interfacelist":
+						_ = json.NewEncoder(w).Encode(createInterfaceListResponse())
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+			},
+			wantError: false,
+			wantKeys:  []string{"guestOSInfo", "filesystems", "users", "networkInterfaces"},
+		},
+		{
+			name:      "partial success - some queries fail",
+			namespace: "default",
+			vmName:    "test-vm",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					// Only guestosinfo succeeds
+					if r.URL.Path == "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/guestosinfo" {
+						_ = json.NewEncoder(w).Encode(createGuestOSInfoResponse())
+						return
+					}
+					http.NotFound(w, r)
+				}))
+			},
+			wantError:     false,
+			wantKeys:      []string{"guestOSInfo"},
+			wantErrorKeys: []string{"filesystemsError", "usersError", "networkInterfacesError"},
+		},
+		{
+			name:      "all queries fail",
+			namespace: "default",
+			vmName:    "test-vm",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.NotFound(w, r)
+				}))
+			},
+			wantError:     true,
+			errorContains: "guest agent is not responding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.setupServer()
+			defer server.Close()
+
+			config := createTestRESTConfig(server)
+			result, err := GetAllGuestInfo(context.Background(), config, tt.namespace, tt.vmName)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("Expected error, got nil")
+					return
+				}
+				if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
+					t.Errorf("Error = %v, want to contain %q", err, tt.errorContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if result == nil {
+				t.Error("Expected non-nil result, got nil")
+				return
+			}
+
+			// Check expected data keys
+			for _, key := range tt.wantKeys {
+				if _, ok := result[key]; !ok {
+					t.Errorf("Result missing expected key %q", key)
+				}
+			}
+
+			// Check expected error keys
+			for _, key := range tt.wantErrorKeys {
+				if _, ok := result[key]; !ok {
+					t.Errorf("Result missing expected error key %q", key)
+				}
+			}
+		})
+	}
+}
+
+func TestGetVMISubresource(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		vmiName     string
+		subresource string
+		setupServer func() *httptest.Server
+		wantError   bool
+	}{
+		{
+			name:        "successfully retrieves subresource",
+			namespace:   "default",
+			vmiName:     "test-vm",
+			subresource: "guestosinfo",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					response := &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "subresources.kubevirt.io/v1",
+							"kind":       "VirtualMachineInstanceGuestOSInfo",
+							"test":       "data",
+						},
+					}
+					_ = json.NewEncoder(w).Encode(response)
+				}))
+			},
+			wantError: false,
+		},
+		{
+			name:        "returns error when subresource not found",
+			namespace:   "default",
+			vmiName:     "test-vm",
+			subresource: "guestosinfo",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.NotFound(w, r)
+				}))
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.setupServer()
+			defer server.Close()
+
+			config := createTestRESTConfig(server)
+			result, err := getVMISubresource(context.Background(), config, tt.namespace, tt.vmiName, tt.subresource)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if result == nil {
+				t.Error("Expected non-nil result, got nil")
+			}
+		})
+	}
+}
+
+// guestInfoTestFunc is a function type for guest info retrieval functions
+type guestInfoTestFunc func(context.Context, *rest.Config, string, string) (map[string]any, error)
+
+// testGuestInfoFunction is a generic test helper for guest info functions
+func testGuestInfoFunction(
+	t *testing.T,
+	fn guestInfoTestFunc,
+	urlPath string,
+	responseFactory func() map[string]interface{},
+	resultKey string,
+	errorMessage string,
+) {
+	t.Helper()
+
+	tests := []struct {
+		name          string
+		namespace     string
+		vmName        string
+		setupServer   func() *httptest.Server
+		wantError     bool
+		errorContains string
+	}{
+		{
+			name:      "successfully retrieves info",
+			namespace: "default",
+			vmName:    "test-vm",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == urlPath {
+						w.Header().Set("Content-Type", "application/json")
+						_ = json.NewEncoder(w).Encode(responseFactory())
+						return
+					}
+					http.NotFound(w, r)
+				}))
+			},
+			wantError: false,
+		},
+		{
+			name:      "returns error when guest agent not available",
+			namespace: "default",
+			vmName:    "test-vm",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.NotFound(w, r)
+				}))
+			},
+			wantError:     true,
+			errorContains: errorMessage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.setupServer()
+			defer server.Close()
+
+			config := createTestRESTConfig(server)
+			result, err := fn(context.Background(), config, tt.namespace, tt.vmName)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("Expected error, got nil")
+					return
+				}
+				if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
+					t.Errorf("Error = %v, want to contain %q", err, tt.errorContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if result == nil {
+				t.Error("Expected non-nil result, got nil")
+				return
+			}
+
+			if _, ok := result[resultKey]; !ok {
+				t.Errorf("Result missing %q key", resultKey)
+			}
+		})
+	}
+}
+
+// contains is a helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && containsHelper(s, substr)))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/kubevirt/gvr.go
+++ b/pkg/kubevirt/gvr.go
@@ -1,8 +1,12 @@
 package kubevirt
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// Scheme is the runtime scheme for KubeVirt resources
+var Scheme = runtime.NewScheme()
 
 // KubeVirt core resources
 var (
@@ -23,6 +27,13 @@ var (
 	// VirtualMachineInstanceGVR is the GroupVersionResource for VirtualMachineInstance resources
 	VirtualMachineInstanceGVR = schema.GroupVersionResource{
 		Group:    "kubevirt.io",
+		Version:  "v1",
+		Resource: "virtualmachineinstances",
+	}
+
+	// VirtualMachineInstanceSubresourcesGVR is the GroupVersionResource for VirtualMachineInstance subresources
+	VirtualMachineInstanceSubresourcesGVR = schema.GroupVersionResource{
+		Group:    "subresources.kubevirt.io",
 		Version:  "v1",
 		Resource: "virtualmachineinstances",
 	}

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -73,6 +73,7 @@ func TestMain(m *testing.M) {
 			CRD("route.openshift.io", "v1", "routes", "Route", "route", true),
 			// Kubevirt
 			CRD("kubevirt.io", "v1", "virtualmachines", "VirtualMachine", "virtualmachine", true),
+			CRD("kubevirt.io", "v1", "virtualmachineinstances", "VirtualMachineInstance", "virtualmachineinstance", true),
 			CRD("clone.kubevirt.io", "v1beta1", "virtualmachineclones", "VirtualMachineClone", "virtualmachineclone", true),
 			CRD("cdi.kubevirt.io", "v1beta1", "datasources", "DataSource", "datasource", true),
 			CRD("instancetype.kubevirt.io", "v1beta1", "virtualmachineclusterinstancetypes", "VirtualMachineClusterInstancetype", "virtualmachineclusterinstancetype", false),

--- a/pkg/mcp/kubevirt_test.go
+++ b/pkg/mcp/kubevirt_test.go
@@ -23,6 +23,7 @@ import (
 
 var kubevirtApis = []schema.GroupVersionResource{
 	{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"},
+	{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachineinstances"},
 	{Group: "clone.kubevirt.io", Version: "v1beta1", Resource: "virtualmachineclones"},
 	{Group: "cdi.kubevirt.io", Version: "v1beta1", Resource: "datasources"},
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachineclusterinstancetypes"},
@@ -780,6 +781,265 @@ func (s *KubevirtSuite) TestVMTroubleshootPrompt() {
 		s.Error(err, "expected error for missing name")
 		s.Nil(result)
 		s.Contains(err.Error(), "name")
+	})
+}
+
+func (s *KubevirtSuite) TestVMGuestInfo() {
+	s.Run("vm_guest_info missing required params", func() {
+		testCases := []string{"namespace", "name"}
+		for _, param := range testCases {
+			s.Run("missing "+param, func() {
+				params := map[string]interface{}{
+					"namespace": "default",
+					"name":      "test-vm",
+				}
+				delete(params, param)
+				toolResult, err := s.CallTool("vm_guest_info", params)
+				s.Require().Nilf(err, "call tool failed %v", err)
+				s.Truef(toolResult.IsError, "expected call tool to fail due to missing %s", param)
+				s.Equal(toolResult.Content[0].(*mcp.TextContent).Text, param+" parameter required")
+			})
+		}
+	})
+
+	s.Run("vm_guest_info with non-existent VMI", func() {
+		toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+			"namespace": "default",
+			"name":      "non-existent-vm",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected call tool to fail for non-existent VMI")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "VirtualMachineInstance not found")
+	})
+
+	s.Run("vm_guest_info with stopped VM (no VMI)", func() {
+		// Create a VM (not VMI, since it's not running)
+		// This tests the case where a VM definition exists but it's not running,
+		// so there's no VMI to query the guest agent from
+		dynamicClient := dynamic.NewForConfigOrDie(envTestRestConfig)
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "stopped-vm",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"runStrategy": "Halted",
+			},
+		})
+		_, err := dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachines",
+		}).Namespace("default").Create(s.T().Context(), vm, metav1.CreateOptions{})
+		s.Require().NoError(err, "failed to create stopped VM")
+
+		toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+			"namespace": "default",
+			"name":      "stopped-vm",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected call tool to fail when VMI doesn't exist (VM is stopped)")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "VirtualMachineInstance not found")
+
+		// Cleanup
+		_ = dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachines",
+		}).Namespace("default").Delete(s.T().Context(), "stopped-vm", metav1.DeleteOptions{})
+	})
+
+	s.Run("vm_guest_info with running VM (no guest agent)", func() {
+		// Create a running VMI
+		dynamicClient := dynamic.NewForConfigOrDie(envTestRestConfig)
+		vmi := &unstructured.Unstructured{}
+		vmi.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstance",
+			"metadata": map[string]interface{}{
+				"name":      "running-vm",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"domain": map[string]interface{}{
+					"devices": map[string]interface{}{},
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Running",
+			},
+		})
+		_, err := dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachineinstances",
+		}).Namespace("default").Create(s.T().Context(), vmi, metav1.CreateOptions{})
+		s.Require().NoError(err, "failed to create running VMI")
+
+		s.Run("info_type=all returns error when guest agent unavailable", func() {
+			toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+				"namespace": "default",
+				"name":      "running-vm",
+				"info_type": "all",
+			})
+			s.Nilf(err, "call tool failed %v", err)
+			// In envtest without real KubeVirt, the subresource API calls will fail
+			// The tool should handle this gracefully and return an error
+			s.Truef(toolResult.IsError, "expected error when guest agent data is unavailable")
+		})
+
+		s.Run("info_type=os returns error when guest agent unavailable", func() {
+			toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+				"namespace": "default",
+				"name":      "running-vm",
+				"info_type": "os",
+			})
+			s.Nilf(err, "call tool failed %v", err)
+			s.Truef(toolResult.IsError, "expected error when guest agent data is unavailable")
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "guest agent")
+		})
+
+		s.Run("info_type=filesystem returns error when guest agent unavailable", func() {
+			toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+				"namespace": "default",
+				"name":      "running-vm",
+				"info_type": "filesystem",
+			})
+			s.Nilf(err, "call tool failed %v", err)
+			s.Truef(toolResult.IsError, "expected error when guest agent data is unavailable")
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "guest agent")
+		})
+
+		s.Run("info_type=users returns error when guest agent unavailable", func() {
+			toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+				"namespace": "default",
+				"name":      "running-vm",
+				"info_type": "users",
+			})
+			s.Nilf(err, "call tool failed %v", err)
+			s.Truef(toolResult.IsError, "expected error when guest agent data is unavailable")
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "guest agent")
+		})
+
+		s.Run("info_type=network returns error when guest agent unavailable", func() {
+			toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+				"namespace": "default",
+				"name":      "running-vm",
+				"info_type": "network",
+			})
+			s.Nilf(err, "call tool failed %v", err)
+			s.Truef(toolResult.IsError, "expected error when guest agent data is unavailable")
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "guest agent")
+		})
+
+		s.Run("invalid info_type returns error", func() {
+			toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+				"namespace": "default",
+				"name":      "running-vm",
+				"info_type": "invalid_type",
+			})
+			s.Nilf(err, "call tool failed %v", err)
+			s.Truef(toolResult.IsError, "expected error for invalid info_type")
+			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "invalid info_type")
+		})
+
+		// Cleanup
+		_ = dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachineinstances",
+		}).Namespace("default").Delete(s.T().Context(), "running-vm", metav1.DeleteOptions{})
+	})
+
+	s.Run("vm_guest_info with VMI not in Running phase", func() {
+		// Create a VMI in a non-running state
+		dynamicClient := dynamic.NewForConfigOrDie(envTestRestConfig)
+		vmi := &unstructured.Unstructured{}
+		vmi.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstance",
+			"metadata": map[string]interface{}{
+				"name":      "pending-vm",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"domain": map[string]interface{}{
+					"devices": map[string]interface{}{},
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Pending",
+			},
+		})
+		_, err := dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachineinstances",
+		}).Namespace("default").Create(s.T().Context(), vmi, metav1.CreateOptions{})
+		s.Require().NoError(err, "failed to create pending VMI")
+
+		toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+			"namespace": "default",
+			"name":      "pending-vm",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected error for non-running VM")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "not running")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "Pending")
+
+		// Cleanup
+		_ = dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachineinstances",
+		}).Namespace("default").Delete(s.T().Context(), "pending-vm", metav1.DeleteOptions{})
+	})
+
+	s.Run("vm_guest_info with default info_type", func() {
+		// Create a running VMI
+		dynamicClient := dynamic.NewForConfigOrDie(envTestRestConfig)
+		vmi := &unstructured.Unstructured{}
+		vmi.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstance",
+			"metadata": map[string]interface{}{
+				"name":      "default-info-vm",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"domain": map[string]interface{}{
+					"devices": map[string]interface{}{},
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Running",
+			},
+		})
+		_, err := dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachineinstances",
+		}).Namespace("default").Create(s.T().Context(), vmi, metav1.CreateOptions{})
+		s.Require().NoError(err, "failed to create running VMI")
+
+		// Call without info_type to test default behavior
+		toolResult, err := s.CallTool("vm_guest_info", map[string]interface{}{
+			"namespace": "default",
+			"name":      "default-info-vm",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		// Should default to "all" and fail gracefully in envtest
+		s.Truef(toolResult.IsError, "expected error when guest agent data is unavailable")
+
+		// Cleanup
+		_ = dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachineinstances",
+		}).Namespace("default").Delete(s.T().Context(), "default-info-vm", metav1.DeleteOptions{})
 	})
 }
 

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -158,6 +158,47 @@
   },
   {
     "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Virtual Machine: Guest Agent Info"
+    },
+    "description": "Get guest operating system information from a VirtualMachine's QEMU guest agent. Requires the guest agent to be installed and running inside the VM. Provides detailed information about the OS, filesystems, network interfaces, and logged-in users.",
+    "inputSchema": {
+      "properties": {
+        "info_type": {
+          "default": "all",
+          "description": "Type of information to retrieve: 'all' (default - all available info), 'os' (operating system details), 'filesystem' (disk and filesystem info), 'users' (logged-in users), 'network' (network interfaces and IPs)",
+          "enum": [
+            "all",
+            "os",
+            "filesystem",
+            "users",
+            "network"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the virtual machine",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The namespace of the virtual machine",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "vm_guest_info",
+    "title": "Virtual Machine: Guest Agent Info"
+  },
+  {
+    "annotations": {
       "destructiveHint": true,
       "openWorldHint": false,
       "title": "Virtual Machine: Lifecycle"

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -8,6 +8,7 @@ import (
 	kubevirtdefaults "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
 	vm_clone "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/clone"
 	vm_create "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/create"
+	vm_guestagent "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/guestagent"
 	vm_lifecycle "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/lifecycle"
 )
 
@@ -27,12 +28,15 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 	return slices.Concat(
 		vm_clone.Tools(),
 		vm_create.Tools(),
+		vm_guestagent.Tools(),
 		vm_lifecycle.Tools(),
 	)
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {
-	return initVMTroubleshoot()
+	return slices.Concat(
+		initVMTroubleshoot(),
+	)
 }
 
 func (t *Toolset) GetResources() []api.ServerResource {

--- a/pkg/toolsets/kubevirt/vm/guestagent/tool.go
+++ b/pkg/toolsets/kubevirt/vm/guestagent/tool.go
@@ -1,0 +1,154 @@
+package guestagent
+
+import (
+	"fmt"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/google/jsonschema-go/jsonschema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+)
+
+// GuestAgentInfoType represents the type of information to retrieve from guest agent
+type GuestAgentInfoType string
+
+const (
+	InfoTypeAll        GuestAgentInfoType = "all"
+	InfoTypeOS         GuestAgentInfoType = "os"
+	InfoTypeFilesystem GuestAgentInfoType = "filesystem"
+	InfoTypeUsers      GuestAgentInfoType = "users"
+	InfoTypeNetwork    GuestAgentInfoType = "network"
+)
+
+func Tools() []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "vm_guest_info",
+				Description: "Get guest operating system information from a VirtualMachine's QEMU guest agent. Requires the guest agent to be installed and running inside the VM. Provides detailed information about the OS, filesystems, network interfaces, and logged-in users.",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "The namespace of the virtual machine",
+						},
+						"name": {
+							Type:        "string",
+							Description: "The name of the virtual machine",
+						},
+						"info_type": {
+							Type:        "string",
+							Enum:        []any{"all", "os", "filesystem", "users", "network"},
+							Description: "Type of information to retrieve: 'all' (default - all available info), 'os' (operating system details), 'filesystem' (disk and filesystem info), 'users' (logged-in users), 'network' (network interfaces and IPs)",
+							Default:     api.ToRawMessage("all"),
+						},
+					},
+					Required: []string{"namespace", "name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Virtual Machine: Guest Agent Info",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(false),
+				},
+			},
+			Handler: guestInfo,
+		},
+	}
+}
+
+// validateVMI checks if the VMI exists and is running
+func validateVMI(params api.ToolHandlerParams, namespace, name string) error {
+	vmi, err := params.DynamicClient().Resource(kubevirt.VirtualMachineInstanceGVR).
+		Namespace(namespace).
+		Get(params.Context, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("VirtualMachineInstance not found - VM may not be running: %w", err)
+	}
+
+	phase, found, err := unstructured.NestedString(vmi.Object, "status", "phase")
+	if err != nil || !found || phase != "Running" {
+		return fmt.Errorf("VirtualMachineInstance is not running (phase: %s) - guest agent requires VM to be running", phase)
+	}
+
+	return nil
+}
+
+// fetchGuestInfo retrieves the requested guest information based on info type
+func fetchGuestInfo(params api.ToolHandlerParams, namespace, name, infoType string) (map[string]any, error) {
+	ctx := params.Context
+	restConfig := params.RESTConfig()
+
+	switch GuestAgentInfoType(infoType) {
+	case InfoTypeOS:
+		return kubevirt.GetGuestOSInfo(ctx, restConfig, namespace, name)
+	case InfoTypeFilesystem:
+		return kubevirt.GetFilesystemInfo(ctx, restConfig, namespace, name)
+	case InfoTypeUsers:
+		return kubevirt.GetUserInfo(ctx, restConfig, namespace, name)
+	case InfoTypeNetwork:
+		return kubevirt.GetNetworkInfo(ctx, restConfig, namespace, name)
+	case InfoTypeAll:
+		return kubevirt.GetAllGuestInfo(ctx, restConfig, namespace, name)
+	default:
+		return nil, fmt.Errorf("invalid info_type '%s': must be one of 'all', 'os', 'filesystem', 'users', 'network'", infoType)
+	}
+}
+
+// formatGuestInfoOutput formats the guest information as YAML output
+func formatGuestInfoOutput(namespace, name, infoType string, result map[string]any) (string, error) {
+	marshalledYaml, err := output.MarshalYaml(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal guest agent info: %w", err)
+	}
+
+	message := fmt.Sprintf("# Guest Agent Information for VM: %s/%s\n\n", namespace, name)
+	if infoType != "all" {
+		message += fmt.Sprintf("**Info Type:** %s\n\n", infoType)
+	}
+
+	return message + marshalledYaml, nil
+}
+
+func guestInfo(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	namespace, err := api.RequiredString(params, "namespace")
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	name, err := api.RequiredString(params, "name")
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	args := params.GetArguments()
+	infoType := "all"
+	if val, ok := args["info_type"]; ok && val != nil {
+		s, ok := val.(string)
+		if !ok {
+			return api.NewToolCallResult("", fmt.Errorf("info_type parameter must be a string")), nil
+		}
+		infoType = s
+	}
+
+	if err := validateVMI(params, namespace, name); err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	result, err := fetchGuestInfo(params, namespace, name, infoType)
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	output, err := formatGuestInfoOutput(namespace, name, infoType, result)
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	return api.NewToolCallResult(output, nil), nil
+}

--- a/pkg/toolsets/kubevirt/vm/guestagent/tool_test.go
+++ b/pkg/toolsets/kubevirt/vm/guestagent/tool_test.go
@@ -1,0 +1,61 @@
+package guestagent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type GuestAgentToolSuite struct {
+	suite.Suite
+}
+
+func (s *GuestAgentToolSuite) TestToolRegistration() {
+	s.Run("tool is registered", func() {
+		tools := Tools()
+		s.Require().Len(tools, 1, "Expected 1 guest agent tool")
+		s.Equal("vm_guest_info", tools[0].Tool.Name)
+		s.Equal("Virtual Machine: Guest Agent Info", tools[0].Tool.Annotations.Title)
+		s.NotNil(tools[0].Tool.InputSchema)
+		s.NotNil(tools[0].Handler)
+	})
+
+	s.Run("tool has correct properties", func() {
+		tools := Tools()
+		tool := tools[0].Tool
+
+		// Check annotations
+		s.True(*tool.Annotations.ReadOnlyHint, "guest info should be read-only")
+		s.False(*tool.Annotations.DestructiveHint, "guest info should not be destructive")
+		s.True(*tool.Annotations.IdempotentHint, "guest info should be idempotent")
+
+		// Check schema
+		schema := tool.InputSchema
+		s.Require().NotNil(schema.Properties)
+		s.Contains(schema.Properties, "namespace")
+		s.Contains(schema.Properties, "name")
+		s.Contains(schema.Properties, "info_type")
+
+		// Check required fields
+		s.ElementsMatch([]string{"namespace", "name"}, schema.Required)
+
+		// Check info_type enum values
+		infoTypeSchema := schema.Properties["info_type"]
+		s.Require().NotNil(infoTypeSchema)
+		s.ElementsMatch([]any{"all", "os", "filesystem", "users", "network"}, infoTypeSchema.Enum)
+	})
+}
+
+func (s *GuestAgentToolSuite) TestInfoTypeConstants() {
+	s.Run("info type constants are defined", func() {
+		s.Equal(GuestAgentInfoType("all"), InfoTypeAll)
+		s.Equal(GuestAgentInfoType("os"), InfoTypeOS)
+		s.Equal(GuestAgentInfoType("filesystem"), InfoTypeFilesystem)
+		s.Equal(GuestAgentInfoType("users"), InfoTypeUsers)
+		s.Equal(GuestAgentInfoType("network"), InfoTypeNetwork)
+	})
+}
+
+func TestGuestAgentToolSuite(t *testing.T) {
+	suite.Run(t, new(GuestAgentToolSuite))
+}


### PR DESCRIPTION
Implements vm_guest_info tool to retrieve information from inside running VMs via QEMU guest agent without requiring SSH credentials.

Assisted-By: Claude <noreply@anthropic.com>