### PR TITLE
feat(evals): add mcpchecker diff to compare PR results against baseline

### DIFF
--- a/.github/workflows/mcpchecker-report.yaml
+++ b/.github/workflows/mcpchecker-report.yaml
@@ -52,6 +52,7 @@ jobs:
           ASSERTIONS_PASSED=$(jq -r '.assertions_passed' eval-context/context.json)
           ASSERTIONS_TOTAL=$(jq -r '.assertions_total' eval-context/context.json)
           PASSED=$(jq -r '.passed' eval-context/context.json)
+          HAS_DIFF=$(jq -r '.has_diff // "false"' eval-context/context.json)
 
           PASS_RATE=$(awk "BEGIN {printf \"%.1f\", $TASK_PASS_RATE * 100}")
 
@@ -61,6 +62,24 @@ jobs:
             OVERALL="✅ Passed"
           else
             OVERALL="❌ Failed"
+          fi
+
+          # Build diff section if available
+          DIFF_SECTION=""
+          if [[ "$HAS_DIFF" == "true" ]] && [[ -f eval-context/diff-output.txt ]]; then
+            DIFF_CONTENT=$(cat eval-context/diff-output.txt)
+            DIFF_SECTION=$(cat <<DIFF_EOF
+
+          ### Diff vs. Baseline (main)
+
+          <details>
+          <summary>Click to expand mcpchecker diff</summary>
+
+          ${DIFF_CONTENT}
+
+          </details>
+          DIFF_EOF
+          )
           fi
 
           gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$(cat <<EOF
@@ -74,6 +93,7 @@ jobs:
           | Tasks Passed | ${TASKS_PASSED}/${TASKS_TOTAL} |
           | Assertions Passed | ${ASSERTIONS_PASSED}/${ASSERTIONS_TOTAL} |
           | Overall | ${OVERALL} |
+          ${DIFF_SECTION}
 
           [View full results](https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})
           EOF

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -223,6 +223,44 @@ jobs:
           make stop-server || true
           make kind-delete-cluster KIND_CLUSTER_NAME=${{ env.KIND_CLUSTER_NAME }} || true
 
+      # Compare PR results against baseline from main branch
+      - name: Fetch baseline results from main
+        if: needs.check-trigger.outputs.is-pr == 'true'
+        env:
+          EVAL_CONFIG: 'evals/openai-agent/eval.yaml'
+        run: |
+          # Derive agent name from eval-config path (same logic as commit-results job)
+          AGENT_NAME=$(echo "$EVAL_CONFIG" | sed 's|evals/||; s|/eval\.yaml||')
+          git fetch origin main --depth=1
+          git show "origin/main:evals/results/${AGENT_NAME}-latest.json" > /tmp/baseline-results.json 2>/dev/null || true
+
+      - name: Run mcpchecker diff
+        id: mcpchecker-diff
+        if: needs.check-trigger.outputs.is-pr == 'true'
+        run: |
+          RESULTS_FILE=$(ls -t mcpchecker-*-out.json 2>/dev/null | head -1)
+          if [ -z "$RESULTS_FILE" ]; then
+            echo "No mcpchecker results file found, skipping diff"
+            echo "has-diff=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [ ! -s /tmp/baseline-results.json ]; then
+            echo "No baseline results found on main branch, skipping diff"
+            echo "has-diff=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          make mcpchecker
+          MCPCHECKER=$(pwd)/_output/tools/bin/mcpchecker
+
+          mkdir -p eval-context
+          if $MCPCHECKER diff --base /tmp/baseline-results.json --current "$RESULTS_FILE" --output markdown > eval-context/diff-output.txt; then
+            echo "has-diff=true" >> $GITHUB_OUTPUT
+          else
+            echo "mcpchecker diff exited with non-zero status, output may still be useful"
+            echo "has-diff=true" >> $GITHUB_OUTPUT
+          fi
+
       # Save context and results for the reporting workflow
       - name: Save evaluation context
         if: always() && needs.check-trigger.outputs.is-pr == 'true'
@@ -237,7 +275,8 @@ jobs:
             "task_pass_rate": "${{ steps.mcpchecker.outputs.task-pass-rate }}",
             "assertions_passed": "${{ steps.mcpchecker.outputs.assertions-passed }}",
             "assertions_total": "${{ steps.mcpchecker.outputs.assertions-total }}",
-            "passed": "${{ steps.mcpchecker.outputs.passed }}"
+            "passed": "${{ steps.mcpchecker.outputs.passed }}",
+            "has_diff": "${{ steps.mcpchecker-diff.outputs.has-diff || 'false' }}"
           }
           EOF
 

--- a/build/evals.mk
+++ b/build/evals.mk
@@ -32,6 +32,23 @@ run-evals: mcpchecker ## Run mcpchecker evaluations against the MCP server
 		$(if $(filter true,$(EVAL_VERBOSE)),--verbose,) \
 		--output json
 
+.PHONY: diff-evals
+diff-evals: mcpchecker ## Diff latest mcpchecker results against baseline
+	@AGENT_NAME=$$(echo "$(EVAL_CONFIG)" | sed 's|evals/||; s|/eval\.yaml||'); \
+	RESULTS_FILE=$$(ls -t mcpchecker-*-out.json 2>/dev/null | head -1); \
+	BASELINE="evals/results/$${AGENT_NAME}-latest.json"; \
+	if [ -z "$$RESULTS_FILE" ]; then \
+		echo "Error: No mcpchecker results file found"; \
+		exit 1; \
+	fi; \
+	if [ ! -f "$$BASELINE" ]; then \
+		echo "No baseline results found at $$BASELINE, skipping diff"; \
+		exit 0; \
+	fi; \
+	echo ""; \
+	echo "=== Diff vs. baseline ($$BASELINE) ==="; \
+	$(MCPCHECKER) diff --base "$$BASELINE" --current "$$RESULTS_FILE" --output markdown
+
 .PHONY: run-server
 run-server: build ## Start MCP server in background and wait for health check
 	@echo "Starting MCP server on port $(MCP_PORT)..."


### PR DESCRIPTION
- Compare evaluation results from PR runs against the latest saved baseline on main using `mcpchecker diff --output markdown` The diff is included in the PR comment via a collapsible details section. 
- A make diff-evals target is also added for local use.