### PR TITLE
fix(helm): normalize scheme, host, and path in allowlist matching

### DIFF
--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -34,7 +34,9 @@ func (c *Config) Validate() error {
 		if u.Host == "" {
 			return fmt.Errorf("allowed_registries entry %q must be a valid URL with scheme and host", entry)
 		}
-		c.AllowedRegistries[i] = strings.TrimRight(entry, "/")
+		// Normalize to lowercase scheme + host and strip trailing slashes
+		// so runtime comparison against the normalized chart reference is case-insensitive.
+		c.AllowedRegistries[i] = strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host) + strings.TrimRight(u.Path, "/")
 	}
 	return nil
 }

--- a/pkg/helm/config_test.go
+++ b/pkg/helm/config_test.go
@@ -30,16 +30,16 @@ func (s *ConfigSuite) TestValidate() {
 		var cfg *Config
 		s.Error(cfg.Validate())
 	})
-	s.Run("trims trailing slashes from allowed registries", func() {
+	s.Run("normalizes entries to lowercase and trims trailing slashes", func() {
 		cfg := &Config{
 			AllowedRegistries: []string{
-				"oci://ghcr.io/myorg/",
-				"https://charts.example.com/",
+				"OCI://GHCR.IO/myorg/",
+				"HTTPS://Charts.Example.COM/repo/",
 			},
 		}
 		s.NoError(cfg.Validate())
 		s.Equal("oci://ghcr.io/myorg", cfg.AllowedRegistries[0])
-		s.Equal("https://charts.example.com", cfg.AllowedRegistries[1])
+		s.Equal("https://charts.example.com/repo", cfg.AllowedRegistries[1])
 	})
 	s.Run("rejects entry without scheme", func() {
 		cfg := &Config{AllowedRegistries: []string{"ghcr.io/myorg"}}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -142,7 +142,11 @@ func validateChartReference(chart string, cfg *Config) error {
 	switch strings.ToLower(u.Scheme) {
 	case "oci", "https":
 		if cfg != nil && len(cfg.AllowedRegistries) > 0 {
-			normalized := u.Scheme + "://" + u.Host + path.Clean(u.Path)
+			cleaned := path.Clean(u.Path)
+			if cleaned == "." {
+				cleaned = ""
+			}
+			normalized := strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host) + cleaned
 			for _, allowed := range cfg.AllowedRegistries {
 				if normalized == allowed || strings.HasPrefix(normalized, allowed+"/") {
 					return nil

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -193,6 +193,16 @@ func (s *HelmSuite) TestValidateChartReference() {
 			s.Error(err)
 			s.Contains(err.Error(), "only registry URLs from the allowed list are permitted")
 		})
+		s.Run("matches case-insensitively", func() {
+			s.NoError(validateChartReference("OCI://GHCR.IO/myorg/mychart", cfg))
+		})
+		s.Run("matches registry with no path", func() {
+			registryCfg := &Config{
+				AllowedRegistries: []string{"oci://registry.example.com"},
+			}
+			s.NoError(validateChartReference("oci://registry.example.com/chart", registryCfg))
+			s.NoError(validateChartReference("oci://registry.example.com", registryCfg))
+		})
 		s.Run("still blocks file:// scheme", func() {
 			err := validateChartReference("file:///tmp/chart", cfg)
 			s.Error(err)


### PR DESCRIPTION
Follow-up fix based on code rabbit static pattern analysis: normalize URL scheme/host case and handle `path.Clean("")` returning `"."` in allowlist matching. :rabbit: 

Related to https://github.com/containers/kubernetes-mcp-server/pull/950