### PR TITLE
chore(evals): rename remaining gevals references to mcpchecker

### DIFF
--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -151,7 +151,7 @@ jobs:
               ;;
           esac
 
-  # Run gevals evaluation with Kind cluster
+  # Run mcpchecker evaluation with Kind cluster
   run-evaluation:
     name: Run MCP Evaluation
     needs: check-trigger

--- a/build/evals.mk
+++ b/build/evals.mk
@@ -1,4 +1,4 @@
-# Gevals evaluation support
+# Evals - mcpchecker evaluation support
 
 MCP_PORT ?= 8080
 MCP_HEALTH_TIMEOUT ?= 60

--- a/evals/README.md
+++ b/evals/README.md
@@ -38,14 +38,14 @@ The tasks and MCP configuration are shared - only the agent configuration differ
 - Kubernetes cluster (kind, minikube, or any cluster)
 - kubectl configured
 - Kubernetes MCP server running at `http://localhost:8080/mcp`
-- Built binaries: `gevals` and `agent`
+- Built binaries: `mcpchecker` and `agent`
 
 ## Running Examples
 
 ### Option 1: Claude Code
 
 ```bash
-./gevals eval examples/kube-mcp-server/claude-code/eval.yaml
+mcpchecker check examples/kube-mcp-server/claude-code/eval.yaml
 ```
 
 **Requirements:**
@@ -64,7 +64,7 @@ export MODEL_BASE_URL='https://your-api-endpoint.com/v1'
 export MODEL_KEY='your-api-key'
 
 # Run the test
-./gevals eval examples/kube-mcp-server/openai-agent/eval.yaml
+mcpchecker check examples/kube-mcp-server/openai-agent/eval.yaml
 ```
 
 **Note:** Different AI models may choose different tools from the MCP server (`pods_*` or `resources_*`) to accomplish the same task. Both approaches work correctly.
@@ -107,10 +107,10 @@ Tasks are organized into suites using labels. You can filter which tasks to run 
 
 ```bash
 # Using OpenAI agent
-./gevals eval evals/openai-agent/eval.yaml --label-selector suite=kubernetes
+mcpchecker check evals/openai-agent/eval.yaml --label-selector suite=kubernetes
 
 # Using Claude Code agent
-./gevals eval evals/claude-code/eval.yaml --label-selector suite=kubernetes
+mcpchecker check evals/claude-code/eval.yaml --label-selector suite=kubernetes
 ```
 
 **Requirements:**
@@ -121,10 +121,10 @@ Tasks are organized into suites using labels. You can filter which tasks to run 
 
 ```bash
 # Using OpenAI agent
-../gevals/gevals eval evals/openai-agent/eval.yaml --label-selector suite=kiali
+mcpchecker check evals/openai-agent/eval.yaml --label-selector suite=kiali
 
 # Using Claude Code agent
-../gevals/gevals eval evals/claude-code/eval.yaml --label-selector suite=kiali
+mcpchecker check evals/claude-code/eval.yaml --label-selector suite=kiali
 ```
 
 **Requirements:**
@@ -147,4 +147,4 @@ Both examples should produce:
 - ✅ Assertions passed - appropriate tools were called
 - ✅ Verification passed - pod exists and is running
 
-Results saved to: `gevals-<eval-name>-out.json`
+Results saved to: `mcpchecker-<eval-name>-out.json`


### PR DESCRIPTION
## Summary

- Rename `build/gevals.mk` to `build/evals.mk` and update file header comment
- Update `evals/README.md` CLI examples: `gevals` → `mcpchecker`, `eval` → `check`
- Fix stale `gevals` comment in `.github/workflows/mcpchecker.yaml`
- ~Update `evals/tasks/kubevirt/README.md` framework reference~

Kiali task YAML label references (`gevals.kiali.io/test`) are excluded
as they are addressed in separate PRs.