### PR TITLE
feat(config): add skip_jwt_verification to enforce OIDC verification

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -467,6 +467,7 @@ Configure OAuth/OIDC authentication for HTTP mode deployments.
 | `require_oauth` | boolean | `false` | When `true`, requires OAuth authentication for all requests. |
 | `oauth_audience` | string | `""` | Valid audience for OAuth tokens (for offline JWT claim validation). |
 | `authorization_url` | string | `""` | URL of the OIDC authorization server for token validation and STS exchange. |
+| `skip_jwt_verification` | boolean | `false` | When `true`, allows JWTs without cryptographic signature verification when `require_oauth` is enabled but no `authorization_url` is configured. Only use behind a trusted reverse proxy that already verifies tokens. When `false` (default), the server refuses to start in this configuration. |
 | `disable_dynamic_client_registration` | boolean | `false` | When `true`, disables dynamic client registration in `.well-known` endpoints. |
 | `oauth_scopes` | string[] | `[]` | Supported client scopes for the OAuth flow. |
 | `sts_client_id` | string | `""` | OAuth client ID for backend token exchange. |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,12 @@ type StaticConfig struct {
 	// AuthorizationURL is the URL of the OIDC authorization server.
 	// It is used for token validation and for STS token exchange.
 	AuthorizationURL string `toml:"authorization_url,omitempty"`
+	// SkipJWTVerification allows the server to accept JWTs without cryptographic
+	// signature verification when require_oauth is enabled but no authorization_url
+	// is configured (offline-only validation). Only use behind a trusted reverse proxy
+	// that performs token verification. When false (default), the server refuses to
+	// start if require_oauth is true and authorization_url is empty.
+	SkipJWTVerification bool `toml:"skip_jwt_verification,omitempty"`
 	// DisableDynamicClientRegistration indicates whether dynamic client registration is disabled.
 	// If true, the .well-known endpoints will not expose the registration endpoint.
 	DisableDynamicClientRegistration bool `toml:"disable_dynamic_client_registration,omitempty"`
@@ -490,6 +496,9 @@ func (c *StaticConfig) Validate() error {
 			klog.Warningf("authorization-url is using http://, this is not recommended production use")
 		}
 	}
