### PR TITLE
refactor: expose cluster provider strategy to toolsets

### DIFF
--- a/internal/tools/update-readme/main.go
+++ b/internal/tools/update-readme/main.go
@@ -21,13 +21,17 @@ import (
 	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
 )
 
-type OpenShift struct{}
+type ToolsetEnv struct{}
 
-func (o *OpenShift) IsOpenShift(_ context.Context) bool {
+func (o *ToolsetEnv) IsOpenShift(_ context.Context) bool {
 	return true
 }
 
-var _ api.Openshift = (*OpenShift)(nil)
+func (o *ToolsetEnv) GetClusterProviderStrategy() string {
+	return ""
+}
+
+var _ api.ToolsetEnv = (*ToolsetEnv)(nil)
 
 func main() {
 	// Snyk reports false positive unless we flow the args through filepath.Clean and filepath.Localize in this specific order
@@ -84,7 +88,7 @@ func main() {
 	toolsetTools := strings.Builder{}
 	for _, toolset := range toolsetsList {
 		toolsetTools.WriteString("<details>\n\n<summary>" + toolset.GetName() + "</summary>\n\n")
-		tools := toolset.GetTools(&OpenShift{})
+		tools := toolset.GetTools(&ToolsetEnv{})
 		for _, tool := range tools {
 			toolsetTools.WriteString(fmt.Sprintf("- **%s** - %s\n", tool.Tool.Name, tool.Tool.Description))
 			for _, propName := range slices.Sorted(maps.Keys(tool.Tool.InputSchema.Properties)) {

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -42,10 +42,15 @@ type Toolset interface {
 	// GetDescription returns a human-readable description of the toolset.
 	// Will be used to generate documentation and help text.
 	GetDescription() string
-	GetTools(o Openshift) []ServerTool
+	GetTools(e ToolsetEnv) []ServerTool
 	// GetPrompts returns the prompts provided by this toolset.
 	// Returns nil if the toolset doesn't provide any prompts.
 	GetPrompts() []ServerPrompt
+}
+
+type ToolsetEnv interface {
+	Openshift
+	GetClusterProviderStrategy() string
 }
 
 type ToolCallRequest interface {

--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -235,6 +235,10 @@ func (p *kcpClusterProvider) IsOpenShift(ctx context.Context) bool {
 	return false
 }
 
+func (p *kcpClusterProvider) GetClusterProviderStrategy() string {
+	return api.ClusterProviderKcp
+}
+
 func (p *kcpClusterProvider) GetTargets(_ context.Context) ([]string, error) {
 	workspaces := make([]string, 0, len(p.managers))
 	for ws := range p.managers {

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -19,6 +19,7 @@ type Provider interface {
 	// For the kubecontext case, a user might be targeting both an OpenShift flavored cluster and a vanilla Kubernetes cluster.
 	// See: https://github.com/containers/kubernetes-mcp-server/pull/372#discussion_r2421592315
 	api.Openshift
+	GetClusterProviderStrategy() string
 	GetTargets(ctx context.Context) ([]string, error)
 	GetDerivedKubernetes(ctx context.Context, target string) (*Kubernetes, error)
 	GetDefaultTarget() string

--- a/pkg/kubernetes/provider_kubeconfig.go
+++ b/pkg/kubernetes/provider_kubeconfig.go
@@ -105,6 +105,10 @@ func (p *kubeConfigClusterProvider) IsOpenShift(ctx context.Context) bool {
 	return p.managers[p.defaultContext].IsOpenShift(ctx)
 }
 
+func (p *kubeConfigClusterProvider) GetClusterProviderStrategy() string {
+	return api.ClusterProviderKubeConfig
+}
+
 func (p *kubeConfigClusterProvider) GetTargets(_ context.Context) ([]string, error) {
 	contextNames := make([]string, 0, len(p.managers))
 	for contextName := range p.managers {

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -74,6 +74,10 @@ func (p *singleClusterProvider) IsOpenShift(ctx context.Context) bool {
 	return p.manager.IsOpenShift(ctx)
 }
 
+func (p *singleClusterProvider) GetClusterProviderStrategy() string {
+	return p.strategy
+}
+
 func (p *singleClusterProvider) GetTargets(_ context.Context) ([]string, error) {
 	return []string{""}, nil
 }

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -36,6 +36,10 @@ func (p *tokenExchangingProvider) GetDerivedKubernetes(ctx context.Context, targ
 	return p.provider.GetDerivedKubernetes(ctx, target)
 }
 
+func (p *tokenExchangingProvider) GetClusterProviderStrategy() string {
+	return p.provider.GetClusterProviderStrategy()
+}
+
 func (p *tokenExchangingProvider) IsOpenShift(ctx context.Context) bool {
 	return p.provider.IsOpenShift(ctx)
 }

--- a/pkg/mcp/mcp_toolset_prompts_test.go
+++ b/pkg/mcp/mcp_toolset_prompts_test.go
@@ -369,7 +369,7 @@ func (m *mockToolsetWithPrompts) GetDescription() string {
 	return m.description
 }
 
-func (m *mockToolsetWithPrompts) GetTools(_ api.Openshift) []api.ServerTool {
+func (m *mockToolsetWithPrompts) GetTools(_ api.ToolsetEnv) []api.ServerTool {
 	return nil
 }
 

--- a/pkg/toolsets/config/toolset.go
+++ b/pkg/toolsets/config/toolset.go
@@ -19,7 +19,7 @@ func (t *Toolset) GetDescription() string {
 	return "View and manage the current local Kubernetes configuration (kubeconfig)"
 }
 
-func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
+func (t *Toolset) GetTools(_ api.ToolsetEnv) []api.ServerTool {
 	return slices.Concat(
 		initConfiguration(),
 	)

--- a/pkg/toolsets/core/toolset.go
+++ b/pkg/toolsets/core/toolset.go
@@ -25,13 +25,13 @@ func (t *Toolset) GetDescription() string {
 	return "Most common tools for Kubernetes management (Pods, Generic Resources, Events, etc.)"
 }
 
-func (t *Toolset) GetTools(o api.Openshift) []api.ServerTool {
+func (t *Toolset) GetTools(env api.ToolsetEnv) []api.ServerTool {
 	return slices.Concat(
 		initEvents(),
-		initNamespaces(o),
+		initNamespaces(env),
 		initNodes(),
 		initPods(),
-		initResources(o),
+		initResources(env),
 	)
 }
 

--- a/pkg/toolsets/helm/toolset.go
+++ b/pkg/toolsets/helm/toolset.go
@@ -19,7 +19,7 @@ func (t *Toolset) GetDescription() string {
 	return "Tools for managing Helm charts and releases"
 }
 
-func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
+func (t *Toolset) GetTools(_ api.ToolsetEnv) []api.ServerTool {
 	return slices.Concat(
 		initHelm(),
 	)

--- a/pkg/toolsets/kcp/toolset.go
+++ b/pkg/toolsets/kcp/toolset.go
@@ -19,7 +19,7 @@ func (t *Toolset) GetDescription() string {
 	return "Manage kcp workspaces and multi-tenancy features"
 }
 
-func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
+func (t *Toolset) GetTools(_ api.ToolsetEnv) []api.ServerTool {
 	return slices.Concat(
 		initWorkspaceTools(),
 	)

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -21,7 +21,7 @@ func (t *Toolset) GetDescription() string {
 	return defaults.ToolsetDescription()
 }
 
-func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
+func (t *Toolset) GetTools(_ api.ToolsetEnv) []api.ServerTool {
 	return slices.Concat(
 		kialiTools.InitGetMeshGraph(),
 		kialiTools.InitManageIstioConfigRead(),

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -22,7 +22,7 @@ func (t *Toolset) GetDescription() string {
 	return "KubeVirt virtual machine management tools"
 }
 
-func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
+func (t *Toolset) GetTools(_ api.ToolsetEnv) []api.ServerTool {
 	return slices.Concat(
 		vm_clone.Tools(),
 		vm_create.Tools(),

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -32,7 +32,7 @@ func (t *TestToolset) GetName() string { return t.name }
 
 func (t *TestToolset) GetDescription() string { return t.description }
 
-func (t *TestToolset) GetTools(_ api.Openshift) []api.ServerTool { return nil }
+func (t *TestToolset) GetTools(_ api.ToolsetEnv) []api.ServerTool { return nil }
 
 func (t *TestToolset) GetPrompts() []api.ServerPrompt { return nil }
 


### PR DESCRIPTION
When we initially made the cluster provider strategy, the thinking was that everything could be handled transparently from the toolsets. While this has been true for the most part, as some toolsets are now adding functionality that calls to non kube API server APIs (e.g. a prometheus instance in the cluster), this somewhat breaks down.

In these scenarios, there is sometimes a need for the toolset to know what the strategy was so that it can determine if it needs/should use extra config (e.g. TLS config if not in the cluster).

This attempts to expose that config to toolsets where they can optionally consume it as needed