### PR TITLE
fix(mcp): tool call without arguments does not panic

### DIFF
--- a/internal/test/mcp.go
+++ b/internal/test/mcp.go
@@ -3,8 +3,10 @@ package test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -248,6 +250,36 @@ func (m *McpClient) CallTool(name string, args map[string]any) (*mcp.CallToolRes
 		Name:      name,
 		Arguments: args,
 	})
+}
+
+// CallToolRaw sends a raw JSON-RPC tools/call request bypassing the go-sdk client.
+// This allows sending requests exactly as a non-go-sdk MCP client would, without
+// the go-sdk's automatic normalization (e.g., the go-sdk always adds "arguments": {}
+// even when nil).
+// The jsonParams is the raw JSON for the "params" field of the JSON-RPC request.
+func (m *McpClient) CallToolRaw(t *testing.T, jsonParams string) *http.Response {
+	t.Helper()
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":99,"method":"tools/call","params":%s}`, jsonParams)
+	return McpRawPost(t, m.testServer.URL+"/mcp", m.Session.ID(), body)
+}
+
+// McpRawPost sends a raw JSON-RPC request to an MCP HTTP endpoint.
+// This is useful for testing MCP protocol edge cases that can't be reproduced through
+// the go-sdk client due to its automatic normalization (e.g., always adding "arguments": {},
+// always setting clientInfo).
+// The jsonBody should be a complete JSON-RPC message.
+func McpRawPost(t *testing.T, endpoint, sessionID, jsonBody string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(jsonBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
 }
 
 // ListTools helper function to list available tools

--- a/pkg/mcp/gosdk.go
+++ b/pkg/mcp/gosdk.go
@@ -81,8 +81,10 @@ func GoSdkToolCallRequestToToolCallRequest(request *mcp.CallToolRequest) (*ToolC
 
 func GoSdkToolCallParamsToToolCallRequest(toolCallParams *mcp.CallToolParamsRaw) (*ToolCallRequest, error) {
 	var arguments map[string]any
-	if err := json.Unmarshal(toolCallParams.Arguments, &arguments); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal tool call arguments: %w", err)
+	if len(toolCallParams.Arguments) > 0 {
+		if err := json.Unmarshal(toolCallParams.Arguments, &arguments); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal tool call arguments: %w", err)
+		}
 	}
 	return &ToolCallRequest{
 		Name:      toolCallParams.Name,

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -70,8 +70,10 @@ func toolCallLoggingMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 		switch params := req.GetParams().(type) {
 		case *mcp.CallToolParamsRaw:
-			toolCallRequest, _ := GoSdkToolCallParamsToToolCallRequest(params)
-			klog.V(5).Infof("mcp tool call: %s(%v)", toolCallRequest.Name, toolCallRequest.GetArguments())
+			toolCallRequest, err := GoSdkToolCallParamsToToolCallRequest(params)
+			if err == nil {
+				klog.V(5).Infof("mcp tool call: %s(%v)", toolCallRequest.Name, toolCallRequest.GetArguments())
+			}
 			if req.GetExtra() != nil && req.GetExtra().Header != nil {
 				buffer := bytes.NewBuffer(make([]byte, 0))
 				if err := req.GetExtra().Header.WriteSubset(buffer, map[string]bool{"Authorization": true, "authorization": true}); err == nil {

--- a/pkg/mcp/namespaces_test.go
+++ b/pkg/mcp/namespaces_test.go
@@ -46,6 +46,24 @@ func (s *NamespacesSuite) TestNamespacesList() {
 	})
 }
 
+// TestNamespacesListWithoutArguments verifies that namespaces_list can be called when the
+// MCP client omits the "arguments" field from the tools/call JSON-RPC request.
+// The MCP spec defines arguments as optional (arguments?: { [key: string]: unknown }),
+// so spec-compliant clients may omit it entirely for tools with no required parameters.
+// This is an edge case because most mainstream MCP clients (Claude Desktop, Cursor, etc.)
+// always send "arguments": {}, but custom or minimal clients may not.
+// https://github.com/containers/kubernetes-mcp-server/issues/849
+func (s *NamespacesSuite) TestNamespacesListWithoutArguments() {
+	s.InitMcpClient()
+	s.Run("namespaces_list without arguments does not panic", func() {
+		// Send a raw JSON-RPC request without the "arguments" field, bypassing
+		// the go-sdk client which always normalizes nil arguments to {}.
+		resp := s.CallToolRaw(s.T(), `{"name":"namespaces_list"}`)
+		defer func() { _ = resp.Body.Close() }()
+		s.Equal(200, resp.StatusCode)
+	})
+}
+
 func (s *NamespacesSuite) TestNamespacesListDenied() {
 	s.Require().NoError(toml.Unmarshal([]byte(`
 		denied_resources = [ { version = "v1", kind = "Namespace" } ]


### PR DESCRIPTION
## Summary

- Fix nil pointer dereference panic when an MCP client omits the `arguments` field from a `tools/call` JSON-RPC request
- The MCP spec defines `arguments` as [optional](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-11-25/schema.ts) (`arguments?: { [key: string]: unknown }`), so clients that omit it are spec-compliant
- This is an edge case since most mainstream MCP clients always send `"arguments": {}`, but custom or minimal clients may not
- Bug has been present since v0.0.55 (introduced in `b4c20f9` — the go-sdk refactor)

### Changes

- `GoSdkToolCallParamsToToolCallRequest` now skips `json.Unmarshal` when `Arguments` is nil, returning a valid `ToolCallRequest` instead of an error
- `toolCallLoggingMiddleware` now checks the error from `GoSdkToolCallParamsToToolCallRequest` instead of discarding it with `_`
- Adds `test.McpRawPost`, a reusable helper for sending raw JSON-RPC requests to MCP HTTP endpoints bypassing go-sdk client normalization
- Adds `McpClient.CallToolRaw` convenience wrapper for tests using `BaseMcpSuite`

### Overlap with #848

This PR introduces `test.McpRawPost` which serves the same purpose as the inline raw HTTP code in #848. Once this PR is merged, #848 can be rebased to replace its inline HTTP boilerplate with `test.McpRawPost` calls.

## Test plan

- [x] New test `TestNamespacesListWithoutArguments` sends a raw `tools/call` request without `arguments` through the full MCP middleware chain — panics without the fix, passes with it
- [x] Existing `TestMcpLogging` and `TestNamespaces` tests pass (no regressions)

Fixes #849