### PR TITLE
fix(api): migrate tool handlers to WrapParams sticky-error pattern

### DIFF
--- a/pkg/api/params.go
+++ b/pkg/api/params.go
@@ -45,14 +45,14 @@ func RequiredString(params ToolHandlerParams, key string) (string, error) {
 
 // OptionalString extracts an optional string parameter from tool arguments.
 // Returns the string value if present and valid, or defaultVal if missing or not a string.
+//
+// Deprecated: this helper silently returns defaultVal when the argument is
+// present but of the wrong type, masking client errors. New code should use
+// WrapParams and the Params.OptionalString method, which records a sticky
+// type-mismatch error exposed via Params.Err.
 func OptionalString(params ToolHandlerParams, key, defaultVal string) string {
-	args := params.GetArguments()
-	val, ok := args[key]
-	if !ok {
-		return defaultVal
-	}
-	str, ok := val.(string)
-	if !ok {
+	str, err := optionalString(params, key, defaultVal)
+	if err != nil {
 		return defaultVal
 	}
 	return str
@@ -60,15 +60,141 @@ func OptionalString(params ToolHandlerParams, key, defaultVal string) string {
 
 // OptionalBool extracts an optional boolean parameter from tool arguments.
 // Returns the boolean value if present and valid, or defaultVal if missing or not a boolean.
+//
+// Deprecated: this helper silently returns defaultVal when the argument is
+// present but of the wrong type, masking client errors. New code should use
+// WrapParams and the Params.OptionalBool method, which records a sticky
+// type-mismatch error exposed via Params.Err.
 func OptionalBool(params ToolHandlerParams, key string, defaultVal bool) bool {
-	args := params.GetArguments()
-	val, ok := args[key]
-	if !ok {
-		return defaultVal
-	}
-	b, ok := val.(bool)
-	if !ok {
+	b, err := optionalBool(params, key, defaultVal)
+	if err != nil {
 		return defaultVal
 	}
 	return b
+}
+
+// optionalString is the type-strict variant that powers Params.OptionalString.
+// Missing key returns defaultVal with no error; a present-but-wrong-type value
+// returns an error.
+func optionalString(params ToolHandlerParams, key, defaultVal string) (string, error) {
+	val, ok := params.GetArguments()[key]
+	if !ok {
+		return defaultVal, nil
+	}
+	str, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("%s parameter must be a string", key)
+	}
+	return str, nil
+}
+
+// optionalBool is the type-strict variant that powers Params.OptionalBool.
+// Missing key returns defaultVal with no error; a present-but-wrong-type value
+// returns an error.
+func optionalBool(params ToolHandlerParams, key string, defaultVal bool) (bool, error) {
+	val, ok := params.GetArguments()[key]
+	if !ok {
+		return defaultVal, nil
+	}
+	b, ok := val.(bool)
+	if !ok {
+		return false, fmt.Errorf("%s parameter must be a boolean", key)
+	}
+	return b, nil
+}
+
+// Params wraps ToolHandlerParams with sticky-error parameter extraction, so a
+// handler can extract several arguments and check for type mismatches once at
+// the end rather than after each call. Once an extraction fails, subsequent
+// extractions return their default/zero value and do not overwrite the first
+// error (matching the idiom used by bufio.Scanner and sql.Rows).
+//
+// Unlike the package-level OptionalString / OptionalBool helpers, the Params
+// methods surface type mismatches as errors instead of silently falling back
+// to the default: the tool InputSchema advertises the expected type, so a
+// present-but-wrong-type value indicates a malformed client call that the
+// caller should see.
+//
+// Typical usage:
+//
+//	p := api.WrapParams(params)
+//	ns := p.OptionalString("namespace", "")
+//	name := p.RequiredString("name")
+//	tail := p.OptionalInt64("tail", 0)
+//	if err := p.Err(); err != nil {
+//	    return api.NewToolCallResult("", fmt.Errorf("failed to X: %w", err)), nil
+//	}
+type Params struct {
+	ToolHandlerParams
+	err error
+}
+
+// WrapParams returns a sticky-error wrapper around the given ToolHandlerParams.
+func WrapParams(params ToolHandlerParams) *Params {
+	return &Params{ToolHandlerParams: params}
+}
+
+// Err returns the first type-mismatch error encountered by any extraction
+// call, or nil if all extractions succeeded.
+func (p *Params) Err() error { return p.err }
+
+// RequiredString is the sticky-error variant of the package-level RequiredString.
+func (p *Params) RequiredString(key string) string {
+	if p.err != nil {
+		return ""
+	}
+	v, err := RequiredString(p.ToolHandlerParams, key)
+	if err != nil {
+		p.err = err
+	}
+	return v
+}
+
+// OptionalString extracts an optional string. Missing key returns defaultVal
+// with no sticky error; a present-but-wrong-type value records a sticky error
+// and returns defaultVal.
+func (p *Params) OptionalString(key, defaultVal string) string {
+	if p.err != nil {
+		return defaultVal
+	}
+	v, err := optionalString(p.ToolHandlerParams, key, defaultVal)
+	if err != nil {
+		p.err = err
+		return defaultVal
+	}
+	return v
+}
+
+// OptionalBool extracts an optional bool. Missing key returns defaultVal with
+// no sticky error; a present-but-wrong-type value records a sticky error and
+// returns defaultVal.
+func (p *Params) OptionalBool(key string, defaultVal bool) bool {
+	if p.err != nil {
+		return defaultVal
+	}
+	v, err := optionalBool(p.ToolHandlerParams, key, defaultVal)
+	if err != nil {
+		p.err = err
+		return defaultVal
+	}
+	return v
+}
+
+// OptionalInt64 extracts an optional int64 parameter. Missing key returns
+// defaultVal with no sticky error; a present-but-wrong-type value records a
+// sticky error and returns defaultVal.
+func (p *Params) OptionalInt64(key string, defaultVal int64) int64 {
+	if p.err != nil {
+		return defaultVal
+	}
+	val, ok := p.GetArguments()[key]
+	if !ok || val == nil {
+		return defaultVal
+	}
+	v, err := ParseInt64(val)
+	if err != nil {
+		p.err = fmt.Errorf("%s parameter must be an integer: %w", key, err)
+		return defaultVal
+	}
+	return v
 }

--- a/pkg/api/params.go
+++ b/pkg/api/params.go
@@ -83,7 +83,7 @@ func optionalString(params ToolHandlerParams, key, defaultVal string) (string, e
 	}
 	str, ok := val.(string)
 	if !ok {
-		return "", fmt.Errorf("%s parameter must be a string", key)
+		return defaultVal, fmt.Errorf("%s parameter must be a string", key)
 	}
 	return str, nil
 }
@@ -98,7 +98,7 @@ func optionalBool(params ToolHandlerParams, key string, defaultVal bool) (bool, 
 	}
 	b, ok := val.(bool)
 	if !ok {
-		return false, fmt.Errorf("%s parameter must be a boolean", key)
+		return defaultVal, fmt.Errorf("%s parameter must be a boolean", key)
 	}
 	return b, nil
 }

--- a/pkg/api/params_test.go
+++ b/pkg/api/params_test.go
@@ -148,63 +148,108 @@ func (s *ParamsSuite) TestRequiredString() {
 func (s *ParamsSuite) TestOptionalString() {
 	s.Run("returns string value when present", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{"name": "test-value"}}}
-		result := OptionalString(params, "name", "default")
-		s.Equal("test-value", result)
+		s.Equal("test-value", OptionalString(params, "name", "default"))
 	})
 
 	s.Run("returns default when key is missing", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{}}}
