### PR TITLE
fix(helm): replace blunt .0 removal with targeted regex in configmap template

### DIFF
--- a/charts/kubernetes-mcp-server/templates/configmap.yaml
+++ b/charts/kubernetes-mcp-server/templates/configmap.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "kubernetes-mcp-server.labels" . | nindent 4 }}
 data:
   config.toml: |
-    {{- tpl (toToml .Values.config) . | replace ".0" "" | nindent 4 }}
+    {{- regexReplaceAll "(?m)(= \\d+)\\.0$" (tpl (toToml .Values.config) .) "${1}" | nindent 4 }}


### PR DESCRIPTION
## Problem

The current ConfigMap template uses `| replace ".0" ""` to strip Helm's `.0` suffix from integer TOML values (e.g. `port = 8080.0` → `port = 8080`).

This is too aggressive — it strips `.0` from **all** string values too. For example, an OIDC authorization URL like:

```
authorization_url = "https://login.microsoftonline.com/TENANT/v2.0"
```

becomes:

```
authorization_url = "https://login.microsoftonline.com/TENANT/v2"
```

This breaks OIDC discovery since the truncated URL doesn't match any valid OpenID Connect issuer.

## Fix

Replace the blanket `replace ".0" ""` with a targeted `regexReplaceAll` that only removes `.0` from numeric TOML values at the end of a line:

```
regexReplaceAll "(?m)(= \\d+)\\.0$" ... "${1}"
```

This matches patterns like `= 8080.0` (end of line) and strips the `.0`, while leaving string values like `/v2.0` intact.

## Testing

Tested with `helm template` using various config values including `authorization_url` with `/v2.0` suffix — all values render correctly. Deployed and validated in a production environment with OIDC authentication against Azure AD.