### PR TITLE
test(security): add require_tls validation and enforcement tests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,3 +366,16 @@ func (c *StaticConfig) IsValidationEnabled() bool {
 func (c *StaticConfig) IsRequireTLS() bool {
 	return c.RequireTLS
 }
+
+// ValidateRequireTLS validates outbound URL schemes when RequireTLS is enabled.
+// Called at startup (root.go Validate) and on config reload (ReloadConfiguration).
+func (c *StaticConfig) ValidateRequireTLS() error {
+	if !c.RequireTLS {
+		return nil
+	}
+	return ValidateURLsRequireTLS(map[string]string{
+		"authorization_url": c.AuthorizationURL,
+		"server_url":        c.ServerURL,
+		"sse_base_url":      c.SSEBaseURL,
+	})
+}

--- a/pkg/config/tls_test.go
+++ b/pkg/config/tls_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -50,6 +51,57 @@ func (s *TLSSuite) TestValidateURLRequiresTLS() {
 		err := ValidateURLRequiresTLS("://invalid", "test_url")
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid test_url")
+	})
+}
+
+func (s *TLSSuite) TestValidateURLsRequireTLS() {
+	s.Run("returns nil when all URLs are HTTPS", func() {
+		err := ValidateURLsRequireTLS(map[string]string{
+			"authorization_url": "https://example.com/auth",
+			"server_url":        "https://example.com:8080",
+		})
+		s.NoError(err)
+	})
+
+	s.Run("returns nil when all URLs are empty", func() {
+		err := ValidateURLsRequireTLS(map[string]string{
+			"authorization_url": "",
+			"server_url":        "",
+			"sse_base_url":      "",
+		})
+		s.NoError(err)
+	})
+
+	s.Run("returns error for single HTTP URL", func() {
+		err := ValidateURLsRequireTLS(map[string]string{
+			"authorization_url": "https://example.com/auth",
+			"server_url":        "http://example.com:8080",
+		})
+		s.Require().Error(err)
+		s.Contains(err.Error(), "server_url")
+		s.Contains(err.Error(), "secure scheme required")
+	})
+
+	s.Run("returns combined errors for multiple HTTP URLs in sorted order", func() {
+		err := ValidateURLsRequireTLS(map[string]string{
+			"server_url":        "http://example.com:8080",
+			"authorization_url": "http://example.com/auth",
+		})
+		s.Require().Error(err)
+		msg := err.Error()
+		s.Contains(msg, "authorization_url")
+		s.Contains(msg, "server_url")
+		// Verify sorted order: authorization_url should appear before server_url
+		s.Less(
+			strings.Index(msg, "authorization_url"),
+			strings.Index(msg, "server_url"),
+			"authorization_url error should appear before server_url (sorted order)",
+		)
+	})
+
+	s.Run("returns nil for empty map", func() {
+		err := ValidateURLsRequireTLS(map[string]string{})
+		s.NoError(err)
 	})
 }
 

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -343,14 +343,8 @@ func (m *MCPServerOptions) Validate() error {
 		}
 	}
 	// Validate outbound URLs when require_tls is enabled
-	if m.StaticConfig.RequireTLS {
-		if err := config.ValidateURLsRequireTLS(map[string]string{
-			"authorization_url": m.StaticConfig.AuthorizationURL,
-			"server_url":        m.StaticConfig.ServerURL,
-			"sse_base_url":      m.StaticConfig.SSEBaseURL,
-		}); err != nil {
-			return err
-		}
+	if err := m.StaticConfig.ValidateRequireTLS(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -485,6 +485,103 @@ func TestStateless(t *testing.T) {
 	})
 }
 
