### PR TITLE
fix(pods): resolve default container for multi-container pods (KEP-2227)

### DIFF
--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -27,6 +27,34 @@ import (
 // DefaultTailLines is the default number of lines to retrieve from the end of the logs
 const DefaultTailLines = int64(100)
 
+// DefaultContainerAnnotation is the annotation key used by kubectl to specify the default container
+// for operations like logs and exec in multi-container pods (KEP-2227).
+const DefaultContainerAnnotation = "kubectl.kubernetes.io/default-container"
+
+// resolveContainer returns the container name to use when no explicit container is provided.
+// It follows the KEP-2227 resolution order:
+//  1. If container is explicitly specified, use it.
+//  2. If the pod has a single container, use it.
+//  3. If the kubectl.kubernetes.io/default-container annotation is set, use it.
+//  4. Fall back to the first container in the pod spec.
+func resolveContainer(pod *v1.Pod, container string) string {
+	if container != "" {
+		return container
+	}
+	if len(pod.Spec.Containers) == 1 {
+		return pod.Spec.Containers[0].Name
+	}
+	if pod.Annotations != nil {
+		if defaultContainer, exists := pod.Annotations[DefaultContainerAnnotation]; exists && defaultContainer != "" {
+			return defaultContainer
+		}
+	}
+	if len(pod.Spec.Containers) > 0 {
+		return pod.Spec.Containers[0].Name
+	}
+	return ""
+}
+
 func (c *Core) PodsListInAllNamespaces(ctx context.Context, options api.ListOptions) (runtime.Unstructured, error) {
 	return c.ResourcesList(ctx, &schema.GroupVersionKind{
 		Group: "", Version: "v1", Kind: "Pod",
@@ -89,7 +117,16 @@ func (c *Core) PodsDelete(ctx context.Context, namespace, name string) (string, 
 }
 
 func (c *Core) PodsLog(ctx context.Context, namespace, name, container string, previous bool, tail int64) (string, error) {
-	pods := c.CoreV1().Pods(c.NamespaceOrDefault(namespace))
+	namespace = c.NamespaceOrDefault(namespace)
+	pods := c.CoreV1().Pods(namespace)
+
+	if container == "" {
+		pod, err := pods.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		container = resolveContainer(pod, "")
+	}
 
 	logOptions := &v1.PodLogOptions{
 		Container: container,
@@ -236,9 +273,7 @@ func (c *Core) PodsExec(ctx context.Context, namespace, name, container string, 
 	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
 		return "", fmt.Errorf("cannot exec into a container in a completed pod; current phase is %s", pod.Status.Phase)
 	}
-	if container == "" {
-		container = pod.Spec.Containers[0].Name
-	}
+	container = resolveContainer(pod, container)
 	podExecOptions := &v1.PodExecOptions{
 		Container: container,
 		Command:   command,

--- a/pkg/kubernetes/pods_test.go
+++ b/pkg/kubernetes/pods_test.go
@@ -1,0 +1,108 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ResolveContainerSuite struct {
+	suite.Suite
+}
+
+func (s *ResolveContainerSuite) TestResolveContainer() {
+	s.Run("explicit container is returned as-is", func() {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "main"},
+					{Name: "sidecar"},
+				},
+			},
+		}
+		s.Equal("explicit", resolveContainer(pod, "explicit"))
+	})
+	s.Run("single container pod returns that container", func() {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "only-container"},
+				},
+			},
+		}
+		s.Equal("only-container", resolveContainer(pod, ""))
+	})
+	s.Run("multi-container pod with annotation returns annotated container", func() {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					DefaultContainerAnnotation: "sidecar",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "main"},
+					{Name: "sidecar"},
+				},
+			},
+		}
+		s.Equal("sidecar", resolveContainer(pod, ""))
+	})
+	s.Run("multi-container pod without annotation falls back to first container", func() {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "first"},
+					{Name: "second"},
+				},
+			},
+		}
+		s.Equal("first", resolveContainer(pod, ""))
+	})
+	s.Run("annotation with empty value falls back to first container", func() {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					DefaultContainerAnnotation: "",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "first"},
+					{Name: "second"},
+				},
+			},
+		}
+		s.Equal("first", resolveContainer(pod, ""))
+	})
+	s.Run("pod with no containers returns empty string", func() {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{},
+			},
+		}
+		s.Equal("", resolveContainer(pod, ""))
+	})
+	s.Run("explicit container takes precedence over annotation", func() {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					DefaultContainerAnnotation: "sidecar",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "main"},
+					{Name: "sidecar"},
+				},
+			},
+		}
+		s.Equal("main", resolveContainer(pod, "main"))
+	})
+}
+
+func TestResolveContainer(t *testing.T) {
+	suite.Run(t, new(ResolveContainerSuite))
+}

--- a/pkg/mcp/pods_exec_test.go
+++ b/pkg/mcp/pods_exec_test.go
@@ -109,6 +109,91 @@ func (s *PodsExecSuite) TestPodsExec() {
 	})
 }
 
