### PR TITLE
fix(kiali): limit response body size to prevent unbounded memory consumption

### DIFF
--- a/pkg/kiali/kiali.go
+++ b/pkg/kiali/kiali.go
@@ -137,6 +137,11 @@ func (k *Kiali) authorizationHeader() string {
 	return "Bearer " + token
 }
 
+// maxResponseBodySize is the maximum number of bytes read from a Kiali API
+// response. Responses exceeding this limit are truncated to prevent unbounded
+// memory consumption from a misbehaving or compromised upstream server.
+const maxResponseBodySize = 512 << 10 // 512 KiB
+
 // executeRequest executes an HTTP request (optionally with a body) and handles common error scenarios.
 func (k *Kiali) executeRequest(ctx context.Context, method, endpoint, contentType string, body io.Reader) (string, error) {
 	if method == "" {
@@ -164,7 +169,7 @@ func (k *Kiali) executeRequest(ctx context.Context, method, endpoint, contentTyp
 		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}


### PR DESCRIPTION
Wrap Kiali API response reads with io.LimitReader to cap at 512 KiB, preventing a misbehaving or compromised upstream server from exhausting MCP server memory via arbitrarily large responses.

Closes https://github.com/containers/kubernetes-mcp-server/issues/926 