### PR TITLE
fix(config): normalize trimmed paths in validation before use

### DIFF
--- a/charts/kubernetes-mcp-server/README.md
+++ b/charts/kubernetes-mcp-server/README.md
@@ -126,7 +126,7 @@ Each container accepts any valid Kubernetes container field including `image`, `
 | service | object | `{"annotations":{},"port":8080,"targetPort":"http","type":"ClusterIP"}` | This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | service.annotations | object | `{}` | Annotations to add to the service |
 | service.port | int | `8080` | This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports |
-| service.targetPort | string | `"http"` | Target port for the service. Useful when deploying with an proxy sidecar or exposing a different port. Set this to the sidecar's port to route traffic through the proxy before reaching the main container. |
+| service.targetPort | string | `"http"` | Target port for the service. Useful when deploying with a proxy sidecar or exposing a different port. Set this to the sidecar's port to route traffic through the proxy before reaching the main container. |
 | service.type | string | `"ClusterIP"` | This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types |
 | serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/ |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -118,8 +118,7 @@ service:
   type: ClusterIP
   # -- This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8080
-  # -- This sets the target port on the pod. Defaults to "http" (the container port name).
-  # -- Target port for the service. Useful when deploying with an proxy sidecar or exposing a different port. Set this to the sidecar's port to route traffic through the proxy before reaching the main container.
+  # -- Target port for the service. Useful when deploying with a proxy sidecar or exposing a different port. Set this to the sidecar's port to route traffic through the proxy before reaching the main container.
   targetPort: http
   # -- Annotations to add to the service
   annotations: {}

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -303,14 +303,17 @@ func (m *MCPServerOptions) Validate() error {
 		}
 	}
 	// Validate that certificate_authority is a valid file
-	if caValue := strings.TrimSpace(m.StaticConfig.CertificateAuthority); caValue != "" {
-		if _, err := os.Stat(caValue); err != nil {
+	m.StaticConfig.CertificateAuthority = strings.TrimSpace(m.StaticConfig.CertificateAuthority)
+	if m.StaticConfig.CertificateAuthority != "" {
+		if _, err := os.Stat(m.StaticConfig.CertificateAuthority); err != nil {
 			return fmt.Errorf("certificate-authority must be a valid file path: %w", err)
 		}
 	}
 	// Validate TLS configuration
 	tlsCert := strings.TrimSpace(m.StaticConfig.TLSCert)
 	tlsKey := strings.TrimSpace(m.StaticConfig.TLSKey)
+	m.StaticConfig.TLSCert = tlsCert
+	m.StaticConfig.TLSKey = tlsKey
 	if (tlsCert != "" && tlsKey == "") || (tlsCert == "" && tlsKey != "") {
 		return fmt.Errorf("both --tls-cert and --tls-key must be provided together")
 	}


### PR DESCRIPTION
Validation trims whitespace from certificate paths (`TLSCert`, `TLSKey`, `CertificateAuthority`) but didn't write the trimmed values back to the config struct. This could cause a runtime failure if a config file had trailing whitespace in a path — validation would pass on the trimmed value, but the untrimmed value would be passed to `ListenAndServeTLS`.

Also removes a duplicate helm-docs comment on `service.targetPort` and fixes a grammar typo ("an proxy" → "a proxy").

Follows up on #739 
/cc @mjudeikis