### PR TITLE
fix(helm-charts): address HTTPRoute follow-ups from #1059

### DIFF
--- a/build/helm.mk
+++ b/build/helm.mk
@@ -10,6 +10,9 @@ HELM_CHART_NAME = kubernetes-mcp-server
 
 KUBECONFORM = $(shell pwd)/_output/tools/bin/kubeconform
 KUBECONFORM_VERSION ?= latest
+# CRD schemas from the datreeio catalog (e.g. gateway.networking.k8s.io/HTTPRoute); required so kubeconform
+# actually validates the HTTPRoute spec instead of silently skipping it under -ignore-missing-schemas.
+KUBECONFORM_SCHEMA_LOCATIONS = -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
 
 HELM_DOCS = $(shell pwd)/_output/tools/bin/helm-docs
 HELM_DOCS_VERSION ?= v1.14.2
@@ -59,16 +62,16 @@ kubeconform:
 .PHONY: helm-validate
 helm-validate: kubeconform ## Validate Helm chart manifests with kubeconform
 	@echo "Validating with default values..."
-	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) --set ingress.host=localhost | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) --set ingress.host=localhost | $(KUBECONFORM) -strict -summary -ignore-missing-schemas $(KUBECONFORM_SCHEMA_LOCATIONS)'
 	@echo ""
 	@echo "Validating with tpl-exercising values..."
-	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/tpl-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/tpl-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas $(KUBECONFORM_SCHEMA_LOCATIONS)'
 	@echo ""
 	@echo "Validating with configmap-numeric-test values..."
-	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/configmap-numeric-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/configmap-numeric-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas $(KUBECONFORM_SCHEMA_LOCATIONS)'
 	@echo ""
 	@echo "Validating with Gateway API HTTPRoute values..."
-	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/httproute-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/httproute-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas $(KUBECONFORM_SCHEMA_LOCATIONS)'
 	@echo ""
 	@echo "Testing ConfigMap numeric .0 cleanup..."
 	@output=$$(helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/configmap-numeric-test-values.yaml 2>&1); \

--- a/build/helm.mk
+++ b/build/helm.mk
@@ -10,9 +10,6 @@ HELM_CHART_NAME = kubernetes-mcp-server
 
 KUBECONFORM = $(shell pwd)/_output/tools/bin/kubeconform
 KUBECONFORM_VERSION ?= latest
-# CRD schemas from the datreeio catalog (e.g. gateway.networking.k8s.io/HTTPRoute); required so kubeconform
-# actually validates the HTTPRoute spec instead of silently skipping it under -ignore-missing-schemas.
-KUBECONFORM_SCHEMA_LOCATIONS = -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
 
 HELM_DOCS = $(shell pwd)/_output/tools/bin/helm-docs
 HELM_DOCS_VERSION ?= v1.14.2
@@ -62,16 +59,16 @@ kubeconform:
 .PHONY: helm-validate
 helm-validate: kubeconform ## Validate Helm chart manifests with kubeconform
 	@echo "Validating with default values..."
-	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) --set ingress.host=localhost | $(KUBECONFORM) -strict -summary -ignore-missing-schemas $(KUBECONFORM_SCHEMA_LOCATIONS)'
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) --set ingress.host=localhost | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
 	@echo ""
 	@echo "Validating with tpl-exercising values..."
-	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/tpl-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas $(KUBECONFORM_SCHEMA_LOCATIONS)'
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/tpl-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
 	@echo ""
 	@echo "Validating with configmap-numeric-test values..."
-	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/configmap-numeric-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas $(KUBECONFORM_SCHEMA_LOCATIONS)'
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/configmap-numeric-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
 	@echo ""
 	@echo "Validating with Gateway API HTTPRoute values..."
-	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/httproute-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas $(KUBECONFORM_SCHEMA_LOCATIONS)'
+	@bash -o pipefail -c 'helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/httproute-test-values.yaml | $(KUBECONFORM) -strict -summary -ignore-missing-schemas'
 	@echo ""
 	@echo "Testing ConfigMap numeric .0 cleanup..."
 	@output=$$(helm template test-release $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/ci/configmap-numeric-test-values.yaml 2>&1); \

--- a/charts/kubernetes-mcp-server/README.md
+++ b/charts/kubernetes-mcp-server/README.md
@@ -25,7 +25,7 @@ helm upgrade -i -n kubernetes-mcp-server --create-namespace kubernetes-mcp-serve
 
 ### Gateway API (HTTPRoute)
 
