### PR TITLE
feat(resources): add gotemplate parameter for resources_list and resources_get

### DIFF
--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -1029,6 +1029,113 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 	})
 }
 
+func (s *ResourcesSuite) TestResourcesListGoTemplate() {
+	s.InitMcpClient()
+	s.Run("resources_list with gotemplate extracts names", func() {
+		result, err := s.CallTool("resources_list", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"namespace":  "default",
+			"gotemplate": "{{range .items}}{{.metadata.name}}\n{{end}}",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		content := result.Content[0].(*mcp.TextContent).Text
+		s.Contains(content, "a-pod-in-default")
+	})
+	s.Run("resources_list with gotemplate extracts namespace and name", func() {
+		result, err := s.CallTool("resources_list", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"namespace":  "default",
+			"gotemplate": "{{range .items}}{{.metadata.namespace}}/{{.metadata.name}}\n{{end}}",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		content := result.Content[0].(*mcp.TextContent).Text
+		s.Contains(content, "default/a-pod-in-default")
+	})
+	s.Run("resources_list with invalid gotemplate returns error", func() {
+		result, _ := s.CallTool("resources_list", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"namespace":  "default",
+			"gotemplate": "{{invalid",
+		})
+		s.Truef(result.IsError, "call tool should fail for invalid template")
+		s.Contains(result.Content[0].(*mcp.TextContent).Text, "invalid go template expression")
+	})
+	s.Run("resources_list with gotemplate on empty list returns no output", func() {
+		result, err := s.CallTool("resources_list", map[string]interface{}{
+			"apiVersion":    "v1",
+			"kind":          "Pod",
+			"namespace":     "default",
+			"labelSelector": "nonexistent-label=nonexistent-value",
+			"gotemplate":    "{{range .items}}{{.metadata.name}}\n{{end}}",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool should not fail: %v", result.Content)
+		content := result.Content[0].(*mcp.TextContent).Text
+		s.Equal("(no output from go template)", content)
+	})
+}
+
+func (s *ResourcesSuite) TestResourcesListGoTemplateInTableMode() {
+	s.Cfg.ListOutput = "table"
+	s.InitMcpClient()
+	s.Run("resources_list with gotemplate works even when list output is table", func() {
+		result, err := s.CallTool("resources_list", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"namespace":  "default",
+			"gotemplate": "{{range .items}}{{.metadata.name}}\n{{end}}",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		content := result.Content[0].(*mcp.TextContent).Text
+		s.Contains(content, "a-pod-in-default")
+	})
+}
+
+func (s *ResourcesSuite) TestResourcesGetGoTemplate() {
+	s.InitMcpClient()
+	s.Run("resources_get with gotemplate extracts specific field", func() {
+		result, err := s.CallTool("resources_get", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"name":       "default",
+			"gotemplate": "{{.metadata.name}}",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		content := result.Content[0].(*mcp.TextContent).Text
+		s.Equal("default", content)
+	})
+	s.Run("resources_get with gotemplate extracts nested fields", func() {
+		result, err := s.CallTool("resources_get", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"namespace":  "default",
+			"name":       "a-pod-in-default",
+			"gotemplate": "{{.kind}}/{{.metadata.name}}",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		content := result.Content[0].(*mcp.TextContent).Text
+		s.Equal("Pod/a-pod-in-default", content)
+	})
+	s.Run("resources_get with invalid gotemplate returns error", func() {
+		result, _ := s.CallTool("resources_get", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"name":       "default",
+			"gotemplate": "{{invalid",
+		})
+		s.Truef(result.IsError, "call tool should fail for invalid template")
+		s.Contains(result.Content[0].(*mcp.TextContent).Text, "invalid go template expression")
+	})
+}
+
 func TestResources(t *testing.T) {
 	suite.Run(t, new(ResourcesSuite))
 }

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -449,11 +449,15 @@
       "readOnlyHint": true,
       "title": "Resources: Get"
     },
-    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "gotemplate": {
+          "description": "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{.spec.source.repoURL}}, {{.status.phase}})",
           "type": "string"
         },
         "kind": {
@@ -486,7 +490,7 @@
       "readOnlyHint": true,
       "title": "Resources: List"
     },
-    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
@@ -496,6 +500,10 @@
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter resources by field values (e.g. 'status.phase=Running', 'metadata.name=myresource'). Supported fields vary by resource type. For Pods: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
           "pattern": "^[.\\-A-Za-z0-9]+([=!,]{1,2}[.\\-A-Za-z0-9]+)+$",
+          "type": "string"
+        },
+        "gotemplate": {
+          "description": "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{range .items}}{{.metadata.name}}\\n{{end}}, {{.spec.source.repoURL}})",
           "type": "string"
         },
         "kind": {

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -546,7 +546,7 @@
       "readOnlyHint": true,
       "title": "Resources: Get"
     },
-    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
@@ -555,6 +555,10 @@
         },
         "context": {
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "gotemplate": {
+          "description": "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{.spec.source.repoURL}}, {{.status.phase}})",
           "type": "string"
         },
         "kind": {
@@ -587,7 +591,7 @@
       "readOnlyHint": true,
       "title": "Resources: List"
     },
-    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
@@ -601,6 +605,10 @@
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter resources by field values (e.g. 'status.phase=Running', 'metadata.name=myresource'). Supported fields vary by resource type. For Pods: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
           "pattern": "^[.\\-A-Za-z0-9]+([=!,]{1,2}[.\\-A-Za-z0-9]+)+$",
+          "type": "string"
+        },
+        "gotemplate": {
+          "description": "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{range .items}}{{.metadata.name}}\\n{{end}}, {{.spec.source.repoURL}})",
           "type": "string"
         },
         "kind": {

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -484,11 +484,15 @@
       "readOnlyHint": true,
       "title": "Resources: Get"
     },
-    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
+    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "gotemplate": {
+          "description": "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{.spec.source.repoURL}}, {{.status.phase}})",
           "type": "string"
         },
         "kind": {
@@ -521,7 +525,7 @@
       "readOnlyHint": true,
       "title": "Resources: List"
     },
-    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
+    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
@@ -531,6 +535,10 @@
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter resources by field values (e.g. 'status.phase=Running', 'metadata.name=myresource'). Supported fields vary by resource type. For Pods: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
           "pattern": "^[.\\-A-Za-z0-9]+([=!,]{1,2}[.\\-A-Za-z0-9]+)+$",
+          "type": "string"
+        },
+        "gotemplate": {
+          "description": "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{range .items}}{{.metadata.name}}\\n{{end}}, {{.spec.source.repoURL}})",
           "type": "string"
         },
         "kind": {

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -469,11 +469,15 @@
       "readOnlyHint": true,
       "title": "Resources: Get"
     },
-    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
           "description": "apiVersion of the resource (examples of valid apiVersion are: v1, apps/v1, networking.k8s.io/v1)",
+          "type": "string"
+        },
+        "gotemplate": {
+          "description": "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{.spec.source.repoURL}}, {{.status.phase}})",
           "type": "string"
         },
         "kind": {
@@ -506,7 +510,7 @@
       "readOnlyHint": true,
       "title": "Resources: List"
     },
