### PR TITLE
feat(kubevirt): add product name override mechanism for downstream branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `namespace` (`string`) **(required)** - The namespace of the source virtual machine
   - `targetName` (`string`) **(required)** - The name for the new cloned virtual machine
 
-- **vm_create** - Create a VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.
+- **vm_create** - Create a KubeVirt VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.
   - `autostart` (`boolean`) - Optional flag to automatically start the VM after creation (sets runStrategy to Always instead of Halted). Defaults to false.
   - `instancetype` (`string`) - Optional instance type name for the VM (e.g., 'u1.small', 'u1.medium', 'u1.large')
   - `name` (`string`) **(required)** - The name of the virtual machine
@@ -531,7 +531,7 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `storage` (`string`) - Optional storage size for the VM's root disk when using DataSources (e.g., '30Gi', '50Gi', '100Gi'). Defaults to 30Gi. Ignored when using container disks.
   - `workload` (`string`) - The workload for the VM. Accepts OS names (e.g., 'fedora' (default), 'ubuntu', 'centos', 'centos-stream', 'debian', 'rhel', 'opensuse', 'opensuse-tumbleweed', 'opensuse-leap') or full container disk image URLs
 
-- **vm_lifecycle** - Manage VirtualMachine lifecycle: start, stop, or restart a VM
+- **vm_lifecycle** - Manage KubeVirt VirtualMachine lifecycle: start, stop, or restart a VM
   - `action` (`string`) **(required)** - The lifecycle action to perform: 'start' (changes runStrategy to Always), 'stop' (changes runStrategy to Halted), or 'restart' (stops then starts the VM)
   - `name` (`string`) **(required)** - The name of the virtual machine
   - `namespace` (`string`) **(required)** - The namespace of the virtual machine
@@ -588,7 +588,7 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 <summary>kubevirt</summary>
 
-- **vm-troubleshoot** - Generate a step-by-step troubleshooting guide for diagnosing VirtualMachine issues
+- **vm-troubleshoot** - Generate a step-by-step troubleshooting guide for diagnosing KubeVirt VirtualMachine issues
   - `namespace` (`string`) **(required)** - The namespace of the VirtualMachine to troubleshoot
   - `name` (`string`) **(required)** - The name of the VirtualMachine to troubleshoot
 

--- a/pkg/mcp/kubevirt_test.go
+++ b/pkg/mcp/kubevirt_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	kubevirttesting "github.com/containers/kubernetes-mcp-server/pkg/kubevirt/testing"
+	kubevirttoolset "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sync/errgroup"
@@ -756,7 +757,8 @@ func (s *KubevirtSuite) TestVMTroubleshootPrompt() {
 
 			textContent, ok := result.Messages[0].Content.(*mcp.TextContent)
 			s.Require().True(ok, "expected TextContent")
-			s.Contains(textContent.Text, "# VirtualMachine Troubleshooting Guide")
+			promptTitle := (&kubevirttoolset.Toolset{}).GetPrompts()[0].Prompt.Title
+			s.Contains(textContent.Text, fmt.Sprintf("# %sing Guide", promptTitle))
 			s.Contains(textContent.Text, "test-vm")
 			s.Contains(textContent.Text, "default")
 		})

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -39,7 +39,7 @@
       "openWorldHint": false,
       "title": "Virtual Machine: Create"
     },
