### PR TITLE
test(core): add fake kube dynamic client; add Core resources testing …

### DIFF
--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -1,0 +1,166 @@
+package kubernetes
+
+import (
+	"encoding/json"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	kubetesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	metricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
+)
+
+// resettableRESTMapper wraps a meta.DefaultRESTMapper to satisfy meta.ResettableRESTMapper.
+type resettableRESTMapper struct {
+	*meta.DefaultRESTMapper
+}
+
+func (r *resettableRESTMapper) Reset() {
+	// no-op for tests
+}
+
+// fakeKubernetesClient is a test-only implementation of api.KubernetesClient
+// that uses k8s.io/client-go/dynamic/fake for the dynamic client.
+type fakeKubernetesClient struct {
+	*fake.Clientset
+	dynamicClient   *dynamicfake.FakeDynamicClient
+	restMapper      meta.ResettableRESTMapper
+	discoveryClient discovery.CachedDiscoveryInterface
+	namespace       string
+}
+
+var _ api.KubernetesClient = (*fakeKubernetesClient)(nil)
+
+// newFakeKubernetesClient creates a fakeKubernetesClient wired with a dynamic/fake client.
+// gvToListKind maps each GVR to its list kind (e.g. {v1 pods} -> "PodList").
+// objects are pre-populated runtime.Objects in the fake dynamic client.
+func newFakeKubernetesClient(gvToListKind map[schema.GroupVersionResource]string, objects ...runtime.Object) *fakeKubernetesClient {
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvToListKind, objects...)
+
+	// Reactor to handle Apply (ApplyPatchType) by creating or updating the object in the tracker
+	dynClient.PrependReactor("patch", "*", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(kubetesting.PatchAction)
+		if !ok || patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		obj := &unstructured.Unstructured{}
+		if err := json.Unmarshal(patchAction.GetPatch(), &obj.Object); err != nil {
+			return true, nil, err
+		}
+		gvr := patchAction.GetResource()
+		// Try to update existing object, if not found create it
+		if err := dynClient.Tracker().Update(gvr, obj, patchAction.GetNamespace()); err != nil {
+			if err := dynClient.Tracker().Create(gvr, obj, patchAction.GetNamespace()); err != nil {
+				return true, nil, err
+			}
+		}
+		return true, obj, nil
+	})
+
+	// Build REST mapper from the GVR-to-ListKind mapping
+	var groupVersions []schema.GroupVersion
+	gvSet := map[schema.GroupVersion]bool{}
+	for gvr := range gvToListKind {
+		gv := gvr.GroupVersion()
+		if !gvSet[gv] {
+			groupVersions = append(groupVersions, gv)
+			gvSet[gv] = true
+		}
+	}
+
+	// Build REST mapper and discovery API resources from the GVR-to-ListKind mapping
+	mapper := meta.NewDefaultRESTMapper(groupVersions)
+	clientSet := fake.NewSimpleClientset()
+	apiResourcesByGV := map[string][]metav1.APIResource{}
+	for gvr, listKind := range gvToListKind {
+		// Derive GVK from GVR: resource "pods" with listKind "PodList" -> kind "Pod"
+		kind := listKind
+		if len(kind) > 4 && kind[len(kind)-4:] == "List" {
+			kind = kind[:len(kind)-4]
+		}
+		gvk := gvr.GroupVersion().WithKind(kind)
+		mapper.Add(gvk, meta.RESTScopeNamespace)
+		apiResourcesByGV[gvr.GroupVersion().String()] = append(apiResourcesByGV[gvr.GroupVersion().String()], metav1.APIResource{
+			Name:       gvr.Resource,
+			Kind:       kind,
+			Namespaced: true,
+			Verbs:      metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"},
+		})
+	}
+
+	// Configure fake discovery resources
+	var apiResourceLists []*metav1.APIResourceList
+	for gv, resources := range apiResourcesByGV {
+		apiResourceLists = append(apiResourceLists, &metav1.APIResourceList{
+			GroupVersion: gv,
+			APIResources: resources,
+		})
+	}
+	clientSet.Resources = apiResourceLists
+
+	cachedDiscovery := memory.NewMemCacheClient(clientSet.Discovery())
+
+	return &fakeKubernetesClient{
+		Clientset:       clientSet,
+		dynamicClient:   dynClient,
+		restMapper:      &resettableRESTMapper{DefaultRESTMapper: mapper},
+		discoveryClient: cachedDiscovery,
+		namespace:       "default",
+	}
+}
+
+func (f *fakeKubernetesClient) DynamicClient() dynamic.Interface {
+	return f.dynamicClient
+}
+
+func (f *fakeKubernetesClient) RESTMapper() meta.ResettableRESTMapper {
+	return f.restMapper
+}
+
+func (f *fakeKubernetesClient) DiscoveryClient() discovery.CachedDiscoveryInterface {
+	return f.discoveryClient
+}
+
+func (f *fakeKubernetesClient) RESTConfig() *rest.Config {
+	return &rest.Config{}
+}
+
+func (f *fakeKubernetesClient) NamespaceOrDefault(namespace string) string {
+	if namespace == "" {
+		return f.namespace
+	}
+	return namespace
+}
+
+func (f *fakeKubernetesClient) MetricsV1beta1Client() *metricsv1beta1.MetricsV1beta1Client {
+	return nil
+}
+
+func (f *fakeKubernetesClient) ToRESTConfig() (*rest.Config, error) {
+	return f.RESTConfig(), nil
+}
+
+func (f *fakeKubernetesClient) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return f.discoveryClient, nil
+}
+
+func (f *fakeKubernetesClient) ToRESTMapper() (meta.RESTMapper, error) {
+	return f.restMapper, nil
+}
+
+func (f *fakeKubernetesClient) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, nil)
+}

