### PR TITLE
test(mcp): add integration tests for prompt target parameter in multi-cluster

### DIFF
--- a/pkg/mcp/testdata/toolsets-full-prompts-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-prompts-multicluster.json
@@ -1,0 +1,20 @@
+[
+  {
+    "arguments": [
+      {
+        "name": "namespace",
+        "description": "Optional namespace to limit health check scope (default: all namespaces)"
+      },
+      {
+        "name": "check_events",
+        "description": "Include recent warning/error events (true/false, default: true)"
+      },
+      {
+        "name": "context",
+        "description": "Optional parameter selecting which context to run the prompt in. Defaults to fake-context if not set"
+      }
+    ],
+    "description": "Perform comprehensive health assessment of Kubernetes/OpenShift cluster",
+    "name": "cluster-health-check"
+  }
+]

--- a/pkg/mcp/testdata/toolsets-full-prompts.json
+++ b/pkg/mcp/testdata/toolsets-full-prompts.json
@@ -1,0 +1,16 @@
+[
+  {
+    "arguments": [
+      {
+        "name": "namespace",
+        "description": "Optional namespace to limit health check scope (default: all namespaces)"
+      },
+      {
+        "name": "check_events",
+        "description": "Include recent warning/error events (true/false, default: true)"
+      }
+    ],
+    "description": "Perform comprehensive health assessment of Kubernetes/OpenShift cluster",
+    "name": "cluster-health-check"
+  }
+]

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -124,6 +124,51 @@ func (s *ToolsetsSuite) TestDefaultToolsetsToolsInMultiCluster() {
 	})
 }
 
+func (s *ToolsetsSuite) TestDefaultToolsetsPrompts() {
+	s.Run("Default configuration toolsets", func() {
+		s.InitMcpClient()
+		prompts, err := s.ListPrompts()
+		s.Run("ListPrompts returns prompts", func() {
+			s.NotNil(prompts, "Expected prompts from ListPrompts")
+			s.NoError(err, "Expected no error from ListPrompts")
+			s.NotEmpty(prompts.Prompts, "Expected at least one prompt")
+		})
+		s.Run("ListPrompts returns correct Prompt metadata", func() {
+			s.assertJsonSnapshot("toolsets-full-prompts.json", prompts.Prompts)
+		})
+		s.Run("cluster-aware prompts do not have context argument in single cluster", func() {
+			s.Require().NotNil(prompts)
+			for _, prompt := range prompts.Prompts {
+				for _, arg := range prompt.Arguments {
+					s.NotEqualf("context", arg.Name,
+						"Prompt %s should not have context argument in single-cluster mode", prompt.Name)
+				}
+			}
+		})
+	})
+}
+
+func (s *ToolsetsSuite) TestDefaultToolsetsPromptsInMultiCluster() {
+	s.Run("Default configuration toolsets in multi-cluster (with 11 clusters)", func() {
+		kubeconfig := s.Kubeconfig()
+		for i := 0; i < 10; i++ {
+			// Add multiple fake contexts to force multi-cluster behavior
+			kubeconfig.Contexts[strconv.Itoa(i)] = clientcmdapi.NewContext()
+		}
+		s.Cfg.KubeConfig = test.KubeconfigFile(s.T(), kubeconfig)
+		s.InitMcpClient()
+		prompts, err := s.ListPrompts()
+		s.Run("ListPrompts returns prompts", func() {
+			s.NotNil(prompts, "Expected prompts from ListPrompts")
+			s.NoError(err, "Expected no error from ListPrompts")
+			s.NotEmpty(prompts.Prompts, "Expected at least one prompt")
+		})
+		s.Run("ListPrompts returns correct Prompt metadata", func() {
+			s.assertJsonSnapshot("toolsets-full-prompts-multicluster.json", prompts.Prompts)
+		})
+	})
+}
+
 func (s *ToolsetsSuite) TestGranularToolsetsTools() {
 	testCases := []api.Toolset{
 		&core.Toolset{},


### PR DESCRIPTION
## Summary
- Add `TestDefaultToolsetsPrompts` verifying cluster-aware prompts do NOT get a context argument in single-cluster mode
- Add `TestDefaultToolsetsPromptsInMultiCluster` verifying cluster-aware prompts DO get the context argument when multiple kubeconfig contexts are present
- Mirrors the existing `TestDefaultToolsetsToolsInMultiCluster` pattern for prompts, closing the integration test gap from #980

## Test plan
- [x] `go test ./pkg/mcp/ -run TestToolsets` passes (all existing + new tests)