### PR TITLE
feat(http): add per-session rate limiting via MCP middleware

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,18 +162,23 @@ Configure HTTP server settings to protect against denial-of-service attacks.
 |-------|------|---------|-------------|
 | `http.read_header_timeout` | duration | `"10s"` | Maximum duration for reading request headers. Primary defense against Slowloris attacks. |
 | `http.max_body_bytes` | integer | `16777216` | Maximum size of request body in bytes (default: 16 MB). |
+| `http.rate_limit_rps` | float | `0` | Maximum requests per second per session. When `0` (default), rate limiting is disabled. |
+| `http.rate_limit_burst` | integer | `10` | Maximum burst size for rate limiting. Allows short bursts above the rate limit. Only effective when `rate_limit_rps > 0`. |
 
 Duration values use Go duration syntax: `"30s"`, `"5m"`, `"1h30m"`.
 
 **Security Considerations:**
 - `read_header_timeout` is the primary defense against Slowloris attacks, which send headers extremely slowly to exhaust server connections
 - `max_body_bytes` prevents memory exhaustion from unbounded request payloads. The 16 MB default accommodates large Kubernetes manifests (CRDs, ConfigMaps)
+- `rate_limit_rps` prevents any single session from overwhelming the server with requests. Rate limiting is per-session, so one client hitting the limit does not affect other sessions. Requests with no session ID (e.g., STDIO transport) bypass rate limiting.
 
 **Example:**
 ```toml
 [http]
 read_header_timeout = "10s"
 max_body_bytes = 16777216    # 16 MB
+rate_limit_rps = 5           # 5 requests per second per session
+rate_limit_burst = 10        # allow bursts of up to 10 requests
 ```
 
 ### Kubernetes Connection
@@ -702,6 +707,8 @@ stateless = false
 [http]
 read_header_timeout = "10s"  # Slowloris protection
 max_body_bytes = 16777216    # 16 MB for large K8s manifests
+rate_limit_rps = 5           # Per-session rate limiting
+rate_limit_burst = 10
 
 # Kubernetes connection
 kubeconfig = "/home/user/.kube/config"

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/time v0.14.0
 	google.golang.org/protobuf v1.36.11
 	helm.sh/helm/v3 v3.20.2
 	k8s.io/api v0.35.3
@@ -148,7 +149,6 @@ require (
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/pkg/config/http_config.go
+++ b/pkg/config/http_config.go
@@ -1,5 +1,11 @@
 package config
 
+import "fmt"
+
+// DefaultRateLimitBurst is the default burst size used when rate_limit_rps is
+// set but rate_limit_burst is not specified (zero value).
+const DefaultRateLimitBurst = 10
+
 // HTTPConfig contains HTTP server configuration options for security.
 type HTTPConfig struct {
 	// ReadHeaderTimeout is the amount of time allowed to read request headers.
@@ -19,6 +25,18 @@ type HTTPConfig struct {
 	// RateLimitBurst is the maximum burst size for rate limiting per session.
 	// Allows short bursts of requests above the rate limit.
 	// Only effective when rate_limit_rps > 0.
-	// Defaults to 10 when rate_limit_rps is set but burst is not specified.
+	// When zero, the rate limiting middleware applies DefaultRateLimitBurst.
 	RateLimitBurst int `toml:"rate_limit_burst,omitzero"`
+}
+
+// Validate checks HTTPConfig for invalid values.
+// It rejects negative RateLimitRPS and negative RateLimitBurst.
+func (c *HTTPConfig) Validate() error {
+	if c.RateLimitRPS < 0 {
+		return fmt.Errorf("rate_limit_rps must not be negative (got %v)", c.RateLimitRPS)
+	}
+	if c.RateLimitBurst < 0 {
+		return fmt.Errorf("rate_limit_burst must not be negative (got %d)", c.RateLimitBurst)
+	}
+	return nil
 }

--- a/pkg/config/http_config.go
+++ b/pkg/config/http_config.go
@@ -11,4 +11,14 @@ type HTTPConfig struct {
 	// so the default is 16MB to accommodate CRDs and ConfigMaps.
 	// Type is int64 to match http.MaxBytesReader signature.
 	MaxBodyBytes int64 `toml:"max_body_bytes,omitzero"`
+
+	// RateLimitRPS is the maximum number of requests per second per session.
+	// When set to 0 (default), rate limiting is disabled.
+	RateLimitRPS float64 `toml:"rate_limit_rps,omitzero"`
+
+	// RateLimitBurst is the maximum burst size for rate limiting per session.
+	// Allows short bursts of requests above the rate limit.
+	// Only effective when rate_limit_rps > 0.
+	// Defaults to 10 when rate_limit_rps is set but burst is not specified.
+	RateLimitBurst int `toml:"rate_limit_burst,omitzero"`
 }

--- a/pkg/config/http_config_test.go
+++ b/pkg/config/http_config_test.go
@@ -73,6 +73,43 @@ read_header_timeout = "invalid"
 	})
 }
 
