### PR TITLE
fix(test): adapt config provider tests for downstream default overrides

### DIFF
--- a/pkg/mcp/mcp_config_provider_test.go
+++ b/pkg/mcp/mcp_config_provider_test.go
@@ -97,6 +97,7 @@ func (s *McpConfigProviderSuite) TestToolHandlerReceivesToolsetConfig() {
 	`))
 	s.Require().NoError(err)
 	cfg.KubeConfig = s.Cfg.KubeConfig
+	cfg.ReadOnly = s.Cfg.ReadOnly
 	s.Cfg = cfg
 
 	s.InitMcpClient()
@@ -146,7 +147,7 @@ func (s *McpConfigProviderSuite) TestStrategyReflectsConfigReload() {
 	})
 
 	// Reload config with different strategy
-	newConfig := config.Default()
+	newConfig := config.BaseDefault()
 	newConfig.KubeConfig = s.Cfg.KubeConfig
 	s.Require().NoError(toml.Unmarshal([]byte(`
 		toolsets = ["config-provider-test"]


### PR DESCRIPTION
Ensure mcp_config_provider_test.go works when downstream overrides set read_only=true in config defaults. Use BaseDefault() instead of Default() for reload config, and inherit ReadOnly from the base test config after ReadToml().

Both changes are no-ops upstream where BaseDefault() and Default() produce identical results.