-		result := OptionalString(params, "name", "default-value")
-		s.Equal("default-value", result)
+		s.Equal("default-value", OptionalString(params, "name", "default-value"))
 	})
 
 	s.Run("returns default when value is not a string", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{"name": 123}}}
-		result := OptionalString(params, "name", "fallback")
-		s.Equal("fallback", result)
+		s.Equal("fallback", OptionalString(params, "name", "fallback"))
 	})
 
 	s.Run("returns empty string when value is empty string", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{"name": ""}}}
-		result := OptionalString(params, "name", "default")
-		s.Equal("", result)
+		s.Equal("", OptionalString(params, "name", "default"))
 	})
 
 	s.Run("returns empty string when default is empty and key is missing", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{}}}
-		result := OptionalString(params, "name", "")
-		s.Equal("", result)
+		s.Equal("", OptionalString(params, "name", ""))
 	})
 }
 
 func (s *ParamsSuite) TestOptionalBool() {
 	s.Run("returns true when value is true", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{"enabled": true}}}
-		result := OptionalBool(params, "enabled", false)
-		s.True(result)
+		s.True(OptionalBool(params, "enabled", false))
 	})
 
 	s.Run("returns false when value is false", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{"enabled": false}}}
-		result := OptionalBool(params, "enabled", true)
-		s.False(result)
+		s.False(OptionalBool(params, "enabled", true))
 	})
 
 	s.Run("returns default when key is missing", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{}}}
