### PR TITLE
chore(formatting) fix incorrect formatting 

### DIFF
--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -127,8 +127,8 @@ func (m *Manager) Derived(ctx context.Context) (*Kubernetes, error) {
 		userAgent = ua
 	}
 	derivedCfg := &rest.Config{
-		Host:          m.kubernetes.RESTConfig().Host,
-		APIPath:       m.kubernetes.RESTConfig().APIPath,
+		Host:    m.kubernetes.RESTConfig().Host,
+		APIPath: m.kubernetes.RESTConfig().APIPath,
 		// Copy only server verification TLS settings (CA bundle and server name)
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure:   m.kubernetes.RESTConfig().Insecure,


### PR DESCRIPTION
Since `make build` runs formatting rules, now after each build code is locally changed, due to  https://github.com/containers/kubernetes-mcp-server/pull/861 removing field