### PR TITLE
test(observability): add comprehensive test suites for telemetry and metrics

### DIFF
--- a/pkg/mcp/mcp_metrics_test.go
+++ b/pkg/mcp/mcp_metrics_test.go
@@ -1,0 +1,172 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/suite"
+)
+
+type McpMetricsSuite struct {
+	BaseMcpSuite
+}
+
+func TestMcpMetrics(t *testing.T) {
+	suite.Run(t, new(McpMetricsSuite))
+}
+
+func (s *McpMetricsSuite) TestToolCallMetricsRecorded() {
+	s.InitMcpClient()
+	toolResult, err := s.CallTool("namespaces_list", map[string]interface{}{})
+	s.Require().Nilf(err, "call tool failed %v", err)
+	s.Require().Falsef(toolResult.IsError, "call tool failed")
+
+	stats := s.mcpServer.GetMetrics().GetStats()
+
+	s.Run("increments total tool call count", func() {
+		s.GreaterOrEqual(stats.TotalToolCalls, int64(1))
+	})
+
+	s.Run("records tool call by name", func() {
+		s.GreaterOrEqual(stats.ToolCallsByName["namespaces_list"], int64(1))
+	})
+
+	s.Run("does not record errors for successful calls", func() {
+		s.Equal(int64(0), stats.ToolErrorsByName["namespaces_list"])
+	})
+}
+
+func (s *McpMetricsSuite) TestToolCallErrorMetricsRecorded() {
+	s.InitMcpClient()
+
+	// Call a tool with missing required params to trigger an error result
+	toolResult, err := s.CallTool("pods_get", map[string]interface{}{})
+	s.Require().Nilf(err, "call tool should not return transport error %v", err)
+	s.Require().True(toolResult.IsError, "call tool should return error result for missing params")
+
+	stats := s.mcpServer.GetMetrics().GetStats()
+
+	s.Run("increments total tool call count", func() {
+		s.GreaterOrEqual(stats.TotalToolCalls, int64(1))
+	})
+
+	s.Run("records tool call by name", func() {
+		s.GreaterOrEqual(stats.ToolCallsByName["pods_get"], int64(1))
+	})
+}
+
+func (s *McpMetricsSuite) TestMultipleToolCallsAggregate() {
+	s.InitMcpClient()
+
+	_, err := s.CallTool("namespaces_list", map[string]interface{}{})
+	s.Require().Nilf(err, "first call failed %v", err)
+
+	_, err = s.CallTool("namespaces_list", map[string]interface{}{})
+	s.Require().Nilf(err, "second call failed %v", err)
+
+	_, err = s.CallTool("pods_list", map[string]interface{}{})
+	s.Require().Nilf(err, "third call failed %v", err)
+
+	stats := s.mcpServer.GetMetrics().GetStats()
+
+	s.Run("total count matches sum of calls", func() {
+		s.GreaterOrEqual(stats.TotalToolCalls, int64(3))
+	})
+
+	s.Run("per-tool counts are correct", func() {
+		s.GreaterOrEqual(stats.ToolCallsByName["namespaces_list"], int64(2))
+		s.GreaterOrEqual(stats.ToolCallsByName["pods_list"], int64(1))
+	})
+}
+
+func (s *McpMetricsSuite) TestPrometheusHandlerReflectsToolCalls() {
+	s.InitMcpClient()
+
+	_, err := s.CallTool("namespaces_list", map[string]interface{}{})
+	s.Require().Nilf(err, "call tool failed %v", err)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	s.mcpServer.GetMetrics().PrometheusHandler().ServeHTTP(rec, req)
+
+	s.Run("returns 200 OK", func() {
+		s.Equal(http.StatusOK, rec.Code)
+	})
+
+	body := rec.Body.String()
+
+	s.Run("contains tool call metrics", func() {
+		s.Contains(body, "k8s_mcp_tool_calls")
+	})
+
+	s.Run("contains tool duration metrics", func() {
+		s.Contains(body, "k8s_mcp_tool_duration")
+	})
+
+	s.Run("contains server info metric", func() {
+		s.Contains(body, "k8s_mcp_server_info")
+	})
+}
+
+func (s *McpMetricsSuite) TestStatsInitializedBeforeCalls() {
+	s.InitMcpClient()
+	stats := s.mcpServer.GetMetrics().GetStats()
+
+	s.Run("maps are initialized", func() {
+		s.NotNil(stats.ToolCallsByName)
+		s.NotNil(stats.ToolErrorsByName)
+		s.NotNil(stats.HTTPRequestsByPath)
+		s.NotNil(stats.HTTPRequestsByStatus)
+		s.NotNil(stats.HTTPRequestsByMethod)
+	})
+
+	s.Run("start time is set", func() {
+		s.Greater(stats.StartTime, int64(0))
+	})
+}
+
+func (s *McpMetricsSuite) TestMetricsShutdown() {
+	s.InitMcpClient()
+
+	_, err := s.CallTool("namespaces_list", map[string]interface{}{})
+	s.Require().Nilf(err, "call tool failed %v", err)
+
+	s.Run("completes without error", func() {
+		err := s.mcpServer.GetMetrics().Shutdown(context.Background())
+		s.NoError(err)
+	})
+}
+
+func (s *McpMetricsSuite) TestMetricsExportedToConfigEndpoint() {
+	var requestReceived atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	s.T().Setenv("OTEL_METRICS_EXPORTER", "")
+	s.T().Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	s.T().Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "")
+
+	s.Require().NoError(toml.Unmarshal([]byte(`
+		[telemetry]
+		endpoint = "`+server.URL+`"
+		protocol = "http/protobuf"
+	`), s.Cfg))
+	s.InitMcpClient()
+
+	_, err := s.CallTool("namespaces_list", map[string]interface{}{})
+	s.Require().Nilf(err, "call tool failed %v", err)
+
+	// Shutdown flushes the periodic reader, triggering export to the configured endpoint
+	s.Require().NoError(s.mcpServer.GetMetrics().Shutdown(context.Background()))
+
+	s.Run("exports to TOML-configured endpoint", func() {
+		s.True(requestReceived.Load(), "metrics should be exported to the TOML-configured endpoint")
+	})
+}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -2,8 +2,12 @@ package telemetry
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -38,20 +42,19 @@ func (s *TelemetrySuite) TestInitTracer() {
 	})
 
 	s.Run("sets global tracer provider", func() {
+		s.T().Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 		initialProvider := otel.GetTracerProvider()
 
 		cleanup, err := InitTracer("test-service", "1.0.0")
 		s.Require().NoError(err)
 		defer cleanup()
 
-		// Provider should be set (even if tracing is disabled)
 		currentProvider := otel.GetTracerProvider()
 		s.NotNil(currentProvider, "tracer provider should be set")
 
-		// If we actually got a TracerProvider, it should be different from initial
-		if _, ok := currentProvider.(*trace.TracerProvider); ok {
-			s.NotEqual(initialProvider, currentProvider, "should set new tracer provider")
-		}
+		_, isSDKProvider := currentProvider.(*trace.TracerProvider)
+		s.True(isSDKProvider, "should set SDK TracerProvider")
+		s.NotEqual(initialProvider, currentProvider, "should set new tracer provider")
 	})
 }
 