+	if err := c.validateSkipJWTVerification(); err != nil {
+		return err
+	}
 	if c.CertificateAuthority != "" {
 		if _, err := os.Stat(c.CertificateAuthority); err != nil {
 			return fmt.Errorf("certificate-authority must be a valid file path: %w", err)
@@ -544,6 +553,24 @@ func (c *StaticConfig) validateConfirmation() error {
 		return fmt.Errorf("invalid confirmation rules:\n%w", errors.Join(ruleErrors...))
 	}
 	return nil
+}
+
+// validateSkipJWTVerification checks that the user has explicitly opted in to
+// skipping JWT signature verification when require_oauth is enabled but no
+// authorization_url is configured.
+func (c *StaticConfig) validateSkipJWTVerification() error {
+	if !c.RequireOAuth || c.AuthorizationURL != "" {
+		return nil
+	}
+	if c.SkipJWTVerification {
+		klog.Warningf("skip_jwt_verification is enabled: JWTs will be accepted without cryptographic signature verification. " +
+			"Only use this behind a trusted reverse proxy that performs token verification.")
+		return nil
+	}
+	return fmt.Errorf("require_oauth is enabled but authorization_url is not configured: " +
+		"JWTs cannot be cryptographically verified without an OIDC provider. " +
+		"Set authorization_url to an OIDC issuer, or set skip_jwt_verification=true " +
+		"if the server is behind a trusted reverse proxy that verifies tokens")
 }
 
 // validateTokenExchange validates token-exchange-related fields:

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -140,6 +140,7 @@ func (s *ValidateSuite) TestCertificateAuthority() {
 	s.Run("non-existent file is rejected", func() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.CertificateAuthority = "/nonexistent/path/ca.crt"
 		err := cfg.Validate()
 		s.Require().Error(err)
@@ -153,6 +154,7 @@ func (s *ValidateSuite) TestCertificateAuthority() {
 
 		cfg := s.validConfig()
 		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.CertificateAuthority = caPath
 		s.NoError(cfg.Validate())
 	})
@@ -245,6 +247,7 @@ func (s *ValidateSuite) TestTokenExchangeStrategy() {
 	s.Run("unknown strategy is skipped without WithTokenExchangeStrategies", func() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.TokenExchangeStrategy = "nonexistent-strategy"
 		s.NoError(cfg.Validate())
 	})
@@ -252,6 +255,7 @@ func (s *ValidateSuite) TestTokenExchangeStrategy() {
 	s.Run("unknown strategy is rejected with WithTokenExchangeStrategies", func() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.TokenExchangeStrategy = "nonexistent-strategy"
 		err := cfg.WithTokenExchangeStrategies([]string{"rfc8693", "keycloak-v1", "entra-obo"}).Validate()
 		s.Require().Error(err)
@@ -262,6 +266,7 @@ func (s *ValidateSuite) TestTokenExchangeStrategy() {
 	s.Run("valid strategy is accepted with WithTokenExchangeStrategies", func() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.TokenExchangeStrategy = "rfc8693"
 		s.NoError(cfg.WithTokenExchangeStrategies([]string{"rfc8693", "keycloak-v1", "entra-obo"}).Validate())
 	})
@@ -480,6 +485,47 @@ func (s *ValidateSuite) TestConfirmationRules() {
 		s.Require().Error(err)
 		s.Contains(err.Error(), "confirmation_rules[0]")
 		s.Contains(err.Error(), "confirmation_rules[1]")
+	})
+}
+
+func (s *ValidateSuite) TestSkipJWTVerification() {
+	s.Run("require_oauth with authorization_url set is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "https://example.com/auth"
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("require_oauth without authorization_url and skip_jwt_verification=false is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = ""
+		cfg.SkipJWTVerification = false
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_oauth is enabled but authorization_url is not configured")
+		s.Contains(err.Error(), "skip_jwt_verification=true")
+	})
+
+	s.Run("require_oauth without authorization_url and skip_jwt_verification=true is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = ""
+		cfg.SkipJWTVerification = true
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("require_oauth=false with skip_jwt_verification=true is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = false
+		cfg.SkipJWTVerification = true
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("require_oauth=false is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = false
+		s.NoError(cfg.Validate())
 	})
 }
 

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-jose/go-jose/v4"
@@ -38,9 +39,11 @@ func write401(w http.ResponseWriter, wwwAuthenticateHeader, errorType, message s
 //
 //	 2. requireOAuth is set to true, server is protected:
 //
-//	    2.1. Raw Token Validation (oidcProvider is nil):
+//	    2.1. Raw Token Validation (oidcProvider is nil, SkipJWTVerification is true):
+//	         - Requires skip_jwt_verification=true; otherwise the request is rejected with 500.
 //	         - The token is validated offline for basic sanity checks (expiration).
 //	         - If OAuthAudience is set, the token is validated against the audience.
+//	         - No cryptographic signature verification is performed.
 //
 //	         see TestAuthorizationRawToken
 //
@@ -51,6 +54,7 @@ func write401(w http.ResponseWriter, wwwAuthenticateHeader, errorType, message s
 //
 //	         see TestAuthorizationOidcToken
 func AuthorizationMiddleware(staticConfig *config.StaticConfig, oauthState *oauth.State) func(http.Handler) http.Handler {
+	var skipJWTWarningOnce sync.Once
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Skip auth for infrastructure endpoints (health, metrics) and well-known endpoints
@@ -101,7 +105,15 @@ func AuthorizationMiddleware(staticConfig *config.StaticConfig, oauthState *oaut
 						write401(w, wwwAuthenticateHeader, "temporarily_unavailable", "OIDC provider is not available")
 						return
 					}
-					// No provider configured — offline validation only
+					// No provider configured - require explicit opt-in via skip_jwt_verification
+					if !staticConfig.SkipJWTVerification {
+						klog.V(1).Infof("Authentication rejected - JWT verification not configured: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+						http.Error(w, "JWT verification not configured - set authorization_url or skip_jwt_verification", http.StatusInternalServerError)
+						return
+					}
+					skipJWTWarningOnce.Do(func() {
+						klog.Warningf("JWT accepted without signature verification - set authorization_url for secure validation")
+					})
 				} else {
 					err = claims.ValidateWithProvider(r.Context(), staticConfig.OAuthAudience, snapshot.OIDCProvider)
 				}

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -345,6 +345,7 @@ func (s *AuthorizationSuite) TestAuthorizationRequireOAuthFalse() {
 
 func (s *AuthorizationSuite) TestAuthorizationRawToken() {
 	s.MockServer.ResetHandlers()
+	s.StaticConfig.SkipJWTVerification = true
 
 	cases := []string{"", "mcp-server"}
 	for _, audience := range cases {
@@ -509,6 +510,94 @@ func (s *AuthorizationSuite) TestAuthorizationOidcTokenExchange() {
 			s.Require().NoError(s.WaitForShutdown())
 		})
 	}
+}
+
+func (s *AuthorizationSuite) TestAuthorizationOfflineOnlyWarning() {
+	// When require_oauth=true, skip_jwt_verification=true, and no OIDC provider
+	// is configured (offline-only mode), a warning log should be emitted once.
+	s.MockServer.ResetHandlers()
+	s.StaticConfig.OAuthAudience = "mcp-server"
+	s.StaticConfig.AuthorizationURL = ""
+	s.StaticConfig.SkipJWTVerification = true
+	s.logBuffer.Reset()
+	s.StartServer()
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + tokenBasicNotExpired,
+	})
+
+	s.Run("warning log emitted for offline-only JWT validation", func() {
+		s.Require().NotNil(s.mcpClient.Session, "Expected session for successful authentication")
+		s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initial request to not be nil")
+		s.Contains(s.logBuffer.String(), "JWT accepted without signature verification",
+			"Expected warning log for offline-only JWT validation")
+		s.Contains(s.logBuffer.String(), "set authorization_url for secure validation",
+			"Expected guidance to set authorization_url in warning")
+	})
+	s.mcpClient.Close()
+	s.mcpClient = nil
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
+}
+
+func (s *AuthorizationSuite) TestAuthorizationOfflineOnlyWarningOnce() {
+	// The warning should fire exactly once even with multiple requests.
+	s.MockServer.ResetHandlers()
+	s.StaticConfig.OAuthAudience = "mcp-server"
+	s.StaticConfig.AuthorizationURL = ""
+	s.StaticConfig.SkipJWTVerification = true
+	s.logBuffer.Reset()
+	s.StartServer()
+
+	// Send multiple HTTP requests
+	for i := 0; i < 3; i++ {
+		resp := s.HttpGet("Bearer " + tokenBasicNotExpired)
+		_ = resp.Body.Close()
+	}
+
+	s.Run("warning log appears exactly once", func() {
+		logs := s.logBuffer.String()
+		count := strings.Count(logs, "JWT accepted without signature verification")
+		s.Equal(1, count, "Expected warning to fire exactly once, got %d", count)
+	})
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
+}
+
+func (s *AuthorizationSuite) TestAuthorizationOfflineOnlyRejectedWithoutSkipFlag() {
+	// When require_oauth=true, skip_jwt_verification=false (default), and no OIDC
+	// provider is configured, requests should be rejected at runtime.
+	s.MockServer.ResetHandlers()
+	s.StaticConfig.OAuthAudience = "mcp-server"
+	s.StaticConfig.AuthorizationURL = ""
+	s.StaticConfig.SkipJWTVerification = false
+	s.logBuffer.Reset()
+	s.StartServer()
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + tokenBasicNotExpired,
+	})
+
+	s.Run("MCP session is rejected without skip_jwt_verification", func() {
+		s.Nil(s.mcpClient.Session, "Expected no session when skip_jwt_verification is false")
+	})
+
+	s.Run("HTTP request returns 500 Internal Server Error", func() {
+		resp := s.HttpGet("Bearer " + tokenBasicNotExpired)
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
+
+		s.Equal(http.StatusInternalServerError, resp.StatusCode, "Expected HTTP 500 for server misconfiguration")
+	})
+
+	s.Run("logs rejection", func() {
+		s.Contains(s.logBuffer.String(), "JWT verification not configured",
+			"Expected log entry for JWT verification not configured")
+	})
+
+	if s.mcpClient != nil {
+		s.mcpClient.Close()
+		s.mcpClient = nil
+	}
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
 }
 
 func (s *AuthorizationSuite) TestAuthorizationExemptEndpointsFromOAuth() {

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -78,6 +78,7 @@ const (
 	flagRequireOAuth         = "require-oauth"
 	flagOAuthAudience        = "oauth-audience"
 	flagAuthorizationURL     = "authorization-url"
+	flagSkipJWTVerification  = "skip-jwt-verification"
 	flagServerUrl            = "server-url"
 	flagCertificateAuthority = "certificate-authority"
 	flagDisableMultiCluster  = "disable-multi-cluster"
@@ -101,6 +102,7 @@ type MCPServerOptions struct {
 	RequireOAuth         bool
 	OAuthAudience        string
 	AuthorizationURL     string
+	SkipJWTVerification  bool
 	CertificateAuthority string
 	ServerURL            string
 	DisableMultiCluster  bool
@@ -163,6 +165,8 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	_ = cmd.Flags().MarkHidden(flagOAuthAudience)
 	cmd.Flags().StringVar(&o.AuthorizationURL, flagAuthorizationURL, o.AuthorizationURL, "OAuth authorization server URL for protected resource endpoint. If not provided, the Kubernetes API server host will be used. Only valid if require-oauth is enabled.")
 	_ = cmd.Flags().MarkHidden(flagAuthorizationURL)
+	cmd.Flags().BoolVar(&o.SkipJWTVerification, flagSkipJWTVerification, o.SkipJWTVerification, "Skip JWT cryptographic signature verification when require-oauth is enabled but no authorization-url is configured. Only use behind a trusted reverse proxy that verifies tokens.")
+	_ = cmd.Flags().MarkHidden(flagSkipJWTVerification)
 	cmd.Flags().StringVar(&o.ServerURL, flagServerUrl, o.ServerURL, "Server URL of this application. Optional. If set, this url will be served in protected resource metadata endpoint and tokens will be validated with this audience. If not set, expected audience is kubernetes-mcp-server. Only valid if require-oauth is enabled.")
 	_ = cmd.Flags().MarkHidden(flagServerUrl)
 	cmd.Flags().StringVar(&o.CertificateAuthority, flagCertificateAuthority, o.CertificateAuthority, "Certificate authority path to verify certificates. Optional. Only valid if require-oauth is enabled.")
@@ -233,6 +237,9 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 	if cmd.Flag(flagAuthorizationURL).Changed {
 		m.StaticConfig.AuthorizationURL = m.AuthorizationURL
+	}
+	if cmd.Flag(flagSkipJWTVerification).Changed {
+		m.StaticConfig.SkipJWTVerification = m.SkipJWTVerification
 	}
 	if cmd.Flag(flagServerUrl).Changed {
 		m.StaticConfig.ServerURL = m.ServerURL

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -234,6 +234,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
 		newConfig := config.Default()
 		newConfig.RequireOAuth = true
 		newConfig.RequireTLS = true
+		newConfig.AuthorizationURL = "https://example.com/auth"
 		newConfig.ServerURL = "http://example.com:8080"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 		err := server.ReloadConfiguration(newConfig)
@@ -313,6 +314,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 	s.Run("reload with non-existent certificate_authority is rejected", func() {
 		newConfig := config.Default()
 		newConfig.RequireOAuth = true
+		newConfig.AuthorizationURL = "https://example.com/auth"
 		newConfig.CertificateAuthority = "/nonexistent/path/ca.crt"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 		err := server.ReloadConfiguration(newConfig)
@@ -328,6 +330,27 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		err := server.ReloadConfiguration(newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "both --tls-cert and --tls-key must be provided together")
+	})
+
+	s.Run("reload with require_oauth without authorization_url and skip_jwt_verification=false is rejected", func() {
+		newConfig := config.Default()
+		newConfig.RequireOAuth = true
+		newConfig.AuthorizationURL = ""
+		newConfig.SkipJWTVerification = false
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_oauth is enabled but authorization_url is not configured")
+	})
+
+	s.Run("reload with require_oauth without authorization_url and skip_jwt_verification=true is accepted", func() {
+		newConfig := config.Default()
+		newConfig.RequireOAuth = true
+		newConfig.AuthorizationURL = ""
+		newConfig.SkipJWTVerification = true
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+		err := server.ReloadConfiguration(newConfig)
+		s.NoError(err)
 	})
 }
 


### PR DESCRIPTION
When `require_oauth=true` but `authorization_url` is not configured, the `AuthorizationMiddleware` silently falls through to offline-only JWT validation without cryptographic signature verification. This makes the insecure fallback explicit and opt-in.

- Add `SkipJWTVerification` field to `StaticConfig`
- Add `validateSkipJWTVerification()` that rejects `require_oauth=true` without `authorization_url` unless `skip_jwt_verification=true`
- Add runtime guard in middleware to reject requests when `skip_jwt_verification=false` and no OIDC provider is configured
- Add warning log (once per middleware instance) when JWT is accepted without signature verification
- Add (hidden) `--skip-jwt-verification` CLI flag
- Add config validation, middleware warning, and reload tests
- Fix existing tests that set `require_oauth=true` without `authorization_url`

Fixes: https://github.com/containers/kubernetes-mcp-server/issues/1079