### PR TITLE
refactor(api): expose BaseConfig to tool and prompt handlers

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -26,12 +26,7 @@ type ExtendedConfig interface {
 	Validate() error
 }
 
-// ConfigProvider provides read-only access to configuration from tool and prompt handlers.
-// This interface is embedded in ToolHandlerParams and PromptHandlerParams, allowing
-// toolsets to access configuration at execution time (not just at initialization).
-type ConfigProvider interface {
-	// GetClusterProviderStrategy returns the cluster provider strategy (e.g. "kubeconfig", "in-cluster").
-	GetClusterProviderStrategy() string
+type ExtendedConfigProvider interface {
 	// GetProviderConfig returns the extended configuration for the given provider strategy.
 	// The boolean return value indicates whether the configuration was found.
 	GetProviderConfig(strategy string) (ExtendedConfig, bool)
@@ -67,7 +62,7 @@ type BaseConfig interface {
 	AuthProvider
 	ClusterProvider
 	DeniedResourcesProvider
-	ConfigProvider
+	ExtendedConfigProvider
 	StsConfigProvider
 	ValidationEnabledProvider
 }

--- a/pkg/api/prompts.go
+++ b/pkg/api/prompts.go
@@ -84,7 +84,7 @@ func NewPromptCallResult(description string, messages []PromptMessage, err error
 // PromptHandlerParams contains the parameters passed to a prompt handler
 type PromptHandlerParams struct {
 	context.Context
-	ConfigProvider
+	BaseConfig
 	KubernetesClient
 	PromptCallRequest
 	Elicitor

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -99,7 +99,7 @@ func NewToolCallResultStructured(structured any, err error) *ToolCallResult {
 
 type ToolHandlerParams struct {
 	context.Context
-	ConfigProvider
+	BaseConfig
 	KubernetesClient
 	ToolCallRequest
 	ListOutput output.Output

--- a/pkg/kiali/kiali.go
+++ b/pkg/kiali/kiali.go
@@ -24,7 +24,7 @@ type Kiali struct {
 }
 
 // NewKiali creates a new Kiali instance
-func NewKiali(configProvider api.ConfigProvider, kubernetes *rest.Config) *Kiali {
+func NewKiali(configProvider api.ExtendedConfigProvider, kubernetes *rest.Config) *Kiali {
 	kiali := &Kiali{bearerToken: kubernetes.BearerToken}
 	if cfg, ok := configProvider.GetToolsetConfig("kiali"); ok {
 		if kc, ok := cfg.(*Config); ok && kc != nil {

--- a/pkg/mcp/gosdk.go
+++ b/pkg/mcp/gosdk.go
@@ -48,7 +48,7 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 
 		result, err := tool.Handler(api.ToolHandlerParams{
 			Context:          ctx,
-			ConfigProvider:   s.configuration,
+			BaseConfig:       s.configuration,
 			KubernetesClient: k,
 			ToolCallRequest:  toolCallRequest,
 			ListOutput:       s.configuration.ListOutput(),

--- a/pkg/mcp/prompts_gosdk.go
+++ b/pkg/mcp/prompts_gosdk.go
@@ -57,7 +57,7 @@ func ServerPromptToGoSdkPrompt(s *Server, serverPrompt api.ServerPrompt) (*mcp.P
 
 		params := api.PromptHandlerParams{
 			Context:           ctx,
-			ConfigProvider:    s.configuration,
+			BaseConfig:        s.configuration,
 			KubernetesClient:  k8s,
 			PromptCallRequest: &promptCallRequestAdapter{request: request},
 			Elicitor:          &sessionElicitor{},


### PR DESCRIPTION
## Summary

PR #836 identified the need to expose the cluster provider strategy to toolsets. As some toolsets now call non-kube-API-server endpoints (e.g. Prometheus), they need to know the strategy to determine TLS and authentication configuration.

The approach in #836 expanded the `GetTools()` parameter, but this is evaluated at server startup — if the strategy changes via drop-in configuration support, toolsets would still see the stale value. Additionally, `GetTools()` should eventually take no parameters.

This PR takes an alternative approach: embed `BaseConfig` (instead of `ExtendedConfigProvider`) in `ToolHandlerParams` and `PromptHandlerParams`. Since `BaseConfig` already composes `ClusterProvider` (which provides `GetClusterProviderStrategy()`) and `ExtendedConfigProvider`, no new interface is needed. Toolsets can access the strategy at execution time — always reflecting the current configuration, even after a drop-in config reload.

Downstream consumers (e.g. [openshift/openshift-mcp-server#124](https://github.com/openshift/openshift-mcp-server/pull/124)) can now call `params.GetClusterProviderStrategy()` in their tool handlers to determine TLS/auth behavior, following the same pattern Kiali already uses for its configuration.

### Changes

- **`pkg/api/toolsets.go`** / **`pkg/api/prompts.go`** — Embed `BaseConfig` instead of `ExtendedConfigProvider` in handler params
- **`pkg/mcp/gosdk.go`** / **`pkg/mcp/prompts_gosdk.go`** — Update field assignment
- **`pkg/mcp/mcp_config_provider_test.go`** — Behavioral tests verifying strategy access from tool/prompt handlers and config reload

Refs #836