+func (s *PodsExecSuite) TestPodsExecDefaultContainer() {
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !strings.HasSuffix(req.URL.Path, "/exec") {
+			return
+		}
+		var stdin, stdout bytes.Buffer
+		ctx, err := test.CreateHTTPStreams(w, req, &test.StreamOptions{
+			Stdin:  &stdin,
+			Stdout: &stdout,
+		})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(err.Error()))
+			return
+		}
+		defer func(conn io.Closer) { _ = conn.Close() }(ctx.Closer)
+		_, _ = io.WriteString(ctx.StdoutStream, "container:"+strings.Join(req.URL.Query()["container"], " ")+"\n")
+	}))
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/v1/namespaces/default/pods/multi-with-annotation":
+			test.WriteObject(w, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "multi-with-annotation",
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/default-container": "sidecar",
+					},
+				},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "main"},
+					{Name: "sidecar"},
+				}},
+			})
+		case "/api/v1/namespaces/default/pods/multi-no-annotation":
+			test.WriteObject(w, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "multi-no-annotation",
+				},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "first"},
+					{Name: "second"},
+				}},
+			})
+		}
+	}))
+	s.InitMcpClient()
+
+	s.Run("multi-container pod with annotation uses annotated container", func() {
+		result, err := s.CallTool("pods_exec", map[string]interface{}{
+			"name":    "multi-with-annotation",
+			"command": []interface{}{"echo", "hello"},
+		})
+		s.Require().NotNil(result)
+		s.Require().NoError(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		s.Contains(result.Content[0].(*mcp.TextContent).Text, "container:sidecar",
+			"expected annotation container 'sidecar', got %v", result.Content[0].(*mcp.TextContent).Text)
+	})
+	s.Run("multi-container pod without annotation falls back to first container", func() {
+		result, err := s.CallTool("pods_exec", map[string]interface{}{
+			"name":    "multi-no-annotation",
+			"command": []interface{}{"echo", "hello"},
+		})
+		s.Require().NotNil(result)
+		s.Require().NoError(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		s.Contains(result.Content[0].(*mcp.TextContent).Text, "container:first",
+			"expected first container 'first', got %v", result.Content[0].(*mcp.TextContent).Text)
+	})
+	s.Run("explicit container takes precedence over annotation", func() {
+		result, err := s.CallTool("pods_exec", map[string]interface{}{
+			"name":      "multi-with-annotation",
+			"command":   []interface{}{"echo", "hello"},
+			"container": "main",
+		})
+		s.Require().NotNil(result)
+		s.Require().NoError(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		s.Contains(result.Content[0].(*mcp.TextContent).Text, "container:main",
+			"expected explicit container 'main', got %v", result.Content[0].(*mcp.TextContent).Text)
+	})
+}
+
 func (s *PodsExecSuite) TestPodsExecDenied() {
 	s.Require().NoError(toml.Unmarshal([]byte(`
 		denied_resources = [ { version = "v1", kind = "Pod" } ]

--- a/pkg/mcp/pods_test.go
+++ b/pkg/mcp/pods_test.go
@@ -686,6 +686,60 @@ func (s *PodsSuite) TestPodsLogDenied() {
 	})
 }
 
+func (s *PodsSuite) TestPodsLogDefaultContainer() {
+	kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
+	// Multi-container pod with default-container annotation
+	_, _ = kc.CoreV1().Pods("default").Create(s.T().Context(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "multi-container-with-annotation",
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/default-container": "sidecar",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Image: "nginx"},
+				{Name: "sidecar", Image: "nginx"},
+			},
+		},
+	}, metav1.CreateOptions{})
+	// Multi-container pod without annotation
+	_, _ = kc.CoreV1().Pods("default").Create(s.T().Context(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "multi-container-no-annotation",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "first", Image: "nginx"},
+				{Name: "second", Image: "nginx"},
+			},
+		},
+	}, metav1.CreateOptions{})
+	s.InitMcpClient()
+	s.Run("multi-container pod with annotation uses annotated container", func() {
+		toolResult, err := s.CallTool("pods_log", map[string]interface{}{
+			"name": "multi-container-with-annotation",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(toolResult.IsError, "call tool should not fail, got: %v", toolResult.Content[0].(*mcp.TextContent).Text)
+	})
+	s.Run("multi-container pod without annotation falls back to first container", func() {
+		toolResult, err := s.CallTool("pods_log", map[string]interface{}{
+			"name": "multi-container-no-annotation",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(toolResult.IsError, "call tool should not fail, got: %v", toolResult.Content[0].(*mcp.TextContent).Text)
+	})
+	s.Run("explicit container param takes precedence over annotation", func() {
+		toolResult, err := s.CallTool("pods_log", map[string]interface{}{
+			"name":      "multi-container-with-annotation",
+			"container": "main",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(toolResult.IsError, "call tool should not fail, got: %v", toolResult.Content[0].(*mcp.TextContent).Text)
+	})
+}
+
 func (s *PodsSuite) TestPodsListWithLabelSelector() {
 	s.InitMcpClient()
 	kc := kubernetes.NewForConfigOrDie(envTestRestConfig)


### PR DESCRIPTION
`pods_log` fails on multi-container pods when no container parameter is provided because it passes an empty string to the Kubernetes API. `pods_exec` had a partial fix (falling back to the first container) but did not honor the `kubectl.kubernetes.io/default-container` annotation.

Add a resolveContainer helper implementing the KEP-2227 resolution order:
* explicit param → single container → annotation → first container.  

Both `PodsLog` and `PodsExec` now use this shared logic.

Fixes #1000