### PR TITLE
fix(kiali): return error when response exceeds maximum allowed size

### DIFF
--- a/pkg/kiali/kiali.go
+++ b/pkg/kiali/kiali.go
@@ -169,9 +169,12 @@ func (k *Kiali) executeRequest(ctx context.Context, method, endpoint, contentTyp
 		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize+1))
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+	if int64(len(respBody)) > maxResponseBodySize {
+		return "", fmt.Errorf("kiali API response exceeded maximum allowed size of %d bytes", maxResponseBodySize)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if len(respBody) > 0 {

--- a/pkg/kiali/kiali_test.go
+++ b/pkg/kiali/kiali_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
@@ -202,6 +203,15 @@ func (s *KialiSuite) TestExecuteRequest() {
 	})
 	s.Run("response body is correct", func() {
 		s.Equal("ok", out, "Unexpected response body")
+	})
+	s.Run("returns error when response exceeds maximum allowed size", func() {
+		s.MockServer.ResetHandlers()
+		s.MockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(strings.Repeat("x", maxResponseBodySize+1)))
+		}))
+		_, err := k.executeRequest(s.T().Context(), http.MethodGet, "/api/large", "", nil)
+		s.Require().Error(err, "Expected error for oversized response")
+		s.ErrorContains(err, fmt.Sprintf("kiali API response exceeded maximum allowed size of %d bytes", maxResponseBodySize))
 	})
 }
 


### PR DESCRIPTION
## Summary

- Instead of silently truncating the Kiali API response body at 512 KiB
  (which could produce invalid JSON without any indication), read one
  extra byte and return a clear error when the limit is exceeded
- Add a test for the oversized response scenario

Follows up on review comments from #927.