### PR TITLE
fix(build): restore ARCHS variable, simplify multi-arch, and enable s390x/ppc64le container images

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -28,6 +28,10 @@ jobs:
             tag: amd64
           - runner: ubuntu-24.04-arm
             tag: arm64
+          - runner: ubuntu-latest
+            tag: s390x
+          - runner: ubuntu-latest
+            tag: ppc64le
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - name: Checkout
@@ -76,7 +80,9 @@ jobs:
           podman manifest create \
             "${{ env.QUAY_IMAGE_NAME }}:${{ env.TAG }}" \
             "${{ env.QUAY_IMAGE_NAME }}:${{ env.TAG }}-linux-amd64" \
-            "${{ env.QUAY_IMAGE_NAME }}:${{ env.TAG }}-linux-arm64"
+            "${{ env.QUAY_IMAGE_NAME }}:${{ env.TAG }}-linux-arm64" \
+            "${{ env.QUAY_IMAGE_NAME }}:${{ env.TAG }}-linux-s390x" \
+            "${{ env.QUAY_IMAGE_NAME }}:${{ env.TAG }}-linux-ppc64le"
           podman manifest push \
             "${{ env.QUAY_IMAGE_NAME }}:${{ env.TAG }}"
       - name: Create and Push GHCR Manifest
@@ -84,6 +90,8 @@ jobs:
           podman manifest create \
             "${{ env.GHCR_IMAGE_NAME }}:${{ env.TAG }}" \
             "${{ env.GHCR_IMAGE_NAME }}:${{ env.TAG }}-linux-amd64" \
-            "${{ env.GHCR_IMAGE_NAME }}:${{ env.TAG }}-linux-arm64"
+            "${{ env.GHCR_IMAGE_NAME }}:${{ env.TAG }}-linux-arm64" \
+            "${{ env.GHCR_IMAGE_NAME }}:${{ env.TAG }}-linux-s390x" \
+            "${{ env.GHCR_IMAGE_NAME }}:${{ env.TAG }}-linux-ppc64le"
           podman manifest push \
             "${{ env.GHCR_IMAGE_NAME }}:${{ env.TAG }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM golang:latest AS builder
+FROM --platform=$BUILDPLATFORM golang:latest AS builder
 
-# Set by docker buildx automatically
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 
 WORKDIR /app
 COPY ./ ./
 
-# Use build-multiarch target instead of build (skips lint/format/tidy)
 RUN make build-multiarch TARGETOS=${TARGETOS} TARGETARCH=${TARGETARCH}
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,13 @@ GOLANGCI_LINT_VERSION ?= v2.11.4
 # NPM version should not append the -dirty flag
 GIT_TAG_VERSION ?= $(shell echo $(shell git describe --tags --always) | sed 's/^v//')
 OSES = darwin linux windows
-LINUX_ARCHS   = amd64 arm64 s390x ppc64le
-DARWIN_ARCHS  = amd64 arm64
-WINDOWS_ARCHS = amd64 arm64
-
+ARCHS = amd64 arm64
+LINUX_EXTRA_ARCHS = s390x ppc64le
 
 CLEAN_TARGETS :=
 CLEAN_TARGETS += '$(BINARY_NAME)'
-CLEAN_TARGETS += $(foreach arch,$(LINUX_ARCHS),  $(BINARY_NAME)-linux-$(arch))
-CLEAN_TARGETS += $(foreach arch,$(DARWIN_ARCHS), $(BINARY_NAME)-darwin-$(arch))
-CLEAN_TARGETS += $(foreach arch,$(WINDOWS_ARCHS),$(BINARY_NAME)-windows-$(arch).exe)
-
+CLEAN_TARGETS += $(foreach os,$(OSES),$(foreach arch,$(ARCHS),$(BINARY_NAME)-$(os)-$(arch)$(if $(findstring windows,$(os)),.exe,)))
+CLEAN_TARGETS += $(foreach arch,$(LINUX_EXTRA_ARCHS),$(BINARY_NAME)-linux-$(arch))
 
 # The help will print out all targets with their descriptions organized bellow their categories. The categories are represented by `##@` and the target descriptions by `##`.
 # The awk commands is responsible to read the entire set of makefiles included in this invocation, looking for lines of the file as xyz: ## something, and then pretty-format the target and help. Then, if there's a line with ##@ something, that gets pretty-printed as a category.
