### PR TITLE
chore(evals): migrate claude code agent to acp

### DIFF
--- a/evals/claude-code/agent.yaml
+++ b/evals/claude-code/agent.yaml
@@ -1,5 +1,5 @@
 kind: Agent
 metadata:
-  name: "claude-code"
-builtin:
-  type: "claude-code"
+  name: "claude-code-acp"
+acp:
+  cmd: "claude-code-acp"


### PR DESCRIPTION
We are moving to using ACP within mcpchecker as it gives us much more rich information from the agent