### PR TITLE
feat(helm): add backend storage driver support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -584,16 +584,18 @@ token = "your-kiali-token"
 ```toml
 [toolset_configs.helm]
 allowed_registries = ["oci://ghcr.io/myorg", "https://charts.example.com"]
+storage_driver = "configmap"
 ```
 
 #### Helm Configuration
 
-The Helm toolset supports an optional `allowed_registries` allowlist to restrict which registries
-`helm_install` can fetch charts from.
-
 | Field | Type | Description |
 |-------|------|-------------|
 | `allowed_registries` | string array | Optional list of permitted chart registry URL prefixes. Only `oci://` and `https://` schemes are accepted. |
+| `storage_driver` | string | Optional default storage driver for Helm operations. Supported values: `secret` (default) and `configmap`. |
+
+The Helm toolset supports an optional `allowed_registries` allowlist to restrict which registries
+`helm_install` can fetch charts from.
 
 **Behavior:**
 

--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -14,6 +14,7 @@ import (
 // Config holds Helm toolset configuration
 type Config struct {
 	AllowedRegistries []string `toml:"allowed_registries,omitempty"`
+	StorageDriver     string   `toml:"storage_driver,omitempty"`
 }
 
 var _ api.ExtendedConfig = (*Config)(nil)
@@ -38,6 +39,14 @@ func (c *Config) Validate() error {
 		// so runtime comparison against the normalized chart reference is case-insensitive.
 		c.AllowedRegistries[i] = strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host) + strings.TrimRight(u.Path, "/")
 	}
