### PR TITLE
fix(helm): replace blunt .0 removal with targeted regex in configmap template

### DIFF
--- a/charts/kubernetes-mcp-server/templates/configmap.yaml
+++ b/charts/kubernetes-mcp-server/templates/configmap.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "kubernetes-mcp-server.labels" . | nindent 4 }}
 data:
   config.toml: |
-    {{- tpl (toToml .Values.config) . | replace ".0" "" | nindent 4 }}
+    {{- tpl (toToml .Values.config) . | regexReplaceAll "(?m)(= \\d+)\\.0$" "${1}" | nindent 4 }}


### PR DESCRIPTION
## Problem

The ConfigMap template uses `| replace ".0" ""` to strip trailing `.0` from integer values rendered as floats by Helm's `toToml` function (e.g., `log_level = 2.0` → `log_level = 2`).

However, this blunt string replacement removes **all** occurrences of `.0` from the entire TOML output, including legitimate `.0` sequences inside quoted string values.

### Impact

When using Azure AD / Microsoft Entra ID as OIDC provider, the issuer URL `https://login.microsoftonline.com/{tenant}/v2.0` gets truncated to `/v2`, causing:

```
Error: unable to setup OIDC provider: 404 Not Found
```

The server tries to fetch `/.well-known/openid-configuration` from the truncated URL and gets a 404.

## Fix

Replace the blunt `| replace ".0" ""` with a targeted regex that only strips `.0` from bare numeric TOML values at end-of-line:

```diff
- {{- tpl (toToml .Values.config) . | replace ".0" "" | nindent 4 }}
+ {{- tpl (toToml .Values.config) . | regexReplaceAll "(?m)(= \\d+)\\.0$" "${1}" | nindent 4 }}
```

The regex `(?m)(= \d+)\.0$` matches lines where a TOML value assignment ends with an integer followed by `.0` (like `log_level = 2.0`), and strips only that trailing `.0`. String values (which are inside quotes) are never matched because the line does not end with `.0` — it ends with `.0"`.

## Testing

Verified with Azure AD OIDC configuration:
- **Before**: `authorization_url = "https://login.microsoftonline.com/.../v2"` (broken)
- **After**: `authorization_url = "https://login.microsoftonline.com/.../v2.0"` (correct)
- Integer values like `log_level = 2` still render correctly (no spurious `.0`)
