### PR TITLE
fix(config): validate token exchange fields at config load (#1057)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -157,6 +157,8 @@ type StaticConfig struct {
 	configDirPath string
 	// Internal: known provider strategies, set via WithProviderStrategies
 	providerStrategies []string
+	// Internal: known token exchange strategies, set via WithTokenExchangeStrategies
+	tokenExchangeStrategies []string
 }
 
 var _ api.BaseConfig = (*StaticConfig)(nil)
@@ -455,6 +457,16 @@ func (c *StaticConfig) WithProviderStrategies(strategies []string) *StaticConfig
 	return c
 }
 
+// WithTokenExchangeStrategies sets the known token exchange strategies for
+// validation. Callers that have access to the token exchange registry should
+// chain this before Validate so that token_exchange_strategy is checked:
+//
+//	cfg.WithTokenExchangeStrategies(tokenexchange.GetRegisteredStrategies()).Validate()
+func (c *StaticConfig) WithTokenExchangeStrategies(strategies []string) *StaticConfig {
+	c.tokenExchangeStrategies = strategies
+	return c
+}
+
 // Validate validates config-level invariants that must hold at both startup and
 // on SIGHUP reload.
 func (c *StaticConfig) Validate() error {
@@ -512,8 +524,49 @@ func (c *StaticConfig) Validate() error {
 	if err := c.ValidateClusterAuthMode(); err != nil {
 		return err
 	}
+	if err := c.validateTokenExchange(); err != nil {
+		return err
+	}
 	if err := c.HTTP.Validate(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateTokenExchange validates token-exchange-related fields:
+//   - token_exchange_strategy must be a known strategy (when registry is provided)
+//   - sts_auth_style must be one of "params", "header", "assertion"
+//   - when sts_auth_style is "assertion", sts_client_cert_file and sts_client_key_file
+//     must both be set and reference existing files
+func (c *StaticConfig) validateTokenExchange() error {
+	if c.TokenExchangeStrategy != "" && len(c.tokenExchangeStrategies) > 0 {
+		if !slices.Contains(c.tokenExchangeStrategies, c.TokenExchangeStrategy) {
+			return fmt.Errorf("invalid token_exchange_strategy: %s, valid values are: %s", c.TokenExchangeStrategy, strings.Join(c.tokenExchangeStrategies, ", "))
+		}
+	}
+	const (
+		authStyleParams    = "params"
+		authStyleHeader    = "header"
+		authStyleAssertion = "assertion"
+	)
+	switch c.StsAuthStyle {
+	case "", authStyleParams, authStyleHeader:
+		// valid
+	case authStyleAssertion:
+		if c.StsClientCertFile == "" {
+			return fmt.Errorf("sts_client_cert_file is required when sts_auth_style is %q", authStyleAssertion)
+		}
+		if c.StsClientKeyFile == "" {
+			return fmt.Errorf("sts_client_key_file is required when sts_auth_style is %q", authStyleAssertion)
+		}
+		if _, err := os.Stat(c.StsClientCertFile); err != nil {
+			return fmt.Errorf("sts_client_cert_file must be a valid file path: %w", err)
+		}
+		if _, err := os.Stat(c.StsClientKeyFile); err != nil {
+			return fmt.Errorf("sts_client_key_file must be a valid file path: %w", err)
+		}
+	default:
+		return fmt.Errorf("invalid sts_auth_style %q: must be %q, %q, or %q", c.StsAuthStyle, authStyleParams, authStyleHeader, authStyleAssertion)
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"k8s.io/klog/v2"
 )
@@ -544,20 +545,15 @@ func (c *StaticConfig) validateTokenExchange() error {
 			return fmt.Errorf("invalid token_exchange_strategy: %s, valid values are: %s", c.TokenExchangeStrategy, strings.Join(c.tokenExchangeStrategies, ", "))
 		}
 	}
-	const (
-		authStyleParams    = "params"
-		authStyleHeader    = "header"
-		authStyleAssertion = "assertion"
-	)
 	switch c.StsAuthStyle {
-	case "", authStyleParams, authStyleHeader:
+	case "", tokenexchange.AuthStyleParams, tokenexchange.AuthStyleHeader:
 		// valid
-	case authStyleAssertion:
+	case tokenexchange.AuthStyleAssertion:
 		if c.StsClientCertFile == "" {
-			return fmt.Errorf("sts_client_cert_file is required when sts_auth_style is %q", authStyleAssertion)
+			return fmt.Errorf("sts_client_cert_file is required when sts_auth_style is %q", tokenexchange.AuthStyleAssertion)
 		}
 		if c.StsClientKeyFile == "" {
-			return fmt.Errorf("sts_client_key_file is required when sts_auth_style is %q", authStyleAssertion)
+			return fmt.Errorf("sts_client_key_file is required when sts_auth_style is %q", tokenexchange.AuthStyleAssertion)
 		}
 		if _, err := os.Stat(c.StsClientCertFile); err != nil {
 			return fmt.Errorf("sts_client_cert_file must be a valid file path: %w", err)
@@ -566,7 +562,7 @@ func (c *StaticConfig) validateTokenExchange() error {
 			return fmt.Errorf("sts_client_key_file must be a valid file path: %w", err)
 		}
 	default:
-		return fmt.Errorf("invalid sts_auth_style %q: must be %q, %q, or %q", c.StsAuthStyle, authStyleParams, authStyleHeader, authStyleAssertion)
+		return fmt.Errorf("invalid sts_auth_style %q: must be %q, %q, or %q", c.StsAuthStyle, tokenexchange.AuthStyleParams, tokenexchange.AuthStyleHeader, tokenexchange.AuthStyleAssertion)
 	}
 	return nil
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -237,6 +237,126 @@ func (s *ValidateSuite) TestTLSCertKey() {
 	})
 }
 
+func (s *ValidateSuite) TestTokenExchangeStrategy() {
+	s.Run("unknown strategy is skipped without WithTokenExchangeStrategies", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.TokenExchangeStrategy = "nonexistent-strategy"
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("unknown strategy is rejected with WithTokenExchangeStrategies", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.TokenExchangeStrategy = "nonexistent-strategy"
+		err := cfg.WithTokenExchangeStrategies([]string{"rfc8693", "keycloak-v1", "entra-obo"}).Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid token_exchange_strategy")
+		s.Contains(err.Error(), "nonexistent-strategy")
+	})
+
+	s.Run("valid strategy is accepted with WithTokenExchangeStrategies", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.TokenExchangeStrategy = "rfc8693"
+		s.NoError(cfg.WithTokenExchangeStrategies([]string{"rfc8693", "keycloak-v1", "entra-obo"}).Validate())
+	})
+}
+
+func (s *ValidateSuite) TestStsAuthStyle() {
+	s.Run("invalid sts_auth_style is rejected", func() {
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = "invalid-style"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid sts_auth_style")
+		s.Contains(err.Error(), "invalid-style")
+	})
+
+	s.Run("empty sts_auth_style is accepted", func() {
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = ""
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("params sts_auth_style is accepted", func() {
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = "params"
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("header sts_auth_style is accepted", func() {
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = "header"
+		s.NoError(cfg.Validate())
+	})
+}
+
+func (s *ValidateSuite) TestStsClientCertKey() {
+	s.Run("assertion auth_style without cert file is rejected", func() {
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = "assertion"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "sts_client_cert_file is required")
+	})
+
+	s.Run("assertion auth_style without key file is rejected", func() {
+		tmpDir := s.T().TempDir()
+		certPath := filepath.Join(tmpDir, "cert.pem")
+		s.Require().NoError(os.WriteFile(certPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = "assertion"
+		cfg.StsClientCertFile = certPath
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "sts_client_key_file is required")
+	})
+
+	s.Run("non-existent sts_client_cert_file is rejected", func() {
+		tmpDir := s.T().TempDir()
+		keyPath := filepath.Join(tmpDir, "key.pem")
+		s.Require().NoError(os.WriteFile(keyPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = "assertion"
+		cfg.StsClientCertFile = "/nonexistent/cert.pem"
+		cfg.StsClientKeyFile = keyPath
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "sts_client_cert_file must be a valid file path")
+	})
+
+	s.Run("non-existent sts_client_key_file is rejected", func() {
+		tmpDir := s.T().TempDir()
+		certPath := filepath.Join(tmpDir, "cert.pem")
+		s.Require().NoError(os.WriteFile(certPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = "assertion"
+		cfg.StsClientCertFile = certPath
+		cfg.StsClientKeyFile = "/nonexistent/key.pem"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "sts_client_key_file must be a valid file path")
+	})
+
+	s.Run("assertion auth_style with valid cert and key is accepted", func() {
+		tmpDir := s.T().TempDir()
+		certPath := filepath.Join(tmpDir, "cert.pem")
+		keyPath := filepath.Join(tmpDir, "key.pem")
+		s.Require().NoError(os.WriteFile(certPath, []byte("test"), 0644))
+		s.Require().NoError(os.WriteFile(keyPath, []byte("test"), 0644))
+
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = "assertion"
+		cfg.StsClientCertFile = certPath
+		cfg.StsClientKeyFile = keyPath
+		s.NoError(cfg.Validate())
+	})
+}
+
 func TestValidate(t *testing.T) {
 	suite.Run(t, new(ValidateSuite))
 }

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	internaloauth "github.com/containers/kubernetes-mcp-server/pkg/oauth"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 	"github.com/containers/kubernetes-mcp-server/pkg/telemetry"
+	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/version"
 )
@@ -276,7 +277,10 @@ func (m *MCPServerOptions) initializeLogging() {
 
 func (m *MCPServerOptions) Validate() error {
 	// Config-level validations (shared with SIGHUP reload)
-	if err := m.StaticConfig.WithProviderStrategies(kubernetes.GetRegisteredStrategies()).Validate(); err != nil {
+	if err := m.StaticConfig.
+		WithProviderStrategies(kubernetes.GetRegisteredStrategies()).
+		WithTokenExchangeStrategies(tokenexchange.GetRegisteredStrategies()).
+		Validate(); err != nil {
 		return err
 	}
 	// CLI-level validations (flag interactions that can't change on reload)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/metrics"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 	"github.com/containers/kubernetes-mcp-server/pkg/prompts"
+	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/version"
 )
@@ -364,7 +365,10 @@ func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 	klog.V(1).Info("Reloading MCP server configuration...")
 
 	// Validate config-level invariants (same checks as startup)
-	if err := newConfig.WithProviderStrategies(internalk8s.GetRegisteredStrategies()).Validate(); err != nil {
+	if err := newConfig.
+		WithProviderStrategies(internalk8s.GetRegisteredStrategies()).
+		WithTokenExchangeStrategies(tokenexchange.GetRegisteredStrategies()).
+		Validate(); err != nil {
 		return fmt.Errorf("configuration reload rejected: %w", err)
 	}
 

--- a/pkg/tokenexchange/registry.go
+++ b/pkg/tokenexchange/registry.go
@@ -1,5 +1,7 @@
 package tokenexchange
 
+import "slices"
+
 var (
 	exchangerRegistry = &tokenExchangerRegistry{exchangers: map[string]TokenExchanger{}}
 )
@@ -18,6 +20,12 @@ func GetTokenExchanger(strategy string) (TokenExchanger, bool) {
 	return exchangerRegistry.get(strategy)
 }
 
+// GetRegisteredStrategies returns a sorted list of all registered token exchange
+// strategy names. Useful for config validation and error messages.
+func GetRegisteredStrategies() []string {
+	return exchangerRegistry.strategies()
+}
+
 type tokenExchangerRegistry struct {
 	exchangers map[string]TokenExchanger
 }
@@ -33,4 +41,13 @@ func (r *tokenExchangerRegistry) register(strategy string, exchanger TokenExchan
 func (r *tokenExchangerRegistry) get(strategy string) (TokenExchanger, bool) {
 	exchanger, ok := r.exchangers[strategy]
 	return exchanger, ok
+}
+
+func (r *tokenExchangerRegistry) strategies() []string {
+	strategies := make([]string, 0, len(r.exchangers))
+	for strategy := range r.exchangers {
+		strategies = append(strategies, strategy)
+	}
+	slices.Sort(strategies)
+	return strategies
 }

--- a/pkg/tokenexchange/registry_test.go
+++ b/pkg/tokenexchange/registry_test.go
@@ -33,6 +33,13 @@ func (s *TokenExchangerRegistryTestSuite) TestGetTokenExchanger() {
 	})
 }
 
+func (s *TokenExchangerRegistryTestSuite) TestGetRegisteredStrategies() {
+	s.Run("returns sorted list of registered strategies", func() {
+		strategies := GetRegisteredStrategies()
+		s.Equal([]string{StrategyEntraOBO, StrategyKeycloakV1, StrategyRFC8693}, strategies)
+	})
+}
+
 func (s *TokenExchangerRegistryTestSuite) TestRegisterTokenExchanger() {
 	s.Run("panics on duplicate registration", func() {
 		s.Panics(func() {


### PR DESCRIPTION
## Summary

Closes #1057.

Several token exchange configuration fields were only validated at runtime (when a token exchange request was made), so invalid values were silently accepted at startup and on SIGHUP reload:

- **`token_exchange_strategy`** — unknown strategies fell back to STS with only a warning. Now rejected via a new `WithTokenExchangeStrategies` option (mirrors the `WithProviderStrategies` pattern from #989) backed by a new `tokenexchange.GetRegisteredStrategies()` helper.
- **`sts_auth_style`** — invalid values are now rejected at config load (`"params"`, `"header"`, `"assertion"`, or empty).
- **`sts_client_cert_file` / `sts_client_key_file`** — when `sts_auth_style = "assertion"`, both must be set and reference existing files. Mirrors the runtime contract in `TargetTokenExchangeConfig.Validate()` and `loadCertificateAndKey`.

Both startup (`pkg/kubernetes-mcp-server/cmd/root.go`) and SIGHUP reload (`pkg/mcp/mcp.go`) now chain `WithTokenExchangeStrategies(tokenexchange.GetRegisteredStrategies())` into `Validate()`, so the new checks fire on both paths.