@@ -56,16 +52,17 @@ build: clean tidy format lint ## Build the project
 	go build $(COMMON_BUILD_ARGS) -o $(BINARY_NAME) ./cmd/kubernetes-mcp-server
 
 .PHONY: build-multiarch
-build-multiarch: ## Build the project for a specific OS/ARCH (used by Docker multi-arch builds)
+build-multiarch: ## Build the project for a specific OS/ARCH (used by container multi-arch builds)
 	CGO_ENABLED=0 GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build $(COMMON_BUILD_ARGS) -o $(BINARY_NAME) ./cmd/kubernetes-mcp-server
 
-# Update build-all-platforms
 .PHONY: build-all-platforms
 build-all-platforms: clean tidy format lint ## Build the project for all platforms
-	$(foreach arch,$(LINUX_ARCHS),   GOOS=linux   GOARCH=$(arch) go build $(COMMON_BUILD_ARGS) -o $(BINARY_NAME)-linux-$(arch)   ./cmd/kubernetes-mcp-server;)
-	$(foreach arch,$(DARWIN_ARCHS),  GOOS=darwin  GOARCH=$(arch) go build $(COMMON_BUILD_ARGS) -o $(BINARY_NAME)-darwin-$(arch)  ./cmd/kubernetes-mcp-server;)
-	$(foreach arch,$(WINDOWS_ARCHS), GOOS=windows GOARCH=$(arch) go build $(COMMON_BUILD_ARGS) -o $(BINARY_NAME)-windows-$(arch).exe ./cmd/kubernetes-mcp-server;)
-
+	$(foreach os,$(OSES),$(foreach arch,$(ARCHS), \
+		GOOS=$(os) GOARCH=$(arch) go build $(COMMON_BUILD_ARGS) -o $(BINARY_NAME)-$(os)-$(arch)$(if $(findstring windows,$(os)),.exe,) ./cmd/kubernetes-mcp-server; \
+	))
+	$(foreach arch,$(LINUX_EXTRA_ARCHS), \
+		GOOS=linux GOARCH=$(arch) go build $(COMMON_BUILD_ARGS) -o $(BINARY_NAME)-linux-$(arch) ./cmd/kubernetes-mcp-server; \
+	)
 
 .PHONY: test
 test: ## Run the tests


### PR DESCRIPTION
Follows up on #1029 and #1032 to fix a broken variable reference,
clean up multi-arch build infrastructure, and complete container
image support for s390x and ppc64le.

**Makefile (critical fix):**
- Restore `ARCHS` variable — #1029 removed it but `build/node.mk`
  still references `$(ARCHS)` in 5 places (clean targets, binary
  copy, package.json generation, and npm publish). Without this fix,
  npm releases produce empty packages since all foreach loops over
  `$(ARCHS)` expand to nothing.
- Replace `LINUX_ARCHS`, `DARWIN_ARCHS`, `WINDOWS_ARCHS` with simpler
  `ARCHS` + `LINUX_EXTRA_ARCHS` pattern
- `OSES × ARCHS` cross-product serves both build and npm distribution,
  Linux extras are appended separately

**Dockerfile:**
- Add `--platform=$BUILDPLATFORM` to builder stage so Go always runs
  natively on the host architecture and cross-compiles via
  TARGETOS/TARGETARCH (no QEMU emulation needed)

**release-image.yml:**
- Add s390x and ppc64le to the build matrix (cross-compiled on
  ubuntu-latest via podman)
- Add both architectures to Quay and GHCR manifest lists

Tested locally: all four platform images (amd64, arm64, s390x,
ppc64le) build successfully with `podman build --platform` and
produce correctly-tagged architecture binaries.