### PR TITLE
refactor(kubernetes): use typed errors in schema validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/logr v1.4.3
+	github.com/google/gnostic-models v0.7.0
 	github.com/google/jsonschema-go v0.4.2
 	github.com/modelcontextprotocol/go-sdk v1.4.0
 	github.com/prometheus/client_golang v1.23.2
@@ -28,6 +29,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.42.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.19.0
+	google.golang.org/protobuf v1.36.11
 	helm.sh/helm/v3 v3.20.0
 	k8s.io/api v0.35.2
 	k8s.io/apiextensions-apiserver v0.35.2
@@ -35,6 +37,7 @@ require (
 	k8s.io/cli-runtime v0.35.2
 	k8s.io/client-go v0.35.2
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
 	k8s.io/kubectl v0.35.2
 	k8s.io/metrics v0.35.2
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
@@ -77,7 +80,6 @@ require (
 	github.com/go-openapi/swag v0.23.1 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
@@ -145,13 +147,11 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/grpc v1.79.2 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.35.2 // indirect
 	k8s.io/component-base v0.35.2 // indirect
-	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.20.1 // indirect

--- a/pkg/kubernetes/schema_validator.go
+++ b/pkg/kubernetes/schema_validator.go
@@ -2,13 +2,16 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/klog/v2"
+	openapierrors "k8s.io/kube-openapi/pkg/util/proto/validation"
 	kubectlopenapi "k8s.io/kubectl/pkg/util/openapi"
 	kubectlvalidation "k8s.io/kubectl/pkg/validation"
 )
@@ -111,20 +114,40 @@ func convertKubectlValidationError(err error) *api.ValidationError {
 		return nil
 	}
 
-	errMsg := err.Error()
-
 	var field string
-	if strings.Contains(errMsg, "unknown field") {
-		if start := strings.Index(errMsg, "\""); start != -1 {
-			if end := strings.Index(errMsg[start+1:], "\""); end != -1 {
-				field = errMsg[start+1 : start+1+end]
+	var agg utilerrors.Aggregate
+	if errors.As(err, &agg) {
+		for _, e := range agg.Errors() {
+			if f := extractUnknownField(e); f != "" {
+				field = f
+				break
 			}
 		}
+	} else {
+		field = extractUnknownField(err)
 	}
 
 	return &api.ValidationError{
 		Code:    api.ErrorCodeInvalidField,
-		Message: errMsg,
+		Message: err.Error(),
 		Field:   field,
 	}
+}
+
+// extractUnknownField extracts the field name from an UnknownFieldError.
+// The error may be wrapped in a ValidationError from kube-openapi, which
+// does not implement Unwrap(), so we check both the error itself and the
+// wrapped Err field.
+func extractUnknownField(err error) string {
+	var unknownField openapierrors.UnknownFieldError
+	if errors.As(err, &unknownField) {
+		return unknownField.Field
+	}
+	var validationErr openapierrors.ValidationError
+	if errors.As(err, &validationErr) {
+		if errors.As(validationErr.Err, &unknownField) {
+			return unknownField.Field
+		}
+	}
+	return ""
 }

--- a/pkg/kubernetes/schema_validator_test.go
+++ b/pkg/kubernetes/schema_validator_test.go
@@ -1,0 +1,187 @@
+package kubernetes
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+)
+
+type SchemaValidatorTestSuite struct {
+	suite.Suite
+	mockServer      *test.MockServer
+	schemaValidator *SchemaValidator
+}
+
+func (s *SchemaValidatorTestSuite) SetupTest() {
+	s.mockServer = test.NewMockServer()
+	s.mockServer.Handle(test.NewDiscoveryClientHandler())
+	s.mockServer.Handle(newOpenAPISchemaHandler())
+
+	clientSet, err := kubernetes.NewForConfig(s.mockServer.Config())
+	s.Require().NoError(err)
+	discoveryClient := clientSet.Discovery()
+
+	s.schemaValidator = NewSchemaValidator(func() discovery.DiscoveryInterface {
+		return discoveryClient
+	})
+}
+
+func (s *SchemaValidatorTestSuite) TearDownTest() {
+	s.mockServer.Close()
+}
+
+func (s *SchemaValidatorTestSuite) createRequest(verb string, body string) *api.HTTPValidationRequest {
+	return &api.HTTPValidationRequest{
+		GVK:  &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+		Body: []byte(body),
+		Verb: verb,
+	}
+}
+
+func (s *SchemaValidatorTestSuite) TestName() {
+	s.Equal("schema", s.schemaValidator.Name())
+}
+
+func (s *SchemaValidatorTestSuite) TestValidate() {
+	s.Run("nil GVK returns no error", func() {
+		err := s.schemaValidator.Validate(context.Background(), &api.HTTPValidationRequest{
+			Body: []byte(`{"apiVersion":"v1","kind":"Pod"}`),
+			Verb: "create",
+		})
+		s.NoError(err)
+	})
+	s.Run("empty body returns no error", func() {
+		err := s.schemaValidator.Validate(context.Background(), &api.HTTPValidationRequest{
+			GVK:  &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Verb: "create",
+		})
+		s.NoError(err)
+	})
+	s.Run("non create or update verb returns no error", func() {
+		for _, verb := range []string{"get", "list", "delete", "patch", "watch"} {
+			err := s.schemaValidator.Validate(context.Background(), s.createRequest(verb, `{"apiVersion":"v1","kind":"Pod","specTypo":"bad"}`))
+			s.NoError(err, "verb %q should not trigger validation", verb)
+		}
+	})
+	s.Run("nil discovery client returns no error", func() {
+		sv := NewSchemaValidator(func() discovery.DiscoveryInterface { return nil })
+		err := sv.Validate(context.Background(), s.createRequest("create", `{"apiVersion":"v1","kind":"Pod"}`))
+		s.NoError(err)
+	})
+	s.Run("valid manifest returns no error", func() {
+		err := s.schemaValidator.Validate(context.Background(), s.createRequest("create",
+			`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test"},"spec":{"containers":[]}}`))
+		s.NoError(err)
+	})
+	s.Run("unknown field returns validation error with field name", func() {
+		err := s.schemaValidator.Validate(context.Background(), s.createRequest("create",
+			`{"apiVersion":"v1","kind":"Pod","specTypo":"bad"}`))
+		s.Require().Error(err)
+		var ve *api.ValidationError
+		s.Require().ErrorAs(err, &ve)
+		s.Equal(api.ErrorCodeInvalidField, ve.Code)
+		s.Equal("specTypo", ve.Field)
+		s.Contains(ve.Message, "specTypo")
+	})
+	s.Run("unknown nested field returns validation error with field name", func() {
+		err := s.schemaValidator.Validate(context.Background(), s.createRequest("create",
+			`{"apiVersion":"v1","kind":"Pod","spec":{"badField":"value"}}`))
+		s.Require().Error(err)
+		var ve *api.ValidationError
+		s.Require().ErrorAs(err, &ve)
+		s.Equal(api.ErrorCodeInvalidField, ve.Code)
+		s.Equal("badField", ve.Field)
+	})
+	s.Run("update verb triggers validation", func() {
+		err := s.schemaValidator.Validate(context.Background(), s.createRequest("update",
+			`{"apiVersion":"v1","kind":"Pod","unknownField":"bad"}`))
+		s.Error(err)
+	})
+	s.Run("unknown resource type skips validation", func() {
+		req := &api.HTTPValidationRequest{
+			GVK:  &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "UnknownKind"},
+			Body: []byte(`{"apiVersion":"v1","kind":"UnknownKind","whatever":"bad"}`),
+			Verb: "create",
+		}
+		err := s.schemaValidator.Validate(context.Background(), req)
+		s.NoError(err)
+	})
+}
+
+func TestSchemaValidator(t *testing.T) {
+	suite.Run(t, new(SchemaValidatorTestSuite))
+}
+
+// newOpenAPISchemaHandler creates an HTTP handler that serves a minimal OpenAPI v2
+// document at /openapi/v2 as protobuf. It defines a Pod resource (v1/Pod) with
+// apiVersion, kind, metadata, and spec properties so that schema validation can
+// detect unknown fields.
+func newOpenAPISchemaHandler() http.Handler {
+	doc := &openapi_v2.Document{
+		Swagger: "2.0",
+		Info:    &openapi_v2.Info{Title: "Test", Version: "v1"},
+		Definitions: &openapi_v2.Definitions{
+			AdditionalProperties: []*openapi_v2.NamedSchema{
+				{
+					Name: "io.k8s.api.core.v1.Pod",
+					Value: &openapi_v2.Schema{
+						Type: &openapi_v2.TypeItem{Value: []string{"object"}},
+						Properties: &openapi_v2.Properties{
+							AdditionalProperties: []*openapi_v2.NamedSchema{
+								{Name: "apiVersion", Value: &openapi_v2.Schema{Type: &openapi_v2.TypeItem{Value: []string{"string"}}}},
+								{Name: "kind", Value: &openapi_v2.Schema{Type: &openapi_v2.TypeItem{Value: []string{"string"}}}},
+								{Name: "metadata", Value: &openapi_v2.Schema{Type: &openapi_v2.TypeItem{Value: []string{"object"}}}},
+								{Name: "spec", Value: &openapi_v2.Schema{
+									Type: &openapi_v2.TypeItem{Value: []string{"object"}},
+									Properties: &openapi_v2.Properties{
+										AdditionalProperties: []*openapi_v2.NamedSchema{
+											{Name: "containers", Value: &openapi_v2.Schema{
+												Type: &openapi_v2.TypeItem{Value: []string{"array"}},
+												Items: &openapi_v2.ItemsItem{
+													Schema: []*openapi_v2.Schema{
+														{Type: &openapi_v2.TypeItem{Value: []string{"object"}}},
+													},
+												},
+											}},
+										},
+									},
+								}},
+							},
+						},
+						VendorExtension: []*openapi_v2.NamedAny{
+							{
+								Name: "x-kubernetes-group-version-kind",
+								Value: &openapi_v2.Any{
+									Yaml: "- group: \"\"\n  version: v1\n  kind: Pod\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := proto.Marshal(doc)
+	if err != nil {
+		panic("failed to marshal OpenAPI v2 document: " + err.Error())
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/openapi/v2" {
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	})
+}


### PR DESCRIPTION
## Summary

- Replace brittle string parsing in `convertKubectlValidationError` with typed error assertions using `errors.As`
- Handle the kube-openapi wrapping chain (`Aggregate` → `ValidationError` → `UnknownFieldError`) since `ValidationError` doesn't implement `Unwrap()`
- Add `SchemaValidator` test suite using `MockServer` with a minimal OpenAPI v2 schema handler that exercises the full discovery → schema parsing → validation pipeline


Fixes #888