### PR TITLE
feat(auth): add OAuth scope-based authorization for MCP tools

### DIFF
--- a/docs/KEYCLOAK_OIDC_SETUP.md
+++ b/docs/KEYCLOAK_OIDC_SETUP.md
@@ -152,6 +152,38 @@ The setup automatically configures:
 - **mcp:openshift**: Optional scope for token exchange with audience mapper
 - **groups**: Group membership mapper (included in tokens)
 
+### Tool Authorization Scopes (Optional)
+
+The MCP server supports scope-based access control for tools. When configured, users must have the appropriate scope in their JWT to call tools:
+
+- **read**: Required for read-only tools (list, get, view operations)
+- **write**: Required for write tools (create, update, delete operations)
+
+**To enable scope-based authorization:**
+
+1. **Create client scopes in Keycloak Admin Console:**
+   - Go to `openshift` realm → **Client Scopes** → **Create**
+   - Create scope named `read` (Type: Optional, Protocol: openid-connect)
+   - Create scope named `write` (Type: Optional, Protocol: openid-connect)
+
+2. **Assign scopes to the mcp-server client:**
+   - Go to **Clients** → **mcp-server** → **Client Scopes**
+   - Add `read` and `write` as **Default** scopes
+
+3. **Configure the MCP server** (in `config.toml`):
+   ```toml
+   read_scope = "read"    # Default
+   write_scope = "write"  # Default
+   ```
+
+**Backward Compatibility:** If tokens don't include scope claims, all tools are allowed. This ensures existing setups continue working without modification.
+
+**Note:** Write scope implies read access. Users with only the `write` scope can also call read-only tools.
+
+**Role-based access example:**
+- Create a `viewer` role with only `read` scope → can only use read-only tools
+- Create an `operator` role with `write` scope → full access (write implies read)
+
 ### Default User
 - **Username**: `mcp`
 - **Password**: `mcp`
@@ -175,6 +207,10 @@ sts_audience = "openshift"  # Triggers token exchange
 sts_scopes = ["mcp:openshift"]
 
 certificate_authority = "_output/cert-manager-ca/ca.crt"  # For HTTPS validation
+
+# Tool authorization scopes (optional - defaults shown)
+# read_scope = "read"   # Required for read-only tools
+# write_scope = "write" # Required for write tools
 ```
 
 ## Useful Commands

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -412,12 +412,37 @@ Configure OAuth/OIDC authentication for HTTP mode deployments.
 | `authorization_url` | string | `""` | URL of the OIDC authorization server for token validation and STS exchange. |
 | `disable_dynamic_client_registration` | boolean | `false` | When `true`, disables dynamic client registration in `.well-known` endpoints. |
 | `oauth_scopes` | string[] | `[]` | Supported client scopes for the OAuth flow. |
+| `read_scope` | string | `"read"` | OAuth scope required for read-only tool operations. Tools with `readOnlyHint=true` require this scope. |
+| `write_scope` | string | `"write"` | OAuth scope required for write tool operations. Tools without `readOnlyHint=true` require this scope. |
 | `sts_client_id` | string | `""` | OAuth client ID for backend token exchange. |
 | `sts_client_secret` | string | `""` | OAuth client secret for backend token exchange. |
 | `sts_audience` | string | `""` | Audience for STS token exchange. |
 | `sts_scopes` | string[] | `[]` | Scopes for STS token exchange. |
 | `certificate_authority` | string | `""` | Path to CA certificate for validating authorization server connections. |
 | `server_url` | string | `""` | Public URL of the MCP server (used for OAuth metadata). |
+
+**Scope-Based Tool Authorization:**
+
+When `require_oauth` is enabled, the server enforces scope-based authorization for MCP tool calls:
+
+- **Read-only tools** (annotated with `readOnlyHint=true`) require the scope specified by `read_scope`
+- **Write tools** (all other tools) require the scope specified by `write_scope`
+
+**Note:** Write scope implies read access. Users with only the `write_scope` can also call read-only tools. This follows standard RBAC conventions where write permissions include read permissions.
+
+The JWT must include the required scope in either the `scope` claim (standard OAuth) or `scp` claim (Entra ID / Azure AD). Both use space-separated lists:
+
+**Standard OAuth (Keycloak, Auth0, etc.):**
+```json
+{
+  "scope": "openid read write",
+  "aud": "kubernetes-mcp-server"
+}
+```
+
+The server automatically detects which claim is present, with `scope` taking precedence if both exist.
+
+**Backward Compatibility:** If the JWT has no scope claims (neither `scope` nor `scp`), all tools are allowed. This ensures existing OAuth setups continue working without modification.
 
 **Example:**
 ```toml
