### PR TITLE
test(mcp): add regression test for nil ClientInfo panic

### DIFF
--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"sync"
 	"testing"
@@ -255,6 +257,54 @@ func (s *UserAgentPropagationSuite) TestFallsBackToServerPrefixWhenNoClientInfo(
 	s.Require().NotNil(podsHeaders, "No requests were made to /api/v1/namespaces/default/pods")
 	s.Run("User-Agent uses server prefix only without trailing space", func() {
 		// When no HTTP User-Agent and empty MCP ClientInfo, should use server prefix only
+		s.Equal(
+			fmt.Sprintf("kubernetes-mcp-server/0.0.0 (%s/%s)", runtime.GOOS, runtime.GOARCH),
+			podsHeaders.Get("User-Agent"),
+		)
+	})
+}
+
+func (s *UserAgentPropagationSuite) TestDoesNotPanicWhenClientInfoIsNil() {
+	// Regression test for https://github.com/containers/kubernetes-mcp-server/issues/842
+	// Fixed in https://github.com/containers/kubernetes-mcp-server/pull/844
+	//
+	// The MCP spec mandates that clientInfo is sent during initialization:
+	// https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization
+	// However, some non-compliant clients omit it, which caused a nil pointer panic
+	// in the user-agent middleware. This test verifies that the server handles
+	// non-compliant clients gracefully by sending a raw initialize request without clientInfo.
+	provider, err := internalk8s.NewProvider(s.Cfg)
+	s.Require().NoError(err)
+	s.mcpServer, err = NewServer(Configuration{StaticConfig: s.Cfg}, provider)
+	s.Require().NoError(err)
+	handler := s.mcpServer.ServeHTTP()
+	strippedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Del("User-Agent")
+		handler.ServeHTTP(w, r)
+	})
+	httpServer := httptest.NewServer(strippedHandler)
+	defer httpServer.Close()
+
+	// Send raw initialize request without clientInfo (non-compliant client)
+	endpoint := httpServer.URL + "/mcp"
+	initResp := test.McpRawPost(s.T(), endpoint, "",
+		`{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}`)
+	defer func() { _ = initResp.Body.Close() }()
+	_, _ = io.ReadAll(initResp.Body)
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	s.Require().NotEmpty(sessionID, "Expected session ID in response")
+
+	// Send tool call - this would panic before the fix when ClientInfo was nil
+	toolResp := test.McpRawPost(s.T(), endpoint, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"pods_list","arguments":{}}}`)
+	defer func() { _ = toolResp.Body.Close() }()
+
+	s.pathHeadersMux.Lock()
+	podsHeaders := s.pathHeaders["/api/v1/namespaces/default/pods"]
+	s.pathHeadersMux.Unlock()
+
+	s.Require().NotNil(podsHeaders, "No requests were made to /api/v1/namespaces/default/pods")
+	s.Run("User-Agent uses server prefix only when clientInfo is nil", func() {
 		s.Equal(
 			fmt.Sprintf("kubernetes-mcp-server/0.0.0 (%s/%s)", runtime.GOOS, runtime.GOARCH),
 			podsHeaders.Get("User-Agent"),


### PR DESCRIPTION
Adds a regression test for the nil `ClientInfo` panic fixed in #844 (originally reported in #842).

The existing `TestFallsBackToServerPrefixWhenNoClientInfo` test uses `WithEmptyClientInfo()` which sets `ClientInfo` to an empty (but non-nil) `*Implementation{}`. This doesn't cover the actual panic scenario where `ClientInfo` is `nil` — which happens when a client omits `clientInfo` from the initialize request entirely.

Since the go-sdk client [always sets `clientInfo`](https://github.com/modelcontextprotocol/go-sdk/blob/v1.3.0/mcp/client.go#L241) and [panics if the implementation is nil](https://github.com/modelcontextprotocol/go-sdk/blob/v1.3.0/mcp/client.go#L46-L48), we can't reproduce this through the standard test client. Instead, the new test sends raw HTTP JSON-RPC requests with an initialize payload that omits `clientInfo`, simulating a non-compliant client. This approach is inspired by the [`CallToolRaw` pattern](https://github.com/manusa/podman-mcp-server/blob/b6b0cc1/internal/test/mcp.go#L141) used in [podman-mcp-server](https://github.com/manusa/podman-mcp-server) for testing raw JSON-RPC interactions.

The [MCP spec mandates](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization) that `clientInfo` is sent during initialization, but some clients don't follow this, so we should handle it gracefully.