### PR TITLE
Fix tool schema compatibility with OpenAI models

### DIFF
--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -18,7 +18,8 @@ func initConfiguration() []api.ServerTool {
 				Name:        "configuration_contexts_list",
 				Description: "List all available context names and associated server urls from the kubeconfig file",
 				InputSchema: &jsonschema.Schema{
-					Type: "object",
+					Type:       "object",
+					Properties: make(map[string]*jsonschema.Schema),
 				},
 				Annotations: api.ToolAnnotations{
 					Title:           "Configuration: Contexts List",
@@ -42,7 +43,8 @@ func initConfiguration() []api.ServerTool {
 				Name:        "targets_list",
 				Description: "List all available targets",
 				InputSchema: &jsonschema.Schema{
-					Type: "object",
+					Type:       "object",
+					Properties: make(map[string]*jsonschema.Schema),
 				},
 				Annotations: api.ToolAnnotations{
 					Title:           "Targets List",


### PR DESCRIPTION
OpenAI models require the "properties" field to be present in the JSON schema for tool input, even when a tool takes no parameters. Add an empty properties map to the configuration_contexts_list and targets_list tool schemas to ensure compatibility.

Assisted by: Cursor