### PR TITLE
fix(kubernetes): close old managers before replacing on reset

### DIFF
--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -165,6 +165,13 @@ func (m *Manager) Derived(ctx context.Context) (*Kubernetes, error) {
 	return derived, nil
 }
 
+// Close releases HTTP transport resources held by this manager.
+func (m *Manager) Close() {
+	if m != nil {
+		m.kubernetes.close()
+	}
+}
+
 // Invalidate invalidates the cached discovery information.
 func (m *Manager) Invalidate() {
 	m.kubernetes.DiscoveryClient().Invalidate()

--- a/pkg/kubernetes/provider_kubeconfig.go
+++ b/pkg/kubernetes/provider_kubeconfig.go
@@ -64,6 +64,11 @@ func (p *kubeConfigClusterProvider) reset() error {
 		return err
 	}
 
+	for _, old := range p.managers {
+		if old != nil {
+			old.Close()
+		}
+	}
 	p.managers = map[string]*Manager{
 		rawConfig.CurrentContext: m, // we already initialized a manager for the default context, let's use it
 	}

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -50,6 +50,9 @@ func (p *singleClusterProvider) reset() error {
 			p.config.GetKubeConfigPath())
 	}
 
+	if p.manager != nil {
+		p.manager.Close()
+	}
 	var err error
 	if p.strategy == api.ClusterProviderInCluster || IsInCluster(p.config) {
 		p.manager, err = NewInClusterManager(p.config)


### PR DESCRIPTION
When provider `reset()` is triggered by `kubeconfig` or cluster state changes, old Manager instances were replaced without closing their HTTP transport resources (TCP sockets, TLS sessions, connection pools).

Add `Manager.Close()` and call it in both providers before reassignment.