+func TestRequireTLSValidation(t *testing.T) {
+	t.Run("require-tls without TLS certs in HTTP mode returns error", func(t *testing.T) {
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--port=8080", "--require-tls"})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "require_tls is enabled but TLS certificates are not configured")
+	})
+
+	t.Run("require-tls with TLS certs in HTTP mode succeeds", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certPath := filepath.Join(tempDir, "cert.pem")
+		keyPath := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert content"), 0644))
+		require.NoError(t, os.WriteFile(keyPath, []byte("key content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--port=8080", "--require-tls", "--tls-cert", certPath, "--tls-key", keyPath})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("require-tls in STDIO mode does not require TLS certs", func(t *testing.T) {
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{"--version", "--require-tls"})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+
+	t.Run("require-tls rejects HTTP authorization-url", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certPath := filepath.Join(tempDir, "cert.pem")
+		keyPath := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert content"), 0644))
+		require.NoError(t, os.WriteFile(keyPath, []byte("key content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{
+			"--version", "--port=8080", "--require-tls",
+			"--tls-cert", certPath, "--tls-key", keyPath,
+			"--require-oauth",
+			"--authorization-url", "http://example.com/auth",
+			"--server-url", "https://example.com:8080",
+		})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "authorization_url")
+		assert.Contains(t, err.Error(), "secure scheme required")
+	})
+
+	t.Run("require-tls rejects HTTP server-url", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certPath := filepath.Join(tempDir, "cert.pem")
+		keyPath := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert content"), 0644))
+		require.NoError(t, os.WriteFile(keyPath, []byte("key content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{
+			"--version", "--port=8080", "--require-tls",
+			"--tls-cert", certPath, "--tls-key", keyPath,
+			"--require-oauth",
+			"--authorization-url", "https://example.com/auth",
+			"--server-url", "http://example.com:8080",
+		})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "server_url")
+		assert.Contains(t, err.Error(), "secure scheme required")
+	})
+
+	t.Run("require-tls accepts all HTTPS URLs", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certPath := filepath.Join(tempDir, "cert.pem")
+		keyPath := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(certPath, []byte("cert content"), 0644))
+		require.NoError(t, os.WriteFile(keyPath, []byte("key content"), 0644))
+
+		ioStreams, _ := testStream()
+		rootCmd := NewMCPServer(ioStreams)
+		rootCmd.SetArgs([]string{
+			"--version", "--port=8080", "--require-tls",
+			"--tls-cert", certPath, "--tls-key", keyPath,
+			"--require-oauth",
+			"--authorization-url", "https://example.com/auth",
+			"--server-url", "https://example.com:8080",
+		})
+		err := rootCmd.Execute()
+		require.NoError(t, err)
+	})
+}
+
 func TestTLSValidation(t *testing.T) {
 	t.Run("tls-cert without tls-key returns error", func(t *testing.T) {
 		tempDir := t.TempDir()

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -342,6 +342,11 @@ func (s *Server) GetEnabledPrompts() []string {
 func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 	klog.V(1).Info("Reloading MCP server configuration...")
 
+	// Validate require_tls constraints (fail-fast on reload, same check as startup)
+	if err := newConfig.ValidateRequireTLS(); err != nil {
+		return fmt.Errorf("configuration reload rejected: %w", err)
+	}
+
 	// Update the configuration
 	s.configuration.StaticConfig = newConfig
 	// Clear cached values so they get recomputed

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -209,6 +209,57 @@ func (s *ConfigReloadSuite) TestReloadUpdatesToolsets() {
 	s.True(helmToolFound, "helm tools should be available after reload")
 }
 
+func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
+	provider, err := kubernetes.NewProvider(s.Cfg)
+	s.Require().NoError(err)
+	server, err := NewServer(Configuration{
+		StaticConfig: s.Cfg,
+	}, provider)
+	s.Require().NoError(err)
+	s.server = server
+
+	s.Run("reload with require_tls and HTTP authorization_url is rejected", func() {
+		newConfig := config.Default()
+		newConfig.RequireTLS = true
+		newConfig.AuthorizationURL = "http://example.com/auth"
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "authorization_url")
+		s.Contains(err.Error(), "secure scheme required")
+	})
+
+	s.Run("reload with require_tls and HTTP server_url is rejected", func() {
+		newConfig := config.Default()
+		newConfig.RequireTLS = true
+		newConfig.ServerURL = "http://example.com:8080"
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "server_url")
+		s.Contains(err.Error(), "secure scheme required")
+	})
+
+	s.Run("reload with require_tls and HTTPS URLs succeeds", func() {
+		newConfig := config.Default()
+		newConfig.RequireTLS = true
+		newConfig.AuthorizationURL = "https://example.com/auth"
+		newConfig.ServerURL = "https://example.com:8080"
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.NoError(err)
+	})
+
+	s.Run("reload without require_tls allows HTTP URLs", func() {
+		newConfig := config.Default()
+		newConfig.RequireTLS = false
+		newConfig.AuthorizationURL = "http://example.com/auth"
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.NoError(err)
+	})
+}
+
 func (s *ConfigReloadSuite) TestServerLifecycle() {
 	provider, err := kubernetes.NewProvider(s.Cfg)
 	s.Require().NoError(err)

--- a/pkg/mcp/require_tls_test.go
+++ b/pkg/mcp/require_tls_test.go
@@ -1,0 +1,128 @@
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+// KialiRequireTLSSuite tests Layer 2 (runtime) TLS enforcement for the Kiali toolset.
+// It uses a plain HTTP mock server and verifies that TLSEnforcingTransport blocks
+// requests when require_tls is enabled.
+type KialiRequireTLSSuite struct {
+	BaseMcpSuite
+	mockServer *test.MockServer
+}
+
+func (s *KialiRequireTLSSuite) SetupTest() {
+	s.BaseMcpSuite.SetupTest()
+	s.mockServer = test.NewMockServer()
+	s.mockServer.Config().BearerToken = "token-xyz"
+}
+
+func (s *KialiRequireTLSSuite) TearDownTest() {
+	s.BaseMcpSuite.TearDownTest()
+	if s.mockServer != nil {
+		s.mockServer.Close()
+	}
+}
+
+func (s *KialiRequireTLSSuite) setupConfig(requireTLS bool) {
+	kubeConfig := s.Cfg.KubeConfig
+	// Parse config without require_tls to bypass Layer 1 (config-time) URL validation,
+	// then enable require_tls to test Layer 2 (runtime) TLSEnforcingTransport enforcement.
+	s.Cfg = test.Must(config.ReadToml([]byte(fmt.Sprintf(`
+		toolsets = ["kiali"]
+		[toolset_configs.kiali]
+		url = "%s"
+	`, s.mockServer.Config().Host))))
+	s.Cfg.KubeConfig = kubeConfig
+	s.Cfg.RequireTLS = requireTLS
+}
+
+func (s *KialiRequireTLSSuite) TestRequireTLS_BlocksHTTPRequests() {
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"traceId":"test-trace-123","spans":[]}`))
+	}))
+	s.setupConfig(true)
+	s.InitMcpClient()
+
+	s.Run("kiali tool call to HTTP server is blocked", func() {
+		toolResult, err := s.CallTool("kiali_get_traces", map[string]interface{}{
+			"traceId": "test-trace-123",
+		})
+		s.Require().Nilf(err, "MCP protocol error: %v", err)
+		s.True(toolResult.IsError, "tool call should return an error result")
+		s.Contains(
+			toolResult.Content[0].(*mcp.TextContent).Text,
+			"secure scheme required",
+			"error should indicate TLS enforcement",
+		)
+	})
+}
+
+func (s *KialiRequireTLSSuite) TestRequireTLS_AllowsHTTPWhenDisabled() {
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"traceId":"test-trace-456","spans":[]}`))
+	}))
+	s.setupConfig(false)
+	s.InitMcpClient()
+
+	s.Run("kiali tool call to HTTP server succeeds", func() {
+		toolResult, err := s.CallTool("kiali_get_traces", map[string]interface{}{
+			"traceId": "test-trace-456",
+		})
+		s.Nilf(err, "call tool failed: %v", err)
+		s.Falsef(toolResult.IsError, "call tool failed")
+		s.Contains(
+			toolResult.Content[0].(*mcp.TextContent).Text,
+			"test-trace-456",
+			"response should contain trace ID",
+		)
+	})
+}
+
+func TestKialiRequireTLS(t *testing.T) {
+	suite.Run(t, new(KialiRequireTLSSuite))
+}
+
+// CoreRequireTLSSuite tests that enabling require_tls does not break core
+// Kubernetes tools. The envtest API server uses HTTPS, so core tools should
+// continue to work normally when TLS enforcement is enabled.
+type CoreRequireTLSSuite struct {
+	BaseMcpSuite
+}
+
+func (s *CoreRequireTLSSuite) TestRequireTLS_CoreToolsStillWork() {
+	kubeConfig := s.Cfg.KubeConfig
+	s.Cfg = test.Must(config.ReadToml([]byte(`
+		require_tls = true
+		list_output = "yaml"
+	`)))
+	s.Cfg.KubeConfig = kubeConfig
+	s.InitMcpClient()
+
+	s.Run("namespaces_list succeeds with require_tls enabled", func() {
+		toolResult, err := s.CallTool("namespaces_list", map[string]interface{}{})
+		s.Nilf(err, "call tool failed: %v", err)
+		s.Falsef(toolResult.IsError, "call tool failed")
+		var decoded []unstructured.Unstructured
+		err = yaml.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded)
+		s.Require().NoError(err, "expected valid YAML response")
+		s.True(slices.ContainsFunc(decoded, func(ns unstructured.Unstructured) bool {
+			return ns.GetName() == "default"
+		}), "expected default namespace in the list")
+	})
+}
+
+func TestCoreRequireTLS(t *testing.T) {
+	suite.Run(t, new(CoreRequireTLSSuite))
+}


### PR DESCRIPTION
## Summary

Follow-up to #954 (`require_tls` feature). Adds behavioral black-box tests
and fixes the SIGHUP reload validation gap for `require_tls` URL scheme checks.

### Changes

- **CLI validation tests** (`root_test.go`): 6 test cases covering missing certs,
  HTTP URL rejection for `authorization_url`/`server_url`, STDIO mode, and happy path
- **MCP integration tests** (`require_tls_test.go`): Layer 2 runtime enforcement via
  Kiali toolset (HTTP blocked/allowed) and core toolset regression (`namespaces_list`
  still works with `require_tls` enabled)
- **Config reload tests** (`mcp_reload_test.go`): SIGHUP re-validation rejects HTTP
  URLs when `require_tls` is enabled in reloaded config
- **`ValidateURLsRequireTLS` tests** (`tls_test.go`): Multi-URL validation with sorted
  keys, combined errors, and edge cases
- **Extract `StaticConfig.ValidateRequireTLS()`**: Single source of truth for
  `require_tls` URL validation, called from both startup (`Validate()`) and reload
  (`ReloadConfiguration()`)

Refs #989