--- a/pkg/kubernetes/resources_test.go
+++ b/pkg/kubernetes/resources_test.go
@@ -1,0 +1,276 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var podsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+type CoreTestSuite struct {
+	suite.Suite
+}
+
+func (s *CoreTestSuite) TestResourcesGet() {
+	s.Run("returns existing resource", func() {
+		pod := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      "test-pod",
+					"namespace": "default",
+				},
+			},
+		}
+
+		fakeClient := newFakeKubernetesClient(
+			map[schema.GroupVersionResource]string{podsGVR: "PodList"},
+			pod,
+		)
+		core := NewCore(fakeClient)
+
+		result, err := core.ResourcesGet(ctx(), &schema.GroupVersionKind{
+			Group: "", Version: "v1", Kind: "Pod",
+		}, "default", "test-pod")
+
+		s.Require().NoError(err)
+		s.Equal("test-pod", result.GetName())
+		s.Equal("default", result.GetNamespace())
+	})
+
+	s.Run("returns error for non-existent resource", func() {
+		fakeClient := newFakeKubernetesClient(
+			map[schema.GroupVersionResource]string{podsGVR: "PodList"},
+		)
+		core := NewCore(fakeClient)
+
+		_, err := core.ResourcesGet(ctx(), &schema.GroupVersionKind{
+			Group: "", Version: "v1", Kind: "Pod",
+		}, "default", "non-existent")
+
+		s.Error(err)
+	})
+}
+
+func (s *CoreTestSuite) TestResourcesList() {
+	s.Run("returns list of resources", func() {
+		pod1 := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      "pod-1",
+					"namespace": "default",
+				},
+			},
+		}
+		pod2 := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      "pod-2",
+					"namespace": "default",
+				},
+			},
+		}
+
+		fakeClient := newFakeKubernetesClient(
+			map[schema.GroupVersionResource]string{podsGVR: "PodList"},
+			pod1, pod2,
+		)
+		core := NewCore(fakeClient)
+
+		result, err := core.ResourcesList(ctx(), &schema.GroupVersionKind{
+			Group: "", Version: "v1", Kind: "Pod",
+		}, "default", api.ListOptions{})
+
+		s.Require().NoError(err)
+		list, ok := result.(*unstructured.UnstructuredList)
+		s.Require().True(ok, "expected *unstructured.UnstructuredList")
+		s.Len(list.Items, 2)
+	})
+
+	s.Run("returns empty list when no resources exist", func() {
+		fakeClient := newFakeKubernetesClient(
+			map[schema.GroupVersionResource]string{podsGVR: "PodList"},
+		)
+		core := NewCore(fakeClient)
+
+		result, err := core.ResourcesList(ctx(), &schema.GroupVersionKind{
+			Group: "", Version: "v1", Kind: "Pod",
+		}, "default", api.ListOptions{})
+
+		s.Require().NoError(err)
+		list, ok := result.(*unstructured.UnstructuredList)
+		s.Require().True(ok, "expected *unstructured.UnstructuredList")
+		s.Empty(list.Items)
+	})
+}
+
+func (s *CoreTestSuite) TestResourcesDelete() {
+	s.Run("deletes existing resource", func() {
+		pod := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":      "to-delete",
+					"namespace": "default",
+				},
+			},
+		}
+
+		fakeClient := newFakeKubernetesClient(
+			map[schema.GroupVersionResource]string{podsGVR: "PodList"},
+			pod,
+		)
+		core := NewCore(fakeClient)
+
+		err := core.ResourcesDelete(ctx(), &schema.GroupVersionKind{
+			Group: "", Version: "v1", Kind: "Pod",
+		}, "default", "to-delete", nil)
+
+		s.Require().NoError(err)
+
+		// Verify it's gone
+		_, err = core.ResourcesGet(ctx(), &schema.GroupVersionKind{
+			Group: "", Version: "v1", Kind: "Pod",
+		}, "default", "to-delete")
+		s.Error(err)
+	})
+}
+
+func (s *CoreTestSuite) TestResourcesScale() {
+	deploymentsGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	s.Run("gets current scale without updating", func() {
+		deployment := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name":      "my-deploy",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"replicas": int64(3),
+				},
+			},
+		}
+
+		fakeClient := newFakeKubernetesClient(
+			map[schema.GroupVersionResource]string{
+				podsGVR:        "PodList",
+				deploymentsGVR: "DeploymentList",
+			},
+			deployment,
+		)
+		core := NewCore(fakeClient)
+
+		result, err := core.ResourcesScale(ctx(), &schema.GroupVersionKind{
+			Group: "apps", Version: "v1", Kind: "Deployment",
+		}, "default", "my-deploy", 0, false)
+
+		s.Require().NoError(err)
+		s.NotNil(result)
+	})
+}
+
+func (s *CoreTestSuite) TestResourcesCreateOrUpdate() {
+	s.Run("creates new resource from YAML", func() {
+		resource := `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+spec:
+  containers:
+  - name: test-container
+    image: nginx:latest`
+
+		fakeClient := newFakeKubernetesClient(
+			map[schema.GroupVersionResource]string{podsGVR: "PodList"},
+		)
+		core := NewCore(fakeClient)
+
+		result, err := core.ResourcesCreateOrUpdate(ctx(), resource)
+
+		s.Require().NoError(err)
+		s.NotNil(result)
+		s.Require().Len(result, 1)
+		s.Equal("test-pod", result[0].GetName())
+
+		// Verify the resource was actually created
+		created, err := core.ResourcesGet(ctx(), &schema.GroupVersionKind{
+			Group: "", Version: "v1", Kind: "Pod",
+		}, "default", "test-pod")
+		s.Require().NoError(err)
+		s.Equal("test-pod", created.GetName())
+	})
+
+	s.Run("updates an existing resource", func() {
+		resource := `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+spec:
+  containers:
+  - name: test-container
+    image: nginx:latest`
+
+		fakeClient := newFakeKubernetesClient(
+			map[schema.GroupVersionResource]string{podsGVR: "PodList"},
+		)
+		core := NewCore(fakeClient)
+
+		result, err := core.ResourcesCreateOrUpdate(ctx(), resource)
+
+		s.Require().NoError(err)
+		s.NotNil(result)
+		s.Require().Len(result, 1)
+
+		// Verify the resource was actually created
+		created, err := core.ResourcesGet(ctx(), &schema.GroupVersionKind{
+			Group: "", Version: "v1", Kind: "Pod",
+		}, "default", "test-pod")
+		s.Require().NoError(err)
+		s.Equal("test-pod", created.GetName())
+		containers, _, _ := unstructured.NestedSlice(created.Object, "spec", "containers")
+		s.Require().Len(containers, 1)
+		s.Equal("nginx:latest", containers[0].(map[string]interface{})["image"])
+
+		// Update the resource with a different image
+		resource = `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+spec:
+  containers:
+  - name: test-container
+    image: nginx:1.21`
+		result, err = core.ResourcesCreateOrUpdate(ctx(), resource)
+		s.Require().NoError(err)
+		s.NotNil(result)
+		s.Require().Len(result, 1)
+		s.Equal("test-pod", result[0].GetName())
+		containers, _, _ = unstructured.NestedSlice(result[0].Object, "spec", "containers")
+		s.Require().Len(containers, 1)
+		s.Equal("nginx:1.21", containers[0].(map[string]interface{})["image"])
+	})
+}
+
+func TestCore(t *testing.T) {
+	suite.Run(t, new(CoreTestSuite))
+}
+
+func ctx() context.Context {
+	return context.Background()
+}