+	if c.StorageDriver != "" {
+		// Normalize to lowercase
+		c.StorageDriver = strings.ToLower(c.StorageDriver)
+		if c.StorageDriver != "secret" && c.StorageDriver != "configmap" {
+			return fmt.Errorf("unsupported Helm storage driver %q: must be \"secret\" or \"configmap\"", c.StorageDriver)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/helm/config_test.go
+++ b/pkg/helm/config_test.go
@@ -13,7 +13,7 @@ type ConfigSuite struct {
 }
 
 func (s *ConfigSuite) TestValidate() {
-	s.Run("valid config with no allowed registries", func() {
+	s.Run("valid clean config", func() {
 		cfg := &Config{}
 		s.NoError(cfg.Validate())
 	})
@@ -30,7 +30,7 @@ func (s *ConfigSuite) TestValidate() {
 		var cfg *Config
 		s.Error(cfg.Validate())
 	})
-	s.Run("normalizes entries to lowercase and trims trailing slashes", func() {
+	s.Run("normalizes allowed registries to lowercase and trims trailing slashes", func() {
 		cfg := &Config{
 			AllowedRegistries: []string{
 				"OCI://GHCR.IO/myorg/",
@@ -58,6 +58,49 @@ func (s *ConfigSuite) TestValidate() {
 		err := cfg.Validate()
 		s.Error(err)
 		s.Contains(err.Error(), "must use oci:// or https:// scheme")
+	})
+	s.Run("normalizes storage driver to lowercase", func() {
+		cfg := &Config{
+			StorageDriver: "COnfIgmAP",
+		}
+		s.NoError(cfg.Validate())
+		s.Equal("configmap", cfg.StorageDriver)
+	})
+	s.Run("accepts secret storage driver", func() {
+		cfg := &Config{
+			StorageDriver: "secret",
+		}
+		s.NoError(cfg.Validate())
+	})
+	s.Run("accepts configmap storage driver", func() {
+		cfg := &Config{
+			StorageDriver: "configmap",
+		}
+		s.NoError(cfg.Validate())
+	})
+	s.Run("rejects unsupported memory storage driver", func() {
+		cfg := &Config{
+			StorageDriver: "memory",
+		}
+		err := cfg.Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "unsupported Helm storage driver")
+	})
+	s.Run("rejects unsupported sql storage driver", func() {
+		cfg := &Config{
+			StorageDriver: "sql",
+		}
+		err := cfg.Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "unsupported Helm storage driver")
+	})
+	s.Run("rejects arbitrary storage string", func() {
+		cfg := &Config{
+			StorageDriver: "random",
+		}
+		err := cfg.Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "unsupported Helm storage driver")
 	})
 }
 
@@ -98,6 +141,25 @@ func (s *ConfigSuite) TestParser() {
 		`))
 		s.Error(err)
 		s.Contains(err.Error(), "must use oci:// or https:// scheme")
+	})
+	s.Run("parses storage_driver from TOML", func() {
+		cfg := test.Must(config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			storage_driver = "configmap"
+		`)))
+		helmCfg, ok := cfg.GetToolsetConfig("helm")
+		s.Require().True(ok)
+		hc, ok := helmCfg.(*Config)
+		s.Require().True(ok)
+		s.Equal("configmap", hc.StorageDriver)
+	})
+	s.Run("rejects unsupported storage_driver in TOML", func() {
+		_, err := config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			storage_driver = "memory"
+		`))
+		s.Error(err)
+		s.Contains(err.Error(), "unsupported Helm storage driver")
 	})
 }
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -36,7 +36,7 @@ func (h *Helm) Install(ctx context.Context, chart string, values map[string]inte
 	if err := validateChartReference(chart, helmCfg); err != nil {
 		return "", err
 	}
-	cfg, err := h.newAction(h.kubernetes.NamespaceOrDefault(namespace), false)
+	cfg, err := h.newAction(h.kubernetes.NamespaceOrDefault(namespace), false, helmCfg)
 	if err != nil {
 		return "", err
 	}
@@ -73,8 +73,8 @@ func (h *Helm) Install(ctx context.Context, chart string, values map[string]inte
 }
 
 // List lists all the releases for the specified namespace (or current namespace if). Or allNamespaces is true, it lists all releases across all namespaces.
-func (h *Helm) List(namespace string, allNamespaces bool) (string, error) {
-	cfg, err := h.newAction(namespace, allNamespaces)
+func (h *Helm) List(namespace string, allNamespaces bool, helmCfg *Config) (string, error) {
+	cfg, err := h.newAction(namespace, allNamespaces, helmCfg)
 	if err != nil {
 		return "", err
 	}
@@ -93,8 +93,8 @@ func (h *Helm) List(namespace string, allNamespaces bool) (string, error) {
 	return string(ret), nil
 }
 
-func (h *Helm) Uninstall(name string, namespace string) (string, error) {
-	cfg, err := h.newAction(h.kubernetes.NamespaceOrDefault(namespace), false)
+func (h *Helm) Uninstall(name string, namespace string, helmCfg *Config) (string, error) {
+	cfg, err := h.newAction(h.kubernetes.NamespaceOrDefault(namespace), false, helmCfg)
 	if err != nil {
 		return "", err
 	}
@@ -111,7 +111,11 @@ func (h *Helm) Uninstall(name string, namespace string) (string, error) {
 	return fmt.Sprintf("Uninstalled release %s %s", uninstalledRelease.Release.Name, uninstalledRelease.Info), nil
 }
 
-func (h *Helm) newAction(namespace string, allNamespaces bool) (*action.Configuration, error) {
+func (h *Helm) newAction(namespace string, allNamespaces bool, helmCfg *Config) (*action.Configuration, error) {
+	storageDriver := ""
+	if helmCfg != nil {
+		storageDriver = helmCfg.StorageDriver
+	}
 	cfg := new(action.Configuration)
 	applicableNamespace := ""
 	if !allNamespaces {
@@ -122,7 +126,7 @@ func (h *Helm) newAction(namespace string, allNamespaces bool) (*action.Configur
 		return nil, err
 	}
 	cfg.RegistryClient = registryClient
-	return cfg, cfg.Init(h.kubernetes, applicableNamespace, "", klog.V(5).Infof)
+	return cfg, cfg.Init(h.kubernetes, applicableNamespace, storageDriver, klog.V(5).Infof)
 }
 
 // validateChartReference blocks chart references using dangerous URL schemes.

--- a/pkg/toolsets/helm/helm.go
+++ b/pkg/toolsets/helm/helm.go
@@ -132,7 +132,13 @@ func helmList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if v, ok := params.GetArguments()["namespace"].(string); ok {
 		namespace = v
 	}
-	ret, err := helm.NewHelm(params).List(namespace, allNamespaces)
+	var helmCfg *helm.Config
+	if cfg, ok := params.GetToolsetConfig("helm"); ok {
+		if hc, ok := cfg.(*helm.Config); ok {
+			helmCfg = hc
+		}
+	}
+	ret, err := helm.NewHelm(params).List(namespace, allNamespaces, helmCfg)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list helm releases in namespace '%s': %w", namespace, err)), nil
 	}
@@ -149,7 +155,13 @@ func helmUninstall(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if v, ok := params.GetArguments()["namespace"].(string); ok {
 		namespace = v
 	}
-	ret, err := helm.NewHelm(params).Uninstall(name, namespace)
+	var helmCfg *helm.Config
+	if cfg, ok := params.GetToolsetConfig("helm"); ok {
+		if hc, ok := cfg.(*helm.Config); ok {
+			helmCfg = hc
+		}
+	}
+	ret, err := helm.NewHelm(params).Uninstall(name, namespace, helmCfg)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to uninstall helm chart '%s': %w", name, err)), nil
 	}


### PR DESCRIPTION
Currently helm toolset supports only default, 'secret' storage driver. This PR adds support of defining default storage driver (via config file) and per-call driver overrides. 

Supported values: "secret", "configmap" and "" (Helms default driver - currently "secret").