### PR TITLE
test(evals): add update-vm-instancetype eval task

### DIFF
--- a/evals/tasks/kubevirt/README.md
+++ b/evals/tasks/kubevirt/README.md
@@ -49,6 +49,9 @@ KubeVirt-focused MCP tasks live here. Each folder under this directory represent
 - **[hard] update-vm-resources** - Update VM CPU and memory resources
   - **Prompt:** *A VirtualMachine named test-vm-update exists in the vm-test namespace. It currently has 1 vCPU and 2Gi of memory. Please update the VirtualMachine to add an additional vCPU (making it 2 vCPUs total) and increase the memory to at least 3Gi.*
 
+- **[hard] update-vm-instancetype** - Double a VM's memory by switching its instancetype
+  - **Prompt:** *A Fedora VirtualMachine named fedora-vm exists in the vm-test-instancetype-update namespace using the u1.small instancetype. Double its memory by updating the instance type.*
+
 ### VM Troubleshooting
 
 - **[hard] troubleshoot-vm** - Use the vm-troubleshoot prompt to diagnose VirtualMachine issues

--- a/evals/tasks/kubevirt/update-vm-instancetype/task.yaml
+++ b/evals/tasks/kubevirt/update-vm-instancetype/task.yaml
@@ -1,0 +1,94 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: "update-vm-instancetype"
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  difficulty: hard
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: fedora-vm
+          namespace: vm-test
+        spec:
+          runStrategy: Halted
+          instancetype:
+            name: u1.small
+            kind: VirtualMachineClusterInstancetype
+          template:
+            spec:
+              domain:
+                devices:
+                  disks:
+                  - name: containerdisk
+                    disk:
+                      bus: virtio
+              volumes:
+              - name: containerdisk
+                containerDisk:
+                  image: quay.io/containerdisks/fedora:latest
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          NS="vm-test"
+          VM_NAME="fedora-vm"
+
+          # Verify VM still exists
+          kubectl get virtualmachine "$VM_NAME" -n "$NS" > /dev/null
+          echo "VirtualMachine $VM_NAME exists"
+
+          # Verify VM uses the expected u1.medium instancetype
+          INSTANCETYPE=$(kubectl get virtualmachine "$VM_NAME" -n "$NS" -o jsonpath='{.spec.instancetype.name}')
+          if [ "$INSTANCETYPE" != "u1.medium" ]; then
+            echo "ERROR: Expected instancetype 'u1.medium', found: '$INSTANCETYPE'"
+            exit 1
+          fi
+          echo "Instancetype is u1.medium"
+
+          # Verify no direct resource specification
+          GUEST_MEMORY=$(kubectl get virtualmachine "$VM_NAME" -n "$NS" -o jsonpath='{.spec.template.spec.domain.memory.guest}')
+          if [ -n "$GUEST_MEMORY" ]; then
+            echo "WARNING: VirtualMachine has direct memory specification: $GUEST_MEMORY"
+          else
+            echo "VirtualMachine uses instancetype for resources (no direct memory spec)"
+          fi
+
+          echo "All validations passed"
+          exit 0
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: fedora-vm
+          namespace: vm-test
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      A Fedora VirtualMachine named fedora-vm exists in the vm-test namespace using the u1.small instancetype. Double its memory by updating the instance type.

--- a/evals/tasks/kubevirt/update-vm-instancetype/task.yaml
+++ b/evals/tasks/kubevirt/update-vm-instancetype/task.yaml
@@ -1,10 +1,10 @@
 kind: Task
 apiVersion: mcpchecker/v1alpha2
 metadata:
-  name: "update-vm-instancetype"
   labels:
     suite: kubevirt
     requires: kubevirt
+  name: "update-vm-instancetype"
   difficulty: hard
 spec:
   requires:
@@ -15,19 +15,19 @@ spec:
         apiVersion: v1
         kind: Namespace
         metadata:
-          name: vm-test
+          name: vm-test-instancetype-update
         ignoreNotFound: true
     - k8s.create:
         apiVersion: v1
         kind: Namespace
         metadata:
-          name: vm-test
+          name: vm-test-instancetype-update
     - k8s.create:
         apiVersion: kubevirt.io/v1
         kind: VirtualMachine
         metadata:
           name: fedora-vm
-          namespace: vm-test
+          namespace: vm-test-instancetype-update
         spec:
           runStrategy: Halted
           instancetype:
@@ -49,29 +49,12 @@ spec:
     - script:
         inline: |-
           #!/usr/bin/env bash
-          set -e
-          NS="vm-test"
-          VM_NAME="fedora-vm"
+          source ../helpers/verify-vm.sh
+          NS="vm-test-instancetype-update"
 
-          # Verify VM still exists
-          kubectl get virtualmachine "$VM_NAME" -n "$NS" > /dev/null
-          echo "VirtualMachine $VM_NAME exists"
-
-          # Verify VM uses the expected u1.medium instancetype
-          INSTANCETYPE=$(kubectl get virtualmachine "$VM_NAME" -n "$NS" -o jsonpath='{.spec.instancetype.name}')
-          if [ "$INSTANCETYPE" != "u1.medium" ]; then
-            echo "ERROR: Expected instancetype 'u1.medium', found: '$INSTANCETYPE'"
-            exit 1
-          fi
-          echo "Instancetype is u1.medium"
-
-          # Verify no direct resource specification
-          GUEST_MEMORY=$(kubectl get virtualmachine "$VM_NAME" -n "$NS" -o jsonpath='{.spec.template.spec.domain.memory.guest}')
-          if [ -n "$GUEST_MEMORY" ]; then
-            echo "WARNING: VirtualMachine has direct memory specification: $GUEST_MEMORY"
-          else
-            echo "VirtualMachine uses instancetype for resources (no direct memory spec)"
-          fi
+          verify_vm_exists "fedora-vm" "$NS" || exit 1
+          verify_instancetype "fedora-vm" "$NS" "u1.medium" || exit 1
+          verify_no_direct_resources "fedora-vm" "$NS"
 
           echo "All validations passed"
           exit 0
