### PR TITLE
test(evals): add suite:config to all config tasks, add nodes-top.yaml

### DIFF
--- a/evals/claude-code/eval.yaml
+++ b/evals/claude-code/eval.yaml
@@ -27,7 +27,7 @@ config:
         maxToolCalls: 20
     - glob: ../tasks/config/*/*.yaml
       labelSelector:
-        suite: kubernetes
+        suite: config
       assertions:
         toolsUsed:
           - server: kubernetes

--- a/evals/openai-agent/eval.yaml
+++ b/evals/openai-agent/eval.yaml
@@ -27,7 +27,7 @@ config:
         maxToolCalls: 20
     - glob: ../tasks/config/*/*.yaml
       labelSelector:
-        suite: kubernetes
+        suite: config
       assertions:
         toolsUsed:
           - server: kubernetes

--- a/evals/tasks/config/identify-context-for-task/identify-context-for-task.yaml
+++ b/evals/tasks/config/identify-context-for-task/identify-context-for-task.yaml
@@ -1,6 +1,8 @@
 kind: Task
 apiVersion: mcpchecker/v1alpha2
 metadata:
+  labels:
+    suite: config
   name: "identify-context-for-task"
   difficulty: medium
 spec:

--- a/evals/tasks/config/list-contexts/list-contexts.yaml
+++ b/evals/tasks/config/list-contexts/list-contexts.yaml
@@ -1,6 +1,8 @@
 kind: Task
 apiVersion: mcpchecker/v1alpha2
 metadata:
+  labels:
+    suite: config
   name: "list-contexts"
   difficulty: easy
 spec:

--- a/evals/tasks/config/view-current-config/view-current-config.yaml
+++ b/evals/tasks/config/view-current-config/view-current-config.yaml
@@ -1,6 +1,8 @@
 kind: Task
 apiVersion: mcpchecker/v1alpha2
 metadata:
+  labels:
+    suite: config
   name: "view-current-config"
   difficulty: easy
 spec:

--- a/evals/tasks/kubernetes/nodes-top/nodes-top.yaml
+++ b/evals/tasks/kubernetes/nodes-top/nodes-top.yaml
@@ -1,0 +1,13 @@
+kind: Task
+metadata:
+  labels:
+    suite: kubernetes
+  name: nodes-top
+  difficulty: easy
+steps:
+  setup:
+  verify:
+    contains: "master"
+  cleanup:
+  prompt:
+    inline: "Check the resource usage of the master nodes in the cluster."


### PR DESCRIPTION
Right now, the tasks in config folder do not have any selector at all, but the eval.yaml files have labelSelector selected for the path. This means the tasks are never selected. 

I propose adding "suite: config" to them. 

I also add one very simple task to easily smoke-test the functionality (as create-pod is not working very well for me for this). 