-If your platform uses [Gateway API](https://gateway.networking.k8s.io/) instead of classic Ingress, set `ingress.enabled` to `false` and enable `httpRoute` with `parentRefs`, `rules` (each rule must include `matches`; optional `filters` and `timeouts` are passed through), and optionally `hostnames`. The chart adds `backendRefs` pointing at the release `Service` and `service.port`. `parentRefs` and `hostnames` are rendered with `tpl` on their YAML so you can reference `Release` metadata in values.
+If your platform uses [Gateway API](https://gateway.networking.k8s.io/) instead of classic Ingress, set `ingress.enabled` to `false` and enable `httpRoute` with `parentRefs`, `rules` (optional `matches`, `filters`, and `timeouts` are passed through), and optionally `hostnames`. The chart adds `backendRefs` pointing at the release `Service` and `service.port`. `parentRefs` and `hostnames` are rendered with `tpl` on their YAML so you can reference `Release` metadata in values. `httpRoute.parentRefs` is required when `httpRoute.enabled=true`; leaving it empty fails at `helm template` / `helm install` time.
 
 ```yaml
 ingress:

--- a/charts/kubernetes-mcp-server/README.md.gotmpl
+++ b/charts/kubernetes-mcp-server/README.md.gotmpl
@@ -25,7 +25,7 @@ helm upgrade -i -n kubernetes-mcp-server --create-namespace kubernetes-mcp-serve
 
 ### Gateway API (HTTPRoute)
 
-If your platform uses [Gateway API](https://gateway.networking.k8s.io/) instead of classic Ingress, set `ingress.enabled` to `false` and enable `httpRoute` with `parentRefs`, `rules` (each rule must include `matches`; optional `filters` and `timeouts` are passed through), and optionally `hostnames`. The chart adds `backendRefs` pointing at the release `Service` and `service.port`. `parentRefs` and `hostnames` are rendered with `tpl` on their YAML so you can reference `Release` metadata in values.
+If your platform uses [Gateway API](https://gateway.networking.k8s.io/) instead of classic Ingress, set `ingress.enabled` to `false` and enable `httpRoute` with `parentRefs`, `rules` (optional `matches`, `filters`, and `timeouts` are passed through), and optionally `hostnames`. The chart adds `backendRefs` pointing at the release `Service` and `service.port`. `parentRefs` and `hostnames` are rendered with `tpl` on their YAML so you can reference `Release` metadata in values. `httpRoute.parentRefs` is required when `httpRoute.enabled=true`; leaving it empty fails at `helm template` / `helm install` time.
 
 ```yaml
 ingress:

--- a/charts/kubernetes-mcp-server/ci/httproute-test-values.yaml
+++ b/charts/kubernetes-mcp-server/ci/httproute-test-values.yaml
@@ -1,6 +1,7 @@
-# HTTPRoute alongside Ingress; tpl in parentRefs/hostnames via chart tpl(toYaml).
+# HTTPRoute in place of Ingress (matches the documented flow in README.md);
+# tpl in parentRefs/hostnames via chart tpl(toYaml); exercises rules with and without matches.
 ingress:
-  host: localhost
+  enabled: false
 
 httpRoute:
   enabled: true
@@ -16,4 +17,18 @@ httpRoute:
     - matches:
         - path:
             type: PathPrefix
-            value: /
+            value: /api
+      filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            add:
+              - name: X-Forwarded-Prefix
+                value: /api
+      timeouts:
+        request: 10s
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Route
+                value: catch-all

--- a/charts/kubernetes-mcp-server/templates/httproute.yaml
+++ b/charts/kubernetes-mcp-server/templates/httproute.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.httpRoute.enabled -}}
+{{- if empty .Values.httpRoute.parentRefs -}}
+{{- fail "httpRoute.parentRefs must be set when httpRoute.enabled=true" -}}
+{{- end -}}
 {{- $fullName := include "kubernetes-mcp-server.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: gateway.networking.k8s.io/v1
@@ -16,33 +19,31 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.httpRoute.parentRefs }}
   parentRefs:
-    {{- tpl (. | toYaml) $ | nindent 4 }}
-  {{- end }}
+    {{- tpl (.Values.httpRoute.parentRefs | toYaml) $ | nindent 4 }}
   {{- with .Values.httpRoute.hostnames }}
   hostnames:
     {{- tpl (. | toYaml) $ | nindent 4 }}
   {{- end }}
   rules:
     {{- range .Values.httpRoute.rules }}
-    {{- with .matches }}
-    - matches:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .filters }}
-      filters:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .timeouts }}
-      timeouts:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-      backendRefs:
+    - backendRefs:
         - group: ''
           kind: Service
           name: {{ $fullName }}
           port: {{ $servicePort }}
           weight: 1
+      {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/kubernetes-mcp-server/templates/httproute.yaml
+++ b/charts/kubernetes-mcp-server/templates/httproute.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.httpRoute.enabled -}}
 {{- if empty .Values.httpRoute.parentRefs -}}
-{{- fail "httpRoute.parentRefs must be set when httpRoute.enabled=true" -}}
+{{- fail "httpRoute.parentRefs is required when httpRoute.enabled=true (see charts/kubernetes-mcp-server/README.md#gateway-api-httproute)" -}}
 {{- end -}}
 {{- $fullName := include "kubernetes-mcp-server.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}


### PR DESCRIPTION
Follow-ups from the review of #1059 (tracked in #1080).

## Summary
- **Rule without `matches` now renders valid YAML** — the list-item dash was attached to the optional `matches` block, so a rule with only `filters` (or a catch-all rule) produced sibling keys instead of a new list item. Dash is now anchored on `backendRefs`, which is always rendered, with `matches` / `filters` / `timeouts` as conditional siblings.
- **Fast-fail when `httpRoute.enabled=true` and `parentRefs` is empty** — previously rendered an HTTPRoute without `parentRefs` that the API server rejected at apply time. Now fails at `helm template` / `helm install` time with a message that points at the chart README.
- **CI fixture matches the documented flow** — `ci/httproute-test-values.yaml` now sets `ingress.enabled: false` (the README's recommended Gateway API setup) and includes a filters-only rule to exercise the bugfix above.

The feature is opt-in and disabled by default, so none of these are user-facing regressions — this is cleanup on top of #1059.

## Not addressed: follow-up #4 (kubeconform Gateway API schema)

Item `#4` from #1080 asked to wire in a Gateway API CRD schema so kubeconform stops silently skipping HTTPRoute under `-ignore-missing-schemas`. An initial attempt pointed `-schema-location` at `raw.githubusercontent.com/datreeio/CRDs-catalog`, but that introduces a per-run network dependency on a third-party host, which doesn't fit air-gapped / offline CI. The alternatives considered (vendor the JSON schema in-repo, download-once-to-`_output/tools/` like `kubeconform` itself, `kubeconform -cache`) each have their own trade-offs and felt out of scope for this follow-up PR.

Closes #1080 partially (`#1` – `#3`)