+func (s *HTTPConfigSuite) TestValidate() {
+	s.Run("zero RPS is valid (disabled)", func() {
+		cfg := HTTPConfig{RateLimitRPS: 0}
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("positive RPS is valid", func() {
+		cfg := HTTPConfig{RateLimitRPS: 10}
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("negative RPS is rejected", func() {
+		cfg := HTTPConfig{RateLimitRPS: -1}
+		err := cfg.Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "rate_limit_rps must not be negative")
+	})
+
+	s.Run("negative burst is rejected", func() {
+		cfg := HTTPConfig{RateLimitBurst: -5}
+		err := cfg.Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "rate_limit_burst must not be negative")
+	})
+
+	s.Run("zero burst is valid (uses default)", func() {
+		cfg := HTTPConfig{RateLimitRPS: 10, RateLimitBurst: 0}
+		s.NoError(cfg.Validate())
+	})
+}
+
+func (s *HTTPConfigSuite) TestDefaultRateLimitBurst() {
+	s.Run("constant has expected value", func() {
+		s.Equal(10, DefaultRateLimitBurst)
+	})
+}
+
 func TestHTTPConfig(t *testing.T) {
 	suite.Run(t, new(HTTPConfigSuite))
 }

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -346,6 +346,9 @@ func (m *MCPServerOptions) Validate() error {
 	if err := m.StaticConfig.ValidateClusterAuthMode(); err != nil {
 		return err
 	}
+	if err := m.StaticConfig.HTTP.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/time/rate"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
@@ -70,6 +71,7 @@ type Server struct {
 	enabledPrompts []string
 	p              internalk8s.Provider
 	metrics        *metrics.Metrics // Metrics collection system
+	rateLimitDone  chan struct{}    // Closed to stop the rate limiter reaper goroutine
 }
 
 func NewServer(configuration Configuration, targetProvider internalk8s.Provider) (*Server, error) {
@@ -108,6 +110,16 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 
 	s.server.AddReceivingMiddleware(sessionInjectionMiddleware)
 	s.server.AddReceivingMiddleware(traceContextPropagationMiddleware)
+	if configuration.HTTP.RateLimitRPS > 0 {
+		burst := configuration.HTTP.RateLimitBurst
+		if burst == 0 {
+			burst = 10
+		}
+		s.rateLimitDone = make(chan struct{})
+		s.server.AddReceivingMiddleware(
+			rateLimitingMiddleware(s.rateLimitDone, rate.Limit(configuration.HTTP.RateLimitRPS), burst),
+		)
+	}
 	s.server.AddReceivingMiddleware(tracingMiddleware(version.BinaryName + "/mcp"))
 	s.server.AddReceivingMiddleware(authHeaderPropagationMiddleware)
 	s.server.AddReceivingMiddleware(userAgentPropagationMiddleware(version.BinaryName, version.Version))
@@ -368,6 +380,10 @@ func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 }
 
 func (s *Server) Close() {
+	if s.rateLimitDone != nil {
+		close(s.rateLimitDone)
+		s.rateLimitDone = nil
+	}
 	if s.p != nil {
 		s.p.Close()
 	}

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -72,6 +72,7 @@ type Server struct {
 	p              internalk8s.Provider
 	metrics        *metrics.Metrics // Metrics collection system
 	rateLimitDone  chan struct{}    // Closed to stop the rate limiter reaper goroutine
+	closeOnce      sync.Once
 }
 
 func NewServer(configuration Configuration, targetProvider internalk8s.Provider) (*Server, error) {
@@ -110,16 +111,19 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 
 	s.server.AddReceivingMiddleware(sessionInjectionMiddleware)
 	s.server.AddReceivingMiddleware(traceContextPropagationMiddleware)
-	if configuration.HTTP.RateLimitRPS > 0 {
-		burst := configuration.HTTP.RateLimitBurst
-		if burst == 0 {
-			burst = 10
-		}
-		s.rateLimitDone = make(chan struct{})
-		s.server.AddReceivingMiddleware(
-			rateLimitingMiddleware(s.rateLimitDone, rate.Limit(configuration.HTTP.RateLimitRPS), burst),
-		)
-	}
+	s.rateLimitDone = make(chan struct{})
+	s.server.AddReceivingMiddleware(
+		rateLimitingMiddleware(s.rateLimitDone, func() (rate.Limit, int) {
+			s.mu.RLock()
+			rps := s.configuration.HTTP.RateLimitRPS
+			burst := s.configuration.HTTP.RateLimitBurst
+			s.mu.RUnlock()
+			if burst == 0 {
+				burst = config.DefaultRateLimitBurst
+			}
+			return rate.Limit(rps), burst
+		}),
+	)
 	s.server.AddReceivingMiddleware(tracingMiddleware(version.BinaryName + "/mcp"))
 	s.server.AddReceivingMiddleware(authHeaderPropagationMiddleware)
 	s.server.AddReceivingMiddleware(userAgentPropagationMiddleware(version.BinaryName, version.Version))
@@ -363,12 +367,18 @@ func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 	if err := newConfig.ValidateRequireTLS(); err != nil {
 		return fmt.Errorf("configuration reload rejected: %w", err)
 	}
+	if err := newConfig.HTTP.Validate(); err != nil {
+		return fmt.Errorf("configuration reload rejected: %w", err)
+	}
 
-	// Update the configuration
+	// Update the configuration (protected by mu so concurrent readers see a
+	// consistent snapshot, e.g. the rate-limit configFn closure).
+	s.mu.Lock()
 	s.configuration.StaticConfig = newConfig
 	// Clear cached values so they get recomputed
 	s.configuration.listOutput = nil
 	s.configuration.toolsets = nil
+	s.mu.Unlock()
 
 	// Reload the Kubernetes provider (this will also rebuild tools)
 	if err := s.reloadToolsets(); err != nil {
@@ -380,13 +390,12 @@ func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 }
 
 func (s *Server) Close() {
-	if s.rateLimitDone != nil {
+	s.closeOnce.Do(func() {
 		close(s.rateLimitDone)
-		s.rateLimitDone = nil
-	}
-	if s.p != nil {
-		s.p.Close()
-	}
+		if s.p != nil {
+			s.p.Close()
+		}
+	})
 }
 
 // Shutdown gracefully shuts down the server, flushing any pending metrics.

--- a/pkg/mcp/mcp_middleware_test.go
+++ b/pkg/mcp/mcp_middleware_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/time/rate"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
 )
@@ -247,4 +248,142 @@ func (s *TraceContextPropagationSuite) TestTraceContextPropagationCarrierWithPro
 
 func TestTraceContextPropagation(t *testing.T) {
 	suite.Run(t, new(TraceContextPropagationSuite))
+}
+
+// RateLimitingSuite tests the rateLimitingMiddleware
+type RateLimitingSuite struct {
+	BaseMcpSuite
+}
+
+func (s *RateLimitingSuite) TestRequestsWithinRateLimitSucceed() {
+	s.Run("multiple requests under the limit all succeed", func() {
+		s.Cfg.HTTP.RateLimitRPS = 100
+		s.Cfg.HTTP.RateLimitBurst = 100
+		s.InitMcpClient()
+
+		for i := 0; i < 5; i++ {
+			_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
+			s.NoError(err)
+		}
+	})
+}
+
+func (s *RateLimitingSuite) TestRequestsExceedingRateLimitReturnError() {
+	s.Run("returns rate limit error after exceeding burst", func() {
+		s.Cfg.HTTP.RateLimitRPS = 0.001 // nearly zero replenishment
+		s.Cfg.HTTP.RateLimitBurst = 10
+		s.InitMcpClient()
+
+		var rateLimitErr error
+		for i := 0; i < 20; i++ {
+			_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
+			if err != nil {
+				rateLimitErr = err
+				break
+			}
+		}
+		s.Require().Error(rateLimitErr, "Expected rate limit error after exceeding burst")
+		s.Contains(rateLimitErr.Error(), "rate limit exceeded")
+	})
+}
+
+func (s *RateLimitingSuite) TestSeparateSessionsHaveIndependentLimits() {
+	s.Run("second session succeeds after first is exhausted", func() {
+		s.Cfg.HTTP.RateLimitRPS = 0.001
+		s.Cfg.HTTP.RateLimitBurst = 10
+		s.InitMcpClient()
+
+		// Create a second client against the same server
+		client2 := test.NewMcpClient(s.T(), s.mcpServer.ServeHTTP())
+		defer client2.Close()
+
+		// Exhaust rate limit on first session
+		for i := 0; i < 20; i++ {
+			_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
+			if err != nil {
+				break
+			}
+		}
+
+		// Second session should still work (independent limiter)
+		_, err := client2.CallTool("configuration_view", map[string]any{"minified": false})
+		s.NoError(err, "Second session should have independent rate limit")
+	})
+}
+
+func (s *RateLimitingSuite) TestDisabledRateLimiting() {
+	s.Run("requests succeed when rate limiting is disabled", func() {
+		s.Cfg.HTTP.RateLimitRPS = 0
+		s.InitMcpClient()
+
+		for i := 0; i < 20; i++ {
+			_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
+			s.NoError(err)
+		}
+	})
+}
+
+func (s *RateLimitingSuite) TestDefaultBurst() {
+	s.Run("requests succeed when burst is not specified", func() {
+		s.Cfg.HTTP.RateLimitRPS = 100
+		s.Cfg.HTTP.RateLimitBurst = 0 // should default to 10
+		s.InitMcpClient()
+
+		// Verify that requests succeed, confirming the default burst was applied
+		for i := 0; i < 5; i++ {
+			_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
+			s.NoError(err)
+		}
+	})
+}
+
+func (s *RateLimitingSuite) TestSessionBypass() {
+	s.Run("empty session ID bypasses rate limiting", func() {
+		done := make(chan struct{})
+		defer close(done)
+		middleware := rateLimitingMiddleware(done, rate.Limit(0.001), 1)
+
+		called := 0
+		handler := middleware(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			called++
+			return nil, nil
+		})
+
+		req := &mcp.ServerRequest[*mcp.CallToolParamsRaw]{
+			Session: &mcp.ServerSession{},
+			Params:  &mcp.CallToolParamsRaw{},
+		}
+
+		for i := 0; i < 5; i++ {
+			_, err := handler(context.Background(), "tools/call", req)
+			s.NoError(err)
+		}
+		s.Equal(5, called)
+	})
+
+	s.Run("nil session bypasses rate limiting", func() {
+		done := make(chan struct{})
+		defer close(done)
+		middleware := rateLimitingMiddleware(done, rate.Limit(0.001), 1)
+
+		called := 0
+		handler := middleware(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			called++
+			return nil, nil
+		})
+
+		req := &mcp.ServerRequest[*mcp.CallToolParamsRaw]{
+			Params: &mcp.CallToolParamsRaw{},
+		}
+
+		for i := 0; i < 5; i++ {
+			_, err := handler(context.Background(), "tools/call", req)
+			s.NoError(err)
+		}
+		s.Equal(5, called)
+	})
+}
+
+func TestRateLimiting(t *testing.T) {
+	suite.Run(t, new(RateLimitingSuite))
 }

--- a/pkg/mcp/mcp_middleware_test.go
+++ b/pkg/mcp/mcp_middleware_test.go
@@ -7,7 +7,10 @@ import (
 	"strconv"
 	"testing"
 
+	"errors"
+
 	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
@@ -284,6 +287,9 @@ func (s *RateLimitingSuite) TestRequestsExceedingRateLimitReturnError() {
 		}
 		s.Require().Error(rateLimitErr, "Expected rate limit error after exceeding burst")
 		s.Contains(rateLimitErr.Error(), "rate limit exceeded")
+		var rpcErr *jsonrpc.Error
+		s.Require().True(errors.As(rateLimitErr, &rpcErr), "Expected error to be a jsonrpc.Error")
+		s.Equal(int64(CodeRateLimitExceeded), rpcErr.Code)
 	})
 }
 
