### PR TITLE
chore(ci): extend labeler with kiali and tekton toolsets

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,23 @@
+toolset/kiali:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'pkg/toolsets/kiali/**'
+      - 'pkg/kiali/**'
+      - 'pkg/mcp/kiali*'
+      - 'build/kiali.mk'
+
+toolset/kubevirt:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'pkg/toolsets/kubevirt/**'
+      - 'pkg/kubevirt/**'
+      - 'pkg/mcp/kubevirt*'
+      - 'build/kubevirt.mk'
+
+toolset/tekton:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'pkg/toolsets/tekton/**'
+      - 'pkg/mcp/tekton*'
+      - 'evals/tasks/tekton/**'
+      - 'build/tekton.mk'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,0 @@
-toolset/kubevirt:
-  - changed-files:
-    - any-glob-to-any-file:
-      - 'pkg/toolsets/kubevirt/**'
-      - 'pkg/kubevirt/**'
-      - 'pkg/mcp/kubevirt*'
-      - 'build/kubevirt.mk'

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -12,4 +12,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yaml


### PR DESCRIPTION
## Summary
- Add `toolset/kiali` and `toolset/tekton` label patterns to `.github/labeler.yaml`
- Bump `actions/labeler` from v5 to v6
- Rename `.github/labeler.yml` to `.github/labeler.yaml` for consistency with other workflow files

Builds on #971.