-		result := OptionalBool(params, "enabled", true)
-		s.True(result)
+		s.True(OptionalBool(params, "enabled", true))
 	})
 
 	s.Run("returns default when value is not a bool", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{"enabled": "true"}}}
-		result := OptionalBool(params, "enabled", true)
-		s.True(result)
+		s.True(OptionalBool(params, "enabled", true))
 	})
 
 	s.Run("returns false default when key is missing", func() {
 		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{}}}
-		result := OptionalBool(params, "enabled", false)
-		s.False(result)
+		s.False(OptionalBool(params, "enabled", false))
+	})
+}
+
+func (s *ParamsSuite) TestParamsWrapper() {
+	s.Run("no error when all extractions succeed", func() {
+		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{
+			"name":    "hello",
+			"enabled": true,
+			"count":   float64(42),
+		}}}
+		p := WrapParams(params)
+		s.Equal("hello", p.RequiredString("name"))
+		s.True(p.OptionalBool("enabled", false))
+		s.Equal(int64(42), p.OptionalInt64("count", 0))
+		s.NoError(p.Err())
+	})
+
+	s.Run("sticky error captures first type mismatch and suppresses subsequent extractions", func() {
+		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{
+			"namespace": 123,
+			"name":      456,
+		}}}
+		p := WrapParams(params)
+		ns := p.OptionalString("namespace", "default-ns")
+		name := p.RequiredString("name")
+		s.Equal("default-ns", ns, "returns default when an error is recorded")
+		s.Equal("", name, "returns zero value once sticky error is set")
+		s.Error(p.Err())
+		s.Contains(p.Err().Error(), "namespace parameter must be a string",
+			"sticky error preserves the first mismatch, not later ones")
+	})
+
+	s.Run("missing optional keys do not set an error", func() {
+		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{}}}
+		p := WrapParams(params)
+		s.Equal("fallback", p.OptionalString("namespace", "fallback"))
+		s.True(p.OptionalBool("enabled", true))
+		s.Equal(int64(99), p.OptionalInt64("count", 99))
+		s.NoError(p.Err())
+	})
+
+	s.Run("RequiredString missing key sets error", func() {
+		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{}}}
+		p := WrapParams(params)
+		s.Equal("", p.RequiredString("name"))
+		s.Error(p.Err())
+		s.Contains(p.Err().Error(), "name parameter required")
+	})
+
+	s.Run("OptionalInt64 with wrong type sets error", func() {
+		params := ToolHandlerParams{ToolCallRequest: &mockToolCallRequest{args: map[string]any{"count": "nope"}}}
+		p := WrapParams(params)
+		s.Equal(int64(7), p.OptionalInt64("count", 7), "returns default when type mismatch is recorded")
+		s.Error(p.Err())
+		s.Contains(p.Err().Error(), "count parameter must be an integer")
 	})
 }

--- a/pkg/mcp/configuration_test.go
+++ b/pkg/mcp/configuration_test.go
@@ -89,12 +89,14 @@ func (s *ConfigurationSuite) TestConfigurationView() {
 			s.Equalf("fake", decoded.AuthInfos[0].Name, "fake-auth not found: %v", decoded.AuthInfos)
 		})
 	})
