### PR TITLE
fix(http): stop leaking internal details in well-known error responses

### DIFF
--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"k8s.io/klog/v2"
 )
 
 const maxWellKnownResponseSize = 1 << 20 // 1 MB
@@ -71,19 +72,22 @@ func (w WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 	}
 	req, err := http.NewRequest(request.Method, upstreamURL, nil)
 	if err != nil {
-		http.Error(writer, "Failed to create request: "+err.Error(), http.StatusInternalServerError)
+		klog.V(1).Infof("Well-known proxy failed to create request for %s: %v", request.URL.Path, err)
+		http.Error(writer, "Failed to create upstream request", http.StatusInternalServerError)
 		return
 	}
 	resp, err := w.httpClient.Do(req.WithContext(request.Context()))
 	if err != nil {
-		http.Error(writer, "Failed to perform request: "+err.Error(), http.StatusInternalServerError)
+		klog.V(1).Infof("Well-known proxy request failed for %s: %v", request.URL.Path, err)
+		http.Error(writer, "Failed to fetch upstream well-known metadata", http.StatusInternalServerError)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 	var resourceMetadata map[string]interface{}
 	err = json.NewDecoder(io.LimitReader(resp.Body, maxWellKnownResponseSize)).Decode(&resourceMetadata)
 	if err != nil {
-		http.Error(writer, "Failed to read response body: "+err.Error(), http.StatusInternalServerError)
+		klog.V(1).Infof("Well-known proxy failed to decode response for %s: %v", request.URL.Path, err)
+		http.Error(writer, "Failed to read upstream response", http.StatusInternalServerError)
 		return
 	}
 	if w.disableDynamicClientRegistration {
@@ -95,7 +99,8 @@ func (w WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 	}
 	body, err := json.Marshal(resourceMetadata)
 	if err != nil {
-		http.Error(writer, "Failed to marshal response body: "+err.Error(), http.StatusInternalServerError)
+		klog.V(1).Infof("Well-known proxy failed to marshal response for %s: %v", request.URL.Path, err)
+		http.Error(writer, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 	for key, values := range resp.Header {


### PR DESCRIPTION
Error responses from the well-known proxy handler included raw `err.Error()` output, which can expose internal hostnames, DNS errors, and network topology to unauthenticated clients. Log error details server-side via klog and return generic messages to the client.