### PR TITLE
fix(test): call resp.Body.Close() instead of referencing method value

### DIFF
--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -108,7 +108,7 @@ func (s *AuthorizationSuite) TestAuthorizationUnauthorizedMissingHeader() {
 
 	s.Run("Protected resource with MISSING Authorization header", func() {
 		resp := s.HttpGet("")
-		s.T().Cleanup(func() { _ = resp.Body.Close })
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
 
 		s.Run("returns 401 - Unauthorized status", func() {
 			s.Equal(401, resp.StatusCode, "Expected HTTP 401 for MISSING Authorization header")
@@ -137,7 +137,7 @@ func (s *AuthorizationSuite) TestAuthorizationUnauthorizedHeaderIncompatible() {
 
 	s.Run("Protected resource with INCOMPATIBLE Authorization header", func() {
 		resp := s.HttpGet("Basic YWxhZGRpbjpvcGVuc2VzYW1l")
-		s.T().Cleanup(func() { _ = resp.Body.Close })
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
 
 		s.Run("returns 401 - Unauthorized status", func() {
 			s.Equal(401, resp.StatusCode, "Expected HTTP 401 for INCOMPATIBLE Authorization header")
@@ -166,7 +166,7 @@ func (s *AuthorizationSuite) TestAuthorizationUnauthorizedHeaderInvalid() {
 
 	s.Run("Protected resource with INVALID Authorization header", func() {
 		resp := s.HttpGet("Bearer " + strings.ReplaceAll(tokenBasicNotExpired, ".", ".invalid"))
-		s.T().Cleanup(func() { _ = resp.Body.Close })
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
 
 		s.Run("returns 401 - Unauthorized status", func() {
 			s.Equal(401, resp.StatusCode, "Expected HTTP 401 for INVALID Authorization header")
@@ -196,7 +196,7 @@ func (s *AuthorizationSuite) TestAuthorizationUnauthorizedHeaderExpired() {
 
 	s.Run("Protected resource with EXPIRED Authorization header", func() {
 		resp := s.HttpGet("Bearer " + tokenBasicExpired)
-		s.T().Cleanup(func() { _ = resp.Body.Close })
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
 
 		s.Run("returns 401 - Unauthorized status", func() {
 			s.Equal(401, resp.StatusCode, "Expected HTTP 401 for EXPIRED Authorization header")
@@ -227,7 +227,7 @@ func (s *AuthorizationSuite) TestAuthorizationUnauthorizedHeaderInvalidAudience(
 
 	s.Run("Protected resource with INVALID AUDIENCE Authorization header", func() {
 		resp := s.HttpGet("Bearer " + tokenBasicNotExpired)
-		s.T().Cleanup(func() { _ = resp.Body.Close })
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
 
 		s.Run("returns 401 - Unauthorized status", func() {
 			s.Equal(401, resp.StatusCode, "Expected HTTP 401 for INVALID AUDIENCE Authorization header")
@@ -261,7 +261,7 @@ func (s *AuthorizationSuite) TestAuthorizationUnauthorizedOidcValidation() {
 
 	s.Run("Protected resource with INVALID OIDC Authorization header", func() {
 		resp := s.HttpGet("Bearer " + tokenBasicNotExpired)
-		s.T().Cleanup(func() { _ = resp.Body.Close })
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
 
 		s.Run("returns 401 - Unauthorized status", func() {
 			s.Equal(401, resp.StatusCode, "Expected HTTP 401 for INVALID OIDC Authorization header")

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -243,7 +243,7 @@ func TestHealthCheck(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to get health check endpoint: %v", err)
 			}
-			t.Cleanup(func() { _ = resp.Body.Close })
+			t.Cleanup(func() { _ = resp.Body.Close() })
 			if resp.StatusCode != http.StatusOK {
 				t.Errorf("Expected HTTP 200 OK, got %d", resp.StatusCode)
 			}


### PR DESCRIPTION
## Summary

`resp.Body.Close` without parentheses evaluates to a method reference (`func() error`) and discards it via `_ =` assignment. The response body is never actually closed, leaking HTTP response resources during test execution.

The `_ =` suppresses any linter warning, making this bug invisible to static analysis tools like `golangci-lint`.

## Changes

| File | Instances | Description |
|------|-----------|-------------|
| `pkg/http/authorization_mcp_test.go` | 6 | `_ = resp.Body.Close` → `_ = resp.Body.Close()` |
| `pkg/http/http_test.go` | 1 | `_ = resp.Body.Close` → `_ = resp.Body.Close()` |

## Impact

- **Before**: Response bodies leaked in every test case — cleanup callback stored a method reference instead of calling it
- **After**: Response bodies are properly closed via `resp.Body.Close()` in `t.Cleanup()`

## Testing

- `make build` (includes `go fmt`, `go mod tidy`, lint): **passes**
- `TestAuthorization` suite: **all subtests pass**
- Zero remaining instances of `resp.Body.Close` without `()` confirmed via `grep`
