### PR TITLE
fix(observability): honor OTel endpoint from TOML config

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -327,11 +327,12 @@ func getSamplerFromConfig(cfg *config.TelemetryConfig) trace.Sampler {
 // Environment variables take precedence over config values.
 func createExporterWithConfig(ctx context.Context, cfg *config.TelemetryConfig) (*otlptrace.Exporter, error) {
 	protocol := strings.ToLower(cfg.GetProtocol())
+	endpoint := cfg.GetEndpoint()
 
 	switch protocol {
 	case "http/protobuf", "http":
 		klog.V(2).Infof("Using HTTP/protobuf OTLP exporter (protocol=%s)", protocol)
-		return otlptracehttp.New(ctx)
+		return otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(endpoint))
 
 	case "grpc", "":
 		if protocol == "" {
@@ -339,10 +340,10 @@ func createExporterWithConfig(ctx context.Context, cfg *config.TelemetryConfig) 
 		} else {
 			klog.V(2).Info("Using gRPC OTLP exporter")
 		}
-		return otlptracegrpc.New(ctx)
+		return otlptracegrpc.New(ctx, otlptracegrpc.WithEndpointURL(endpoint))
 
 	default:
 		klog.V(1).Infof("Unknown protocol '%s', defaulting to gRPC", protocol)
-		return otlptracegrpc.New(ctx)
+		return otlptracegrpc.New(ctx, otlptracegrpc.WithEndpointURL(endpoint))
 	}
 }


### PR DESCRIPTION
While the docs allude to `telemetry.endpoint` being usable for setting the OpenTelemetry endpoint, the endpoint from config was never passed to the traces/metrics providers as they are built. This PR resolves the issue by explicitly providing the endpoint from config instead.