### PR TITLE
Entra ID / OBO test follow-ups and dead code cleanup

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -19,11 +19,6 @@ const (
 	ClusterAuthKubeconfig = "kubeconfig"
 )
 
-type AuthProvider interface {
-	// IsRequireOAuth indicates whether OAuth authentication is required.
-	IsRequireOAuth() bool
-}
-
 // ClusterAuthProvider provides configuration for how the MCP server authenticates to clusters.
 type ClusterAuthProvider interface {
 	// GetClusterAuthMode returns the raw cluster authentication mode from config.
@@ -90,7 +85,6 @@ type RequireTLSProvider interface {
 }
 
 type BaseConfig interface {
-	AuthProvider
 	ClusterAuthProvider
 	ClusterProvider
 	ConfirmationRulesProvider

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -391,10 +391,6 @@ func (c *StaticConfig) GetToolsetConfig(name string) (api.ExtendedConfig, bool) 
 	return cfg, ok
 }
 
-func (c *StaticConfig) IsRequireOAuth() bool {
-	return c.RequireOAuth
-}
-
 func (c *StaticConfig) GetStsClientId() string {
 	return c.StsClientId
 }

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +19,22 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 )
+
+// bearerRoundTripper adds a static Authorization: Bearer header to every
+// outbound request. Used by the SSE transport test below, since
+// mcp.SSEClientTransport does not expose a headers option.
+type bearerRoundTripper struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (b *bearerRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	// http.RoundTripper must not modify the request it is given; clone before
+	// adding the Authorization header.
+	clone := r.Clone(r.Context())
+	clone.Header.Set("Authorization", "Bearer "+b.token)
+	return b.base.RoundTrip(clone)
+}
 
 type AuthorizationSuite struct {
 	BaseHttpSuite
@@ -382,9 +399,14 @@ func (s *AuthorizationSuite) TestAuthorizationOidcToken() {
 	s.Require().NoError(s.WaitForShutdown())
 }
 
+// TestAuthorizationOidcTokenExchange verifies RFC 8693 / On-Behalf-Of token
+// exchange on both MCP transports. StreamableHTTP propagates the bearer via
+// request headers directly; SSE relies on AuthorizationMiddleware writing the
+// validated token into the request context (OAuthAuthorizationHeader) and
+// authHeaderPropagationMiddleware bridging it into the MCP RequestExtra, so
+// both transports must be exercised end-to-end.
+// SSE coverage: https://github.com/containers/kubernetes-mcp-server/issues/1043
 func (s *AuthorizationSuite) TestAuthorizationOidcTokenExchange() {
-	s.MockServer.ResetHandlers()
-
 	oidcTestServer := NewOidcTestServer(s.T())
 	s.T().Cleanup(oidcTestServer.Close)
 	rawClaims := `{
@@ -407,31 +429,86 @@ func (s *AuthorizationSuite) TestAuthorizationOidcTokenExchange() {
 	s.StaticConfig.StsClientSecret = "test-sts-client-secret"
 	s.StaticConfig.StsAudience = "backend-audience"
 	s.StaticConfig.StsScopes = []string{"backend-scope"}
-	s.logBuffer.Reset()
-	s.StartServer()
-	s.StartClient(map[string]string{
-		"Authorization": "Bearer " + validOidcClientToken,
-	})
 
-	s.Run("Protected resource", func() {
-		s.Run("Initialize returns OK for VALID OIDC EXCHANGE Authorization header", func() {
-			s.Require().NotNil(s.mcpClient.Session, "Expected session for successful authentication")
-			s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initial request to not be nil")
-		})
-		s.Run("Call tool exchanges token VALID OIDC EXCHANGE Authorization header", func() {
-			toolResult, err := s.mcpClient.Session.CallTool(s.T().Context(), &mcp.CallToolParams{
-				Name:      "events_list",
-				Arguments: map[string]any{},
+	testCases := []struct {
+		name    string
+		connect func() *mcp.ClientSession
+	}{
+		{
+			name: "StreamableHTTP transport",
+			connect: func() *mcp.ClientSession {
+				s.StartClient(map[string]string{
+					"Authorization": "Bearer " + validOidcClientToken,
+				})
+				s.Require().NotNil(s.mcpClient.Session, "Expected session for successful authentication")
+				return s.mcpClient.Session
+			},
+		},
+		{
+			name: "SSE transport",
+			connect: func() *mcp.ClientSession {
+				httpClient := &http.Client{
+					Transport: &bearerRoundTripper{token: validOidcClientToken, base: http.DefaultTransport},
+				}
+				sseClient := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1.33.7"}, nil)
+				transport := &mcp.SSEClientTransport{
+					Endpoint:   fmt.Sprintf("http://127.0.0.1:%s/sse", s.StaticConfig.Port),
+					HTTPClient: httpClient,
+				}
+				session, err := sseClient.Connect(s.T().Context(), transport, nil)
+				s.Require().NoError(err, "Expected no error connecting SSE MCP client")
+				return session
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.MockServer.ResetHandlers()
+			// Capture the Authorization header the MCP server sends to the
+			// Kubernetes backend. The downstream credential is the
+			// security-relevant observable: token exchange must replace the
+			// user token with the exchanged token before reaching the cluster.
+			var backendAuth atomic.Value
+			s.MockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if auth := r.Header.Get("Authorization"); auth != "" {
+					backendAuth.Store(auth)
+				}
+			}))
+			s.logBuffer.Reset()
+			s.StartServer()
+
+			session := tc.connect()
+
+			s.Run("Initialize returns OK for VALID OIDC EXCHANGE Authorization header", func() {
+				s.Require().NotNil(session.InitializeResult(), "Expected initial request to not be nil")
 			})
-			s.Require().NoError(err, "Expected no error calling tool")
-			s.Require().NotNil(toolResult, "Expected tool result to not be nil")
-			// Token exchange is verified by the successful tool call with STS configured
+			s.Run("Call tool exchanges token for VALID OIDC EXCHANGE Authorization header", func() {
+				toolResult, err := session.CallTool(s.T().Context(), &mcp.CallToolParams{
+					Name:      "events_list",
+					Arguments: map[string]any{},
+				})
+				s.Require().NoError(err, "Expected no error calling tool")
+				s.Require().NotNil(toolResult, "Expected tool result to not be nil")
+			})
+			s.Run("Backend receives exchanged token, not original user token", func() {
+				got, _ := backendAuth.Load().(string)
+				s.Require().NotEmpty(got, "Expected backend to receive an Authorization header")
+				s.Equal("Bearer "+validOidcBackendToken, got,
+					"Backend must receive the exchanged token; receiving the original user token would mean token exchange silently no-op'd")
+			})
+
+			if s.mcpClient != nil {
+				// McpClient.Close closes the underlying Session for us.
+				s.mcpClient.Close()
+				s.mcpClient = nil
+			} else {
+				s.Require().NoError(session.Close(), "Expected SSE session to close cleanly")
+			}
+			s.StopServer()
+			s.Require().NoError(s.WaitForShutdown())
 		})
-	})
-	s.mcpClient.Close()
-	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	}
 }
 
 func (s *AuthorizationSuite) TestAuthorizationExemptEndpointsFromOAuth() {

--- a/pkg/http/middleware_test.go
+++ b/pkg/http/middleware_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"crypto/tls"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +11,10 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/telemetry"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -281,4 +285,173 @@ func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 
 func TestMaxBodyMiddleware(t *testing.T) {
 	suite.Run(t, new(MaxBodyMiddlewareSuite))
+}
+
+// TrustProxyHeadersSuite verifies that RequestMiddleware only honors
+// X-Forwarded-* and X-Real-IP headers when trust_proxy_headers is enabled.
+// Assertions read url.scheme and client.address from OpenTelemetry span
+// attributes captured by an in-memory recorder bound to httpTracer for the
+// lifetime of each test.
+type TrustProxyHeadersSuite struct {
+	suite.Suite
+	spanRecorder     *tracetest.SpanRecorder
+	origHTTPTracer   trace.Tracer
+	cleanupTelemetry func()
+}
+
+func (s *TrustProxyHeadersSuite) SetupTest() {
+	// Bind httpTracer directly to a fresh in-memory recorder. Swapping the
+	// package-level tracer sidesteps OTel's one-shot delegate locking
+	// (sync.Once on the global proxy tracer), so this suite doesn't need a
+	// TestMain and doesn't interfere with other suites in this package.
+	s.spanRecorder = tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(s.spanRecorder),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	s.origHTTPTracer = httpTracer
+	httpTracer = tp.Tracer("test")
+
+	// RequestMiddleware skips span creation when telemetry.Enabled() is false,
+	// so flip the flag on by initializing the tracer with an OTLP endpoint.
+	s.T().Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+	cleanup, err := telemetry.InitTracer("test", "1.0.0")
+	s.Require().NoError(err, "Expected telemetry.InitTracer to succeed")
+	s.cleanupTelemetry = cleanup
+}
+
+func (s *TrustProxyHeadersSuite) TearDownTest() {
+	httpTracer = s.origHTTPTracer
+	if s.cleanupTelemetry != nil {
+		s.cleanupTelemetry()
+	}
+}
+
+// runRequest drives a request through RequestMiddleware(trustProxy) and
+// returns the attributes of the span that was ended by the middleware.
+// The recorder is reset before each invocation so this helper is safe to call
+// from nested s.Run subtests (SetupTest only runs per top-level test method).
+func (s *TrustProxyHeadersSuite) runRequest(trustProxy bool, mutate func(*http.Request)) map[string]attribute.Value {
+	s.T().Helper()
+	s.spanRecorder.Reset()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	middleware := RequestMiddleware(trustProxy)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.RemoteAddr = "192.168.1.1:443"
+	if mutate != nil {
+		mutate(req)
+	}
+
+	rr := httptest.NewRecorder()
+	middleware.ServeHTTP(rr, req)
+
+	ended := s.spanRecorder.Ended()
+	s.Require().Len(ended, 1, "expected exactly one span to be recorded")
+	attrs := make(map[string]attribute.Value, len(ended[0].Attributes()))
+	for _, kv := range ended[0].Attributes() {
+		attrs[string(kv.Key)] = kv.Value
+	}
+	return attrs
+}
+
+func (s *TrustProxyHeadersSuite) TestClientAddress() {
+	s.Run("trust_proxy=true", func() {
+		s.Run("uses first X-Forwarded-For IP", func() {
+			attrs := s.runRequest(true, func(r *http.Request) {
+				r.Header.Set("X-Forwarded-For", "10.0.0.1")
+			})
+			s.Equal("10.0.0.1", attrs["client.address"].AsString())
+		})
+		s.Run("takes first entry from comma-separated X-Forwarded-For", func() {
+			attrs := s.runRequest(true, func(r *http.Request) {
+				r.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2, 10.0.0.3")
+			})
+			s.Equal("10.0.0.1", attrs["client.address"].AsString())
+		})
+		s.Run("trims whitespace around X-Forwarded-For entry", func() {
+			attrs := s.runRequest(true, func(r *http.Request) {
+				r.Header.Set("X-Forwarded-For", " 10.0.0.1 ")
+			})
+			s.Equal("10.0.0.1", attrs["client.address"].AsString())
+		})
+		s.Run("falls back to X-Real-IP when X-Forwarded-For absent", func() {
+			attrs := s.runRequest(true, func(r *http.Request) {
+				r.Header.Set("X-Real-IP", "10.0.0.2")
+			})
+			s.Equal("10.0.0.2", attrs["client.address"].AsString())
+		})
+		s.Run("X-Forwarded-For wins over X-Real-IP when both present", func() {
+			attrs := s.runRequest(true, func(r *http.Request) {
+				r.Header.Set("X-Forwarded-For", "10.0.0.1")
+				r.Header.Set("X-Real-IP", "10.0.0.2")
+			})
+			s.Equal("10.0.0.1", attrs["client.address"].AsString())
+		})
+	})
+
+	s.Run("trust_proxy=false", func() {
+		s.Run("ignores X-Forwarded-For and X-Real-IP", func() {
+			attrs := s.runRequest(false, func(r *http.Request) {
+				r.Header.Set("X-Forwarded-For", "10.0.0.1")
+				r.Header.Set("X-Real-IP", "10.0.0.2")
+			})
+			s.Equal("192.168.1.1", attrs["client.address"].AsString(),
+				"proxy headers must be ignored when trust_proxy_headers is disabled")
+		})
+		s.Run("uses RemoteAddr host when no proxy headers set", func() {
+			attrs := s.runRequest(false, nil)
+			s.Equal("192.168.1.1", attrs["client.address"].AsString())
+		})
+		s.Run("falls back to RemoteAddr when SplitHostPort fails", func() {
+			attrs := s.runRequest(false, func(r *http.Request) {
+				r.RemoteAddr = "bad-remote-addr"
+			})
+			s.Equal("bad-remote-addr", attrs["client.address"].AsString())
+		})
+	})
+}
+
+func (s *TrustProxyHeadersSuite) TestURLScheme() {
+	s.Run("trust_proxy=true", func() {
+		s.Run("honors X-Forwarded-Proto=https", func() {
+			attrs := s.runRequest(true, func(r *http.Request) {
+				r.Header.Set("X-Forwarded-Proto", "https")
+			})
+			s.Equal("https", attrs["url.scheme"].AsString())
+		})
+		s.Run("defaults to http when X-Forwarded-Proto absent and no TLS", func() {
+			attrs := s.runRequest(true, nil)
+			s.Equal("http", attrs["url.scheme"].AsString())
+		})
+		s.Run("returns https when request has TLS", func() {
+			attrs := s.runRequest(true, func(r *http.Request) {
+				r.TLS = &tls.ConnectionState{}
+			})
+			s.Equal("https", attrs["url.scheme"].AsString())
+		})
+	})
+
+	s.Run("trust_proxy=false", func() {
+		s.Run("ignores X-Forwarded-Proto", func() {
+			attrs := s.runRequest(false, func(r *http.Request) {
+				r.Header.Set("X-Forwarded-Proto", "https")
+			})
+			s.Equal("http", attrs["url.scheme"].AsString(),
+				"X-Forwarded-Proto must be ignored when trust_proxy_headers is disabled")
+		})
+		s.Run("returns https when request has TLS", func() {
+			attrs := s.runRequest(false, func(r *http.Request) {
+				r.TLS = &tls.ConnectionState{}
+			})
+			s.Equal("https", attrs["url.scheme"].AsString())
+		})
+	})
+}
+
+func TestTrustProxyHeaders(t *testing.T) {
+	suite.Run(t, new(TrustProxyHeadersSuite))
 }


### PR DESCRIPTION
## Summary

Follow-ups to #953 (Microsoft Entra ID / OBO token exchange):

- **OBO happy-path assertion** — `TestAuthorizationOidcTokenExchange` now asserts the exchanged backend token (`validOidcBackendToken`) reaches the Kubernetes API, rather than relying on log strings. The backend MockServer captures the incoming `Authorization` header and the test compares it directly.
- **SSE transport coverage (#1043)** — Added `TestAuthorizationOidcTokenExchangeSSE` so the context-injection path used by SSE clients (`internalk8s.OAuthAuthorizationHeader` context key) is exercised end-to-end alongside the existing StreamableHTTP test. The two tests share a `runOidcTokenExchange` helper.
- **`trust_proxy_headers` gating (#1044)** — New `TrustProxyHeadersSuite` in `pkg/http/middleware_test.go` asserts on OTel span attributes (`client.address`, `url.scheme`) read from an in-memory `tracetest.SpanRecorder`. Covers XFF / X-Real-IP precedence, whitespace trimming, comma-separated lists, RemoteAddr fallback, and X-Forwarded-Proto / TLS scheme handling, with and without the flag enabled.
- **Dead code cleanup** — Dropped the unused `AuthProvider` interface and `IsRequireOAuth()` method that became orphaned once `Derived()` moved to `ResolveClusterAuthMode()` (PR #953 review comment).

Closes #1043
Closes #1044