### PR TITLE
fix(mcp): init request w/o client info does not panic

### DIFF
--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -204,7 +204,7 @@ func getMcpReqUserAgent(req mcp.Request) string {
 		return ""
 	}
 	initParams := session.InitializeParams()
-	if initParams == nil || (initParams.ClientInfo.Name == "" && initParams.ClientInfo.Version == "") {
+	if initParams == nil || initParams.ClientInfo == nil || (initParams.ClientInfo.Name == "" && initParams.ClientInfo.Version == "") {
 		return ""
 	}
 	return fmt.Sprintf("%s/%s", initParams.ClientInfo.Name, initParams.ClientInfo.Version)


### PR DESCRIPTION
Fixes #842 

It looks like when init request were sent without client info our user agent middleware (added in #760 ) would panic trying to access the client info.

IMO this case is rare since the spec seems to [mandate that client info is sent](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization), but putting a nil check here is probably fine.

Not sure if we should return something other than "" in this case though