### PR TITLE
fix(config): normalize whitespace for token exchange fields before validation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -475,6 +475,9 @@ func (c *StaticConfig) Validate() error {
 	c.CertificateAuthority = strings.TrimSpace(c.CertificateAuthority)
 	c.TLSCert = strings.TrimSpace(c.TLSCert)
 	c.TLSKey = strings.TrimSpace(c.TLSKey)
+	c.StsAuthStyle = strings.TrimSpace(c.StsAuthStyle)
+	c.StsClientCertFile = strings.TrimSpace(c.StsClientCertFile)
+	c.StsClientKeyFile = strings.TrimSpace(c.StsClientKeyFile)
 	if output.FromString(c.ListOutput) == nil {
 		return fmt.Errorf("invalid output name: %s, valid names are: %s", c.ListOutput, strings.Join(output.Names, ", "))
 	}

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -290,6 +290,12 @@ func (s *ValidateSuite) TestStsAuthStyle() {
 		cfg.StsAuthStyle = "header"
 		s.NoError(cfg.Validate())
 	})
+
+	s.Run("whitespace-only sts_auth_style is treated as empty", func() {
+		cfg := s.validConfig()
+		cfg.StsAuthStyle = "   "
+		s.NoError(cfg.Validate())
+	})
 }
 
 func (s *ValidateSuite) TestStsClientCertKey() {
@@ -353,6 +359,13 @@ func (s *ValidateSuite) TestStsClientCertKey() {
 		cfg.StsAuthStyle = "assertion"
 		cfg.StsClientCertFile = certPath
 		cfg.StsClientKeyFile = keyPath
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("whitespace-only sts_client_cert_file and sts_client_key_file are treated as empty", func() {
+		cfg := s.validConfig()
+		cfg.StsClientCertFile = "   "
+		cfg.StsClientKeyFile = "   "
 		s.NoError(cfg.Validate())
 	})
 }


### PR DESCRIPTION
Extend the existing `TrimSpace` normalization in `Validate()` to cover `StsAuthStyle`, `StsClientCertFile`, and `StsClientKeyFile`, consistent with how `CertificateAuthority`, `TLSCert`, and `TLSKey` are already handled. Without this, whitespace-padded values would bypass empty-string checks and cause misleading file-not-found errors at runtime.