### PR TITLE
refactor(kubernetes): consolidate API path prefix handling in round-tripper

### DIFF
--- a/pkg/kubernetes/accesscontrol_round_tripper.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -31,7 +32,7 @@ type AccessControlRoundTripperConfig struct {
 	Delegate                http.RoundTripper
 	DeniedResourcesProvider api.DeniedResourcesProvider
 	RestMapperProvider      func() meta.RESTMapper
-	APIPathPrefix           string
+	HostURL                 string
 	DiscoveryProvider       func() discovery.DiscoveryInterface
 	AuthClientProvider      func() authv1client.AuthorizationV1Interface
 	ValidationEnabled       bool
@@ -39,11 +40,19 @@ type AccessControlRoundTripperConfig struct {
 
 // NewAccessControlRoundTripper creates a new AccessControlRoundTripper.
 func NewAccessControlRoundTripper(cfg AccessControlRoundTripperConfig) *AccessControlRoundTripper {
+	var apiPathPrefix string
+	if cfg.HostURL != "" {
+		if hostURL, err := url.Parse(cfg.HostURL); err != nil {
+			klog.Warningf("failed to parse Kubernetes API server host %q to determine API path prefix: %v", cfg.HostURL, err)
+		} else {
+			apiPathPrefix = hostURL.Path
+		}
+	}
 	rt := &AccessControlRoundTripper{
 		delegate:                cfg.Delegate,
 		deniedResourcesProvider: cfg.DeniedResourcesProvider,
 		restMapperProvider:      cfg.RestMapperProvider,
-		apiPathPrefix:           strings.TrimSuffix(cfg.APIPathPrefix, "/"),
+		apiPathPrefix:           apiPathPrefix,
 		validationEnabled:       cfg.ValidationEnabled,
 	}
 
@@ -194,7 +203,8 @@ func parseURLToGVR(path string) (gvr schema.GroupVersionResource, ok bool) {
 }
 
 func stripAPIPathPrefix(path, prefix string) string {
-	if prefix == "" || prefix == "/" {
+	prefix = strings.TrimSuffix(prefix, "/")
+	if prefix == "" {
 		return path
 	}
 

--- a/pkg/kubernetes/accesscontrol_round_tripper_test.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper_test.go
@@ -390,6 +390,16 @@ func (s *StripAPIPathPrefixTestSuite) TestStripAPIPathPrefix() {
 		)
 	})
 
+	s.Run("removes prefix with trailing slash", func() {
+		s.Equal(
+			"/api/v1/pods",
+			stripAPIPathPrefix(
+				"/api/v1/kube/clusters/test-cluster/api/v1/pods",
+				"/api/v1/kube/clusters/test-cluster/",
+			),
+		)
+	})
+
 	s.Run("does not trim partial prefix matches", func() {
 		s.Equal(
 			"/api/v1/kube/clusters/test-cluster/api/v1/pods",

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -19,7 +18,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
 	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 )
 
@@ -65,19 +63,12 @@ func NewKubernetes(baseConfig api.BaseConfig, clientCmdConfig clientcmd.ClientCo
 		k.restConfig.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 
-	apiPathPrefix := ""
-	if hostURL, err := url.Parse(k.restConfig.Host); err != nil {
-		klog.Warningf("failed to parse Kubernetes API server host %q to determine API path prefix: %v", k.restConfig.Host, err)
-	} else {
-		apiPathPrefix = hostURL.Path
-	}
-
 	k.restConfig.Wrap(func(original http.RoundTripper) http.RoundTripper {
 		return NewAccessControlRoundTripper(AccessControlRoundTripperConfig{
 			Delegate:                original,
 			DeniedResourcesProvider: baseConfig,
 			RestMapperProvider:      func() meta.RESTMapper { return k.restMapper },
-			APIPathPrefix:           apiPathPrefix,
+			HostURL:                 k.restConfig.Host,
 			DiscoveryProvider:       func() discovery.DiscoveryInterface { return k.discoveryClient },
 			AuthClientProvider:      func() authv1client.AuthorizationV1Interface { return k.AuthorizationV1() },
 			ValidationEnabled:       baseConfig.IsValidationEnabled(),

--- a/pkg/mcp/proxied_kubernetes_test.go
+++ b/pkg/mcp/proxied_kubernetes_test.go
@@ -1,0 +1,103 @@
+package mcp
+
+import (
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/yaml"
+)
+
+const proxyPathPrefix = "/gateway/k8s/clusters/test"
+
+type ProxiedKubernetesSuite struct {
+	BaseMcpSuite
+	proxy *httptest.Server
+}
+
+func (s *ProxiedKubernetesSuite) SetupTest() {
+	s.BaseMcpSuite.SetupTest()
+
+	// Create a reverse proxy that exposes the envtest API server behind a path prefix.
+	// This simulates a gateway/proxy that serves the Kubernetes API under a sub-path.
+	targetURL, err := url.Parse(envTestRestConfig.Host)
+	s.Require().NoError(err, "Expected to parse envtest host URL")
+
+	transport, err := rest.TransportFor(envTestRestConfig)
+	s.Require().NoError(err, "Expected to create transport for envtest")
+
+	s.proxy = httptest.NewServer(&httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(targetURL)
+			r.Out.URL.Path = strings.TrimPrefix(r.In.URL.Path, proxyPathPrefix)
+			if r.Out.URL.Path == "" {
+				r.Out.URL.Path = "/"
+			}
+		},
+		Transport: transport,
+	})
+
+	// Overwrite the kubeconfig with one that points to the proxy with the path prefix
+	kubeConfig := clientcmdapi.NewConfig()
+	kubeConfig.Clusters["test"] = &clientcmdapi.Cluster{
+		Server: s.proxy.URL + proxyPathPrefix,
+	}
+	kubeConfig.AuthInfos["test-user"] = &clientcmdapi.AuthInfo{}
+	kubeConfig.Contexts["test"] = &clientcmdapi.Context{
+		Cluster:  "test",
+		AuthInfo: "test-user",
+	}
+	kubeConfig.CurrentContext = "test"
+
+	data, err := clientcmd.Write(*kubeConfig)
+	s.Require().NoError(err, "Expected to serialize kubeconfig")
+	s.Require().NoError(os.WriteFile(s.Cfg.KubeConfig, data, 0600), "Expected to write kubeconfig file")
+}
+
+func (s *ProxiedKubernetesSuite) TearDownTest() {
+	s.BaseMcpSuite.TearDownTest()
+	if s.proxy != nil {
+		s.proxy.Close()
+	}
+}
+
+func (s *ProxiedKubernetesSuite) TestPodsListThroughProxy() {
+	s.InitMcpClient()
+	s.Run("pods_list returns pods through path-prefixed proxy", func() {
+		toolResult, err := s.CallTool("pods_list", map[string]interface{}{})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(toolResult.IsError, "call tool failed: %s", toolResult.Content[0].(*mcp.TextContent).Text)
+		var decoded []unstructured.Unstructured
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
+		s.Nilf(err, "invalid tool result content %v", err)
+		s.GreaterOrEqual(len(decoded), 3, "expected at least 3 pods")
+	})
+}
+
+func (s *ProxiedKubernetesSuite) TestPodsListDeniedThroughProxy() {
+	s.Require().NoError(toml.Unmarshal([]byte(`
+		denied_resources = [ { version = "v1", kind = "Pod" } ]
+	`), s.Cfg), "Expected to parse denied resources config")
+	s.InitMcpClient()
+	s.Run("pods_list is denied through proxy", func() {
+		toolResult, err := s.CallTool("pods_list", map[string]interface{}{})
+		s.Nilf(err, "call tool should not return error object")
+		s.True(toolResult.IsError, "call tool should fail")
+		msg := toolResult.Content[0].(*mcp.TextContent).Text
+		s.Contains(msg, "resource not allowed:")
+	})
+}
+
+func TestProxiedKubernetes(t *testing.T) {
+	suite.Run(t, new(ProxiedKubernetesSuite))
+}


### PR DESCRIPTION
## Summary

- Move URL parsing and path prefix extraction from `kubernetes.go` into `AccessControlRoundTripper`, so all prefix-related logic lives in one place
- Replace `APIPathPrefix string` config field with `HostURL string` — the caller just passes the raw host URL
- Move trailing slash normalization into `stripAPIPathPrefix` instead of the constructor
- Add integration test (`ProxiedKubernetesSuite`) that exercises the full MCP stack through a reverse proxy with a path prefix

Follows up on #925.