### PR TITLE
test(http): consolidate OAuth-exempt endpoint tests into single test

### DIFF
--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -433,36 +433,24 @@ func (s *AuthorizationSuite) TestAuthorizationOidcTokenExchange() {
 	s.Require().NoError(s.WaitForShutdown())
 }
 
-func (s *AuthorizationSuite) TestAuthorizationMetricsEndpointExemptFromOAuth() {
+func (s *AuthorizationSuite) TestAuthorizationExemptEndpointsFromOAuth() {
 	// https://github.com/containers/kubernetes-mcp-server/issues/932
-	// When require_oauth is true, the /metrics endpoint should still be accessible
-	// without an OAuth token so that Prometheus can scrape metrics.
-	s.StartServer()
-
-	s.Run("metrics endpoint accessible without OAuth token", func() {
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%s/metrics", s.StaticConfig.Port), nil)
-		s.Require().NoError(err, "Failed to create request")
-		resp, err := http.DefaultClient.Do(req)
-		s.Require().NoError(err, "Failed to get metrics endpoint")
-		s.T().Cleanup(func() { _ = resp.Body.Close() })
-		s.Equal(http.StatusOK, resp.StatusCode, "Expected /metrics to be accessible without OAuth token")
-	})
-}
-
-func (s *AuthorizationSuite) TestAuthorizationStatsEndpointExemptFromOAuth() {
 	// https://github.com/containers/kubernetes-mcp-server/issues/964
-	// When require_oauth is true, the /stats endpoint should still be accessible
-	// without an OAuth token as an infrastructure/observability endpoint.
+	// When require_oauth is true, infrastructure/observability endpoints should
+	// still be accessible without an OAuth token.
 	s.StartServer()
 
-	s.Run("stats endpoint accessible without OAuth token", func() {
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%s/stats", s.StaticConfig.Port), nil)
-		s.Require().NoError(err, "Failed to create request")
-		resp, err := http.DefaultClient.Do(req)
-		s.Require().NoError(err, "Failed to get stats endpoint")
-		s.T().Cleanup(func() { _ = resp.Body.Close() })
-		s.Equal(http.StatusOK, resp.StatusCode, "Expected /stats to be accessible without OAuth token")
-	})
+	exemptEndpoints := []string{"/healthz", "/metrics", "/stats"}
+	for _, endpoint := range exemptEndpoints {
+		s.Run(fmt.Sprintf("%s accessible without OAuth token", endpoint), func() {
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%s%s", s.StaticConfig.Port, endpoint), nil)
+			s.Require().NoError(err, "Failed to create request")
+			resp, err := http.DefaultClient.Do(req)
+			s.Require().NoError(err, "Failed to get %s endpoint", endpoint)
+			s.T().Cleanup(func() { _ = resp.Body.Close() })
+			s.Equal(http.StatusOK, resp.StatusCode, "Expected %s to be accessible without OAuth token", endpoint)
+		})
+	}
 }
 
 func TestAuthorization(t *testing.T) {


### PR DESCRIPTION
Replace separate test methods for `/metrics` and `/stats` with a unified
`TestAuthorizationExemptEndpointsFromOAuth` that loops over all exempt
infrastructure endpoints (`/healthz`, `/metrics`, `/stats`).

This reduces duplication and makes it easier to add new exempt endpoints
in the future — just append to the slice.

Refs #932, #964