### PR TITLE
fix(kubernetes): wrappers only applied once in `.Derived`

### DIFF
--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -129,7 +129,6 @@ func (m *Manager) Derived(ctx context.Context) (*Kubernetes, error) {
 	derivedCfg := &rest.Config{
 		Host:          m.kubernetes.RESTConfig().Host,
 		APIPath:       m.kubernetes.RESTConfig().APIPath,
-		WrapTransport: m.kubernetes.RESTConfig().WrapTransport,
 		// Copy only server verification TLS settings (CA bundle and server name)
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure:   m.kubernetes.RESTConfig().Insecure,


### PR DESCRIPTION
While reviewing #850 I realized that we currently have the access control/user agent wrappers applied twice when creating the .Derived:

1. They are in the original base config and copied over into the derived config
2. They are then applied again in `NewKubernetes`, effectively making a chain of AccessControlRoundTripper -> UserAgentRoundTripper -> AccessControlRoundTripper -> UserAgentRoundTripper