### PR TITLE
fix(config): auto-select kubeconfig context when current-context is empty

### DIFF
--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -37,11 +38,17 @@ func NewKubeconfigManager(config api.BaseConfig, kubeconfigContext string) (*Man
 	if config.GetKubeConfigPath() != "" {
 		pathOptions.LoadingRules.ExplicitPath = config.GetKubeConfigPath()
 	}
+
+	resolvedContext, err := resolveKubeconfigContext(pathOptions.LoadingRules, kubeconfigContext)
+	if err != nil {
+		return nil, err
+	}
+
 	clientCmdConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		pathOptions.LoadingRules,
 		&clientcmd.ConfigOverrides{
 			ClusterInfo:    clientcmdapi.Cluster{Server: ""},
-			CurrentContext: kubeconfigContext,
+			CurrentContext: resolvedContext,
 		})
 
 	restConfig, err := clientCmdConfig.ClientConfig()
@@ -50,6 +57,49 @@ func NewKubeconfigManager(config api.BaseConfig, kubeconfigContext string) (*Man
 	}
 
 	return NewManager(config, restConfig, clientCmdConfig)
+}
+
+// resolveKubeconfigContext determines which kubeconfig context to use.
+// If kubeconfigContext is explicitly set, it is returned as-is.
+// If it is empty, the function loads the kubeconfig and:
+//   - returns the current-context if set
+//   - auto-selects the only available context if there is exactly one
+//   - returns a descriptive error if there are zero or multiple contexts
+func resolveKubeconfigContext(loadingRules *clientcmd.ClientConfigLoadingRules, kubeconfigContext string) (string, error) {
+	if kubeconfigContext != "" {
+		return kubeconfigContext, nil
+	}
+
+	rawConfig, err := loadingRules.Load()
+	if err != nil {
+		return "", fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	if rawConfig.CurrentContext != "" {
+		return rawConfig.CurrentContext, nil
+	}
+
+	switch len(rawConfig.Contexts) {
+	case 0:
+		return "", fmt.Errorf( //nolint:ST1005 // user-facing error with actionable guidance
+			"no current-context is set and no contexts are defined in kubeconfig.\n" +
+				"Configure a context with 'kubectl config set-context <name>' and 'kubectl config use-context <name>'")
+	case 1:
+		for name := range rawConfig.Contexts {
+			klog.Infof("current-context is not set in kubeconfig, auto-selecting the only available context %q", name)
+			return name, nil
+		}
+	}
+
+	names := make([]string, 0, len(rawConfig.Contexts))
+	for name := range rawConfig.Contexts {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return "", fmt.Errorf( //nolint:ST1005 // user-facing error with actionable guidance
+		"current-context is not set in kubeconfig and multiple contexts are available (%s).\n"+
+			"Set one with 'kubectl config use-context <context-name>'",
+		strings.Join(names, ", "))
 }
 
 func NewInClusterManager(config api.BaseConfig) (*Manager, error) {

--- a/pkg/kubernetes/manager_test.go
+++ b/pkg/kubernetes/manager_test.go
@@ -169,7 +169,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 			s.Run("returns error", func() {
 				s.Error(err)
 				s.Nil(manager)
-				s.ErrorContains(err, "failed to create kubernetes rest config")
+				s.ErrorContains(err, "no current-context is set and no contexts are defined")
 			})
 		})
 		s.Run("with empty kubeconfig in env", func() {
@@ -180,7 +180,44 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 			s.Run("returns error", func() {
 				s.Error(err)
 				s.Nil(manager)
-				s.ErrorContains(err, "no configuration has been provided")
+				s.ErrorContains(err, "no current-context is set and no contexts are defined")
+			})
+		})
+		s.Run("with empty current-context and single context auto-selects it", func() {
+			kubeconfig := s.mockServer.Kubeconfig()
+			kubeconfig.CurrentContext = ""
+			kubeconfigFile := test.KubeconfigFile(s.T(), kubeconfig)
+			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigFile))
+			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+			s.Require().NoError(err)
+			s.Require().NotNil(manager)
+			s.Run("rest config host points to mock server", func() {
+				s.Equal(s.mockServer.Config().Host, manager.kubernetes.RESTConfig().Host)
+			})
+		})
+		s.Run("with empty current-context and multiple contexts returns error", func() {
+			kubeconfig := s.mockServer.Kubeconfig()
+			kubeconfig.CurrentContext = ""
+			kubeconfig.Contexts["another-context"] = clientcmdapi.NewContext()
+			kubeconfigFile := test.KubeconfigFile(s.T(), kubeconfig)
+			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigFile))
+			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+			s.Run("returns error listing available contexts", func() {
+				s.Error(err)
+				s.Nil(manager)
+				s.ErrorContains(err, "current-context is not set")
+				s.ErrorContains(err, "kubectl config use-context")
+			})
+		})
+		s.Run("with empty current-context and no contexts returns error", func() {
+			kubeconfig := clientcmdapi.NewConfig()
+			kubeconfigFile := test.KubeconfigFile(s.T(), kubeconfig)
+			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigFile))
+			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+			s.Run("returns error", func() {
+				s.Error(err)
+				s.Nil(manager)
+				s.ErrorContains(err, "no current-context is set and no contexts are defined")
 			})
 		})
 	})

