### PR TITLE
chore(evals): replace deprecated openai-agent with openai-acp

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -90,14 +90,14 @@ commands:
     claude {{ .McpServerFileArgs }} --print "{{ .Prompt }}"
 ```
 
-### OpenAI Agent (openai-agent/agent.yaml)
+### OpenAI ACP (openai-agent/agent.yaml)
 ```yaml
 builtin:
-  type: "openai-agent"
+  type: "llm-agent"
   model: "gpt-4"
 ```
 
-Uses the built-in OpenAI agent with model configuration.
+Uses the built-in OpenAI ACP agent with model configuration.
 
 ## Filtering Tasks by Suite
 

--- a/evals/claude-code/agent.yaml
+++ b/evals/claude-code/agent.yaml
@@ -2,4 +2,4 @@ kind: Agent
 metadata:
   name: "claude-code-acp"
 acp:
-  cmd: "claude-code-acp"
+  cmd: "claude-agent-acp"

--- a/evals/openai-agent/agent.yaml
+++ b/evals/openai-agent/agent.yaml
@@ -2,7 +2,7 @@ kind: Agent
 metadata:
   name: "openai-agent"
 builtin:
-  type: "openai-agent"
+  type: "llm-agent"
   model: "gpt-5"  # Change to your model
 # Before running, set environment variables:
 #   export MODEL_BASE_URL="https://api.openai.com/v1"

--- a/evals/tasks/kubevirt/openai-agent/eval.yaml
+++ b/evals/tasks/kubevirt/openai-agent/eval.yaml
@@ -3,7 +3,7 @@ metadata:
   name: "kubevirt-basic-operations"
 config:
   agent:
-    type: "builtin.openai-agent"
+    type: "builtin.llm-agent"
     model: "gemini-2.0-flash"
   mcpConfigFile: ../../../mcp-config.yaml
   extensions:


### PR DESCRIPTION
### Summary

- Migrate deprecated `openai-agent `configs to `openai-acp`, and update kubevirt eval to `builtin.openai-acp`.
- Update Claude ACP command from `claude-code-acp` to `claude-agent-acp`. 
  -  https://github.com/containers/kubernetes-mcp-server/issues/944

Fixes #944