-    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
@@ -516,6 +520,10 @@
         "fieldSelector": {
           "description": "Optional Kubernetes field selector to filter resources by field values (e.g. 'status.phase=Running', 'metadata.name=myresource'). Supported fields vary by resource type. For Pods: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
           "pattern": "^[.\\-A-Za-z0-9]+([=!,]{1,2}[.\\-A-Za-z0-9]+)+$",
+          "type": "string"
+        },
+        "gotemplate": {
+          "description": "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{range .items}}{{.metadata.name}}\\n{{end}}, {{.spec.source.repoURL}})",
           "type": "string"
         },
         "kind": {

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -1,11 +1,14 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"text/template"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 
@@ -23,7 +26,7 @@ func initResources(o api.Openshift) []api.ServerTool {
 	return []api.ServerTool{
 		{Tool: api.Tool{
 			Name:        "resources_list",
-			Description: "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n" + commonApiVersion,
+			Description: "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n" + commonApiVersion,
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -49,6 +52,10 @@ func initResources(o api.Openshift) []api.ServerTool {
 						Description: "Optional Kubernetes field selector to filter resources by field values (e.g. 'status.phase=Running', 'metadata.name=myresource'). Supported fields vary by resource type. For Pods: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/",
 						Pattern:     REGEX_FIELDSELECTOR,
 					},
+					"gotemplate": {
+						Type:        "string",
+						Description: "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{range .items}}{{.metadata.name}}\\n{{end}}, {{.spec.source.repoURL}})",
+					},
 				},
 				Required: []string{"apiVersion", "kind"},
 			},
@@ -61,7 +68,7 @@ func initResources(o api.Openshift) []api.ServerTool {
 		}, Handler: resourcesList},
 		{Tool: api.Tool{
 			Name:        "resources_get",
-			Description: "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n" + commonApiVersion,
+			Description: "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name. Use the optional gotemplate parameter to extract specific fields instead of returning full YAML (same syntax as oc get -o go-template).\n" + commonApiVersion,
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -80,6 +87,10 @@ func initResources(o api.Openshift) []api.ServerTool {
 					"name": {
 						Type:        "string",
 						Description: "Name of the resource",
+					},
+					"gotemplate": {
+						Type:        "string",
+						Description: "Optional Go template to extract specific fields instead of returning full YAML (e.g. {{.spec.source.repoURL}}, {{.status.phase}})",
 					},
 				},
 				Required: []string{"apiVersion", "kind", "name"},
@@ -192,8 +203,9 @@ func resourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		namespace = ""
 	}
 	labelSelector := params.GetArguments()["labelSelector"]
+	_, hasGoTemplate := params.GetArguments()["gotemplate"].(string)
 	resourceListOptions := api.ListOptions{
-		AsTable: params.ListOutput.AsTable(),
+		AsTable: params.ListOutput.AsTable() && !hasGoTemplate,
 	}
 
 	if labelSelector != nil {
@@ -225,6 +237,29 @@ func resourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list resources: %w", err)), nil
 	}
+
+	if tmplExpr, ok := params.GetArguments()["gotemplate"].(string); ok && tmplExpr != "" {
+		var data interface{}
+		if ul, ok := ret.(*unstructured.UnstructuredList); ok {
+			obj := ul.Object
+			items := make([]interface{}, len(ul.Items))
+			for i := range ul.Items {
+				items[i] = ul.Items[i].Object
+			}
+			obj["items"] = items
+			data = obj
+		} else if u, ok := ret.(*unstructured.Unstructured); ok {
+			data = u.Object
+		}
+		if data != nil {
+			result, tmplErr := applyGoTemplate(tmplExpr, data)
+			if tmplErr != nil {
+				return api.NewToolCallResult("", tmplErr), nil
+			}
+			return api.NewToolCallResult(result, nil), nil
+		}
+	}
+
 	return api.NewToolCallResult(params.ListOutput.PrintObj(ret)), nil
 }
 
@@ -256,7 +291,32 @@ func resourcesGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get resource: %w", err)), nil
 	}
+
+	if tmplExpr, ok := params.GetArguments()["gotemplate"].(string); ok && tmplExpr != "" {
+		result, tmplErr := applyGoTemplate(tmplExpr, ret.Object)
+		if tmplErr != nil {
+			return api.NewToolCallResult("", tmplErr), nil
+		}
+		return api.NewToolCallResult(result, nil), nil
+	}
+
 	return api.NewToolCallResult(output.MarshalYaml(ret)), nil
+}
+
+func applyGoTemplate(expr string, data interface{}) (string, error) {
+	tmpl, err := template.New("filter").Option("missingkey=zero").Parse(expr)
+	if err != nil {
+		return "", fmt.Errorf("invalid go template expression: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("go template execution failed: %w", err)
+	}
+	result := buf.String()
+	if result == "" {
+		return "(no output from go template)", nil
+	}
+	return result, nil
 }
 
 func resourcesCreateOrUpdate(params api.ToolHandlerParams) (*api.ToolCallResult, error) {


### PR DESCRIPTION
Adds an optional gotemplate parameter (same syntax as oc get -o go-template) that lets callers extract specific fields server-side instead of returning full YAML.

Why: LLMs currently receive entire resource YAML even when they only need one field. This wastes context window tokens and slows down responses. With gotemplate, the LLM declares exactly what it needs and the server returns only that — easily 10-100x fewer tokens for targeted queries.

Benefits:

Token efficiency — {{.status.phase}} returns a single value instead of hundreds of YAML lines
CLI parity — uses the same Go template syntax as oc get -o go-template, so templates are portable between CLI and MCP workflows
Server-side projection — iteration, conditionals, and field extraction run on the server, not in the LLM
Backward compatible — parameter is optional; omitting it preserves existing full-YAML behavior

Examples:

resources_list(kind="Pod", gotemplate="{{range .items}}{{.metadata.name}}\n{{end}}")
resources_get(kind="Application", name="my-app", gotemplate="{{.spec.source.repoURL}}")

Assisted by: Cursor
