### PR TITLE
test(config): tool override tests are compatible with downstream changes

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1066,13 +1066,14 @@ func (s *ConfigSuite) TestToolOverridesParsed() {
 	s.Require().NotNil(config)
 
 	s.Run("parses tool_overrides with multiple entries", func() {
-		s.Require().Len(config.ToolOverrides, 2)
+		s.Require().Contains(config.ToolOverrides, "pods_list")
+		s.Require().Contains(config.ToolOverrides, "resources_get")
 		s.Equal("Custom pods list description", config.ToolOverrides["pods_list"].Description)
 		s.Equal("Custom resources get description", config.ToolOverrides["resources_get"].Description)
 	})
 }
 
-func (s *ConfigSuite) TestToolOverridesNilWhenNotSpecified() {
+func (s *ConfigSuite) TestToolOverridesMatchDefaultsWhenNotSpecified() {
 	configPath := s.writeConfig(`
 		log_level = 1
 	`)
@@ -1081,8 +1082,8 @@ func (s *ConfigSuite) TestToolOverridesNilWhenNotSpecified() {
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
-	s.Run("ToolOverrides is nil when not specified", func() {
-		s.Nil(config.ToolOverrides)
+	s.Run("ToolOverrides matches defaults when not specified", func() {
+		s.Equal(s.defaults.ToolOverrides, config.ToolOverrides)
 	})
 }
 


### PR DESCRIPTION
With the tests for the tool overrides, we run into issues on any downstream forks if you actually apply any default overrides to tool descriptions.

This PR aims to keep the spirit of the test cases intact while updating the assertions to compare against whatever the default is, rather than against exact values