### PR TITLE
fix(ci): add v prefix to OCI identifier in MCP registry publish

### DIFF
--- a/.github/workflows/release-mcp-registry.yaml
+++ b/.github/workflows/release-mcp-registry.yaml
@@ -53,7 +53,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           jq --arg v "$VERSION" \
-            '.version = $v | .packages[] |= if .registryType == "oci" then .identifier = (.identifier | sub(":[^:]+$"; ":" + $v)) else .version = $v end' \
+            '.version = $v | .packages[] |= if .registryType == "oci" then .identifier = (.identifier | sub(":[^:]+$"; ":v" + $v)) else .version = $v end' \
             server.json > server.json.tmp && mv server.json.tmp server.json
           echo "Updated server.json:"
           cat server.json


### PR DESCRIPTION
The `release-image` workflow tags container images with the full git ref name
(e.g., `v0.0.59`), but the MCP registry workflow was stripping the `v` prefix
from the OCI identifier, producing a tag (`0.0.59`) that doesn't exist in the
container registry.

This caused the MCP registry publish to fail with:
> OCI image 'ghcr.io/containers/kubernetes-mcp-server:0.0.59' does not exist in the registry

The fix prepends `v` to the version when updating the OCI identifier in `server.json`.