-    "description": "Create a VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.",
+    "description": "Create a KubeVirt VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.",
     "inputSchema": {
       "properties": {
         "autostart": {
@@ -162,7 +162,7 @@
       "openWorldHint": false,
       "title": "Virtual Machine: Lifecycle"
     },
-    "description": "Manage VirtualMachine lifecycle: start, stop, or restart a VM",
+    "description": "Manage KubeVirt VirtualMachine lifecycle: start, stop, or restart a VM",
     "inputSchema": {
       "properties": {
         "action": {

--- a/pkg/toolsets/kubevirt/internal/defaults/defaults.go
+++ b/pkg/toolsets/kubevirt/internal/defaults/defaults.go
@@ -1,0 +1,22 @@
+package defaults
+
+const (
+	DefaultToolsetDescription = "KubeVirt virtual machine management tools, check the [KubeVirt documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/kubevirt.md) for more details."
+	DefaultProductName        = "KubeVirt"
+)
+
+func ToolsetDescription() string {
+	overrideDescription := ToolsetDescriptionOverride()
+	if overrideDescription != "" {
+		return overrideDescription
+	}
+	return DefaultToolsetDescription
+}
+
+func ProductName() string {
+	overrideProductName := ProductNameOverride()
+	if overrideProductName != "" {
+		return overrideProductName
+	}
+	return DefaultProductName
+}

--- a/pkg/toolsets/kubevirt/internal/defaults/defaults_override.go
+++ b/pkg/toolsets/kubevirt/internal/defaults/defaults_override.go
@@ -1,0 +1,14 @@
+package defaults
+
+const (
+	toolsetDescriptionOverride = ""
+	productNameOverride        = ""
+)
+
+func ToolsetDescriptionOverride() string {
+	return toolsetDescriptionOverride
+}
+
+func ProductNameOverride() string {
+	return productNameOverride
+}

--- a/pkg/toolsets/kubevirt/internal/defaults/defaults_test.go
+++ b/pkg/toolsets/kubevirt/internal/defaults/defaults_test.go
@@ -1,0 +1,15 @@
+package defaults
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProductNameReturnsDefault(t *testing.T) {
+	assert.NotEmpty(t, ProductName())
+}
+
+func TestToolsetDescriptionReturnsDefault(t *testing.T) {
+	assert.NotEmpty(t, ToolsetDescription())
+}

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
+	kubevirtdefaults "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
 	vm_clone "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/clone"
 	vm_create "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/create"
 	vm_lifecycle "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/lifecycle"
@@ -19,7 +20,7 @@ func (t *Toolset) GetName() string {
 }
 
 func (t *Toolset) GetDescription() string {
-	return "KubeVirt virtual machine management tools, check the [KubeVirt documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/kubevirt.md) for more details."
+	return kubevirtdefaults.ToolsetDescription()
 }
 
 func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {

--- a/pkg/toolsets/kubevirt/vm/clone/tool.go
+++ b/pkg/toolsets/kubevirt/vm/clone/tool.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
 	"github.com/google/jsonschema-go/jsonschema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
@@ -16,7 +17,7 @@ func Tools() []api.ServerTool {
 		{
 			Tool: api.Tool{
 				Name:        "vm_clone",
-				Description: "Clone a KubeVirt VirtualMachine by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the KubeVirt Clone API",
+				Description: fmt.Sprintf("Clone a %s VirtualMachine by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the %s Clone API", defaults.ProductName(), defaults.ProductName()),
 				InputSchema: &jsonschema.Schema{
 					Type: "object",
 					Properties: map[string]*jsonschema.Schema{

--- a/pkg/toolsets/kubevirt/vm/create/tool.go
+++ b/pkg/toolsets/kubevirt/vm/create/tool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
 	"github.com/google/jsonschema-go/jsonschema"
 	"k8s.io/utils/ptr"
 )
@@ -22,7 +23,7 @@ func Tools() []api.ServerTool {
 		{
 			Tool: api.Tool{
 				Name:        "vm_create",
-				Description: "Create a VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.",
+				Description: fmt.Sprintf("Create a %s VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.", defaults.ProductName()),
 				InputSchema: &jsonschema.Schema{
 					Type: "object",
 					Properties: map[string]*jsonschema.Schema{

--- a/pkg/toolsets/kubevirt/vm/lifecycle/tool.go
+++ b/pkg/toolsets/kubevirt/vm/lifecycle/tool.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
 	"github.com/google/jsonschema-go/jsonschema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
@@ -25,7 +26,7 @@ func Tools() []api.ServerTool {
 		{
 			Tool: api.Tool{
 				Name:        "vm_lifecycle",
-				Description: "Manage VirtualMachine lifecycle: start, stop, or restart a VM",
+				Description: fmt.Sprintf("Manage %s VirtualMachine lifecycle: start, stop, or restart a VM", defaults.ProductName()),
 				InputSchema: &jsonschema.Schema{
 					Type: "object",
 					Properties: map[string]*jsonschema.Schema{

--- a/pkg/toolsets/kubevirt/vm_troubleshoot.go
+++ b/pkg/toolsets/kubevirt/vm_troubleshoot.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
 )
 
 // initVMTroubleshoot initializes the VM troubleshooting prompt
@@ -21,8 +22,8 @@ func initVMTroubleshoot() []api.ServerPrompt {
 		{
 			Prompt: api.Prompt{
 				Name:        "vm-troubleshoot",
-				Title:       "VirtualMachine Troubleshoot",
-				Description: "Generate a step-by-step troubleshooting guide for diagnosing VirtualMachine issues",
+				Title:       fmt.Sprintf("%s VirtualMachine Troubleshoot", defaults.ProductName()),
+				Description: fmt.Sprintf("Generate a step-by-step troubleshooting guide for diagnosing %s VirtualMachine issues", defaults.ProductName()),
 				Arguments: []api.PromptArgument{
 					{
 						Name:        "namespace",
@@ -70,11 +71,11 @@ func vmTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCallResul
 	eventsYaml := fetchEvents(ctx, params.KubernetesClient, namespace, name)
 
 	// Build the troubleshooting guide message with embedded resource data
-	guideText := fmt.Sprintf(`# VirtualMachine Troubleshooting Guide
+	guideText := fmt.Sprintf(`# %s VirtualMachine Troubleshooting Guide
 
 ## VM: %s (namespace: %s)
 
-Use this guide to diagnose issues with the VirtualMachine. The relevant resource data has been collected below.
+Use this guide to diagnose issues with the %s VirtualMachine. The relevant resource data has been collected below.
 
 ---
 
@@ -184,7 +185,7 @@ After completing troubleshooting and attempting fixes, report:
 - **Root Cause:** Description or "None found"
 - **Action Taken:** What was done to fix the issue (or "None" if no fix was needed/possible)
 - **Result:** Whether the fix was successful or further action is needed
-`, name, namespace, vmYaml, vmiYaml, volumesYaml, podYaml, podLogsText, eventsYaml)
+`, defaults.ProductName(), name, namespace, defaults.ProductName(), vmYaml, vmiYaml, volumesYaml, podYaml, podLogsText, eventsYaml)
 
 	return api.NewPromptCallResult(
 		"VirtualMachine troubleshooting guide generated",

--- a/pkg/toolsets/kubevirt/vm_troubleshoot_test.go
+++ b/pkg/toolsets/kubevirt/vm_troubleshoot_test.go
@@ -2,10 +2,12 @@ package kubevirt
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	kubevirtdefaults "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -32,7 +34,7 @@ func (s *VMTroubleshootSuite) TestVMTroubleshootPrompt() {
 		prompts := initVMTroubleshoot()
 		s.Require().Len(prompts, 1, "Expected 1 prompt")
 		s.Equal("vm-troubleshoot", prompts[0].Prompt.Name)
-		s.Equal("VirtualMachine Troubleshoot", prompts[0].Prompt.Title)
+		s.Equal(fmt.Sprintf("%s VirtualMachine Troubleshoot", kubevirtdefaults.ProductName()), prompts[0].Prompt.Title)
 		s.Len(prompts[0].Prompt.Arguments, 2, "Expected 2 arguments")
 	})
 


### PR DESCRIPTION
Implement configuration-based override system to allow downstream distributions (e.g., OpenShift) to rebrand user-facing strings while maintaining API compatibility.

Changes:
- Add pkg/toolsets/kubevirt/internal/defaults package with override pattern
- Update toolset description to use defaults.ToolsetDescription()
- Update all tool descriptions to use defaults.ProductName()
- Update vm-troubleshoot prompt to use dynamic product name
- Update tests to use dynamic product name assertions
- Auto-regenerate README.md with updated tool descriptions

Resolves: CNV-78794