@@ -341,7 +347,9 @@ func (s *RateLimitingSuite) TestSessionBypass() {
 	s.Run("empty session ID bypasses rate limiting", func() {
 		done := make(chan struct{})
 		defer close(done)
-		middleware := rateLimitingMiddleware(done, rate.Limit(0.001), 1)
+		middleware := rateLimitingMiddleware(done, func() (rate.Limit, int) {
+			return rate.Limit(0.001), 1
+		})
 
 		called := 0
 		handler := middleware(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
@@ -364,7 +372,9 @@ func (s *RateLimitingSuite) TestSessionBypass() {
 	s.Run("nil session bypasses rate limiting", func() {
 		done := make(chan struct{})
 		defer close(done)
-		middleware := rateLimitingMiddleware(done, rate.Limit(0.001), 1)
+		middleware := rateLimitingMiddleware(done, func() (rate.Limit, int) {
+			return rate.Limit(0.001), 1
+		})
 
 		called := 0
 		handler := middleware(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
@@ -381,6 +391,75 @@ func (s *RateLimitingSuite) TestSessionBypass() {
 			s.NoError(err)
 		}
 		s.Equal(5, called)
+	})
+}
+
+func (s *RateLimitingSuite) TestConfigReloadTakesEffect() {
+	s.Run("reload with higher values allows more requests", func() {
+		s.Cfg.HTTP.RateLimitRPS = 0.001 // nearly zero replenishment
+		s.Cfg.HTTP.RateLimitBurst = 2
+		s.InitMcpClient()
+
+		// Exhaust the initial burst
+		for i := 0; i < 5; i++ {
+			_, _ = s.CallTool("configuration_view", map[string]any{"minified": false})
+		}
+
+		// Verify that we are rate limited
+		_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
+		s.Require().Error(err, "Expected rate limit error")
+
+		// Reload with much higher limits
+		s.Cfg.HTTP.RateLimitRPS = 1000
+		s.Cfg.HTTP.RateLimitBurst = 1000
+
+		// After reload, requests should succeed
+		_, err = s.CallTool("configuration_view", map[string]any{"minified": false})
+		s.NoError(err, "Expected request to succeed after config reload")
+	})
+}
+
+func (s *RateLimitingSuite) TestDisabledToEnabled() {
+	s.Run("enabling rate limiting after starting disabled", func() {
+		s.Cfg.HTTP.RateLimitRPS = 0 // disabled
+		s.InitMcpClient()
+
+		// Requests should succeed when disabled
+		for i := 0; i < 20; i++ {
+			_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
+			s.NoError(err)
+		}
+
+		// Enable rate limiting with tight burst
+		s.Cfg.HTTP.RateLimitRPS = 0.001
+		s.Cfg.HTTP.RateLimitBurst = 2
+
+		// Eventually should hit rate limit
+		var rateLimitErr error
+		for i := 0; i < 20; i++ {
+			_, err := s.CallTool("configuration_view", map[string]any{"minified": false})
+			if err != nil {
+				rateLimitErr = err
+				break
+			}
+		}
+		s.Require().Error(rateLimitErr, "Expected rate limit error after enabling")
+		s.Contains(rateLimitErr.Error(), "rate limit exceeded")
+	})
+}
+
+func (s *RateLimitingSuite) TestDoubleCloseDoesNotPanic() {
+	s.Run("calling Close twice does not panic", func() {
+		s.Cfg.HTTP.RateLimitRPS = 10
+		s.Cfg.HTTP.RateLimitBurst = 10
+		s.InitMcpClient()
+
+		s.NotPanics(func() {
+			s.mcpServer.Close()
+			s.mcpServer.Close()
+		})
+		// Prevent TearDownTest from closing again (already closed)
+		s.mcpServer = nil
 	})
 }
 

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -3,9 +3,12 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
+	"time"
 
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
@@ -15,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/time/rate"
 	"k8s.io/klog/v2"
 )
 
@@ -213,6 +217,74 @@ func getMcpReqUserAgent(req mcp.Request) string {
 		return ""
 	}
 	return fmt.Sprintf("%s/%s", initParams.ClientInfo.Name, initParams.ClientInfo.Version)
+}
+
+// rateLimitingMiddleware creates a per-session rate limiting middleware.
+// Each session gets its own rate.Limiter keyed by session ID.
+// Requests with an empty session ID (e.g. STDIO transport before initialization) bypass rate limiting.
+// Stale session entries are reaped periodically to prevent unbounded memory growth.
+func rateLimitingMiddleware(done <-chan struct{}, limit rate.Limit, burst int) mcp.Middleware {
+	var (
+		mu       sync.Mutex
+		limiters = make(map[string]*rateLimiterEntry)
+	)
+
+	// Reap stale sessions every 5 minutes
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				mu.Lock()
+				now := time.Now()
+				for id, entry := range limiters {
+					if now.Sub(entry.lastSeen) > 10*time.Minute {
+						delete(limiters, id)
+					}
+				}
+				mu.Unlock()
+			}
+		}
+	}()
+
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			session, ok := req.GetSession().(*mcp.ServerSession)
+			if !ok || session == nil {
+				return next(ctx, method, req)
+			}
+			sessionID := session.ID()
+			if sessionID == "" {
+				return next(ctx, method, req)
+			}
+
+			mu.Lock()
+			entry, ok := limiters[sessionID]
+			if !ok {
+				entry = &rateLimiterEntry{
+					limiter:  rate.NewLimiter(limit, burst),
+					lastSeen: time.Now(),
+				}
+				limiters[sessionID] = entry
+			} else {
+				entry.lastSeen = time.Now()
+			}
+			mu.Unlock()
+
+			if !entry.limiter.Allow() {
+				return nil, errors.New("rate limit exceeded")
+			}
+			return next(ctx, method, req)
+		}
+	}
+}
+
+type rateLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
 }
 
 // metaCarrier adapts an MCP Meta map to the OpenTelemetry TextMapCarrier interface

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
 	"github.com/containers/kubernetes-mcp-server/pkg/telemetry"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -219,14 +219,28 @@ func getMcpReqUserAgent(req mcp.Request) string {
 	return fmt.Sprintf("%s/%s", initParams.ClientInfo.Name, initParams.ClientInfo.Version)
 }
 