--- a/pkg/kubernetes/resources_test.go
+++ b/pkg/kubernetes/resources_test.go
@@ -179,6 +179,49 @@ func (s *CoreTestSuite) TestResourcesScale() {
 
 		s.Require().NoError(err)
 		s.NotNil(result)
+
+		// Verify the replicas count is 3
+		replicas, found, err := unstructured.NestedInt64(result.Object, "spec", "replicas")
+		s.Require().NoError(err)
+		s.True(found, "replicas field should be found")
+		s.Equal(int64(3), replicas, "deployment should have 3 replicas")
+	})
+	s.Run("scales deployment to 5 replicas", func() {
+		deployment := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name":      "my-deploy",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"replicas": int64(3),
+				},
+			},
+		}
+
+		fakeClient := newFakeKubernetesClient(
+			map[schema.GroupVersionResource]string{
+				podsGVR:        "PodList",
+				deploymentsGVR: "DeploymentList",
+			},
+			deployment,
+		)
+		core := NewCore(fakeClient)
+
+		result, err := core.ResourcesScale(ctx(), &schema.GroupVersionKind{
+			Group: "apps", Version: "v1", Kind: "Deployment",
+		}, "default", "my-deploy", 5, true)
+
+		s.Require().NoError(err)
+		s.NotNil(result)
+
+		// Verify the replicas count is 5
+		replicas, found, err := unstructured.NestedInt64(result.Object, "spec", "replicas")
+		s.Require().NoError(err)
+		s.True(found, "replicas field should be found")
+		s.Equal(int64(5), replicas, "deployment should have 5 replicas")
 	})
 }
 


### PR DESCRIPTION
This PR adds:
- a fake dynamic client build on top of `k8s.io/client-go/dynamic/fake.FakeDynamicClient`;
- `kubernetes.Interface` that embeds the `k8s.io/client-go/kubernetes/fake.Clientset`;
- no-op `Reset()` `RESTMapper()` pre-configured with GVR->GVK mappings;
- `DiscoveryClient()` - fake clientset's discovery wrapped in `memory.NewMemCacheClient`, with `APIResources` populated to match registered GVRs;
- tests using fake client to exercise `ResourcesGet`, `ResourcesList`, `ResourcesDelete`, `ResourcesScale` and `ResourcesCreateOrUpdate`.

The dryRun feature that is proposed under https://github.com/containers/kubernetes-mcp-server/pull/1026 can't be tested as fake client - currently - ignores opts.

Note: To avoid importing type packages (and use an empty scheme) this is using `fake.NewSimpleDynamicClientWithCustomListKinds` instead of `fake.NewSimpleDynamicClient`.