### PR TITLE
chore(ci): add formatting check to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,25 @@ defaults:
     shell: bash
 
 jobs:
+  check-format:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Run make format
+        run: make format
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::Code is not formatted. Please run 'go fmt ./...' and commit the changes."
+            git diff
+            exit 1
+          fi
+
   check-readme:
     name: Check README is up-to-date
     runs-on: ubuntu-latest
@@ -47,6 +66,7 @@ jobs:
           fi
 
   build:
+    needs: [check-format, check-readme]
     name: Build on ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Adds a `check-format` CI job that runs `make format` and fails if there are uncommitted formatting changes
- Makes the `build` matrix depend on both `check-format` and `check-readme` to save CI resources on early failures
- Prevents issues like #881 where a PR introduces formatting drift that affects subsequent contributors

Refs #881