### PR TITLE
cleanup(kubevirt): Remove snapshot patch in snapshot-vm and restore-vm tasks

### DIFF
--- a/evals/tasks/kubevirt/restore-vm/task.yaml
+++ b/evals/tasks/kubevirt/restore-vm/task.yaml
@@ -11,15 +11,6 @@ spec:
     - extension: kubernetes
       as: k8s
   setup:
-    # Enable Snapshot feature gate - requires kubectl patch (no extension op available)
-    - script:
-        inline: |-
-          #!/usr/bin/env bash
-          set -e
-          echo "Enabling Snapshot feature gate in KubeVirt CR..."
-          KUBEVIRT_CR=$(kubectl get kubevirt -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-          KUBEVIRT_NS=$(kubectl get kubevirt -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "")
-          kubectl patch kubevirt "$KUBEVIRT_CR" -n "$KUBEVIRT_NS" --type=merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates":["Snapshot"]}}}}'
     - k8s.delete:
         apiVersion: v1
         kind: Namespace

--- a/evals/tasks/kubevirt/snapshot-vm/task.yaml
+++ b/evals/tasks/kubevirt/snapshot-vm/task.yaml
@@ -11,15 +11,6 @@ spec:
     - extension: kubernetes
       as: k8s
   setup:
-    # Enable Snapshot feature gate - requires kubectl patch (no extension op available)
-    - script:
-        inline: |-
-          #!/usr/bin/env bash
-          set -e
-          echo "Enabling Snapshot feature gate in KubeVirt CR..."
-          KUBEVIRT_CR=$(kubectl get kubevirt -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-          KUBEVIRT_NS=$(kubectl get kubevirt -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "")
-          kubectl patch kubevirt "$KUBEVIRT_CR" -n "$KUBEVIRT_NS" --type=merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates":["Snapshot"]}}}}'
     - k8s.delete:
         apiVersion: v1
         kind: Namespace


### PR DESCRIPTION
To increase clarity, I removed the snapshot feature gate patch in these tasks. 
The snapshot feature gate is now enabled by default.

Fixes #806