### PR TITLE
refactor(auth): deduplicate OIDC config fetches and simplify token exchange

### DIFF
--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,6 +20,7 @@ import (
 
 const maxWellKnownResponseSize = 1 << 20 // 1 MB
 const oidcConfigCacheTTL = 5 * time.Minute
+const oidcConfigFetchTimeout = 30 * time.Second
 
 var allowedResponseHeaders = map[string]bool{
 	"Cache-Control": true,
@@ -207,14 +209,20 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 	_, _ = writer.Write(body)
 }
 
-// fetchWellKnownEndpoint fetches a well-known endpoint and returns the parsed JSON.
-// Returns nil metadata if the endpoint returns 404 (to allow fallback).
+// fetchWellKnownEndpoint creates a new request from the incoming request's method and context,
+// then fetches the well-known endpoint. Returns nil metadata if the endpoint returns 404.
 func (w *WellKnown) fetchWellKnownEndpoint(request *http.Request, url string) (map[string]interface{}, http.Header, error) {
-	req, err := http.NewRequest(request.Method, url, nil)
+	req, err := http.NewRequestWithContext(request.Context(), request.Method, url, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	resp, err := w.wellKnownHTTPClient().Do(req.WithContext(request.Context()))
+	return w.fetchWellKnownEndpointFromRequest(req)
+}
+
+// fetchWellKnownEndpointFromRequest performs the HTTP fetch using a pre-built request.
+// Returns nil metadata if the endpoint returns 404 (to allow fallback).
+func (w *WellKnown) fetchWellKnownEndpointFromRequest(req *http.Request) (map[string]interface{}, http.Header, error) {
+	resp, err := w.wellKnownHTTPClient().Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to perform request: %w", err)
 	}
@@ -251,19 +259,20 @@ func (w *WellKnown) fetchOpenIDConfiguration(request *http.Request) (map[string]
 	}
 	w.oidcConfigCacheMu.RUnlock()
 
-	// singleflight deduplicates concurrent cache misses for the same authURL
-	val, err, _ := w.oidcConfigFlight.Do(authURL, func() (interface{}, error) {
-		// Re-check cache under singleflight in case another goroutine just populated it
-		w.oidcConfigCacheMu.RLock()
-		if w.oidcConfigCache != nil && w.oidcConfigCacheURL == authURL && time.Since(w.oidcConfigCacheTime) < oidcConfigCacheTTL {
-			result := copyMap(w.oidcConfigCache)
-			w.oidcConfigCacheMu.RUnlock()
-			return result, nil
-		}
-		w.oidcConfigCacheMu.RUnlock()
+	// singleflight deduplicates concurrent cache misses for the same authURL.
+	// We use context.WithoutCancel so that if the winning request is cancelled,
+	// the in-flight fetch still completes for all waiters.
+	val, err, _ := w.oidcConfigFlight.Do(authURL, func() (any, error) {
+		// Decouple from the caller's request lifecycle and apply our own timeout
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(request.Context()), oidcConfigFetchTimeout)
+		defer cancel()
 
-		oidcURL := authURL + openIDConfigurationEndpoint
-		oidcConfig, _, err := w.fetchWellKnownEndpoint(request, oidcURL)
+		fetchReq, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, authURL+openIDConfigurationEndpoint, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create openid-configuration request: %w", err)
+		}
+
+		oidcConfig, _, err := w.fetchWellKnownEndpointFromRequest(fetchReq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch openid-configuration: %w", err)
 		}
@@ -285,7 +294,7 @@ func (w *WellKnown) fetchOpenIDConfiguration(request *http.Request) (map[string]
 	if val == nil {
 		return nil, nil
 	}
-	return copyMap(val.(map[string]interface{})), nil
+	return copyMap(val.(map[string]any)), nil
 }
 
 // generateAuthorizationServerMetadata generates oauth-authorization-server metadata

--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 	"k8s.io/klog/v2"
@@ -86,7 +88,8 @@ type WellKnown struct {
 	oidcConfigCache     map[string]interface{}
 	oidcConfigCacheTime time.Time
 	oidcConfigCacheURL  string // tracks which authURL the cache was fetched for
-	oidcConfigCacheLock sync.RWMutex
+	oidcConfigCacheMu   sync.RWMutex
+	oidcConfigFlight    singleflight.Group
 }
 
 var _ http.Handler = &WellKnown{}
@@ -235,36 +238,54 @@ func (w *WellKnown) fetchWellKnownEndpoint(request *http.Request, url string) (m
 }
 
 // fetchOpenIDConfiguration fetches and caches the openid-configuration from the authorization server.
+// Uses singleflight to deduplicate concurrent fetches for the same authorization URL.
 func (w *WellKnown) fetchOpenIDConfiguration(request *http.Request) (map[string]interface{}, error) {
 	authURL := w.authorizationURL()
 
 	// Check cache first (with TTL and URL match — invalidate if authorization URL changed)
-	w.oidcConfigCacheLock.RLock()
+	w.oidcConfigCacheMu.RLock()
 	if w.oidcConfigCache != nil && w.oidcConfigCacheURL == authURL && time.Since(w.oidcConfigCacheTime) < oidcConfigCacheTTL {
 		result := copyMap(w.oidcConfigCache)
-		w.oidcConfigCacheLock.RUnlock()
+		w.oidcConfigCacheMu.RUnlock()
 		return result, nil
 	}
-	w.oidcConfigCacheLock.RUnlock()
+	w.oidcConfigCacheMu.RUnlock()
 
-	// Fetch openid-configuration
-	oidcURL := authURL + openIDConfigurationEndpoint
-	oidcConfig, _, err := w.fetchWellKnownEndpoint(request, oidcURL)
+	// singleflight deduplicates concurrent cache misses for the same authURL
+	val, err, _ := w.oidcConfigFlight.Do(authURL, func() (interface{}, error) {
+		// Re-check cache under singleflight in case another goroutine just populated it
+		w.oidcConfigCacheMu.RLock()
+		if w.oidcConfigCache != nil && w.oidcConfigCacheURL == authURL && time.Since(w.oidcConfigCacheTime) < oidcConfigCacheTTL {
+			result := copyMap(w.oidcConfigCache)
+			w.oidcConfigCacheMu.RUnlock()
+			return result, nil
+		}
+		w.oidcConfigCacheMu.RUnlock()
+
+		oidcURL := authURL + openIDConfigurationEndpoint
+		oidcConfig, _, err := w.fetchWellKnownEndpoint(request, oidcURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch openid-configuration: %w", err)
+		}
+		if oidcConfig == nil {
+			return nil, nil
+		}
+
+		w.oidcConfigCacheMu.Lock()
+		w.oidcConfigCache = copyMap(oidcConfig)
+		w.oidcConfigCacheTime = time.Now()
+		w.oidcConfigCacheURL = authURL
+		w.oidcConfigCacheMu.Unlock()
+
+		return oidcConfig, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch openid-configuration: %w", err)
+		return nil, err
 	}
-	if oidcConfig == nil {
+	if val == nil {
 		return nil, nil
 	}
-
-	// Cache the result with timestamp and URL
-	w.oidcConfigCacheLock.Lock()
-	w.oidcConfigCache = copyMap(oidcConfig)
-	w.oidcConfigCacheTime = time.Now()
-	w.oidcConfigCacheURL = authURL
-	w.oidcConfigCacheLock.Unlock()
-
-	return oidcConfig, nil
+	return copyMap(val.(map[string]interface{})), nil
 }
 
 // generateAuthorizationServerMetadata generates oauth-authorization-server metadata

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -90,14 +90,14 @@ func exchangePassthroughToken(
 	stsConfig *tokenexchange.TargetTokenExchangeConfig,
 ) (string, error) {
 	if strategy := baseConfig.GetStsStrategy(); strategy != "" {
-		return doTokenExchange(ctx, baseConfig, oidcProvider, httpClient, token, func(ctx context.Context) (context.Context, error) {
+		return doTokenExchange(ctx, token, func(ctx context.Context) (context.Context, error) {
 			return strategyBasedTokenExchange(ctx, baseConfig, oidcProvider, httpClient, token, strategy, stsConfig)
 		})
 	}
 
 	sts := NewFromConfig(baseConfig, oidcProvider)
 	if sts.IsEnabled() {
-		return doTokenExchange(ctx, baseConfig, oidcProvider, httpClient, token, func(ctx context.Context) (context.Context, error) {
+		return doTokenExchange(ctx, token, func(ctx context.Context) (context.Context, error) {
 			if httpClient != nil {
 				ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 			}
@@ -116,11 +116,9 @@ func exchangePassthroughToken(
 }
 
 // doTokenExchange runs an exchange function and extracts the Bearer token from the resulting context.
+// Falls back to the original token if the exchange doesn't produce one.
 func doTokenExchange(
 	ctx context.Context,
-	baseConfig api.BaseConfig,
-	oidcProvider *oidc.Provider,
-	httpClient *http.Client,
 	token string,
 	exchangeFn func(ctx context.Context) (context.Context, error),
 ) (string, error) {


### PR DESCRIPTION
small cleanup to #953

context here: https://github.com/containers/kubernetes-mcp-server/pull/953#issuecomment-4241438243 