### PR TITLE
ci: add GitHub Actions labeler for kubevirt toolset PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,7 @@
+toolset/kubevirt:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'pkg/toolsets/kubevirt/**'
+      - 'pkg/kubevirt/**'
+      - 'pkg/mcp/kubevirt*'
+      - 'build/kubevirt.mk'

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,15 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
## Summary
- Adds `actions/labeler@v5` workflow to automatically label PRs that touch kubevirt-related files
- Introduces `.github/labeler.yml` config mapping `toolset/kubevirt` label to `pkg/toolsets/kubevirt/`, `pkg/kubevirt/`, `pkg/mcp/kubevirt*`, and `build/kubevirt.mk`
- Uses `pull_request_target` trigger so it works for PRs from forks
