### PR TITLE
feat(evals): add make target to install mcpchecker agent dependencies

### DIFF
--- a/build/evals.mk
+++ b/build/evals.mk
@@ -7,6 +7,7 @@ MCP_CONFIG_DIR ?= dev/config/mcp-configs
 
 MCPCHECKER = $(shell pwd)/_output/tools/bin/mcpchecker
 MCPCHECKER_VERSION ?= latest
+CLAUDE_AGENT_ACP_VERSION ?= latest
 EVAL_CONFIG ?= evals/openai-agent/eval.yaml
 EVAL_LABEL_SELECTOR ?= suite=kubernetes
 EVAL_TASK_FILTER ?=
@@ -21,6 +22,21 @@ mcpchecker:
 		mkdir -p $(shell dirname $(MCPCHECKER)) ;\
 		GOBIN=$(shell dirname $(MCPCHECKER)) go install github.com/mcpchecker/mcpchecker/cmd/mcpchecker@$(MCPCHECKER_VERSION) ;\
 	}
+
+# Install claude-agent-acp for Claude Code evaluations
+.PHONY: claude-agent-acp
+claude-agent-acp:
+	@command -v claude-agent-acp >/dev/null 2>&1 || { \
+		set -e ;\
+		echo "Installing claude-agent-acp..." ;\
+		npm install -g @agentclientprotocol/claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) ;\
+		echo "claude-agent-acp installed successfully" ;\
+	}
+
+# Install all mcpchecker agent dependencies
+.PHONY: mcpchecker-deps
+mcpchecker-deps: mcpchecker claude-agent-acp ## Install mcpchecker and all agent dependencies
+	@echo "All mcpchecker dependencies installed"
 
 ##@ Evals
 


### PR DESCRIPTION
## Summary

Adds new make targets to install agent dependencies for mcpchecker evaluations.

### Changes

- **`make claude-agent-acp`**: Installs the `@agentclientprotocol/claude-agent-acp` npm package required for running Claude Code evaluations
- **`make mcpchecker-deps`**: Convenience target that installs mcpchecker and all agent dependencies (currently claude-agent-acp)

Also adds `CLAUDE_AGENT_ACP_VERSION` variable (defaults to `latest`) to allow pinning to specific versions if needed.

### Usage

```bash
# Install all dependencies for running mcpchecker with different agents
make mcpchecker-deps

# Or install individual dependencies
make mcpchecker
make claude-agent-acp
```

Fixes #947