### PR TITLE
refactor(config): extract BaseDefault() and decouple tests from downstream overrides

### DIFF
--- a/pkg/config/config_default.go
+++ b/pkg/config/config_default.go
@@ -6,26 +6,24 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-func Default() *StaticConfig {
-	defaultConfig := StaticConfig{
+// BaseDefault returns the upstream base defaults before any
+// build-time overrides are applied. This is useful for understanding
+// the raw upstream configuration independent of downstream customization.
+func BaseDefault() *StaticConfig {
+	return &StaticConfig{
 		ListOutput: "table",
 		Toolsets:   []string{"core", "config", "helm"},
 	}
-	overrides := defaultOverrides()
-	mergedConfig := mergeConfig(defaultConfig, overrides)
-	return &mergedConfig
 }
 
-// HasDefaultOverrides indicates whether the internal defaultOverrides function
-// provides any overrides or an empty StaticConfig.
-func HasDefaultOverrides() bool {
+// Default returns the effective default configuration, with any
+// downstream build-time overrides (from defaultOverrides) merged
+// on top of the base defaults.
+func Default() *StaticConfig {
+	base := BaseDefault()
 	overrides := defaultOverrides()
-	var buf bytes.Buffer
-	if err := toml.NewEncoder(&buf).Encode(overrides); err != nil {
-		// If marshaling fails, assume no overrides
-		return false
-	}
-	return len(bytes.TrimSpace(buf.Bytes())) > 0
+	merged := mergeConfig(*base, overrides)
+	return &merged
 }
 
 // mergeConfig applies non-zero values from override to base using TOML serialization

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -29,6 +29,30 @@ func (s *BaseConfigSuite) writeConfig(content string) string {
 
 type ConfigSuite struct {
 	BaseConfigSuite
+	defaults *StaticConfig
+}
+
+func (s *ConfigSuite) SetupTest() {
+	s.defaults = Default()
+}
+
+func (s *ConfigSuite) TestBaseDefaultValues() {
+	base := BaseDefault()
+	s.Run("ListOutput is table", func() {
+		s.Equal("table", base.ListOutput)
+	})
+	s.Run("Toolsets are core, config, helm", func() {
+		s.Equal([]string{"core", "config", "helm"}, base.Toolsets)
+	})
+	s.Run("ReadOnly is false", func() {
+		s.False(base.ReadOnly)
+	})
+	s.Run("DisableDestructive is false", func() {
+		s.False(base.DisableDestructive)
+	})
+	s.Run("Stateless is false", func() {
+		s.False(base.Stateless)
+	})
 }
 
 func (s *ConfigSuite) TestReadConfigMissingFile() {
@@ -224,9 +248,6 @@ func (s *ConfigSuite) TestReadConfigStatelessExplicitFalse() {
 }
 
 func (s *ConfigSuite) TestReadConfigValidPreservesDefaultsForMissingFields() {
-	if HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
 	validConfigPath := s.writeConfig(`
 		port = "1337"
 	`)
@@ -244,13 +265,10 @@ func (s *ConfigSuite) TestReadConfigValidPreservesDefaultsForMissingFields() {
 		s.Equalf("1337", config.Port, "Expected Port to be 9999, got %s", config.Port)
 	})
 	s.Run("list_output defaulted correctly", func() {
-		s.Equalf("table", config.ListOutput, "Expected ListOutput to be table, got %s", config.ListOutput)
+		s.Equalf(s.defaults.ListOutput, config.ListOutput, "Expected ListOutput to be %s, got %s", s.defaults.ListOutput, config.ListOutput)
 	})
 	s.Run("toolsets defaulted correctly", func() {
-		s.Require().Lenf(config.Toolsets, 3, "Expected 3 toolsets, got %d", len(config.Toolsets))
-		for _, toolset := range []string{"core", "config", "helm"} {
-			s.Containsf(config.Toolsets, toolset, "Expected toolsets to contain %s", toolset)
-		}
+		s.Equal(s.defaults.Toolsets, config.Toolsets, "toolsets should match defaults")
 	})
 }
 
@@ -550,9 +568,6 @@ func (s *ConfigSuite) TestStandaloneConfigDir() {
 
 func (s *ConfigSuite) TestStandaloneConfigDirPreservesDefaults() {
 	// Test that defaults are preserved when using standalone --config-dir
-	if HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
 	tempDir := s.T().TempDir()
 
 	// Create a drop-in file with only partial config
@@ -567,16 +582,13 @@ func (s *ConfigSuite) TestStandaloneConfigDirPreservesDefaults() {
 
 	s.Run("preserves default values", func() {
 		s.Equal("9999", config.Port, "port should be from drop-in")
-		s.Equal("table", config.ListOutput, "list_output should be default")
-		s.Equal([]string{"core", "config", "helm"}, config.Toolsets, "toolsets should be default")
+		s.Equal(s.defaults.ListOutput, config.ListOutput, "list_output should be default")
+		s.Equal(s.defaults.Toolsets, config.Toolsets, "toolsets should be default")
 	})
 }
 
 func (s *ConfigSuite) TestStandaloneConfigDirEmpty() {
 	// Test standalone --config-dir with empty directory
-	if HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
 	tempDir := s.T().TempDir()
 
 	config, err := Read("", tempDir)
@@ -584,22 +596,19 @@ func (s *ConfigSuite) TestStandaloneConfigDirEmpty() {
 	s.Require().NotNil(config)
 
 	s.Run("returns defaults for empty directory", func() {
-		s.Equal("table", config.ListOutput, "list_output should be default")
-		s.Equal([]string{"core", "config", "helm"}, config.Toolsets, "toolsets should be default")
+		s.Equal(s.defaults.ListOutput, config.ListOutput, "list_output should be default")
+		s.Equal(s.defaults.Toolsets, config.Toolsets, "toolsets should be default")
 	})
 }
 
 func (s *ConfigSuite) TestStandaloneConfigDirNonExistent() {
 	// Test standalone --config-dir with non-existent directory
-	if HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
 	config, err := Read("", "/non/existent/directory")
 	s.Require().NoError(err, "Should not error for non-existent directory")
 	s.Require().NotNil(config)
 
 	s.Run("returns defaults for non-existent directory", func() {
-		s.Equal("table", config.ListOutput, "list_output should be default")
+		s.Equal(s.defaults.ListOutput, config.ListOutput, "list_output should be default")
 	})
 }
 
@@ -904,18 +913,14 @@ func (s *ConfigSuite) TestRelativeConfigDirPath() {
 
 func (s *ConfigSuite) TestBothConfigAndConfigDirEmpty() {
 	// Edge case: Read("", "") should return defaults
-	if HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
-
 	config, err := Read("", "")
 	s.Require().NoError(err, "Should not error when both config and config-dir are empty")
 	s.Require().NotNil(config)
 
 	s.Run("returns default configuration", func() {
-		s.Equal("table", config.ListOutput)
-		s.Equal([]string{"core", "config", "helm"}, config.Toolsets)
-		s.Equal(0, config.LogLevel)
+		s.Equal(s.defaults.ListOutput, config.ListOutput)
+		s.Equal(s.defaults.Toolsets, config.Toolsets)
+		s.Equal(s.defaults.LogLevel, config.LogLevel)
 	})
 }
 
@@ -1007,10 +1012,6 @@ func (s *ConfigSuite) TestDropInWithNestedConfig() {
 
 func (s *ConfigSuite) TestEmptyConfigFile() {
 	// Test that an empty main config file works correctly
-	if HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
-
 	tempDir := s.T().TempDir()
 
 	// Create empty main config
@@ -1033,8 +1034,8 @@ func (s *ConfigSuite) TestEmptyConfigFile() {
 		s.Equal(5, config.LogLevel, "log_level should be from drop-in")
 		s.Equal("9999", config.Port, "port should be from drop-in")
 		// Defaults should still be applied for unset values
-		s.Equal("table", config.ListOutput, "list_output should be default")
-		s.Equal([]string{"core", "config", "helm"}, config.Toolsets, "toolsets should be default")
+		s.Equal(s.defaults.ListOutput, config.ListOutput, "list_output should be default")
+		s.Equal(s.defaults.Toolsets, config.Toolsets, "toolsets should be default")
 	})
 }
 

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -218,7 +218,7 @@ func (s *CmdSuite) TestConfigDir() {
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--config-dir", "/nonexistent/path/to/config-dir"})
 		err := rootCmd.Execute()
 		s.Require().NoError(err, "Nonexistent directories should be gracefully skipped")
-		s.Contains(out.String(), "ListOutput: table", "Default values should be used")
+		s.Contains(out.String(), fmt.Sprintf("ListOutput: %s", config.Default().ListOutput), "Default values should be used")
 	})
 	s.Run("--config with --config-dir merges configs", func() {
 		tempDir := s.T().TempDir()
@@ -300,14 +300,12 @@ func TestToolsets(t *testing.T) {
 		}
 	})
 	t.Run("default", func(t *testing.T) {
-		if config.HasDefaultOverrides() {
-			t.Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-		}
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
-		if err := rootCmd.Execute(); !strings.Contains(out.String(), "- Toolsets: core, config, helm") {
-			t.Fatalf("Expected toolsets 'full', got %s %v", out, err)
+		expected := "- Toolsets: " + strings.Join(config.Default().Toolsets, ", ")
+		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
+			t.Fatalf("Expected toolsets '%s', got %s %v", expected, out, err)
 		}
 	})
 	t.Run("set with --toolsets", func(t *testing.T) {
@@ -336,8 +334,10 @@ func TestListOutput(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
-		if err := rootCmd.Execute(); !strings.Contains(out.String(), "- ListOutput: table") {
-			t.Fatalf("Expected list-output 'table', got %s %v", out, err)
+		defaults := config.Default()
+		expected := fmt.Sprintf("- ListOutput: %s", defaults.ListOutput)
+		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
+			t.Fatalf("Expected list-output '%s', got %s %v", defaults.ListOutput, out, err)
 		}
 	})
 	t.Run("set with --list-output", func(t *testing.T) {
@@ -354,14 +354,12 @@ func TestListOutput(t *testing.T) {
 
 func TestReadOnly(t *testing.T) {
 	t.Run("defaults to false", func(t *testing.T) {
-		if config.HasDefaultOverrides() {
-			t.Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-		}
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
-		if err := rootCmd.Execute(); !strings.Contains(out.String(), " - Read-only mode: false") {
-			t.Fatalf("Expected read-only mode false, got %s %v", out, err)
+		expected := fmt.Sprintf(" - Read-only mode: %v", config.Default().ReadOnly)
+		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
+			t.Fatalf("Expected read-only mode %v, got %s %v", config.Default().ReadOnly, out, err)
 		}
 	})
 	t.Run("set with --read-only", func(t *testing.T) {
@@ -381,8 +379,10 @@ func TestDisableDestructive(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
-		if err := rootCmd.Execute(); !strings.Contains(out.String(), " - Disable destructive tools: false") {
-			t.Fatalf("Expected disable destructive false, got %s %v", out, err)
+		defaults := config.Default()
+		expected := fmt.Sprintf(" - Disable destructive tools: %t", defaults.DisableDestructive)
+		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
+			t.Fatalf("Expected disable destructive %t, got %s %v", defaults.DisableDestructive, out, err)
 		}
 	})
 	t.Run("set with --disable-destructive", func(t *testing.T) {
@@ -467,8 +467,10 @@ func TestStateless(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
-		if err := rootCmd.Execute(); !strings.Contains(out.String(), " - Stateless mode: false") {
-			t.Fatalf("Expected stateless mode false, got %s %v", out, err)
+		defaults := config.Default()
+		expected := fmt.Sprintf(" - Stateless mode: %t", defaults.Stateless)
+		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
+			t.Fatalf("Expected stateless mode %t, got %s %v", defaults.Stateless, out, err)
 		}
 	})
 	t.Run("set with --stateless", func(t *testing.T) {

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -191,7 +191,7 @@ type BaseMcpSuite struct {
 }
 
 func (s *BaseMcpSuite) SetupTest() {
-	s.Cfg = config.Default()
+	s.Cfg = config.BaseDefault()
 	s.Cfg.ListOutput = "yaml"
 	s.Cfg.KubeConfig = filepath.Join(s.T().TempDir(), "config")
 	s.Require().NoError(os.WriteFile(s.Cfg.KubeConfig, envTest.KubeConfig, 0600), "Expected to write kubeconfig")

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -76,9 +76,6 @@ func (s *ToolsetsSuite) TestNoToolsets() {
 }
 
 func (s *ToolsetsSuite) TestDefaultToolsetsTools() {
-	if configuration.HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
 	s.Run("Default configuration toolsets", func() {
 		s.InitMcpClient()
 		tools, err := s.ListTools()
@@ -93,9 +90,6 @@ func (s *ToolsetsSuite) TestDefaultToolsetsTools() {
 }
 
 func (s *ToolsetsSuite) TestDefaultToolsetsToolsInOpenShift() {
-	if configuration.HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
 	s.Run("Default configuration toolsets in OpenShift", func() {
 		s.Handle(test.NewInOpenShiftHandler())
 		s.InitMcpClient()
@@ -111,9 +105,6 @@ func (s *ToolsetsSuite) TestDefaultToolsetsToolsInOpenShift() {
 }
 
 func (s *ToolsetsSuite) TestDefaultToolsetsToolsInMultiCluster() {
-	if configuration.HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
 	s.Run("Default configuration toolsets in multi-cluster (with 11 clusters)", func() {
 		kubeconfig := s.Kubeconfig()
 		for i := 0; i < 10; i++ {
@@ -134,9 +125,6 @@ func (s *ToolsetsSuite) TestDefaultToolsetsToolsInMultiCluster() {
 }
 
 func (s *ToolsetsSuite) TestDefaultToolsetsToolsInMultiClusterEnum() {
-	if configuration.HasDefaultOverrides() {
-		s.T().Skip("Skipping test because default configuration overrides are present (this is a downstream fork)")
-	}
 	s.Run("Default configuration toolsets in multi-cluster (with 2 clusters)", func() {
 		kubeconfig := s.Kubeconfig()
 		// Add additional cluster to force multi-cluster behavior with enum parameter


### PR DESCRIPTION
Introduce `BaseDefault` returning upstream-only defaults, separate from `Default` which merges downstream build-time overrides on top. 

Remove `HasDefaultOverrides` and all skip guards that relied on it.

Replace hardcoded default values in test assertions with `config.Default()` and use `BaseDefault()` in `BaseMcpSuite` so feature tests (Helm, Core, etc.) run regardless of downstream overrides. ToolsetsSuite retains `Default()` to verify effective default behavior.

Downstream only needs to regenerate snapshots (`UPDATE_TOOLSETS_JSON=1`) when overrides change.