### PR TITLE
fix(test): TestReloadUpdatesToolsets was reloading a different server than the one under test

### DIFF
--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -180,14 +180,6 @@ func (s *ConfigReloadSuite) TestMultipleReloads() {
 }
 
 func (s *ConfigReloadSuite) TestReloadUpdatesToolsets() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
-	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
-		StaticConfig: s.Cfg,
-	}, provider)
-	s.Require().NoError(err)
-	s.server = server
-
 	// Get initial tools
 	s.InitMcpClient()
 	initialTools, err := s.ListTools()
@@ -199,8 +191,8 @@ func (s *ConfigReloadSuite) TestReloadUpdatesToolsets() {
 	newConfig.Toolsets = []string{"core", "config", "helm"}
 	newConfig.KubeConfig = s.Cfg.KubeConfig
 
-	// Reload configuration
-	err = server.ReloadConfiguration(newConfig)
+	// Reload configuration on the server the MCP client is connected to
+	err = s.mcpServer.ReloadConfiguration(newConfig)
 	s.Require().NoError(err)
 
 	// Verify helm tools are available


### PR DESCRIPTION
The `TestReloadUpdatesToolsets` accidentally created two independent server instances. The reload was applied to one, while the MCP client assertions ran against the other. The test passed coincidentally because the toolset being added was already present in the default configuration.

Remove the redundant server setup and reload `s.mcpServer` directly — the server `InitMcpClient()` creates and the MCP client is connected to.

I noticed this when looking at when removing `helm` from default cfg