### PR TITLE
fix(helm): handle negative integers in configmap .0 cleanup regex

### DIFF
--- a/build/helm.mk
+++ b/build/helm.mk
@@ -63,6 +63,21 @@ helm-validate: kubeconform ## Validate Helm chart manifests with kubeconform
 	@echo ""
 	@echo "Validating with tpl-exercising values..."
 	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/tpl-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
+	@echo ""
+	@echo "Validating with configmap-numeric-test values..."
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/configmap-numeric-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
+	@echo ""
+	@echo "Testing ConfigMap numeric .0 cleanup..."
+	@output=$$(helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/configmap-numeric-test-values.yaml 2>&1); \
+	failed=0; \
+	if echo "$$output" | grep -q 'log_level = 2\.0'; then echo "FAIL: log_level has unwanted .0 suffix"; failed=1; else echo "PASS: log_level integer .0 stripped"; fi; \
+	if echo "$$output" | grep -q 'positive_port = 8080\.0'; then echo "FAIL: positive_port has unwanted .0 suffix"; failed=1; else echo "PASS: positive_port integer .0 stripped"; fi; \
+	if echo "$$output" | grep -q 'zero_value = 0\.0'; then echo "FAIL: zero_value has unwanted .0 suffix"; failed=1; else echo "PASS: zero_value integer .0 stripped"; fi; \
+	if echo "$$output" | grep -q 'negative_offset = -5\.0'; then echo "FAIL: negative_offset has unwanted .0 suffix"; failed=1; else echo "PASS: negative_offset integer .0 stripped"; fi; \
+	if ! echo "$$output" | grep -q 'v2\.0'; then echo "FAIL: authorization_url should preserve v2.0"; failed=1; else echo "PASS: authorization_url preserves v2.0"; fi; \
+	if ! echo "$$output" | grep -q 'v3\.0'; then echo "FAIL: some_url should preserve v3.0"; failed=1; else echo "PASS: some_url preserves v3.0"; fi; \
+	if [ $$failed -eq 1 ]; then echo ""; echo "ConfigMap numeric cleanup test FAILED"; exit 1; fi; \
+	echo ""; echo "ConfigMap numeric cleanup test PASSED"
 
 .PHONY: helm-package
 helm-package: helm-lint helm-template ## Package the Helm chart (supports HELM_CHART_VERSION override)

--- a/charts/kubernetes-mcp-server/ci/configmap-numeric-test-values.yaml
+++ b/charts/kubernetes-mcp-server/ci/configmap-numeric-test-values.yaml
@@ -1,0 +1,21 @@
+# Test values to verify that numeric .0 cleanup in configmap.yaml
+# only strips the .0 suffix from integer TOML values, not from string values.
+#
+# Helm's toToml function can serialize YAML integers as floats (e.g., 8080.0),
+# and the configmap template's regexReplaceAll must strip the .0 from numeric
+# values while preserving .0 in string values (e.g., OIDC URLs like /v2.0).
+
+ingress:
+  host: localhost
+
+config:
+  # Positive integers: .0 suffix should be stripped
+  log_level: 2
+  positive_port: 8080
+  # Zero value: .0 suffix should be stripped
+  zero_value: 0
+  # Negative integers: .0 suffix should also be stripped
+  negative_offset: -5
+  # String values containing .0: must be preserved as-is
+  authorization_url: "https://login.microsoftonline.com/TENANT/v2.0"
+  some_url: "https://example.com/api/v3.0/resource"

--- a/charts/kubernetes-mcp-server/templates/configmap.yaml
+++ b/charts/kubernetes-mcp-server/templates/configmap.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "kubernetes-mcp-server.labels" . | nindent 4 }}
 data:
   config.toml: |
-    {{- regexReplaceAll "(?m)(= \\d+)\\.0$" (tpl (toToml .Values.config) .) "${1}" | nindent 4 }}
+    {{- regexReplaceAll "(?m)(= -?\\d+)\\.0$" (tpl (toToml .Values.config) .) "${1}" | nindent 4 }}


### PR DESCRIPTION
## Summary

- The regex from #983 only matched positive integers (`= \d+`), leaving negative values like `-5.0` uncleaned in the rendered ConfigMap TOML
- Add optional minus sign (`-?`) to the pattern so negative integers are also stripped of the `.0` suffix
- Add assertions to the existing `helm-validate` Makefile target with a CI values file covering positive, zero, and negative integers as well as string values containing `.0` (e.g., OIDC URLs)