--- a/pkg/kubernetes/provider_kubeconfig.go
+++ b/pkg/kubernetes/provider_kubeconfig.go
@@ -70,18 +70,28 @@ func (p *kubeConfigClusterProvider) reset() error {
 		return err
 	}
 
+	// Determine the effective default context.
+	// RawConfig() returns the file's current-context which may be empty when
+	// NewKubeconfigManager auto-selected the only available context.
+	defaultContext := rawConfig.CurrentContext
+	if defaultContext == "" && len(rawConfig.Contexts) == 1 {
+		for name := range rawConfig.Contexts {
+			defaultContext = name
+		}
+	}
+
 	for _, old := range p.managers {
 		if old != nil {
 			old.Close()
 		}
 	}
 	p.managers = map[string]*Manager{
-		rawConfig.CurrentContext: m, // we already initialized a manager for the default context, let's use it
+		defaultContext: m,
 	}
 
 	for name := range rawConfig.Contexts {
-		if name == rawConfig.CurrentContext {
-			continue // already initialized this, don't want to set it to nil
+		if name == defaultContext {
+			continue
 		}
 		p.managers[name] = nil
 	}
@@ -89,7 +99,7 @@ func (p *kubeConfigClusterProvider) reset() error {
 	p.Close()
 	p.kubeconfigWatcher = watcher.NewKubeconfig(m.kubernetes.clientCmdConfig)
 	p.clusterStateWatcher = watcher.NewClusterState(m.kubernetes.DiscoveryClient())
-	p.defaultContext = rawConfig.CurrentContext
+	p.defaultContext = defaultContext
 
 	return nil
 }

--- a/pkg/kubernetes/provider_kubeconfig_test.go
+++ b/pkg/kubernetes/provider_kubeconfig_test.go
@@ -96,6 +96,25 @@ func (s *ProviderKubeconfigTestSuite) TestGetDefaultTarget() {
 	})
 }
 
+func (s *ProviderKubeconfigTestSuite) TestEmptyCurrentContext() {
+	s.Run("with single context auto-selects it as default target", func() {
+		kubeconfig := s.mockServer.Kubeconfig()
+		kubeconfig.CurrentContext = ""
+		provider, err := NewProvider(&config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
+		s.Require().NoError(err, "Expected no error creating provider with empty current-context and single context")
+		s.Equal("fake-context", provider.GetDefaultTarget(), "Expected auto-selected fake-context as default target")
+	})
+	s.Run("with multiple contexts returns error", func() {
+		kubeconfig := s.mockServer.Kubeconfig()
+		kubeconfig.CurrentContext = ""
+		kubeconfig.Contexts["another-context"] = clientcmdapi.NewContext()
+		_, err := NewProvider(&config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
+		s.Require().Error(err, "Expected error creating provider with empty current-context and multiple contexts")
+		s.ErrorContains(err, "current-context is not set")
+		s.ErrorContains(err, "kubectl config use-context")
+	})
+}
+
 func (s *ProviderKubeconfigTestSuite) TestGetTargetParameterName() {
 	s.Equal("context", s.provider.GetTargetParameterName(), "Expected context as target parameter name")
 }


### PR DESCRIPTION
When a kubeconfig file has an empty `current-context` but defines exactly
one context, the server now auto-selects it instead of failing to start.

When multiple contexts exist without a `current-context`, a descriptive
error lists the available contexts and guides the user to set one with
`kubectl config use-context`.

Fixes #1045

/cc @jeffmaury