@@ -110,6 +113,311 @@ func (s *TelemetrySuite) TestInitTracerWithEmptyValues() {
 
 		s.NoError(err, "should handle both empty values")
 		s.NotNil(cleanup, "should return cleanup function")
+	})
+}
+
+func (s *TelemetrySuite) TestEnabled() {
+	s.Run("returns false when no tracer has been initialized", func() {
+		tracingEnabled.Store(false)
+
+		s.False(Enabled())
+	})
+
+	s.Run("returns true after InitTracerWithConfig with valid endpoint", func() {
+		tracingEnabled.Store(false)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := &config.TelemetryConfig{
+			Endpoint: server.URL,
+			Protocol: "http/protobuf",
+		}
+		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		s.Require().NoError(err)
+		defer cleanup()
+
+		s.True(Enabled())
+	})
+
+	s.Run("returns false after cleanup is called", func() {
+		tracingEnabled.Store(false)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := &config.TelemetryConfig{
+			Endpoint: server.URL,
+			Protocol: "http/protobuf",
+		}
+		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		s.Require().NoError(err)
+		s.Require().True(Enabled())
+
+		cleanup()
+
+		s.False(Enabled())
+	})
+}
+
+func (s *TelemetrySuite) TestInitTracerWithConfig() {
+	s.Run("returns no-op cleanup when cfg is nil", func() {
+		cleanup, err := InitTracerWithConfig(nil, "test-service", "1.0.0")
+
+		s.NoError(err)
+		s.NotNil(cleanup)
+		s.NotPanics(func() { cleanup() })
+	})
+
+	s.Run("returns no-op cleanup when cfg is not enabled", func() {
+		enabled := false
+		cfg := &config.TelemetryConfig{
+			Enabled:  &enabled,
+			Endpoint: "http://localhost:4317",
+		}
+
+		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+
+		s.NoError(err)
+		s.NotNil(cleanup)
+		s.False(Enabled())
+	})
+
+	s.Run("returns no-op cleanup when cfg has no endpoint", func() {
+		cfg := &config.TelemetryConfig{}
+
+		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+
+		s.NoError(err)
+		s.NotNil(cleanup)
+		s.False(Enabled())
+	})
+
+	s.Run("initializes tracing when config has valid endpoint", func() {
+		tracingEnabled.Store(false)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := &config.TelemetryConfig{
+			Endpoint: server.URL,
+			Protocol: "http/protobuf",
+		}
+
+		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		s.Require().NoError(err)
+		defer cleanup()
+
+		s.True(Enabled())
+	})
+
+	s.Run("cleanup restores enabled state to false", func() {
+		tracingEnabled.Store(false)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := &config.TelemetryConfig{
+			Endpoint: server.URL,
+			Protocol: "grpc",
+		}
+
+		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		s.Require().NoError(err)
+		s.Require().True(Enabled())
+
+		cleanup()
+
+		s.False(Enabled())
+	})
+
+	s.Run("sets the global OTel tracer provider", func() {
+		tracingEnabled.Store(false)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := &config.TelemetryConfig{
+			Endpoint: server.URL,
+			Protocol: "http/protobuf",
+		}
+		initialProvider := otel.GetTracerProvider()
+
+		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		s.Require().NoError(err)
+		defer cleanup()
+
+		currentProvider := otel.GetTracerProvider()
+		_, isSDKProvider := currentProvider.(*trace.TracerProvider)
+		s.True(isSDKProvider)
+		s.NotEqual(initialProvider, currentProvider)
+	})
+}
+
+func (s *TelemetrySuite) TestCreateExporter() {
+	s.Run("creates gRPC exporter by default", func() {
+		s.T().Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "")
+
+		ctx := context.Background()
+		exporter, err := createExporter(ctx)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("creates gRPC exporter for grpc protocol", func() {
+		s.T().Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+
+		ctx := context.Background()
+		exporter, err := createExporter(ctx)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("creates HTTP exporter for http/protobuf protocol", func() {
+		s.T().Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+
+		ctx := context.Background()
+		exporter, err := createExporter(ctx)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("creates HTTP exporter for http protocol alias", func() {
+		s.T().Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http")
+
+		ctx := context.Background()
+		exporter, err := createExporter(ctx)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("falls back to gRPC for unknown protocol", func() {
+		s.T().Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "unknown_protocol")
+
+		ctx := context.Background()
+		exporter, err := createExporter(ctx)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("handles case-insensitive protocol values", func() {
+		s.T().Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "HTTP/PROTOBUF")
+
+		ctx := context.Background()
+		exporter, err := createExporter(ctx)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+}
+
+func (s *TelemetrySuite) TestCreateExporterWithConfig() {
+	s.Run("creates gRPC exporter by default when protocol is empty", func() {
+		cfg := &config.TelemetryConfig{
+			Endpoint: "http://localhost:4317",
+		}
+
+		ctx := context.Background()
+		exporter, err := createExporterWithConfig(ctx, cfg)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("creates gRPC exporter for grpc protocol", func() {
+		cfg := &config.TelemetryConfig{
+			Endpoint: "http://localhost:4317",
+			Protocol: "grpc",
+		}
+
+		ctx := context.Background()
+		exporter, err := createExporterWithConfig(ctx, cfg)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("creates HTTP exporter for http/protobuf protocol", func() {
+		cfg := &config.TelemetryConfig{
+			Endpoint: "http://localhost:4318",
+			Protocol: "http/protobuf",
+		}
+
+		ctx := context.Background()
+		exporter, err := createExporterWithConfig(ctx, cfg)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("creates HTTP exporter for http protocol alias", func() {
+		cfg := &config.TelemetryConfig{
+			Endpoint: "http://localhost:4318",
+			Protocol: "http",
+		}
+
+		ctx := context.Background()
+		exporter, err := createExporterWithConfig(ctx, cfg)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("falls back to gRPC for unknown protocol", func() {
+		cfg := &config.TelemetryConfig{
+			Endpoint: "http://localhost:4317",
+			Protocol: "unknown_protocol",
+		}
+
+		ctx := context.Background()
+		exporter, err := createExporterWithConfig(ctx, cfg)
+		s.Require().NoError(err)
+		s.NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+	})
+
+	s.Run("sends traces to config endpoint", func() {
+		var requestReceived atomic.Bool
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestReceived.Store(true)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		s.T().Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+		s.T().Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "")
+
+		cfg := &config.TelemetryConfig{
+			Endpoint: server.URL,
+			Protocol: "http/protobuf",
+		}
+
+		ctx := context.Background()
+		exporter, err := createExporterWithConfig(ctx, cfg)
+		s.Require().NoError(err)
+		s.Require().NotNil(exporter)
+		defer func() { _ = exporter.Shutdown(ctx) }()
+
+		// Use a synchronous span processor to export immediately on span end
+		tp := trace.NewTracerProvider(
+			trace.WithSpanProcessor(trace.NewSimpleSpanProcessor(exporter)),
+		)
+		defer func() { _ = tp.Shutdown(ctx) }()
+
+		_, span := tp.Tracer("test").Start(ctx, "test-span")
+		span.End()
+
+		s.True(requestReceived.Load(), "exporter should send traces to the config endpoint")
 	})
 }
 
@@ -215,5 +523,124 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 			sampler := getSamplerFromEnv()
 			s.NotNil(sampler, "sampler should accept 1.0")
 		})
+	})
+}
+
+func (s *TelemetrySuite) TestGetSamplerFromConfig() {
+	s.Run("returns default ParentBased(AlwaysSample) when sampler is empty", func() {
+		cfg := &config.TelemetryConfig{}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+	})
+
+	s.Run("returns AlwaysSample for always_on", func() {
+		cfg := &config.TelemetryConfig{TracesSampler: "always_on"}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+	})
+
+	s.Run("returns NeverSample for always_off", func() {
+		cfg := &config.TelemetryConfig{TracesSampler: "always_off"}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+	})
+
+	s.Run("returns TraceIDRatioBased for traceidratio with valid arg", func() {
+		ratio := 0.5
+		cfg := &config.TelemetryConfig{
+			TracesSampler:    "traceidratio",
+			TracesSamplerArg: &ratio,
+		}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+	})
+
+	s.Run("returns TraceIDRatioBased with default 1.0 for traceidratio without arg", func() {
+		cfg := &config.TelemetryConfig{TracesSampler: "traceidratio"}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+	})
+
+	s.Run("returns ParentBased(AlwaysSample) for parentbased_always_on", func() {
+		cfg := &config.TelemetryConfig{TracesSampler: "parentbased_always_on"}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+	})
+
+	s.Run("returns ParentBased(NeverSample) for parentbased_always_off", func() {
+		cfg := &config.TelemetryConfig{TracesSampler: "parentbased_always_off"}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+	})
+
+	s.Run("returns ParentBased(TraceIDRatioBased) for parentbased_traceidratio", func() {
+		ratio := 0.1
+		cfg := &config.TelemetryConfig{
+			TracesSampler:    "parentbased_traceidratio",
+			TracesSamplerArg: &ratio,
+		}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+	})
+
+	s.Run("returns default for unknown sampler type", func() {
+		cfg := &config.TelemetryConfig{TracesSampler: "unknown_sampler"}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+	})
+
+	s.Run("handles edge case ratio values", func() {
+		s.Run("accepts 0.0", func() {
+			ratio := 0.0
+			cfg := &config.TelemetryConfig{
+				TracesSampler:    "traceidratio",
+				TracesSamplerArg: &ratio,
+			}
+
+			sampler := getSamplerFromConfig(cfg)
+			s.NotNil(sampler)
+		})
+
+		s.Run("accepts 1.0", func() {
+			ratio := 1.0
+			cfg := &config.TelemetryConfig{
+				TracesSampler:    "traceidratio",
+				TracesSamplerArg: &ratio,
+			}
+
+			sampler := getSamplerFromConfig(cfg)
+			s.NotNil(sampler)
+		})
+	})
+
+	s.Run("env var takes precedence over config sampler", func() {
+		s.T().Setenv("OTEL_TRACES_SAMPLER", "always_off")
+		cfg := &config.TelemetryConfig{TracesSampler: "always_on"}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
+		// The sampler returned should respect the env var override
+		// (GetTracesSampler returns the env var value)
+	})
+
+	s.Run("env var takes precedence over config sampler arg", func() {
+		s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "0.1")
+		ratio := 0.9
+		cfg := &config.TelemetryConfig{
+			TracesSampler:    "traceidratio",
+			TracesSamplerArg: &ratio,
+		}
+
+		sampler := getSamplerFromConfig(cfg)
+		s.NotNil(sampler)
 	})
 }


### PR DESCRIPTION
Follow-up to #834.

The observability implementation from #590 shipped without behavioral tests. This PR fills that gap across the telemetry and metrics packages:

- MCP-layer integration tests (`mcp_metrics_test.go`) exercising the full pipeline through `BaseMcpSuite`
- Unit tests for exporter creation, protocol selection, and sampler configuration
- Endpoint wiring tests that spin up an `httptest.Server` and verify the TOML config endpoint is actually used by the exporters (the bug #834 fixed)

Redundant unit tests were dropped where the MCP-layer integration tests already cover the same assertions. Combined `pkg/metrics/` coverage stays at 89.3%.

## Test plan

- [x] `go test ./pkg/telemetry/ -v -run TestTelemetry`
- [x] `go test ./pkg/metrics/ -v -run "TestOtelStatsCollector|TestMetrics"`
- [x] `go test ./pkg/mcp/ -v -run TestMcpMetrics`
- [x] `go vet` clean