-	s.Run("configuration_view with minified as string does not panic", func() {
+	s.Run("configuration_view with minified as string returns error without panicking", func() {
 		toolResult, err := s.CallTool("configuration_view", map[string]interface{}{
 			"minified": "false",
 		})
-		s.Nilf(err, "call tool failed %v", err)
-		s.Falsef(toolResult.IsError, "call tool failed")
+		s.Nilf(err, "call tool should not return error object")
+		s.Truef(toolResult.IsError, "call tool should fail with type mismatch")
+		s.Equalf("failed to get configuration: minified parameter must be a boolean", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("configuration_view(minified=false)", func() {
 		toolResult, err := s.CallTool("configuration_view", map[string]interface{}{

--- a/pkg/mcp/pods_test.go
+++ b/pkg/mcp/pods_test.go
@@ -621,23 +621,27 @@ func (s *PodsSuite) TestPodsLog() {
 		s.Nilf(err, "call tool failed %v", err)
 		s.Falsef(podsPreviousLogFalse.IsError, "call tool failed")
 	})
-	s.Run("pods_log with previous as string does not panic", func() {
+	s.Run("pods_log with previous as string returns error without panicking", func() {
 		toolResult, err := s.CallTool("pods_log", map[string]interface{}{
 			"namespace": "ns-1",
 			"name":      "a-pod-in-ns-1",
 			"previous":  "false",
 		})
-		s.Nilf(err, "call tool failed %v", err)
-		s.Falsef(toolResult.IsError, "call tool failed")
+		s.Nilf(err, "call tool should not return error object")
+		s.Truef(toolResult.IsError, "call tool should fail with type mismatch")
+		s.Equalf("failed to get pod log: previous parameter must be a boolean", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
-	s.Run("pods_log with previous as float64 does not panic", func() {
+	s.Run("pods_log with previous as float64 returns error without panicking", func() {
 		toolResult, err := s.CallTool("pods_log", map[string]interface{}{
 			"namespace": "ns-1",
 			"name":      "a-pod-in-ns-1",
 			"previous":  float64(0),
 		})
-		s.Nilf(err, "call tool failed %v", err)
-		s.Falsef(toolResult.IsError, "call tool failed")
+		s.Nilf(err, "call tool should not return error object")
+		s.Truef(toolResult.IsError, "call tool should fail with type mismatch")
+		s.Equalf("failed to get pod log: previous parameter must be a boolean", toolResult.Content[0].(*mcp.TextContent).Text,
+			"invalid error message, got %v", toolResult.Content[0].(*mcp.TextContent).Text)
 	})
 	s.Run("pods_log(tail=50) returns pod log", func() {
 		podsTailLines, err := s.CallTool("pods_log", map[string]interface{}{
@@ -655,7 +659,7 @@ func (s *PodsSuite) TestPodsLog() {
 			"tail":      "invalid",
 		})
 		s.Truef(podsInvalidTailLines.IsError, "call tool should fail")
-		expectedErrorMsg := "failed to parse tail parameter: expected integer"
+		expectedErrorMsg := "failed to get pod log: tail parameter must be an integer"
 		errMsg := podsInvalidTailLines.Content[0].(*mcp.TextContent).Text
 		s.Containsf(errMsg, expectedErrorMsg, "unexpected error message, expected to contain '%s', got '%s'", expectedErrorMsg, errMsg)
 	})

--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -122,7 +122,11 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func configurationView(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	minify := api.OptionalBool(params, "minified", true)
+	p := api.WrapParams(params)
+	minify := p.OptionalBool("minified", true)
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get configuration: %w", err)), nil
+	}
 	ret, err := kubernetes.NewCore(params).ConfigurationView(minify)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get configuration: %w", err)), nil

--- a/pkg/toolsets/core/events.go
+++ b/pkg/toolsets/core/events.go
@@ -36,7 +36,11 @@ func initEvents() []api.ServerTool {
 }
 
 func eventsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	namespace := api.OptionalString(params, "namespace", "")
+	p := api.WrapParams(params)
+	namespace := p.OptionalString("namespace", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list events in all namespaces: %w", err)), nil
+	}
 	eventMap, err := kubernetes.NewCore(params).EventsList(params, namespace)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list events in all namespaces: %w", err)), nil

--- a/pkg/toolsets/core/pods.go
+++ b/pkg/toolsets/core/pods.go
@@ -260,11 +260,15 @@ func initPods() []api.ServerTool {
 }
 
 func podsListInAllNamespaces(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
 	resourceListOptions := api.ListOptions{
 		AsTable: params.ListOutput.AsTable(),
 	}
-	resourceListOptions.LabelSelector = api.OptionalString(params, "labelSelector", "")
-	resourceListOptions.FieldSelector = api.OptionalString(params, "fieldSelector", "")
+	resourceListOptions.LabelSelector = p.OptionalString("labelSelector", "")
+	resourceListOptions.FieldSelector = p.OptionalString("fieldSelector", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in all namespaces: %w", err)), nil
+	}
 	ret, err := kubernetes.NewCore(params).PodsListInAllNamespaces(params, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in all namespaces: %w", err)), nil
@@ -273,15 +277,16 @@ func podsListInAllNamespaces(params api.ToolHandlerParams) (*api.ToolCallResult,
 }
 
 func podsListInNamespace(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns, err := api.RequiredString(params, "namespace")
-	if err != nil {
-		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace: %w", err)), nil
-	}
+	p := api.WrapParams(params)
+	ns := p.RequiredString("namespace")
 	resourceListOptions := api.ListOptions{
 		AsTable: params.ListOutput.AsTable(),
 	}
-	resourceListOptions.LabelSelector = api.OptionalString(params, "labelSelector", "")
-	resourceListOptions.FieldSelector = api.OptionalString(params, "fieldSelector", "")
+	resourceListOptions.LabelSelector = p.OptionalString("labelSelector", "")
+	resourceListOptions.FieldSelector = p.OptionalString("fieldSelector", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace: %w", err)), nil
+	}
 	ret, err := kubernetes.NewCore(params).PodsListInNamespace(params, ns, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace %s: %w", ns, err)), nil
@@ -290,9 +295,10 @@ func podsListInNamespace(params api.ToolHandlerParams) (*api.ToolCallResult, err
 }
 
 func podsGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := api.OptionalString(params, "namespace", "")
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod: %w", err)), nil
 	}
 	ret, err := kubernetes.NewCore(params).PodsGet(params, ns, name)
@@ -303,9 +309,10 @@ func podsGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func podsDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := api.OptionalString(params, "namespace", "")
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to delete pod: %w", err)), nil
 	}
 	ret, err := kubernetes.NewCore(params).PodsDelete(params, ns, name)
@@ -316,16 +323,15 @@ func podsDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func podsTop(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	podsTopOptions := api.PodsTopOptions{AllNamespaces: true}
-	if v, ok := params.GetArguments()["namespace"].(string); ok {
-		podsTopOptions.Namespace = v
+	p := api.WrapParams(params)
+	podsTopOptions := api.PodsTopOptions{
+		AllNamespaces: p.OptionalBool("all_namespaces", true),
+		Namespace:     p.OptionalString("namespace", ""),
+		Name:          p.OptionalString("name", ""),
 	}
-	podsTopOptions.AllNamespaces = api.OptionalBool(params, "all_namespaces", true)
-	if v, ok := params.GetArguments()["name"].(string); ok {
-		podsTopOptions.Name = v
-	}
-	if v, ok := params.GetArguments()["label_selector"].(string); ok {
-		podsTopOptions.LabelSelector = v
+	podsTopOptions.LabelSelector = p.OptionalString("label_selector", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get pods top: %w", err)), nil
 	}
 	ret, err := kubernetes.NewCore(params).PodsTop(params, podsTopOptions)
 	if err != nil {
@@ -341,24 +347,24 @@ func podsTop(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func podsExec(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := api.OptionalString(params, "namespace", "")
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	container := p.OptionalString("container", "")
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to exec in pod: %w", err)), nil
 	}
-	container := api.OptionalString(params, "container", "")
-	commandArg := params.GetArguments()["command"]
-	command := make([]string, 0)
-	if cmdSlice, ok := commandArg.([]interface{}); ok {
-		for _, cmd := range cmdSlice {
-			s, ok := cmd.(string)
-			if !ok {
-				return api.NewToolCallResult("", errors.New("failed to exec in pod, all command elements must be strings")), nil
-			}
-			command = append(command, s)
+	cmdSlice, ok := params.GetArguments()["command"].([]interface{})
+	if !ok {
+		return api.NewToolCallResult("", errors.New("failed to exec in pod: command parameter must be an array of strings")), nil
+	}
+	command := make([]string, 0, len(cmdSlice))
+	for _, cmd := range cmdSlice {
+		s, ok := cmd.(string)
+		if !ok {
+			return api.NewToolCallResult("", errors.New("failed to exec in pod: command parameter must be an array of strings")), nil
 		}
-	} else {
-		return api.NewToolCallResult("", errors.New("failed to exec in pod, invalid command argument")), nil
+		command = append(command, s)
 	}
 	ret, err := kubernetes.NewCore(params).PodsExec(params, ns, name, container, command)
 	if err != nil {
@@ -370,24 +376,15 @@ func podsExec(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func podsLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := api.OptionalString(params, "namespace", "")
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	container := p.OptionalString("container", "")
+	previousBool := p.OptionalBool("previous", false)
+	tailInt := p.OptionalInt64("tail", 0)
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod log: %w", err)), nil
 	}
-	container := api.OptionalString(params, "container", "")
-	previousBool := api.OptionalBool(params, "previous", false)
-	// Extract tailLines parameter
-	tail := params.GetArguments()["tail"]
-	var tailInt int64
-	if tail != nil {
-		var err error
-		tailInt, err = api.ParseInt64(tail)
-		if err != nil {
-			return api.NewToolCallResult("", fmt.Errorf("failed to parse tail parameter: %w", err)), nil
-		}
-	}
-
 	ret, err := kubernetes.NewCore(params).PodsLog(params.Context, ns, name, container, previousBool, tailInt)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod %s log in namespace %s: %w", name, ns, err)), nil
@@ -398,19 +395,13 @@ func podsLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func podsRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ns := api.OptionalString(params, "namespace", "")
-	name := api.OptionalString(params, "name", "")
-	image, err := api.RequiredString(params, "image")
-	if err != nil {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.OptionalString("name", "")
+	image := p.RequiredString("image")
+	port := int32(p.OptionalInt64("port", 0))
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to run pod: %w", err)), nil
-	}
-	var port int32
-	if portVal, ok := params.GetArguments()["port"]; ok && portVal != nil {
-		portInt, err := api.ParseInt64(portVal)
-		if err != nil {
-			return api.NewToolCallResult("", fmt.Errorf("failed to parse port parameter: %w", err)), nil
-		}
-		port = int32(portInt)
 	}
 	resources, err := kubernetes.NewCore(params).PodsRun(params, ns, name, image, port)
 	if err != nil {

--- a/pkg/toolsets/helm/helm.go
+++ b/pkg/toolsets/helm/helm.go
@@ -131,10 +131,11 @@ func helmInstall(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func helmList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	allNamespaces := api.OptionalBool(params, "all_namespaces", false)
-	namespace := ""
-	if v, ok := params.GetArguments()["namespace"].(string); ok {
-		namespace = v
+	p := api.WrapParams(params)
+	allNamespaces := p.OptionalBool("all_namespaces", false)
+	namespace := p.OptionalString("namespace", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list helm releases: %w", err)), nil
 	}
 	ret, err := newHelmClient(params).List(namespace, allNamespaces)
 	if err != nil {

--- a/pkg/toolsets/kubevirt/vm/create/tool.go
+++ b/pkg/toolsets/kubevirt/vm/create/tool.go
@@ -201,18 +201,21 @@ type createParameters struct {
 
 // parseCreateParameters parses and validates input parameters
 func parseCreateParameters(params api.ToolHandlerParams) (*createParameters, error) {
-	namespace, err := api.RequiredString(params, "namespace")
-	if err != nil {
+	p := api.WrapParams(params)
+	namespace := p.RequiredString("namespace")
+	name := p.RequiredString("name")
+	workload := p.OptionalString("workload", "fedora")
+	instancetype := p.OptionalString("instancetype", "")
+	preference := p.OptionalString("preference", "")
+	size := p.OptionalString("size", "")
+	performance := p.OptionalString("performance", "")
+	storage := p.OptionalString("storage", "30Gi")
+	autostart := p.OptionalBool("autostart", false)
+	if err := p.Err(); err != nil {
 		return nil, err
 	}
 
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
-		return nil, err
-	}
-
-	networksInput := optionalArray(params, "networks")
-	networks, err := parseNetworks(networksInput)
+	networks, err := parseNetworks(optionalArray(params, "networks"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid networks parameter: %w", err)
 	}
@@ -220,13 +223,13 @@ func parseCreateParameters(params api.ToolHandlerParams) (*createParameters, err
 	return &createParameters{
 		Namespace:    namespace,
 		Name:         name,
-		Workload:     api.OptionalString(params, "workload", "fedora"),
-		Instancetype: api.OptionalString(params, "instancetype", ""),
-		Preference:   api.OptionalString(params, "preference", ""),
-		Size:         api.OptionalString(params, "size", ""),
-		Performance:  normalizePerformance(api.OptionalString(params, "performance", "")),
-		Storage:      api.OptionalString(params, "storage", "30Gi"),
-		Autostart:    api.OptionalBool(params, "autostart", false),
+		Workload:     workload,
+		Instancetype: instancetype,
+		Preference:   preference,
+		Size:         size,
+		Performance:  normalizePerformance(performance),
+		Storage:      storage,
+		Autostart:    autostart,
 		Networks:     networks,
 	}, nil
 }

--- a/pkg/toolsets/tekton/pipeline.go
+++ b/pkg/toolsets/tekton/pipeline.go
@@ -52,11 +52,12 @@ func pipelineTools() []api.ServerTool {
 }
 
 func startPipeline(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", err), nil
 	}
-	namespace := api.OptionalString(params, "namespace", params.NamespaceOrDefault(""))
 
 	dynamicClient := params.DynamicClient()
 
@@ -67,6 +68,7 @@ func startPipeline(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 
 	var tektonParams []tektonv1.Param
 	if rawParams, ok := params.GetArguments()["params"].(map[string]interface{}); ok {
+		var err error
 		tektonParams, err = parseParams(rawParams)
 		if err != nil {
 			return api.NewToolCallResult("", fmt.Errorf("failed to parse params: %w", err)), nil

--- a/pkg/toolsets/tekton/pipeline.go
+++ b/pkg/toolsets/tekton/pipeline.go
@@ -56,7 +56,7 @@ func startPipeline(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	name := p.RequiredString("name")
 	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
 	if err := p.Err(); err != nil {
-		return api.NewToolCallResult("", err), nil
+		return api.NewToolCallResult("", fmt.Errorf("failed to start pipeline: %w", err)), nil
 	}
 
 	dynamicClient := params.DynamicClient()

--- a/pkg/toolsets/tekton/pipelinerun.go
+++ b/pkg/toolsets/tekton/pipelinerun.go
@@ -46,11 +46,12 @@ func pipelineRunTools() []api.ServerTool {
 }
 
 func restartPipelineRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", err), nil
 	}
-	namespace := api.OptionalString(params, "namespace", params.NamespaceOrDefault(""))
 
 	dynamicClient := params.DynamicClient()
 

--- a/pkg/toolsets/tekton/pipelinerun.go
+++ b/pkg/toolsets/tekton/pipelinerun.go
@@ -50,7 +50,7 @@ func restartPipelineRun(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 	name := p.RequiredString("name")
 	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
 	if err := p.Err(); err != nil {
-		return api.NewToolCallResult("", err), nil
+		return api.NewToolCallResult("", fmt.Errorf("failed to restart pipeline run: %w", err)), nil
 	}
 
 	dynamicClient := params.DynamicClient()

--- a/pkg/toolsets/tekton/task.go
+++ b/pkg/toolsets/tekton/task.go
@@ -52,11 +52,12 @@ func taskTools() []api.ServerTool {
 }
 
 func startTask(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", err), nil
 	}
-	namespace := api.OptionalString(params, "namespace", params.NamespaceOrDefault(""))
 
 	dynamicClient := params.DynamicClient()
 
@@ -67,6 +68,7 @@ func startTask(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 
 	var tektonParams []tektonv1.Param
 	if rawParams, ok := params.GetArguments()["params"].(map[string]interface{}); ok {
+		var err error
 		tektonParams, err = parseParams(rawParams)
 		if err != nil {
 			return api.NewToolCallResult("", fmt.Errorf("failed to parse params: %w", err)), nil

--- a/pkg/toolsets/tekton/task.go
+++ b/pkg/toolsets/tekton/task.go
@@ -56,7 +56,7 @@ func startTask(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	name := p.RequiredString("name")
 	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
 	if err := p.Err(); err != nil {
-		return api.NewToolCallResult("", err), nil
+		return api.NewToolCallResult("", fmt.Errorf("failed to start task: %w", err)), nil
 	}
 
 	dynamicClient := params.DynamicClient()

--- a/pkg/toolsets/tekton/taskrun.go
+++ b/pkg/toolsets/tekton/taskrun.go
@@ -90,7 +90,7 @@ func restartTaskRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	name := p.RequiredString("name")
 	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
 	if err := p.Err(); err != nil {
-		return api.NewToolCallResult("", err), nil
+		return api.NewToolCallResult("", fmt.Errorf("failed to restart task run: %w", err)), nil
 	}
 
 	dynamicClient := params.DynamicClient()
@@ -143,7 +143,7 @@ func getTaskRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
 	tailInt := p.OptionalInt64("tail", kubernetes.DefaultTailLines)
 	if err := p.Err(); err != nil {
-		return api.NewToolCallResult("", err), nil
+		return api.NewToolCallResult("", fmt.Errorf("failed to get task run logs: %w", err)), nil
 	}
 
 	dynamicClient := params.DynamicClient()

--- a/pkg/toolsets/tekton/taskrun.go
+++ b/pkg/toolsets/tekton/taskrun.go
@@ -86,11 +86,12 @@ func taskRunTools() []api.ServerTool {
 }
 
 func restartTaskRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", err), nil
 	}
-	namespace := api.OptionalString(params, "namespace", params.NamespaceOrDefault(""))
 
 	dynamicClient := params.DynamicClient()
 
@@ -137,22 +138,12 @@ func restartTaskRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func getTaskRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	name, err := api.RequiredString(params, "name")
-	if err != nil {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	tailInt := p.OptionalInt64("tail", kubernetes.DefaultTailLines)
+	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", err), nil
-	}
-	namespace := api.OptionalString(params, "namespace", params.NamespaceOrDefault(""))
-
-	tail := params.GetArguments()["tail"]
-	var tailInt int64
-	if tail != nil {
-		var err error
-		tailInt, err = api.ParseInt64(tail)
-		if err != nil {
-			return api.NewToolCallResult("", fmt.Errorf("failed to parse tail parameter: %w", err)), nil
-		}
-	} else {
-		tailInt = kubernetes.DefaultTailLines
 	}
 
 	dynamicClient := params.DynamicClient()


### PR DESCRIPTION
## Summary

Follow-up to #1039. The free-standing `OptionalString`/`OptionalBool` helpers silently
return the default value when a parameter is present but of the wrong type, masking
malformed client calls. This PR:

- Introduces a `Params` wrapper with sticky-error semantics that surfaces type mismatches
  as errors instead of silently falling back to defaults
- Marks the free-standing `OptionalString`/`OptionalBool` as deprecated
- Migrates all tool handlers (core, config, helm, kubevirt, tekton) to `WrapParams`
- Adds unit tests for the `Params` wrapper
- Updates existing tests to assert error responses for type-mismatch scenarios