@@ -81,14 +64,14 @@ spec:
         kind: VirtualMachine
         metadata:
           name: fedora-vm
-          namespace: vm-test
+          namespace: vm-test-instancetype-update
         ignoreNotFound: true
     - k8s.delete:
         apiVersion: v1
         kind: Namespace
         metadata:
-          name: vm-test
+          name: vm-test-instancetype-update
         ignoreNotFound: true
   prompt:
     inline: |
-      A Fedora VirtualMachine named fedora-vm exists in the vm-test namespace using the u1.small instancetype. Double its memory by updating the instance type.
+      A Fedora VirtualMachine named fedora-vm exists in the vm-test-instancetype-update namespace using the u1.small instancetype. Double its memory by updating the instance type.


### PR DESCRIPTION
/cc @ksimon1 
/cc @codingben 
/cc @Ruclo 

Add a new kubevirt eval that tests doubling VM memory by changing instance types. Includes a verify_instancetype_changed helper function.

```
$ mcpchecker view mcpchecker-kubevirt-basic-operations-out.json
Task: update-vm-instancetype
  Path: /home/lyarwood/redhat/devel/src/k8s/kubernetes-mcp-server/evals/tasks/kubevirt/update-vm-instancetype/task.yaml
  Difficulty: hard
  Status: PASSED
  Prompt: A Fedora VirtualMachine named fedora-vm exists in the vm-test namespace using the u1.small instancetype. Double its memory by updating the instance type.                              Assertions: 3/3 passed
  Call history: tools=4 (kubernetes:4 ok)
    Tool output:
      • kubernetes::resources_get (ok)
        apiVersion: kubevirt.io/v1
        kind: VirtualMachine
        metadata:
          annotations:
            kubevirt.io/latest-observed-api-version: v1
            kubevirt.io/storage-observed-api-version: v1
        … (+52 lines)
      • kubernetes::resources_get (ok)
        apiVersion: instancetype.kubevirt.io/v1beta1
        kind: VirtualMachineClusterInstancetype
        metadata:
          annotations:
            instancetype.kubevirt.io/description: |-
              The U Series is quite neutral and provides resources for
        … (+33 lines)
      • kubernetes::resources_list (ok)
        APIVERSION                         KIND                                NAME             AGE   LABELS
        instancetype.kubevirt.io/v1beta1 VirtualMachineClusterInstancetype cx1.2xlarge 22m
        app.kubernetes.io/component=kubevirt,app.kubernetes.io/managed-by=virt-operator,instancetype.kubevirt.io/class=compute.exclusive,instancetype.kubevirt.io/common-instancetypes-version=v1.5.1,instancetype.kubevirt.io/cpu=8,instancetype.kubevirt.io/dedicatedCPUPlacement=true,instancetype.kubevirt.io/hugepages=2Mi,instancetype.kubevirt.io/icon-pf=pficon-registry,instancetype.kubevirt.io/isolateEmulatorThread=true,instancetype.kubevirt.io/memory=16Gi,instancetype.kubevirt.io/numa=true,instancetype.kubevirt.io/size=2xlarge,instancetype.kubevirt.io/vendor=kubevirt.io,instancetype.kubevirt.io/version=1
        instancetype.kubevirt.io/v1beta1 VirtualMachineClusterInstancetype cx1.2xlarge1gi 22m
        app.kubernetes.io/component=kubevirt,app.kubernetes.io/managed-by=virt-operator,instancetype.kubevirt.io/class=compute.exclusive,instancetype.kubevirt.io/common-instancetypes-version=v1.5.1,instancetype.kubevirt.io/cpu=8,instancetype.kubevirt.io/dedicatedCPUPlacement=true,instancetype.kubevirt.io/hugepages=1Gi,instancetype.kubevirt.io/icon-pf=pficon-registry,instancetype.kubevirt.io/isolateEmulatorThread=true,instancetype.kubevirt.io/memory=16Gi,instancetype.kubevirt.io/numa=true,instancetype.kubevirt.io/size=2xlarge1gi,instancetype.kubevirt.io/vendor=kubevirt.io,instancetype.kubevirt.io/version=1
        instancetype.kubevirt.io/v1beta1 VirtualMachineClusterInstancetype cx1.4xlarge 22m
        … (+105 lines)
      • kubernetes::resources_create_or_update (ok)
        # The following resources (YAML) have been created or updated successfully
        - apiVersion: kubevirt.io/v1
          kind: VirtualMachine
          metadata:
            annotations:
              kubevirt.io/latest-observed-api-version: v1
        … (+135 lines)
  Timeline:
    - note: Done. The `fedora-vm` VirtualMachine has been updated from `u1.small` to `u1.medium`, doubling its
      memory:
    - note: | | Instance Type | CPU | Memory | |---|---|---|---| | Before | `u1.small` | 1 | 2Gi | | After |
      `u1.medium` | 1 | 4Gi |
    - note: The VM is currently stopped (`runStrategy: Halted`), so the new instance type will take effect on
      the next start.
```