### PR TITLE
Revert "chore(test): Increase timeout on namespaces test (#910)"

### DIFF
--- a/pkg/mcp/namespaces_test.go
+++ b/pkg/mcp/namespaces_test.go
@@ -101,7 +101,7 @@ func (s *NamespacesSuite) TestNamespacesListForbidden() {
 				"error message should indicate forbidden")
 		})
 		s.Run("sends log notification", func() {
-			logNotification := capture.RequireLogNotification(s.T(), 5*time.Second)
+			logNotification := capture.RequireLogNotification(s.T(), 2*time.Second)
 			s.Equal("error", logNotification.Level, "forbidden errors should log at error level")
 			s.Contains(logNotification.Data, "Permission denied", "log message should indicate permission denied")
 		})


### PR DESCRIPTION
This reverts commit 38b3658cfc6cf6f2863faf472b140fe6b496e1ba.

Instead this could be fixed on the other CI environment. 