### PR TITLE
chore(docs): reorganize validation documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,10 @@ The `docs/` directory contains user-facing documentation:
 - `docs/getting-started-claude-code.md` – Claude Code CLI integration
 - `docs/KEYCLOAK_OIDC_SETUP.md` – OAuth/OIDC developer setup
 
+The `docs/specs/` directory contains feature specifications (living documentation for coding agents):
+
+- `docs/specs/validation.md` – Pre-execution validation layer specification (resource existence, schema, RBAC)
+
 ### Documentation conventions
 
 - Use **lowercase filenames** for new documentation files (e.g., `configuration.md`, `prompts.md`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,14 @@ Choose the guide that matches your needs:
 - **[Kiali](KIALI.md)** - Tools for Kiali ServiceMesh with Istio
 - **[KubeVirt](kubevirt.md)** - KubeVirt virtual machine management tools
 
+## Feature Specifications
+
+Living documentation for implemented and planned features:
+
+| Spec | Description | Status |
+|------|-------------|--------|
+| **[Validation](specs/validation.md)** | Pre-execution validation layer (resource existence, schema, RBAC) | Implemented |
+
 ## Advanced Topics
 
 - **[MCP Logging](logging.md)** - Structured logging to MCP clients with automatic K8s error categorization and secret redaction

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ This reference focuses on TOML file configuration. For CLI arguments, see the [C
   - [Prompts](#prompts)
   - [OAuth and Authorization](#oauth-and-authorization)
   - [Telemetry](#telemetry)
+  - [Validation](#validation)
   - [Toolset-Specific Configuration](#toolset-specific-configuration)
   - [Cluster Provider Configuration](#cluster-provider-configuration)
 - [CLI Configuration Options](#cli-configuration-options)
@@ -458,6 +459,28 @@ Configure OpenTelemetry distributed tracing and metrics. See [OTEL.md](OTEL.md) 
 endpoint = "http://localhost:4317"
 traces_sampler = "traceidratio"
 traces_sampler_arg = 0.1  # 10% sampling
+```
+
+### Validation
+
+Pre-execution validation catches errors before they reach the Kubernetes API, providing clearer error messages for issues like typos in resource names, invalid fields, and missing permissions.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `validation_enabled` | boolean | `false` | When `true`, enables schema validation and RBAC pre-checks for all API requests. Resource existence is always checked regardless of this setting. |
+
+When enabled, the validation layer runs at the HTTP RoundTripper level, intercepting all Kubernetes API calls (including those from plugins like Helm, KubeVirt, and Kiali). It performs:
+
+- **Schema validation** — Validates resource manifests against the cluster's OpenAPI schema for create/update operations
+- **RBAC pre-checks** — Verifies permissions using `SelfSubjectAccessReview` before attempting operations
+
+Resource existence validation (catching typos like "Deploymnt" instead of "Deployment") runs as part of access control regardless of this setting.
+
+For detailed information about the validation flow, error codes, and behavior, see the [validation specification](specs/validation.md).
+
+**Example:**
+```toml
+validation_enabled = true
 ```
 
 ### Toolset-Specific Configuration

--- a/docs/specs/validation.md
+++ b/docs/specs/validation.md
@@ -13,7 +13,7 @@ the server doesn't have a resource type "Deploymnt"
 With validation enabled, you get clearer feedback:
 
 ```
-Resource apps/v1/Deploymnt does not exist in the cluster
+Validation Error [RESOURCE_NOT_FOUND]: Resource deploymnt does not exist in the cluster
 ```
 
 The validation layer catches these types of issues:
@@ -76,7 +76,7 @@ The access control layer validates that the requested resource type exists in th
 
 **Example error:**
 ```
-RESOURCE_NOT_FOUND: Resource deployments.apps does not exist in the cluster
+Validation Error [RESOURCE_NOT_FOUND]: Resource deploymnt.apps does not exist in the cluster
 ```
 
 ### 2. Schema Validation
@@ -90,7 +90,7 @@ Validates resource manifests against the cluster's OpenAPI schema for create/upd
 
 **Example error:**
 ```
-INVALID_FIELD: unknown field "spec.replcias"
+Validation Error [INVALID_FIELD]: unknown field "spec.replcias"
 ```
 
 **Note:** Schema validation uses kubectl's validation library and caches the OpenAPI schema for 15 minutes.
@@ -106,7 +106,7 @@ Pre-checks permissions using Kubernetes `SelfSubjectAccessReview` before attempt
 
 **Example error:**
 ```
-PERMISSION_DENIED: Cannot create deployments.apps in namespace "production"
+Validation Error [PERMISSION_DENIED]: Cannot create deployments.apps in namespace "production"
 ```
 
 **Note:** RBAC validation uses the same credentials as the actual operation - either the server's service account or the user's token (when OAuth is enabled).


### PR DESCRIPTION
## Summary

- Move validation spec from `docs/VALIDATION.md` to `docs/specs/validation.md` for a clearer separation between user-facing guides and feature specifications used by coding agents
- Add `validation_enabled` configuration option to `docs/configuration.md` (was missing from the configuration reference)
- Fix error format examples in the validation spec to match actual code output (`Validation Error [CODE]: message` format)
- Add Feature Specifications section to `docs/README.md`
- Document `docs/specs/` directory in `AGENTS.md`