### PR TITLE
fix(config): enforce all Validate() checks on SIGHUP reload (#989)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,13 +5,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"k8s.io/klog/v2"
 )
 
@@ -151,6 +155,8 @@ type StaticConfig struct {
 
 	// Internal: the config.toml directory, to help resolve relative file paths
 	configDirPath string
+	// Internal: known provider strategies, set via WithProviderStrategies
+	providerStrategies []string
 }
 
 var _ api.BaseConfig = (*StaticConfig)(nil)
@@ -437,6 +443,79 @@ func (c *StaticConfig) GetConfirmationFallback() string {
 
 func (c *StaticConfig) IsRequireTLS() bool {
 	return c.RequireTLS
+}
+
+// WithProviderStrategies sets the known cluster-provider strategies for
+// validation. Callers that have access to the provider registry should chain
+// this before Validate so that cluster_provider_strategy is checked:
+//
+//	cfg.WithProviderStrategies(kubernetes.GetRegisteredStrategies()).Validate()
+func (c *StaticConfig) WithProviderStrategies(strategies []string) *StaticConfig {
+	c.providerStrategies = strategies
+	return c
+}
+
+// Validate validates config-level invariants that must hold at both startup and
+// on SIGHUP reload.
+func (c *StaticConfig) Validate() error {
+	// Normalize whitespace-padded fields before any checks use them.
+	c.CertificateAuthority = strings.TrimSpace(c.CertificateAuthority)
+	c.TLSCert = strings.TrimSpace(c.TLSCert)
+	c.TLSKey = strings.TrimSpace(c.TLSKey)
+	if output.FromString(c.ListOutput) == nil {
+		return fmt.Errorf("invalid output name: %s, valid names are: %s", c.ListOutput, strings.Join(output.Names, ", "))
+	}
+	if err := toolsets.Validate(c.Toolsets); err != nil {
+		return err
+	}
+	if c.ClusterProviderStrategy != "" && len(c.providerStrategies) > 0 {
+		if !slices.Contains(c.providerStrategies, c.ClusterProviderStrategy) {
+			return fmt.Errorf("invalid cluster-provider: %s, valid values are: %s", c.ClusterProviderStrategy, strings.Join(c.providerStrategies, ", "))
+		}
+	}
+	if !c.RequireOAuth && (c.OAuthAudience != "" || c.AuthorizationURL != "" || c.ServerURL != "" || c.CertificateAuthority != "") {
+		return fmt.Errorf("oauth-audience, authorization-url, server-url and certificate-authority are only valid if require-oauth is enabled. Missing --port may implicitly set require-oauth to false")
+	}
+	if c.AuthorizationURL != "" {
+		u, err := url.Parse(c.AuthorizationURL)
+		if err != nil {
+			return err
+		}
+		if u.Scheme != "https" && u.Scheme != "http" {
+			return fmt.Errorf("--authorization-url must be a valid URL")
+		}
+		if u.Scheme == "http" {
+			klog.Warningf("authorization-url is using http://, this is not recommended production use")
+		}
+	}
+	if c.CertificateAuthority != "" {
+		if _, err := os.Stat(c.CertificateAuthority); err != nil {
+			return fmt.Errorf("certificate-authority must be a valid file path: %w", err)
+		}
+	}
+	if (c.TLSCert != "" && c.TLSKey == "") || (c.TLSCert == "" && c.TLSKey != "") {
+		return fmt.Errorf("both --tls-cert and --tls-key must be provided together")
+	}
+	if c.TLSCert != "" {
+		if _, err := os.Stat(c.TLSCert); err != nil {
+			return fmt.Errorf("tls-cert must be a valid file path: %w", err)
+		}
+	}
+	if c.TLSKey != "" {
+		if _, err := os.Stat(c.TLSKey); err != nil {
+			return fmt.Errorf("tls-key must be a valid file path: %w", err)
+		}
+	}
+	if err := c.ValidateRequireTLS(); err != nil {
+		return err
+	}
+	if err := c.ValidateClusterAuthMode(); err != nil {
+		return err
+	}
+	if err := c.HTTP.Validate(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ValidateRequireTLS validates outbound URL schemes when RequireTLS is enabled.

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -1,0 +1,242 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+
+	// Blank imports to register toolsets and providers in their respective registries.
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/config"
+	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/core"
+)
+
+type ValidateSuite struct {
+	suite.Suite
+}
+
+func (s *ValidateSuite) validConfig() *config.StaticConfig {
+	cfg := config.BaseDefault()
+	return cfg
+}
+
+func (s *ValidateSuite) TestValidDefaultConfig() {
+	s.Run("default config passes validation", func() {
+		cfg := s.validConfig()
+		s.NoError(cfg.Validate())
+	})
+}
+
+func (s *ValidateSuite) TestListOutput() {
+	s.Run("invalid list_output is rejected", func() {
+		cfg := s.validConfig()
+		cfg.ListOutput = "invalid-format"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid output name")
+		s.Contains(err.Error(), "invalid-format")
+	})
+
+	s.Run("empty list_output is rejected", func() {
+		cfg := s.validConfig()
+		cfg.ListOutput = ""
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid output name")
+	})
+
+	s.Run("yaml list_output is accepted", func() {
+		cfg := s.validConfig()
+		cfg.ListOutput = "yaml"
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("table list_output is accepted", func() {
+		cfg := s.validConfig()
+		cfg.ListOutput = "table"
+		s.NoError(cfg.Validate())
+	})
+}
+
+func (s *ValidateSuite) TestToolsets() {
+	s.Run("invalid toolset name is rejected", func() {
+		cfg := s.validConfig()
+		cfg.Toolsets = []string{"nonexistent-toolset"}
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid toolset name")
+		s.Contains(err.Error(), "nonexistent-toolset")
+	})
+
+	s.Run("valid toolset names are accepted", func() {
+		cfg := s.validConfig()
+		cfg.Toolsets = []string{"core", "config"}
+		s.NoError(cfg.Validate())
+	})
+}
+
+func (s *ValidateSuite) TestClusterProviderStrategy() {
+	s.Run("unknown strategy is skipped without WithProviderStrategies", func() {
+		cfg := s.validConfig()
+		cfg.ClusterProviderStrategy = "nonexistent-strategy"
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("unknown strategy is rejected with WithProviderStrategies", func() {
+		cfg := s.validConfig()
+		cfg.ClusterProviderStrategy = "nonexistent-strategy"
+		err := cfg.WithProviderStrategies([]string{"kubeconfig", "in-cluster"}).Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid cluster-provider")
+		s.Contains(err.Error(), "nonexistent-strategy")
+	})
+
+	s.Run("valid strategy is accepted with WithProviderStrategies", func() {
+		cfg := s.validConfig()
+		cfg.ClusterProviderStrategy = "kubeconfig"
+		s.NoError(cfg.WithProviderStrategies([]string{"kubeconfig", "in-cluster"}).Validate())
+	})
+}
+
+func (s *ValidateSuite) TestAuthorizationURL() {
+	s.Run("invalid scheme is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "ftp://example.com/auth"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "--authorization-url must be a valid URL")
+	})
+
+	s.Run("https scheme is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "https://example.com/auth"
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("http scheme is accepted with warning", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "http://example.com/auth"
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("authorization_url without require_oauth is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = false
+		cfg.AuthorizationURL = "https://example.com/auth"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require-oauth is enabled")
+	})
+}
+
+func (s *ValidateSuite) TestCertificateAuthority() {
+	s.Run("non-existent file is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.CertificateAuthority = "/nonexistent/path/ca.crt"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "certificate-authority must be a valid file path")
+	})
+
+	s.Run("existing file is accepted", func() {
+		tmpDir := s.T().TempDir()
+		caPath := filepath.Join(tmpDir, "ca.crt")
+		s.Require().NoError(os.WriteFile(caPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.CertificateAuthority = caPath
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("whitespace-only is treated as empty", func() {
+		cfg := s.validConfig()
+		cfg.CertificateAuthority = "   "
+		s.NoError(cfg.Validate())
+	})
+}
+
+func (s *ValidateSuite) TestTLSCertKey() {
+	s.Run("tls_cert without tls_key is rejected", func() {
+		tmpDir := s.T().TempDir()
+		certPath := filepath.Join(tmpDir, "cert.pem")
+		s.Require().NoError(os.WriteFile(certPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.TLSCert = certPath
+		cfg.TLSKey = ""
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "both --tls-cert and --tls-key must be provided together")
+	})
+
+	s.Run("tls_key without tls_cert is rejected", func() {
+		tmpDir := s.T().TempDir()
+		keyPath := filepath.Join(tmpDir, "key.pem")
+		s.Require().NoError(os.WriteFile(keyPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.TLSCert = ""
+		cfg.TLSKey = keyPath
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "both --tls-cert and --tls-key must be provided together")
+	})
+
+	s.Run("non-existent tls_cert file is rejected", func() {
+		tmpDir := s.T().TempDir()
+		keyPath := filepath.Join(tmpDir, "key.pem")
+		s.Require().NoError(os.WriteFile(keyPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.TLSCert = "/nonexistent/cert.pem"
+		cfg.TLSKey = keyPath
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "tls-cert must be a valid file path")
+	})
+
+	s.Run("non-existent tls_key file is rejected", func() {
+		tmpDir := s.T().TempDir()
+		certPath := filepath.Join(tmpDir, "cert.pem")
+		s.Require().NoError(os.WriteFile(certPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.TLSCert = certPath
+		cfg.TLSKey = "/nonexistent/key.pem"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "tls-key must be a valid file path")
+	})
+
+	s.Run("both tls_cert and tls_key with valid files are accepted", func() {
+		tmpDir := s.T().TempDir()
+		certPath := filepath.Join(tmpDir, "cert.pem")
+		keyPath := filepath.Join(tmpDir, "key.pem")
+		s.Require().NoError(os.WriteFile(certPath, []byte("test"), 0644))
+		s.Require().NoError(os.WriteFile(keyPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.TLSCert = certPath
+		cfg.TLSKey = keyPath
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("whitespace-only tls_cert and tls_key are treated as empty", func() {
+		cfg := s.validConfig()
+		cfg.TLSCert = "   "
+		cfg.TLSKey = "   "
+		s.NoError(cfg.Validate())
+	})
+}
+
+func TestValidate(t *testing.T) {
+	suite.Run(t, new(ValidateSuite))
+}

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
 	"os/signal"
-	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -277,77 +275,18 @@ func (m *MCPServerOptions) initializeLogging() {
 }
 
 func (m *MCPServerOptions) Validate() error {
-	if output.FromString(m.StaticConfig.ListOutput) == nil {
-		return fmt.Errorf("invalid output name: %s, valid names are: %s", m.StaticConfig.ListOutput, strings.Join(output.Names, ", "))
-	}
-	if err := toolsets.Validate(m.StaticConfig.Toolsets); err != nil {
+	// Config-level validations (shared with SIGHUP reload)
+	if err := m.StaticConfig.WithProviderStrategies(kubernetes.GetRegisteredStrategies()).Validate(); err != nil {
 		return err
 	}
-	// Validate cluster provider strategy using registered providers
-	if m.StaticConfig.ClusterProviderStrategy != "" {
-		validStrategies := kubernetes.GetRegisteredStrategies()
-		if !slices.Contains(validStrategies, m.StaticConfig.ClusterProviderStrategy) {
-			return fmt.Errorf("invalid cluster-provider: %s, valid values are: %s", m.StaticConfig.ClusterProviderStrategy, strings.Join(validStrategies, ", "))
-		}
-	}
-	if !m.StaticConfig.RequireOAuth && (m.StaticConfig.OAuthAudience != "" || m.StaticConfig.AuthorizationURL != "" || m.StaticConfig.ServerURL != "" || m.StaticConfig.CertificateAuthority != "") {
-		return fmt.Errorf("oauth-audience, authorization-url, server-url and certificate-authority are only valid if require-oauth is enabled. Missing --port may implicitly set require-oauth to false")
-	}
-	if m.StaticConfig.AuthorizationURL != "" {
-		u, err := url.Parse(m.StaticConfig.AuthorizationURL)
-		if err != nil {
-			return err
-		}
-		if u.Scheme != "https" && u.Scheme != "http" {
-			return fmt.Errorf("--authorization-url must be a valid URL")
-		}
-		if u.Scheme == "http" {
-			klog.Warningf("authorization-url is using http://, this is not recommended production use")
-		}
-	}
-	// Validate that certificate_authority is a valid file
-	m.StaticConfig.CertificateAuthority = strings.TrimSpace(m.StaticConfig.CertificateAuthority)
-	if m.StaticConfig.CertificateAuthority != "" {
-		if _, err := os.Stat(m.StaticConfig.CertificateAuthority); err != nil {
-			return fmt.Errorf("certificate-authority must be a valid file path: %w", err)
-		}
-	}
-	// Validate TLS configuration
-	tlsCert := strings.TrimSpace(m.StaticConfig.TLSCert)
-	tlsKey := strings.TrimSpace(m.StaticConfig.TLSKey)
-	m.StaticConfig.TLSCert = tlsCert
-	m.StaticConfig.TLSKey = tlsKey
-	if (tlsCert != "" && tlsKey == "") || (tlsCert == "" && tlsKey != "") {
-		return fmt.Errorf("both --tls-cert and --tls-key must be provided together")
-	}
-	if tlsCert != "" && m.StaticConfig.Port == "" {
+	// CLI-level validations (flag interactions that can't change on reload)
+	if m.StaticConfig.TLSCert != "" && m.StaticConfig.Port == "" {
 		return fmt.Errorf("--tls-cert and --tls-key require --port to be set (TLS is only supported in HTTP mode)")
 	}
-	if tlsCert != "" {
-		if _, err := os.Stat(tlsCert); err != nil {
-			return fmt.Errorf("tls-cert must be a valid file path: %w", err)
-		}
-	}
-	if tlsKey != "" {
-		if _, err := os.Stat(tlsKey); err != nil {
-			return fmt.Errorf("tls-key must be a valid file path: %w", err)
-		}
-	}
-	// Validate require_tls configuration
 	if m.StaticConfig.RequireTLS && m.StaticConfig.Port != "" {
-		if tlsCert == "" || tlsKey == "" {
+		if m.StaticConfig.TLSCert == "" || m.StaticConfig.TLSKey == "" {
 			return fmt.Errorf("require_tls is enabled but TLS certificates are not configured (set tls_cert and tls_key)")
 		}
-	}
-	// Validate outbound URLs when require_tls is enabled
-	if err := m.StaticConfig.ValidateRequireTLS(); err != nil {
-		return err
-	}
-	if err := m.StaticConfig.ValidateClusterAuthMode(); err != nil {
-		return err
-	}
-	if err := m.StaticConfig.HTTP.Validate(); err != nil {
-		return err
 	}
 	return nil
 }

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -363,11 +363,8 @@ func (s *Server) GetEnabledPrompts() []string {
 func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 	klog.V(1).Info("Reloading MCP server configuration...")
 
-	// Validate require_tls constraints (fail-fast on reload, same check as startup)
-	if err := newConfig.ValidateRequireTLS(); err != nil {
-		return fmt.Errorf("configuration reload rejected: %w", err)
-	}
-	if err := newConfig.HTTP.Validate(); err != nil {
+	// Validate config-level invariants (same checks as startup)
+	if err := newConfig.WithProviderStrategies(internalk8s.GetRegisteredStrategies()).Validate(); err != nil {
 		return fmt.Errorf("configuration reload rejected: %w", err)
 	}
 

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -220,6 +220,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
 
 	s.Run("reload with require_tls and HTTP authorization_url is rejected", func() {
 		newConfig := config.Default()
+		newConfig.RequireOAuth = true
 		newConfig.RequireTLS = true
 		newConfig.AuthorizationURL = "http://example.com/auth"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
@@ -231,6 +232,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
 
 	s.Run("reload with require_tls and HTTP server_url is rejected", func() {
 		newConfig := config.Default()
+		newConfig.RequireOAuth = true
 		newConfig.RequireTLS = true
 		newConfig.ServerURL = "http://example.com:8080"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
@@ -242,6 +244,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
 
 	s.Run("reload with require_tls and HTTPS URLs succeeds", func() {
 		newConfig := config.Default()
+		newConfig.RequireOAuth = true
 		newConfig.RequireTLS = true
 		newConfig.AuthorizationURL = "https://example.com/auth"
 		newConfig.ServerURL = "https://example.com:8080"
@@ -252,11 +255,79 @@ func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
 
 	s.Run("reload without require_tls allows HTTP URLs", func() {
 		newConfig := config.Default()
+		newConfig.RequireOAuth = true
 		newConfig.RequireTLS = false
 		newConfig.AuthorizationURL = "http://example.com/auth"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 		err := server.ReloadConfiguration(newConfig)
 		s.NoError(err)
+	})
+}
+
+func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
+	provider, err := kubernetes.NewProvider(s.Cfg)
+	s.Require().NoError(err)
+	server, err := NewServer(Configuration{
+		StaticConfig: s.Cfg,
+	}, provider)
+	s.Require().NoError(err)
+	s.server = server
+
+	s.Run("reload with invalid list_output is rejected", func() {
+		newConfig := config.Default()
+		newConfig.ListOutput = "invalid-format"
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid output name")
+	})
+
+	s.Run("reload with invalid toolset name is rejected", func() {
+		newConfig := config.Default()
+		newConfig.Toolsets = []string{"nonexistent-toolset"}
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid toolset name")
+	})
+
+	s.Run("reload with invalid cluster_provider_strategy is rejected", func() {
+		newConfig := config.Default()
+		newConfig.ClusterProviderStrategy = "nonexistent-strategy"
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid cluster-provider")
+	})
+
+	s.Run("reload with invalid authorization_url scheme is rejected", func() {
+		newConfig := config.Default()
+		newConfig.RequireOAuth = true
+		newConfig.AuthorizationURL = "ftp://example.com/auth"
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "--authorization-url must be a valid URL")
+	})
+
+	s.Run("reload with non-existent certificate_authority is rejected", func() {
+		newConfig := config.Default()
+		newConfig.RequireOAuth = true
+		newConfig.CertificateAuthority = "/nonexistent/path/ca.crt"
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "certificate-authority must be a valid file path")
+	})
+
+	s.Run("reload with mismatched tls_cert and tls_key is rejected", func() {
+		newConfig := config.Default()
+		newConfig.TLSCert = "/some/cert.pem"
+		newConfig.TLSKey = ""
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "both --tls-cert and --tls-key must be provided together")
 	})
 }
 


### PR DESCRIPTION
`ReloadConfiguration()` previously only checked `ValidateRequireTLS()` and `HTTP.Validate()`, silently accepting
invalid values for `list_output`, `toolsets`, `cluster_provider_strategy`, `authorization_url`, `certificate_authority`,
and `tls_cert`/`tls_key`.

This PR extracts config-level validations from `MCPServerOptions.Validate()` into `StaticConfig.Validate()` so
both startup and SIGHUP reload share the same checks.

Cluster-provider strategy validation uses a chainable `WithProviderStrategies()` method to avoid the circular
dependency (`config → kubernetes → oauth → config`) while keeping the check inside `Validate()`.

Fixes #989