### PR TITLE
fix(core): replace unsafe type assertions with safe parameter helpers

### DIFF
--- a/pkg/mcp/pods_run_test.go
+++ b/pkg/mcp/pods_run_test.go
@@ -21,7 +21,7 @@ func (s *PodsRunSuite) TestPodsRun() {
 	s.Run("pods_run with nil image returns error", func() {
 		toolResult, _ := s.CallTool("pods_run", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to run pod, missing argument image", toolResult.Content[0].(*mcp.TextContent).Text,
+		s.Equalf("failed to run pod: image parameter required", toolResult.Content[0].(*mcp.TextContent).Text,
 			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_run(image=nginx, namespace=nil), uses configured namespace", func() {

--- a/pkg/mcp/pods_test.go
+++ b/pkg/mcp/pods_test.go
@@ -122,7 +122,7 @@ func (s *PodsSuite) TestPodsListInNamespace() {
 	s.Run("pods_list_in_namespace with nil namespace returns error", func() {
 		toolResult, _ := s.CallTool("pods_list_in_namespace", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to list pods in namespace, missing argument namespace", toolResult.Content[0].(*mcp.TextContent).Text,
+		s.Equalf("failed to list pods in namespace: namespace parameter required", toolResult.Content[0].(*mcp.TextContent).Text,
 			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_list_in_namespace(namespace=ns-1) returns pods list", func() {
@@ -321,7 +321,7 @@ func (s *PodsSuite) TestPodsGet() {
 	s.Run("pods_get with nil name returns error", func() {
 		toolResult, _ := s.CallTool("pods_get", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get pod, missing argument name", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
+		s.Equalf("failed to get pod: name parameter required", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_get(name=not-found) with not found name", func() {
 		capture := s.StartCapturingLogNotifications()
@@ -404,7 +404,7 @@ func (s *PodsSuite) TestPodsDelete() {
 	s.Run("pods_delete with nil name returns error", func() {
 		toolResult, _ := s.CallTool("pods_delete", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to delete pod, missing argument name", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
+		s.Equalf("failed to delete pod: name parameter required", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_delete(name=not-found) with not found name", func() {
 		capture := s.StartCapturingLogNotifications()
@@ -562,7 +562,7 @@ func (s *PodsSuite) TestPodsLog() {
 	s.Run("pods_log with nil name returns error", func() {
 		toolResult, _ := s.CallTool("pods_log", map[string]interface{}{})
 		s.Truef(toolResult.IsError, "call tool should fail")
-		s.Equalf("failed to get pod log, missing argument name", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
+		s.Equalf("failed to get pod log: name parameter required", toolResult.Content[0].(*mcp.TextContent).Text, "invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_log with not found name returns error", func() {
 		toolResult, _ := s.CallTool("pods_log", map[string]interface{}{"name": "not-found"})

--- a/pkg/toolsets/core/events.go
+++ b/pkg/toolsets/core/events.go
@@ -36,11 +36,8 @@ func initEvents() []api.ServerTool {
 }
 
 func eventsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	namespace := params.GetArguments()["namespace"]
-	if namespace == nil {
-		namespace = ""
-	}
-	eventMap, err := kubernetes.NewCore(params).EventsList(params, namespace.(string))
+	namespace := api.OptionalString(params, "namespace", "")
+	eventMap, err := kubernetes.NewCore(params).EventsList(params, namespace)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list events in all namespaces: %w", err)), nil
 	}

--- a/pkg/toolsets/core/pods.go
+++ b/pkg/toolsets/core/pods.go
@@ -260,17 +260,11 @@ func initPods() []api.ServerTool {
 }
 
 func podsListInAllNamespaces(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	labelSelector := params.GetArguments()["labelSelector"]
-	fieldSelector := params.GetArguments()["fieldSelector"]
 	resourceListOptions := api.ListOptions{
 		AsTable: params.ListOutput.AsTable(),
 	}
-	if labelSelector != nil {
-		resourceListOptions.LabelSelector = labelSelector.(string)
-	}
-	if fieldSelector != nil {
-		resourceListOptions.FieldSelector = fieldSelector.(string)
-	}
+	resourceListOptions.LabelSelector = api.OptionalString(params, "labelSelector", "")
+	resourceListOptions.FieldSelector = api.OptionalString(params, "fieldSelector", "")
 	ret, err := kubernetes.NewCore(params).PodsListInAllNamespaces(params, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in all namespaces: %w", err)), nil
@@ -279,22 +273,16 @@ func podsListInAllNamespaces(params api.ToolHandlerParams) (*api.ToolCallResult,
 }
 
 func podsListInNamespace(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := params.GetArguments()["namespace"]
-	if ns == nil {
-		return api.NewToolCallResult("", errors.New("failed to list pods in namespace, missing argument namespace")), nil
+	ns, err := api.RequiredString(params, "namespace")
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace: %w", err)), nil
 	}
 	resourceListOptions := api.ListOptions{
 		AsTable: params.ListOutput.AsTable(),
 	}
-	labelSelector := params.GetArguments()["labelSelector"]
-	if labelSelector != nil {
-		resourceListOptions.LabelSelector = labelSelector.(string)
-	}
-	fieldSelector := params.GetArguments()["fieldSelector"]
-	if fieldSelector != nil {
-		resourceListOptions.FieldSelector = fieldSelector.(string)
-	}
-	ret, err := kubernetes.NewCore(params).PodsListInNamespace(params, ns.(string), resourceListOptions)
+	resourceListOptions.LabelSelector = api.OptionalString(params, "labelSelector", "")
+	resourceListOptions.FieldSelector = api.OptionalString(params, "fieldSelector", "")
+	ret, err := kubernetes.NewCore(params).PodsListInNamespace(params, ns, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace %s: %w", ns, err)), nil
 	}
@@ -302,15 +290,12 @@ func podsListInNamespace(params api.ToolHandlerParams) (*api.ToolCallResult, err
 }
 
 func podsGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := params.GetArguments()["namespace"]
-	if ns == nil {
-		ns = ""
+	ns := api.OptionalString(params, "namespace", "")
+	name, err := api.RequiredString(params, "name")
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get pod: %w", err)), nil
 	}
-	name := params.GetArguments()["name"]
-	if name == nil {
-		return api.NewToolCallResult("", errors.New("failed to get pod, missing argument name")), nil
-	}
-	ret, err := kubernetes.NewCore(params).PodsGet(params, ns.(string), name.(string))
+	ret, err := kubernetes.NewCore(params).PodsGet(params, ns, name)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod %s in namespace %s: %w", name, ns, err)), nil
 	}
@@ -318,15 +303,12 @@ func podsGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func podsDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := params.GetArguments()["namespace"]
-	if ns == nil {
-		ns = ""
+	ns := api.OptionalString(params, "namespace", "")
+	name, err := api.RequiredString(params, "name")
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to delete pod: %w", err)), nil
 	}
-	name := params.GetArguments()["name"]
-	if name == nil {
-		return api.NewToolCallResult("", errors.New("failed to delete pod, missing argument name")), nil
-	}
-	ret, err := kubernetes.NewCore(params).PodsDelete(params, ns.(string), name.(string))
+	ret, err := kubernetes.NewCore(params).PodsDelete(params, ns, name)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to delete pod %s in namespace %s: %w", name, ns, err)), nil
 	}
@@ -359,30 +341,26 @@ func podsTop(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func podsExec(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := params.GetArguments()["namespace"]
-	if ns == nil {
-		ns = ""
+	ns := api.OptionalString(params, "namespace", "")
+	name, err := api.RequiredString(params, "name")
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to exec in pod: %w", err)), nil
 	}
-	name := params.GetArguments()["name"]
-	if name == nil {
-		return api.NewToolCallResult("", errors.New("failed to exec in pod, missing argument name")), nil
-	}
-	container := params.GetArguments()["container"]
-	if container == nil {
-		container = ""
-	}
+	container := api.OptionalString(params, "container", "")
 	commandArg := params.GetArguments()["command"]
 	command := make([]string, 0)
-	if _, ok := commandArg.([]interface{}); ok {
-		for _, cmd := range commandArg.([]interface{}) {
-			if _, ok := cmd.(string); ok {
-				command = append(command, cmd.(string))
+	if cmdSlice, ok := commandArg.([]interface{}); ok {
+		for _, cmd := range cmdSlice {
+			s, ok := cmd.(string)
+			if !ok {
+				return api.NewToolCallResult("", errors.New("failed to exec in pod, all command elements must be strings")), nil
 			}
+			command = append(command, s)
 		}
 	} else {
 		return api.NewToolCallResult("", errors.New("failed to exec in pod, invalid command argument")), nil
 	}
-	ret, err := kubernetes.NewCore(params).PodsExec(params, ns.(string), name.(string), container.(string), command)
+	ret, err := kubernetes.NewCore(params).PodsExec(params, ns, name, container, command)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to exec in pod %s in namespace %s: %w", name, ns, err)), nil
 	} else if ret == "" {
@@ -392,18 +370,12 @@ func podsExec(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func podsLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := params.GetArguments()["namespace"]
-	if ns == nil {
-		ns = ""
+	ns := api.OptionalString(params, "namespace", "")
+	name, err := api.RequiredString(params, "name")
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get pod log: %w", err)), nil
 	}
-	name := params.GetArguments()["name"]
-	if name == nil {
-		return api.NewToolCallResult("", errors.New("failed to get pod log, missing argument name")), nil
-	}
-	container := params.GetArguments()["container"]
-	if container == nil {
-		container = ""
-	}
+	container := api.OptionalString(params, "container", "")
 	previousBool := api.OptionalBool(params, "previous", false)
 	// Extract tailLines parameter
 	tail := params.GetArguments()["tail"]
@@ -416,7 +388,7 @@ func podsLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		}
 	}
 
-	ret, err := kubernetes.NewCore(params).PodsLog(params.Context, ns.(string), name.(string), container.(string), previousBool, tailInt)
+	ret, err := kubernetes.NewCore(params).PodsLog(params.Context, ns, name, container, previousBool, tailInt)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod %s log in namespace %s: %w", name, ns, err)), nil
 	} else if ret == "" {
@@ -426,23 +398,21 @@ func podsLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func podsRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := params.GetArguments()["namespace"]
-	if ns == nil {
-		ns = ""
+	ns := api.OptionalString(params, "namespace", "")
+	name := api.OptionalString(params, "name", "")
+	image, err := api.RequiredString(params, "image")
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to run pod: %w", err)), nil
 	}
-	name := params.GetArguments()["name"]
-	if name == nil {
-		name = ""
+	var port int32
+	if portVal, ok := params.GetArguments()["port"]; ok && portVal != nil {
+		portInt, err := api.ParseInt64(portVal)
+		if err != nil {
+			return api.NewToolCallResult("", fmt.Errorf("failed to parse port parameter: %w", err)), nil
+		}
+		port = int32(portInt)
 	}
-	image := params.GetArguments()["image"]
-	if image == nil {
-		return api.NewToolCallResult("", errors.New("failed to run pod, missing argument image")), nil
-	}
-	port := params.GetArguments()["port"]
-	if port == nil {
-		port = float64(0)
-	}
-	resources, err := kubernetes.NewCore(params).PodsRun(params, ns.(string), name.(string), image.(string), int32(port.(float64)))
+	resources, err := kubernetes.NewCore(params).PodsRun(params, ns, name, image, port)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to run pod %s in namespace %s: %w", name, ns, err)), nil
 	}

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -389,12 +389,16 @@ func parseGroupVersionKind(arguments map[string]interface{}) (*schema.GroupVersi
 
 	a, ok := apiVersion.(string)
 	if !ok {
-		return nil, fmt.Errorf("name is not a string")
+		return nil, fmt.Errorf("apiVersion is not a string")
 	}
 
 	gv, err := schema.ParseGroupVersion(a)
 	if err != nil {
 		return nil, errors.New("invalid argument apiVersion")
 	}
-	return &schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: kind.(string)}, nil
+	k, ok := kind.(string)
+	if !ok {
+		return nil, fmt.Errorf("kind is not a string")
+	}
+	return &schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: k}, nil
 }


### PR DESCRIPTION
## Summary

Replace 13+ bare type assertions (e.g. `params["namespace"].(string)`) in pod, event, and resource handlers with the existing safe helpers from `pkg/api/params.go`. This is a follow-up to PR #965 which fixed only the `previous.(bool)` assertion reported in #347, leaving all string and float64 parameter assertions unfixed.

## Problem

The MCP SDK does **not** validate `InputSchema` types before passing arguments to tool handlers — parameters arrive as `map[string]any` from `json.Unmarshal`. When a client sends a parameter with an unexpected JSON type (e.g. `{"namespace": 123}` instead of `{"namespace": "default"}`), bare assertions like `params["namespace"].(string)` cause a **runtime panic** that crashes the entire MCP server process.

This affects all pod tool handlers: `pods_list_in_namespace`, `pods_get`, `pods_delete`, `pods_exec`, `pods_log`, `pods_run`, plus `events_list` and `resources_get/list/create/delete`.

## Changes

| File | What changed |
|------|-------------|
| `pkg/toolsets/core/pods.go` | All 7 handler functions: replaced bare `.(string)` and `.(float64)` with `RequiredString`, `OptionalString`, `ParseInt64`; `podsExec` command array now rejects non-string elements instead of silently dropping them |
| `pkg/toolsets/core/events.go` | `eventsList`: `namespace.(string)` → `OptionalString` |
| `pkg/toolsets/core/resources.go` | `parseGroupVersionKind`: added comma-ok check for `kind.(string)`; fixed pre-existing wrong error message (`"name is not a string"` → `"apiVersion is not a string"`) |
| `pkg/mcp/pods_test.go` | Updated 4 error message assertions to match new format |
| `pkg/mcp/pods_run_test.go` | Updated 1 error message assertion |

## Testing

- **Unit tests**: All existing tests pass (`go test ./pkg/mcp/ -run TestPods`)
- **Integration tests**: Validated against a real 6-node K3s cluster — 17/17 tests passed including 9 safety tests that send wrong-type parameters (int, bool, null, array). All return graceful errors; none crash the server.

## Behavioral notes

- Error message format changed from `"failed to X, missing argument Y"` to `"failed to X: Y parameter required"` (from `RequiredString`'s error wrapped with `%w`). This is a minor wording change in user-facing error text.
- If a client sends `{"namespace": null}`, the old code returned "missing argument namespace"; the new code returns "namespace parameter must be a string". Both are errors — the new message is more precise.
- `podsExec`: `["ls", 123, "-la"]` previously silently became `["ls", "-la"]`; now returns an error. This prevents executing unintended commands.

Follow-up to #965 (which addressed #347)