### PR TITLE
docs(kubevirt): address PR #815 review comments

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,8 +22,8 @@ Choose the guide that matches your needs:
 
 ## Toolset Guides
 
-- **[KubeVirt](kubevirt.md)** - KubeVirt virtual machine management tools
 - **[Kiali](KIALI.md)** - Tools for Kiali ServiceMesh with Istio
+- **[KubeVirt](kubevirt.md)** - KubeVirt virtual machine management tools
 
 ## Advanced Topics
 

--- a/docs/kubevirt.md
+++ b/docs/kubevirt.md
@@ -31,7 +31,7 @@ No additional toolset-specific configuration is required. The server uses your e
 
 Create a VirtualMachine in the cluster. The tool automatically resolves instance types, preferences, and container disk images based on the provided parameters.
 
-- **Workload resolution** - Accepts OS names such as `fedora`, `ubuntu`, `centos`, `centos-stream`, `debian`, `rhel`, `opensuse`, `opensuse-tumbleweed`, and `opensuse-leap`. These are resolved to container disk images from `quay.io/containerdisks`. Full container disk image URLs are also accepted. If DataSources are available in the cluster, the tool will match against those first.
+- **Workload resolution** - Accepts OS names such as `fedora`, `ubuntu`, `centos`, `centos-stream`, `debian`, `rhel8`, `rhel9`, `rhel10`, `opensuse`, `opensuse-tumbleweed`, and `opensuse-leap`. These are resolved to container disk images from `quay.io/containerdisks`. Full container disk image URLs are also accepted. If DataSources are available in the cluster, the tool will match against those first.
 - **Instance type resolution** - Automatically selects an appropriate instance type based on the `size` (e.g., `small`, `medium`, `large`) and `performance` (e.g., `general-purpose`, `overcommitted`, `compute-optimized`, `memory-optimized`) hints. Instance types can also be specified explicitly.
 - **Preference resolution** - Resolves VM preferences from cluster resources or DataSource defaults.
 - **Networking** - Supports attaching secondary network interfaces via Multus NetworkAttachmentDefinitions.


### PR DESCRIPTION
- Sort toolset guides alphabetically in `docs/README.md` (Kiali before KubeVirt)
- Fix OS names in `docs/kubevirt.md` to list `rhel8`, `rhel9`, `rhel10` instead of `rhel`, matching the actual `osMap` in `pkg/toolsets/kubevirt/vm/create/tool.go`

Addresses review comments from #815.