@@ -426,12 +451,16 @@ authorization_url = "https://keycloak.example.com/realms/mcp"
 oauth_audience = "kubernetes-mcp-server"
 oauth_scopes = ["openid", "profile"]
 
+# Scope configuration (these are the defaults)
+read_scope = "read"
+write_scope = "write"
+
 sts_client_id = "mcp-backend"
 sts_client_secret = "your-client-secret"
 sts_audience = "kubernetes-api"
 ```
 
-For a complete OIDC setup guide, see [KEYCLOAK_OIDC_SETUP.md](KEYCLOAK_OIDC_SETUP.md).
+For a complete OIDC setup guide including scope configuration in Keycloak, see [KEYCLOAK_OIDC_SETUP.md](KEYCLOAK_OIDC_SETUP.md).
 
 ### Telemetry
 

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// ScopeProvider is implemented by types that can provide OAuth scopes.
+// This interface allows the MCP layer to check scopes without importing the http package.
+type ScopeProvider interface {
+	GetScopes() []string
+}
+
+// scopeProviderContextKey is the context key for storing a ScopeProvider
+type scopeProviderContextKey struct{}
+
+// ScopeProviderContextKey is used to store/retrieve a ScopeProvider from context
+var ScopeProviderContextKey = scopeProviderContextKey{}
+
+// GetScopeProviderFromContext retrieves a ScopeProvider from the context.
+// Returns nil if no provider is present (e.g., OAuth not enabled or STDIO mode).
+func GetScopeProviderFromContext(ctx context.Context) ScopeProvider {
+	val := ctx.Value(ScopeProviderContextKey)
+	if val == nil {
+		return nil
+	}
+	if provider, ok := val.(ScopeProvider); ok {
+		return provider
+	}
+	klog.Warningf("Context contains unexpected type for ScopeProviderContextKey: %T", val)
+	return nil
+}
+
+// HasScope checks if the given scopes slice contains the required scope.
+// Comparison is case-insensitive to handle IdP variations.
+func HasScope(scopes []string, requiredScope string) bool {
+	for _, s := range scopes {
+		if strings.EqualFold(s, requiredScope) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,6 +69,14 @@ type StaticConfig struct {
 	StsScopes            []string `toml:"sts_scopes,omitempty"`
 	CertificateAuthority string   `toml:"certificate_authority,omitempty"`
 	ServerURL            string   `toml:"server_url,omitempty"`
+	// ReadScope is the OAuth scope required for read-only tool operations.
+	// Tools with readOnlyHint=true require this scope.
+	// Defaults to "read".
+	ReadScope string `toml:"read_scope,omitempty"`
+	// WriteScope is the OAuth scope required for write tool operations.
+	// Tools without readOnlyHint=true require this scope.
+	// Defaults to "write".
+	WriteScope string `toml:"write_scope,omitempty"`
 
 	// TLS configuration for the HTTP server
 	// TLSCert is the path to the TLS certificate file for HTTPS

--- a/pkg/config/config_default.go
+++ b/pkg/config/config_default.go
@@ -13,6 +13,8 @@ func BaseDefault() *StaticConfig {
 	return &StaticConfig{
 		ListOutput: "table",
 		Toolsets:   []string{"core", "config"},
+		ReadScope:  "read",
+		WriteScope: "write",
 	}
 }
 

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/strings/slices"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 )
 
@@ -94,7 +95,9 @@ func AuthorizationMiddleware(staticConfig *config.StaticConfig, oidcProvider *oi
 				return
 			}
 
-			next.ServeHTTP(w, r)
+			// Inject validated JWT claims into context for downstream middleware (scope validation)
+			ctx := context.WithValue(r.Context(), api.ScopeProviderContextKey, claims)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
@@ -118,14 +121,25 @@ var allSignatureAlgorithms = []jose.SignatureAlgorithm{
 type JWTClaims struct {
 	jwt.Claims
 	Token string `json:"-"`
+	// Standard OAuth scope claim (space-separated string)
 	Scope string `json:"scope,omitempty"`
+	// Entra ID / Azure AD scope claim (space-separated string)
+	Scp string `json:"scp,omitempty"`
 }
 
+// Ensure JWTClaims implements api.ScopeProvider
+var _ api.ScopeProvider = (*JWTClaims)(nil)
+
 func (c *JWTClaims) GetScopes() []string {
-	if c.Scope == "" {
-		return nil
+	// Standard OAuth scope claim takes precedence
+	if c.Scope != "" {
+		return strings.Fields(c.Scope)
 	}
-	return strings.Fields(c.Scope)
+	// Fall back to Entra ID's scp claim
+	if c.Scp != "" {
+		return strings.Fields(c.Scp)
+	}
+	return nil
 }
 
 // ValidateOffline Checks if the JWT claims are valid and if the audience matches the expected one.

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -269,7 +269,8 @@ func (s *AuthorizationSuite) TestAuthorizationUnauthorizedTokenExchangeFailure()
 	rawClaims := `{
 		"iss": "` + oidcTestServer.URL + `",
 		"exp": ` + strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10) + `,
-		"aud": "%s"
+		"aud": "%s",
+		"scope": "read write"
 	}`
 	validOidcClientToken := oidctest.SignIDToken(oidcTestServer.PrivateKey, "test-oidc-key-id", oidc.RS256,
 		fmt.Sprintf(rawClaims, "mcp-server"))
@@ -358,7 +359,8 @@ func (s *AuthorizationSuite) TestAuthorizationOidcToken() {
 	rawClaims := `{
 		"iss": "` + oidcTestServer.URL + `",
 		"exp": ` + strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10) + `,
-		"aud": "mcp-server"
+		"aud": "mcp-server",
+		"scope": "read write"
 	}`
 	validOidcToken := oidctest.SignIDToken(oidcTestServer.PrivateKey, "test-oidc-key-id", oidc.RS256, rawClaims)
 
@@ -389,7 +391,8 @@ func (s *AuthorizationSuite) TestAuthorizationOidcTokenExchange() {
 	rawClaims := `{
 		"iss": "` + oidcTestServer.URL + `",
 		"exp": ` + strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10) + `,
-		"aud": "%s"
+		"aud": "%s",
+		"scope": "read write"
 	}`
 	validOidcClientToken := oidctest.SignIDToken(oidcTestServer.PrivateKey, "test-oidc-key-id", oidc.RS256,
 		fmt.Sprintf(rawClaims, "mcp-server"))

--- a/pkg/http/authorization_test.go
+++ b/pkg/http/authorization_test.go
@@ -217,4 +217,36 @@ func TestJWTClaimsGetScopes(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Entra ID scp claim", func(t *testing.T) {
+		claims := &JWTClaims{
+			Scp: "read write",
+		}
+		scopes := claims.GetScopes()
+		expected := []string{"read", "write"}
+
+		if len(scopes) != 2 {
+			t.Errorf("expected 2 scopes, got %d", len(scopes))
+		}
+		for i, expectedScope := range expected {
+			if i >= len(scopes) || scopes[i] != expectedScope {
+				t.Errorf("expected scope[%d] to be '%s', got '%s'", i, expectedScope, scopes[i])
+			}
+		}
+	})
+
+	t.Run("standard scope takes precedence over scp", func(t *testing.T) {
+		claims := &JWTClaims{
+			Scope: "admin",
+			Scp:   "read write",
+		}
+		scopes := claims.GetScopes()
+
+		if len(scopes) != 1 {
+			t.Errorf("expected 1 scope, got %d", len(scopes))
+		}
+		if scopes[0] != "admin" {
+			t.Errorf("expected scope 'admin' (from standard claim), got '%s'", scopes[0])
+		}
+	})
 }

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -246,7 +246,7 @@ func TestHealthCheck(t *testing.T) {
 		})
 	})
 	// Health exposed even when require Authorization
-	testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{RequireOAuth: true, ClusterProviderStrategy: api.ClusterProviderKubeConfig}}, func(ctx *httpContext) {
+	testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{RequireOAuth: true, ReadScope: "read", WriteScope: "write", ClusterProviderStrategy: api.ClusterProviderKubeConfig}}, func(ctx *httpContext) {
 		resp, err := http.Get(fmt.Sprintf("http://%s/healthz", ctx.HttpAddress))
 		if err != nil {
 			t.Fatalf("Failed to get health check endpoint with OAuth: %v", err)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -62,11 +63,44 @@ func (c *Configuration) isToolApplicable(tool api.ServerTool) bool {
 	return true
 }
 
+// validateScopeConfig validates scope configuration and logs warnings for potential issues.
+// Returns an error only for critical misconfigurations.
+func validateScopeConfig(cfg *config.StaticConfig) error {
+	// Only validate scopes when OAuth is enabled
+	if !cfg.IsRequireOAuth() {
+		return nil
+	}
+
+	// Reject empty scope names when OAuth is enabled
+	if cfg.ReadScope == "" {
+		return fmt.Errorf("read_scope must not be empty when require_oauth is enabled")
+	}
+	if cfg.WriteScope == "" {
+		return fmt.Errorf("write_scope must not be empty when require_oauth is enabled")
+	}
+
+	// Warn if scope names contain spaces (should be single tokens)
+	if strings.Contains(cfg.ReadScope, " ") {
+		klog.Warningf("read_scope %q contains spaces; scope names should be single tokens", cfg.ReadScope)
+	}
+	if strings.Contains(cfg.WriteScope, " ") {
+		klog.Warningf("write_scope %q contains spaces; scope names should be single tokens", cfg.WriteScope)
+	}
+
+	// Warn if read and write scopes are the same (unusual configuration)
+	if cfg.ReadScope == cfg.WriteScope {
+		klog.Warningf("read_scope and write_scope are both %q; this means all tools require the same scope", cfg.ReadScope)
+	}
+
+	return nil
+}
+
 type Server struct {
 	mu             sync.RWMutex
 	configuration  *Configuration
 	server         *mcp.Server
 	enabledTools   []string
+	toolsByName    map[string]*api.ServerTool // For scope validation lookups
 	enabledPrompts []string
 	p              internalk8s.Provider
 	metrics        *metrics.Metrics // Metrics collection system
@@ -106,10 +140,21 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 	}
 	s.metrics = metricsInstance
 
+	// Validate scope configuration (logs warnings for potential issues)
+	if err := validateScopeConfig(configuration.StaticConfig); err != nil {
+		return nil, err
+	}
+
 	s.server.AddReceivingMiddleware(sessionInjectionMiddleware)
 	s.server.AddReceivingMiddleware(traceContextPropagationMiddleware)
 	s.server.AddReceivingMiddleware(tracingMiddleware(version.BinaryName + "/mcp"))
 	s.server.AddReceivingMiddleware(authHeaderPropagationMiddleware)
+	s.server.AddReceivingMiddleware(scopeValidationMiddleware(
+		func() (string, string) {
+			return s.configuration.ReadScope, s.configuration.WriteScope
+		},
+		s.GetToolByName,
+	))
 	s.server.AddReceivingMiddleware(userAgentPropagationMiddleware(version.BinaryName, version.Version))
 	s.server.AddReceivingMiddleware(toolCallLoggingMiddleware)
 	s.server.AddReceivingMiddleware(s.metricsMiddleware())
@@ -161,9 +206,16 @@ func (s *Server) reloadToolsets() error {
 		return err
 	}
 
+	// Build tools lookup map for scope validation
+	newToolsByName := make(map[string]*api.ServerTool, len(applicableTools))
+	for i := range applicableTools {
+		newToolsByName[applicableTools[i].Tool.Name] = &applicableTools[i]
+	}
+
 	// Only hold write lock for the final assignment
 	s.mu.Lock()
 	s.enabledTools = newTools
+	s.toolsByName = newToolsByName
 	s.enabledPrompts = newPrompts
 	s.mu.Unlock()
 
@@ -329,6 +381,14 @@ func (s *Server) GetEnabledTools() []string {
 	return s.enabledTools
 }
 
+// GetToolByName returns a tool by name for scope validation.
+// Returns nil if the tool is not found.
+func (s *Server) GetToolByName(name string) *api.ServerTool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.toolsByName[name]
+}
+
 // GetEnabledPrompts returns the names of the currently enabled prompts
 func (s *Server) GetEnabledPrompts() []string {
 	s.mu.RLock()
@@ -341,6 +401,11 @@ func (s *Server) GetEnabledPrompts() []string {
 // configuration changes are detected.
 func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 	klog.V(1).Info("Reloading MCP server configuration...")
+
+	// Validate scope configuration before applying
+	if err := validateScopeConfig(newConfig); err != nil {
+		return fmt.Errorf("invalid scope configuration: %w", err)
+	}
 
 	// Update the configuration
 	s.configuration.StaticConfig = newConfig

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
 	"github.com/containers/kubernetes-mcp-server/pkg/telemetry"
@@ -16,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 // sessionInjectionMiddleware injects the MCP session into the context for logging support.
@@ -47,6 +49,90 @@ func authHeaderPropagationMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 			}
 		}
 		return next(ctx, method, req)
+	}
+}
+
+// scopeValidationMiddleware validates OAuth scopes against tool requirements.
+// If OAuth is enabled (scope provider present in context) AND the token has scopes:
+// - read-only tools (readOnlyHint=true) require the read scope
+// - other tools require the write scope
+// If OAuth is disabled (no scope provider) or token has no scopes, all tools are allowed.
+// The "no scopes = allow" behavior ensures backward compatibility with existing OAuth setups.
+//
+// The scopeGetter function is called per-request to support dynamic configuration reload.
+func scopeValidationMiddleware(scopeGetter func() (readScope, writeScope string), toolLookup func(string) *api.ServerTool) func(mcp.MethodHandler) mcp.MethodHandler {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			// Only validate tools/call method
+			if method != "tools/call" {
+				return next(ctx, method, req)
+			}
+
+			// Get scope provider from context (injected by HTTP AuthorizationMiddleware)
+			// If no provider exists, OAuth is disabled - allow all tools (existing behavior)
+			scopeProvider := api.GetScopeProviderFromContext(ctx)
+			if scopeProvider == nil {
+				// No OAuth configured or running in STDIO mode - skip scope validation
+				return next(ctx, method, req)
+			}
+
+			// Backward compatibility: if token has no scopes, allow access
+			// This supports existing OAuth setups where tokens don't include scope claims
+			scopes := scopeProvider.GetScopes()
+			if len(scopes) == 0 {
+				klog.V(2).Infof("Scope validation skipped: token has no scope claims (backward compatibility)")
+				return next(ctx, method, req)
+			}
+
+			// Parse tool name from request
+			// When OAuth is enabled, reject requests we can't parse (fail secure)
+			params, ok := req.GetParams().(*mcp.CallToolParamsRaw)
+			if !ok {
+				klog.V(1).Infof("Scope validation failed: unexpected params type %T", req.GetParams())
+				return nil, fmt.Errorf("forbidden: unable to validate scope for request")
+			}
+
+			toolReq, err := GoSdkToolCallParamsToToolCallRequest(params)
+			if err != nil {
+				klog.V(1).Infof("Scope validation failed: unable to parse tool request: %v", err)
+				return nil, fmt.Errorf("forbidden: unable to validate scope for request")
+			}
+			if toolReq == nil {
+				klog.V(1).Infof("Scope validation failed: parsed tool request is nil")
+				return nil, fmt.Errorf("forbidden: unable to validate scope for request")
+			}
+
+			// Get current scope configuration (supports dynamic reload)
+			readScope, writeScope := scopeGetter()
+
+			// Determine if tool is read-only based on annotations
+			isReadOnly := false
+			if tool := toolLookup(toolReq.Name); tool != nil {
+				isReadOnly = ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false)
+			} else {
+				klog.V(2).Infof("Scope validation: tool %q not found in registry, defaulting to write scope", toolReq.Name)
+			}
+
+			// Check if user has required scope
+			// Write scope implies read access (users with write can also read)
+			var hasAccess bool
+			var requiredScope string
+			if isReadOnly {
+				requiredScope = readScope
+				hasAccess = api.HasScope(scopes, readScope) || api.HasScope(scopes, writeScope)
+			} else {
+				requiredScope = writeScope
+				hasAccess = api.HasScope(scopes, writeScope)
+			}
+
+			if !hasAccess {
+				klog.V(1).Infof("Scope validation failed for tool %s: required scope %q not present",
+					toolReq.Name, requiredScope)
+				return nil, fmt.Errorf("forbidden: insufficient scope for tool %s, required: %s", toolReq.Name, requiredScope)
+			}
+
+			return next(ctx, method, req)
+		}
 	}
 }
 

--- a/pkg/mcp/scope_validation_test.go
+++ b/pkg/mcp/scope_validation_test.go
@@ -1,0 +1,288 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/utils/ptr"
+)
+
+type ScopeValidationSuite struct {
+	suite.Suite
+}
+
+func TestScopeValidation(t *testing.T) {
+	suite.Run(t, new(ScopeValidationSuite))
+}
+
+// mockScopeProvider implements api.ScopeProvider for testing
+type mockScopeProvider struct {
+	scopes []string
+}
+
+func (m *mockScopeProvider) GetScopes() []string {
+	return m.scopes
+}
+
+func (s *ScopeValidationSuite) TestHasScope() {
+	s.Run("returns true when scope exists", func() {
+		s.True(api.HasScope([]string{"read", "write"}, "read"))
+		s.True(api.HasScope([]string{"read", "write"}, "write"))
+	})
+
+	s.Run("returns false when scope missing", func() {
+		s.False(api.HasScope([]string{"read"}, "write"))
+		s.False(api.HasScope([]string{}, "read"))
+		s.False(api.HasScope(nil, "read"))
+	})
+
+	s.Run("comparison is case-insensitive", func() {
+		// IdPs may return scopes with different casing
+		s.True(api.HasScope([]string{"Read"}, "read"))
+		s.True(api.HasScope([]string{"READ"}, "read"))
+		s.True(api.HasScope([]string{"read"}, "READ"))
+		s.True(api.HasScope([]string{"Write"}, "write"))
+	})
+}
+
+func (s *ScopeValidationSuite) TestGetScopeProviderFromContext() {
+	s.Run("returns provider when present", func() {
+		provider := &mockScopeProvider{scopes: []string{"read"}}
+		ctx := context.WithValue(context.Background(), api.ScopeProviderContextKey, provider)
+
+		result := api.GetScopeProviderFromContext(ctx)
+		s.NotNil(result)
+		s.Equal([]string{"read"}, result.GetScopes())
+	})
+
+	s.Run("returns nil when no provider", func() {
+		ctx := context.Background()
+		result := api.GetScopeProviderFromContext(ctx)
+		s.Nil(result)
+	})
+
+	s.Run("returns nil for wrong type", func() {
+		ctx := context.WithValue(context.Background(), api.ScopeProviderContextKey, "not a provider")
+		result := api.GetScopeProviderFromContext(ctx)
+		s.Nil(result)
+	})
+}
+
+func (s *ScopeValidationSuite) TestDetermineRequiredScope() {
+	s.Run("read-only tool requires read scope", func() {
+		tool := &api.ServerTool{
+			Tool: api.Tool{
+				Name: "config_view",
+				Annotations: api.ToolAnnotations{
+					ReadOnlyHint: ptr.To(true),
+				},
+			},
+		}
+
+		// readOnlyHint=true should require read scope
+		s.True(ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false))
+	})
+
+	s.Run("write tool requires write scope", func() {
+		tool := &api.ServerTool{
+			Tool: api.Tool{
+				Name: "resource_apply",
+				Annotations: api.ToolAnnotations{
+					ReadOnlyHint: ptr.To(false),
+				},
+			},
+		}
+
+		// readOnlyHint=false should require write scope
+		s.False(ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false))
+	})
+
+	s.Run("nil annotations default to write scope", func() {
+		tool := &api.ServerTool{
+			Tool: api.Tool{
+				Name: "some_tool",
+			},
+		}
+
+		// No annotations should default to write scope (readOnlyHint=nil defaults to false)
+		s.False(ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false))
+	})
+}
+
+func (s *ScopeValidationSuite) TestValidateScopeConfig() {
+	s.Run("returns nil when OAuth disabled", func() {
+		cfg := &config.StaticConfig{
+			RequireOAuth: false,
+			ReadScope:    "", // empty is fine when OAuth disabled
+			WriteScope:   "",
+		}
+		err := validateScopeConfig(cfg)
+		s.NoError(err)
+	})
+
+	s.Run("returns error when read_scope empty with OAuth enabled", func() {
+		cfg := &config.StaticConfig{
+			RequireOAuth: true,
+			ReadScope:    "",
+			WriteScope:   "write",
+		}
+		err := validateScopeConfig(cfg)
+		s.Error(err)
+		s.Contains(err.Error(), "read_scope must not be empty")
+	})
+
+	s.Run("returns error when write_scope empty with OAuth enabled", func() {
+		cfg := &config.StaticConfig{
+			RequireOAuth: true,
+			ReadScope:    "read",
+			WriteScope:   "",
+		}
+		err := validateScopeConfig(cfg)
+		s.Error(err)
+		s.Contains(err.Error(), "write_scope must not be empty")
+	})
+
+	s.Run("returns nil with valid scopes and OAuth enabled", func() {
+		cfg := &config.StaticConfig{
+			RequireOAuth: true,
+			ReadScope:    "read",
+			WriteScope:   "write",
+		}
+		err := validateScopeConfig(cfg)
+		s.NoError(err)
+	})
+
+	s.Run("accepts custom scope names", func() {
+		cfg := &config.StaticConfig{
+			RequireOAuth: true,
+			ReadScope:    "kubernetes:read",
+			WriteScope:   "kubernetes:write",
+		}
+		err := validateScopeConfig(cfg)
+		s.NoError(err)
+	})
+}
+
+func (s *ScopeValidationSuite) TestScopeValidationLogic() {
+	s.Run("validates read-only tool with read scope", func() {
+		provider := &mockScopeProvider{scopes: []string{"read"}}
+		requiredScope := "read"
+
+		s.True(api.HasScope(provider.GetScopes(), requiredScope))
+	})
+
+	s.Run("rejects read-only tool without read scope", func() {
+		provider := &mockScopeProvider{scopes: []string{"write"}}
+		requiredScope := "read"
+
+		s.False(api.HasScope(provider.GetScopes(), requiredScope))
+	})
+
+	s.Run("validates write tool with write scope", func() {
+		provider := &mockScopeProvider{scopes: []string{"write"}}
+		requiredScope := "write"
+
+		s.True(api.HasScope(provider.GetScopes(), requiredScope))
+	})
+
+	s.Run("rejects write tool with only read scope", func() {
+		provider := &mockScopeProvider{scopes: []string{"read"}}
+		requiredScope := "write"
+
+		s.False(api.HasScope(provider.GetScopes(), requiredScope))
+	})
+
+	s.Run("accepts both read and write scopes for write operations", func() {
+		provider := &mockScopeProvider{scopes: []string{"read", "write"}}
+
+		s.True(api.HasScope(provider.GetScopes(), "read"))
+		s.True(api.HasScope(provider.GetScopes(), "write"))
+	})
+
+	s.Run("write scope grants read access (write implies read)", func() {
+		// Users with write scope should be able to call read-only tools
+		// This is standard RBAC behavior: write implies read
+		scopes := []string{"write"}
+		readScope := "read"
+		writeScope := "write"
+
+		// For read-only tools, accept either read OR write scope
+		hasReadAccess := api.HasScope(scopes, readScope) || api.HasScope(scopes, writeScope)
+		s.True(hasReadAccess, "write scope should grant read access")
+
+		// But read scope should NOT grant write access
+		scopes = []string{"read"}
+		hasWriteAccess := api.HasScope(scopes, writeScope)
+		s.False(hasWriteAccess, "read scope should not grant write access")
+	})
+
+	s.Run("custom scope names work", func() {
+		provider := &mockScopeProvider{scopes: []string{"kubernetes:read"}}
+
+		s.True(api.HasScope(provider.GetScopes(), "kubernetes:read"))
+		s.False(api.HasScope(provider.GetScopes(), "kubernetes:write"))
+	})
+
+	s.Run("empty scopes should skip validation for backward compatibility", func() {
+		// Tokens without scope claims should allow access (backward compatible)
+		provider := &mockScopeProvider{scopes: []string{}}
+		scopes := provider.GetScopes()
+
+		// len(scopes) == 0 means skip validation, not reject
+		s.Equal(0, len(scopes))
+	})
+
+	s.Run("nil scopes should skip validation for backward compatibility", func() {
+		// Tokens without scope claims should allow access (backward compatible)
+		provider := &mockScopeProvider{scopes: nil}
+		scopes := provider.GetScopes()
+
+		// len(scopes) == 0 means skip validation, not reject
+		s.Equal(0, len(scopes))
+	})
+}
+
+func (s *ScopeValidationSuite) TestBackwardCompatibilityNoScopes() {
+	// This test verifies the middleware allows access when OAuth is enabled
+	// but the token has no scope claims (backward compatibility)
+	s.Run("middleware allows access when token has empty scopes", func() {
+		// Simulate backward compatibility: OAuth enabled but token has no scopes
+		provider := &mockScopeProvider{scopes: []string{}}
+
+		// The middleware checks: if len(scopes) == 0, skip validation
+		scopes := provider.GetScopes()
+		s.Equal(0, len(scopes), "empty scopes should be detected")
+
+		// Verify the backward compatibility behavior:
+		// Even for write tools, empty scopes means "allow" not "deny"
+		// This is because existing OAuth setups may not include scope claims
+		skipValidation := len(scopes) == 0
+		s.True(skipValidation, "empty scopes should trigger skip validation path")
+	})
+
+	s.Run("middleware allows access when token has nil scopes", func() {
+		// Some IdPs may return nil instead of empty slice
+		provider := &mockScopeProvider{scopes: nil}
+
+		scopes := provider.GetScopes()
+		s.Equal(0, len(scopes), "nil scopes should be treated as empty")
+
+		skipValidation := len(scopes) == 0
+		s.True(skipValidation, "nil scopes should trigger skip validation path")
+	})
+
+	s.Run("middleware denies access when token has scopes but missing required", func() {
+		// When token HAS scopes, validation is enforced
+		provider := &mockScopeProvider{scopes: []string{"other-scope"}}
+
+		scopes := provider.GetScopes()
+		s.NotEqual(0, len(scopes), "non-empty scopes should be detected")
+
+		// User has scopes but not the required one
+		hasReadAccess := api.HasScope(scopes, "read") || api.HasScope(scopes, "write")
+		s.False(hasReadAccess, "should deny when scopes present but required scope missing")
+	})
+}


### PR DESCRIPTION
Implement scope-based access control for MCP tool calls when OAuth is enabled. Tools are authorized based on their annotations

 - read-only tools (readOnlyHint=true) require read_scope
 - write tools require write_scope
 - write scope implies read access (standard RBAC convention)

Changes:
- ScopeProvider interface for MCP layer to check JWT scopes
- Support for both 'scope' and 'scp' claims 
- Case-insensitive scope comparison for IdP variations
- Dynamic config reload via SIGHUP
- Backward compatibility: tokens without scopes allow all access