### PR TITLE
fix(evals): add missing suite labels to kubevirt tasks

### DIFF
--- a/evals/tasks/kubevirt/clone-vm/task.yaml
+++ b/evals/tasks/kubevirt/clone-vm/task.yaml
@@ -1,6 +1,9 @@
 kind: Task
 apiVersion: mcpchecker/v1alpha2
 metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
   name: "clone-vm"
   difficulty: medium
 spec:

--- a/evals/tasks/kubevirt/create-vm-with-vlan/task.yaml
+++ b/evals/tasks/kubevirt/create-vm-with-vlan/task.yaml
@@ -1,5 +1,8 @@
 kind: Task
 metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
   name: "create-vm-with-vlan"
   difficulty: hard
 steps:

--- a/evals/tasks/kubevirt/restore-vm/task.yaml
+++ b/evals/tasks/kubevirt/restore-vm/task.yaml
@@ -1,5 +1,8 @@
 kind: Task
 metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
   name: "restore-vm"
   difficulty: medium
 steps:

--- a/evals/tasks/kubevirt/snapshot-vm/task.yaml
+++ b/evals/tasks/kubevirt/snapshot-vm/task.yaml
@@ -1,5 +1,8 @@
 kind: Task
 metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
   name: "snapshot-vm"
   difficulty: medium
 steps:

--- a/evals/tasks/kubevirt/troubleshoot-vm/task.yaml
+++ b/evals/tasks/kubevirt/troubleshoot-vm/task.yaml
@@ -1,5 +1,8 @@
 kind: Task
 metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
   name: "troubleshoot-vm"
   difficulty: hard
   description: "Use the vm-troubleshoot prompt to diagnose and fix VirtualMachine issues"


### PR DESCRIPTION
/cc @ksimon1 
/cc @Cali0707 

5 kubevirt eval tasks (clone-vm, create-vm-with-vlan, snapshot-vm, restore-vm, troubleshoot-vm) were missing the suite: kubevirt label, causing them to be silently skipped when running the mcpchecker workflow with --label-selector suite=kubevirt.
