### PR TITLE
fix(test): improve test accuracy and naming after BaseDefault refactor

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -53,6 +53,9 @@ func (s *ConfigSuite) TestBaseDefaultValues() {
 	s.Run("Stateless is false", func() {
 		s.False(base.Stateless)
 	})
+	s.Run("LogLevel is 0", func() {
+		s.Equal(0, base.LogLevel)
+	})
 }
 
 func (s *ConfigSuite) TestReadConfigMissingFile() {
@@ -262,7 +265,7 @@ func (s *ConfigSuite) TestReadConfigValidPreservesDefaultsForMissingFields() {
 		s.Equalf(0, config.LogLevel, "Expected LogLevel to be 0, got %d", config.LogLevel)
 	})
 	s.Run("port parsed correctly", func() {
-		s.Equalf("1337", config.Port, "Expected Port to be 9999, got %s", config.Port)
+		s.Equalf("1337", config.Port, "Expected Port to be 1337, got %s", config.Port)
 	})
 	s.Run("list_output defaulted correctly", func() {
 		s.Equalf(s.defaults.ListOutput, config.ListOutput, "Expected ListOutput to be %s, got %s", s.defaults.ListOutput, config.ListOutput)

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -299,7 +299,7 @@ func TestToolsets(t *testing.T) {
 			t.Fatalf("Expected all available toolsets, got %s %v", o, err)
 		}
 	})
-	t.Run("default", func(t *testing.T) {
+	t.Run("matches default config", func(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
@@ -330,7 +330,7 @@ func TestListOutput(t *testing.T) {
 			t.Fatalf("Expected all available outputs, got %s %v", o, err)
 		}
 	})
-	t.Run("defaults to table", func(t *testing.T) {
+	t.Run("matches default config", func(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
@@ -353,7 +353,7 @@ func TestListOutput(t *testing.T) {
 }
 
 func TestReadOnly(t *testing.T) {
-	t.Run("defaults to false", func(t *testing.T) {
+	t.Run("matches default config", func(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
@@ -375,7 +375,7 @@ func TestReadOnly(t *testing.T) {
 }
 
 func TestDisableDestructive(t *testing.T) {
-	t.Run("defaults to false", func(t *testing.T) {
+	t.Run("matches default config", func(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
@@ -463,7 +463,7 @@ func TestDisableMultiCluster(t *testing.T) {
 }
 
 func TestStateless(t *testing.T) {
-	t.Run("defaults to false", func(t *testing.T) {
+	t.Run("matches default config", func(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})


### PR DESCRIPTION
Follows up on #817 to address some minor nitpicks

Add missing LogLevel assertion to TestBaseDefaultValues, fix stale assertion message in TestReadConfigValidPreservesDefaultsForMissingFields, and rename dynamic default-checking subtests to "matches default config" since they no longer assert hardcoded values.