### PR TITLE
fix(ci): remove pr target from mcpchecker action as secrets won't be included properly

### DIFF
--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -9,13 +9,6 @@ on:
   issue_comment:
     types: [created]
 
-  # Automatically run kubevirt evals when kubevirt-related files change
-  pull_request:
-    paths:
-      - 'pkg/toolsets/kubevirt/**'
-      - 'evals/tasks/kubevirt/**'
-      - 'build/kubevirt.mk'
-
   # Allow manual workflow dispatch for testing
   workflow_dispatch:
     inputs:
@@ -67,7 +60,6 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/run-mcpchecker'))
@@ -104,11 +96,6 @@ jobs:
               echo "should-run=false" >> $GITHUB_OUTPUT
               echo "User ${{ github.event.comment.user.login }} does not have permission to trigger evaluations"
             fi
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "should-run=true" >> $GITHUB_OUTPUT
-            echo "is-pr=true" >> $GITHUB_OUTPUT
-            echo "pr-number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            echo "pr-sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           else
             echo "should-run=true" >> $GITHUB_OUTPUT
             echo "is-pr=false" >> $GITHUB_OUTPUT
@@ -116,15 +103,12 @@ jobs:
           fi
 
           # Suite selection:
-          # - For pull_request, always run kubevirt (triggered by kubevirt path changes).
           # - For workflow_dispatch, use the provided input.
           # - For other triggers (schedule/issue_comment), default to kubernetes.
           SUITE="${{ github.event.inputs.suite || 'kubernetes' }}"
           TASK_FILTER="${{ github.event.inputs.task-filter || '' }}"
 
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            SUITE_INPUT="kubevirt"
-          elif [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
             # Parse comment: /run-mcpchecker [suite]. Suite = kubernetes | kubevirt | kiali | all
             COMMENT_BODY="${{ github.event.comment.body }}"
             COMMENT_BODY="${COMMENT_BODY//[[:space:]]/ }"


### PR DESCRIPTION
As a security measure, github does not include secrets from the base repo into PRs triggered from a fork.

In general this is probably a good idea and not something we want to work around, in particular as the secrets here are API credentials and can run up a large bill.

This PR removes the automatic run of the evals on a PR, meaning we will have to manually trigger it