+// CodeRateLimitExceeded is the JSON-RPC error code returned when a session
+// exceeds its rate limit. The value -32029 echoes HTTP 429 and does not
+// conflict with standard JSON-RPC codes or existing SDK application codes.
+const CodeRateLimitExceeded = -32029
+
 // rateLimitingMiddleware creates a per-session rate limiting middleware.
 // Each session gets its own rate.Limiter keyed by session ID.
 // Requests with an empty session ID (e.g. STDIO transport before initialization) bypass rate limiting.
 // Stale session entries are reaped periodically to prevent unbounded memory growth.
-func rateLimitingMiddleware(done <-chan struct{}, limit rate.Limit, burst int) mcp.Middleware {
+//
+// The configFn is called on every request to obtain the current rate limit and
+// burst values, making the middleware safe for dynamic configuration reloads.
+// When the returned limit is <= 0 the request is passed through (rate limiting
+// disabled). When the returned values differ from the previously observed ones
+// all existing per-session limiters are discarded so the new settings take
+// effect immediately.
+func rateLimitingMiddleware(done <-chan struct{}, configFn func() (rate.Limit, int)) mcp.Middleware {
 	var (
-		mu       sync.Mutex
-		limiters = make(map[string]*rateLimiterEntry)
+		mu           sync.Mutex
+		limiters     = make(map[string]*rateLimiterEntry)
+		currentLimit rate.Limit
+		currentBurst int
 	)
 
 	// Reap stale sessions every 5 minutes
@@ -252,6 +266,13 @@ func rateLimitingMiddleware(done <-chan struct{}, limit rate.Limit, burst int) m
 
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			limit, burst := configFn()
+
+			// When limit <= 0, rate limiting is disabled — pass through
+			if limit <= 0 {
+				return next(ctx, method, req)
+			}
+
 			session, ok := req.GetSession().(*mcp.ServerSession)
 			if !ok || session == nil {
 				return next(ctx, method, req)
@@ -262,6 +283,12 @@ func rateLimitingMiddleware(done <-chan struct{}, limit rate.Limit, burst int) m
 			}
 
 			mu.Lock()
+			// If config changed, discard all existing limiters
+			if limit != currentLimit || burst != currentBurst {
+				clear(limiters)
+				currentLimit = limit
+				currentBurst = burst
+			}
 			entry, ok := limiters[sessionID]
 			if !ok {
 				entry = &rateLimiterEntry{
@@ -275,7 +302,7 @@ func rateLimitingMiddleware(done <-chan struct{}, limit rate.Limit, burst int) m
 			mu.Unlock()
 
 			if !entry.limiter.Allow() {
-				return nil, errors.New("rate limit exceeded")
+				return nil, &jsonrpc.Error{Code: CodeRateLimitExceeded, Message: "rate limit exceeded"}
 			}
 			return next(ctx, method, req)
 		}


### PR DESCRIPTION
Add configurable per-session rate limiting at the MCP protocol level to protect remote deployments (HTTP/SSE) from request floods. Uses the SDK's middleware pattern with `golang.org/x/time/rate` for token bucket limiting, keyed by session ID with automatic stale session reaping.

The middleware is placed after trace context propagation and before tracing so that rate-limited requests do not generate spans. Requests with no session ID (e.g. STDIO transport) bypass rate limiting.

Configured via `[http]` TOML config:
```toml
  rate_limit_rps   - requests per second per session (0 = disabled)
  rate_limit_burst - burst allowance (default: 10)
```

Fixes https://github.com/containers/kubernetes-mcp-server/issues/1050