### PR TITLE
Add clean_metadata option to resource tools for stripping verbose metadata

### DIFF
--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -456,6 +456,10 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"
@@ -492,6 +496,10 @@
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
+        },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
         },
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter resources by field values (e.g. 'status.phase=Running', 'metadata.name=myresource'). Supported fields vary by resource type. For Pods: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster-enum.json
@@ -723,6 +723,10 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
+        },
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "enum": [
@@ -767,6 +771,10 @@
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
+        },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
         },
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -651,6 +651,10 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
+        },
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "type": "string"
@@ -691,6 +695,10 @@
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
+        },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
         },
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -577,6 +577,10 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"
@@ -613,6 +617,10 @@
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
+        },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
         },
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter resources by field values (e.g. 'status.phase=Running', 'metadata.name=myresource'). Supported fields vary by resource type. For Pods: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -562,6 +562,10 @@
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
         },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
+        },
         "kind": {
           "description": "kind of the resource (examples of valid kind are: Pod, Service, Deployment, Ingress)",
           "type": "string"
@@ -598,6 +602,10 @@
         "apiVersion": {
           "description": "apiVersion of the resources (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
           "type": "string"
+        },
+        "clean_metadata": {
+          "description": "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+          "type": "boolean"
         },
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter resources by field values (e.g. 'status.phase=Running', 'metadata.name=myresource'). Supported fields vary by resource type. For Pods: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -39,6 +39,10 @@ func initResources(o api.Openshift) []api.ServerTool {
 						Type:        "string",
 						Description: "Optional Namespace to retrieve the namespaced resources from (ignored in case of cluster scoped resources). If not provided, will list resources from all namespaces",
 					},
+					"clean_metadata": {
+						Type:        "boolean",
+						Description: "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
+					},
 					"labelSelector": {
 						Type:        "string",
 						Description: "Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the resources by label",
@@ -76,6 +80,10 @@ func initResources(o api.Openshift) []api.ServerTool {
 					"namespace": {
 						Type:        "string",
 						Description: "Optional Namespace to retrieve the namespaced resource from (ignored in case of cluster scoped resources). If not provided, will get resource from configured namespace",
+					},
+					"clean_metadata": {
+						Type:        "boolean",
+						Description: "If true, strips verbose metadata (managedFields, resourceVersion, uid, generation, last-applied-configuration) from the output. Useful for diagnostics where only spec/status matter.",
 					},
 					"name": {
 						Type:        "string",
@@ -225,7 +233,14 @@ func resourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list resources: %w", err)), nil
 	}
-	return api.NewToolCallResult(params.ListOutput.PrintObj(ret)), nil
+	if params.ListOutput.AsTable() {
+		return api.NewToolCallResult(params.ListOutput.PrintObj(ret)), nil
+	}
+	var marshalOpts []output.MarshalOption
+	if clean, _ := params.GetArguments()["clean_metadata"].(bool); clean {
+		marshalOpts = append(marshalOpts, output.WithCleanMetadata())
+	}
+	return api.NewToolCallResult(output.MarshalYaml(ret, marshalOpts...)), nil
 }
 
 func resourcesGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
@@ -256,7 +271,11 @@ func resourcesGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get resource: %w", err)), nil
 	}
-	return api.NewToolCallResult(output.MarshalYaml(ret)), nil
+	var marshalOpts []output.MarshalOption
+	if clean, _ := params.GetArguments()["clean_metadata"].(bool); clean {
+		marshalOpts = append(marshalOpts, output.WithCleanMetadata())
+	}
+	return api.NewToolCallResult(output.MarshalYaml(ret, marshalOpts...)), nil
 }
 
 func resourcesCreateOrUpdate(params api.ToolHandlerParams) (*api.ToolCallResult, error) {


### PR DESCRIPTION
Introduce a clean_metadata boolean parameter on resources_get and resources_list that strips managedFields, resourceVersion, uid, generation, and the last-applied-configuration annotation from output. This reduces token consumption and lets LLMs focus on the diagnostically relevant spec/status fields.

Refactor MarshalYaml to accept functional options, replacing the previous hard-coded SetManagedFields(nil) with an opt-in WithCleanMetadata() option that performs a more thorough cleanup.

Assisted by: Cursor