### PR TITLE
fix(auth): restore default passthrough of Authorization header to cluster

### DIFF
--- a/docs/ENTRA_ID_SETUP.md
+++ b/docs/ENTRA_ID_SETUP.md
@@ -112,9 +112,10 @@ Replace:
 - `<CLIENT_ID>` with your Application (client) ID
 - `<TENANT_ID>` with your Directory (tenant) ID
 
-> **Note:** When `cluster_auth_mode` is not set, the server auto-detects:
-> - If `require_oauth = true` → uses `passthrough`
-> - Otherwise → uses `kubeconfig`
+> **Note:** When `cluster_auth_mode` is not set, the server defaults to `passthrough`:
+> the Authorization header is forwarded to the cluster when present, and kubeconfig
+> credentials are used when absent. Set `cluster_auth_mode = "kubeconfig"` to always
+> use kubeconfig credentials regardless of any Authorization header.
 >
 > In `passthrough` mode, if token exchange is configured (`token_exchange_strategy` or `sts_audience`), the token is exchanged before being passed to the cluster.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -478,7 +478,7 @@ Configure OAuth/OIDC authentication for HTTP mode deployments.
 | `sts_auth_style` | string | `"params"` | How client credentials are sent: `params` (body), `header` (Basic Auth), or `assertion` (JWT). |
 | `sts_client_cert_file` | string | `""` | Path to client certificate PEM file (for `assertion` auth style). |
 | `sts_client_key_file` | string | `""` | Path to client private key PEM file (for `assertion` auth style). |
-| `cluster_auth_mode` | string | `""` | Cluster auth mode: `passthrough` (use OAuth token) or `kubeconfig` (use kubeconfig credentials). |
+| `cluster_auth_mode` | string | `""` | Cluster auth mode: `passthrough` (forward Authorization header when present, fall back to kubeconfig when absent) or `kubeconfig` (always use kubeconfig credentials). Defaults to `passthrough`. |
 | `certificate_authority` | string | `""` | Path to CA certificate for validating authorization server connections. |
 | `server_url` | string | `""` | Public URL of the MCP server (used for OAuth metadata). |
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,8 +98,8 @@ type StaticConfig struct {
 	// StsClientKeyFile is the path to the client private key PEM file for JWT assertion auth
 	StsClientKeyFile string `toml:"sts_client_key_file,omitempty"`
 	// ClusterAuthMode determines how the MCP server authenticates to the cluster.
-	// Valid values: "passthrough" (use OAuth token, with optional exchange), "kubeconfig" (use kubeconfig credentials).
-	// If empty, auto-detects: passthrough when require_oauth=true, otherwise kubeconfig.
+	// Valid values: "passthrough" (forward Authorization header, with optional exchange), "kubeconfig" (use kubeconfig credentials).
+	// If empty, defaults to passthrough: forwards the token when present, falls back to kubeconfig when absent.
 	ClusterAuthMode      string `toml:"cluster_auth_mode,omitempty"`
 	CertificateAuthority string `toml:"certificate_authority,omitempty"`
 	ServerURL            string `toml:"server_url,omitempty"`
@@ -624,16 +624,14 @@ func (c *StaticConfig) GetClusterAuthMode() string {
 }
 
 // ResolveClusterAuthMode returns the effective cluster auth mode.
-// If explicitly set, returns that value. Otherwise auto-detects:
-// passthrough when require_oauth is true, kubeconfig otherwise.
+// If explicitly set, returns that value. Otherwise defaults to passthrough,
+// which forwards the Authorization header to the cluster when present
+// and falls back to kubeconfig credentials when absent.
 func (c *StaticConfig) ResolveClusterAuthMode() string {
 	if c.ClusterAuthMode != "" {
 		return c.ClusterAuthMode
 	}
-	if c.RequireOAuth {
-		return api.ClusterAuthPassthrough
-	}
-	return api.ClusterAuthKubeconfig
+	return api.ClusterAuthPassthrough
 }
 
 // ValidateClusterAuthMode validates cluster_auth_mode and its interaction with
@@ -643,14 +641,11 @@ func (c *StaticConfig) ValidateClusterAuthMode() error {
 		return fmt.Errorf("invalid cluster_auth_mode %q: must be %q or %q", c.ClusterAuthMode, api.ClusterAuthPassthrough, api.ClusterAuthKubeconfig)
 	}
 	hasTokenExchange := c.TokenExchangeStrategy != "" || c.StsAudience != ""
-	if c.ClusterAuthMode == api.ClusterAuthPassthrough && !c.RequireOAuth {
-		return fmt.Errorf("cluster_auth_mode %q requires require_oauth=true (no token to pass through without OAuth)", api.ClusterAuthPassthrough)
-	}
 	if c.ClusterAuthMode == api.ClusterAuthKubeconfig && hasTokenExchange {
 		return fmt.Errorf("token exchange settings (token_exchange_strategy/sts_audience) are incompatible with cluster_auth_mode %q (exchanged token would be unused)", api.ClusterAuthKubeconfig)
 	}
 	if !c.RequireOAuth && hasTokenExchange {
-		return fmt.Errorf("token exchange settings (token_exchange_strategy/sts_audience) require require_oauth=true (no token to exchange without OAuth)")
+		return fmt.Errorf("token exchange requires require_oauth=true (token exchange depends on OAuth-validated tokens)")
 	}
 	return nil
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -529,6 +529,31 @@ func (s *ValidateSuite) TestSkipJWTVerification() {
 	})
 }
 
+func (s *ValidateSuite) TestClusterAuthMode() {
+	s.Run("passthrough without require_oauth is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = false
+		cfg.ClusterAuthMode = api.ClusterAuthPassthrough
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("passthrough with require_oauth is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.SkipJWTVerification = true
+		cfg.ClusterAuthMode = api.ClusterAuthPassthrough
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("invalid cluster_auth_mode is rejected", func() {
+		cfg := s.validConfig()
+		cfg.ClusterAuthMode = "bogus"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid cluster_auth_mode")
+	})
+}
+
 func TestValidate(t *testing.T) {
 	suite.Run(t, new(ValidateSuite))
 }

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -68,6 +68,13 @@ func AuthorizationMiddleware(staticConfig *config.StaticConfig, oauthState *oaut
 				return
 			}
 			if !staticConfig.RequireOAuth {
+				// Always extract the Authorization header so it can be forwarded
+				// to the cluster, even without OAuth validation.
+				if authHeader := r.Header.Get("Authorization"); authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") {
+					ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -620,6 +620,51 @@ func (s *AuthorizationSuite) TestAuthorizationExemptEndpointsFromOAuth() {
 	}
 }
 
+func (s *AuthorizationSuite) TestAuthorizationRawPassthrough() {
+	// When require_oauth=false, the server should extract the Authorization header
+	// from the HTTP request and forward it to the Kubernetes backend without any
+	// JWT validation. This is the default behavior — no cluster_auth_mode needed.
+	s.MockServer.ResetHandlers()
+	rawK8sToken := "k8s-service-account-token-not-a-jwt"
+
+	var backendAuth atomic.Value
+	s.MockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			backendAuth.Store(auth)
+		}
+	}))
+
+	s.StaticConfig.RequireOAuth = false
+	s.StartServer()
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + rawK8sToken,
+	})
+
+	s.Run("Initialize succeeds without OAuth", func() {
+		s.Require().NotNil(s.mcpClient.Session, "Expected session for successful connection")
+		s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initial request to not be nil")
+	})
+	s.Run("Tool call forwards raw token to backend", func() {
+		toolResult, err := s.mcpClient.Session.CallTool(s.T().Context(), &mcp.CallToolParams{
+			Name:      "events_list",
+			Arguments: map[string]any{},
+		})
+		s.Require().NoError(err, "Expected no error calling tool")
+		s.Require().NotNil(toolResult, "Expected tool result to not be nil")
+	})
+	s.Run("Backend receives the raw token", func() {
+		got, _ := backendAuth.Load().(string)
+		s.Require().NotEmpty(got, "Expected backend to receive an Authorization header")
+		s.Equal("Bearer "+rawK8sToken, got,
+			"Backend must receive the original raw token passed in the Authorization header")
+	})
+
+	s.mcpClient.Close()
+	s.mcpClient = nil
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
+}
+
 func TestAuthorization(t *testing.T) {
 	suite.Run(t, new(AuthorizationSuite))
 }

--- a/pkg/kubernetes/kubernetes_derived_test.go
+++ b/pkg/kubernetes/kubernetes_derived_test.go
@@ -268,25 +268,23 @@ users:
 			require_oauth = true
 		`)))
 
-		s.Run("with no authorization header returns oauth token required error", func() {
+		s.Run("with no authorization header falls back to kubeconfig", func() {
 			testManager, err := NewKubeconfigManager(testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			derived, err := testManager.Derived(s.T().Context())
-			s.Require().Error(err, "expected error for missing oauth token, got nil")
-			s.ErrorContains(err, "oauth token required")
-			s.Nil(derived, "expected nil derived kubernetes when oauth token required")
+			s.Require().NoError(err)
+			s.Equal(derived, testManager.kubernetes, "expected original client when no token")
 		})
 
-		s.Run("with invalid authorization header returns oauth token required error", func() {
+		s.Run("with invalid authorization header falls back to kubeconfig", func() {
 			testManager, err := NewKubeconfigManager(testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			ctx := context.WithValue(s.T().Context(), HeaderKey("Authorization"), "invalid-token")
 			derived, err := testManager.Derived(ctx)
-			s.Require().Error(err, "expected error for invalid oauth token, got nil")
-			s.ErrorContains(err, "oauth token required")
-			s.Nil(derived, "expected nil derived kubernetes when oauth token required")
+			s.Require().NoError(err)
+			s.Equal(derived, testManager.kubernetes, "expected original client when invalid token")
 		})
 
 		s.Run("with valid bearer token creates derived kubernetes", func() {

--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -167,13 +167,11 @@ func (m *Manager) Derived(ctx context.Context) (*Kubernetes, error) {
 	authorization, ok := ctx.Value(OAuthAuthorizationHeader).(string)
 	hasToken := ok && strings.HasPrefix(authorization, "Bearer ")
 
-	// No token: use kubeconfig credentials, or reject if passthrough requires one.
+	// No token: fall back to kubeconfig credentials.
 	// In kubeconfig mode, the token exchange layer clears the auth header before we get here,
 	// so this branch handles both "no token sent" and "kubeconfig mode cleared it".
 	if !hasToken {
-		if m.config.ResolveClusterAuthMode() == api.ClusterAuthPassthrough {
-			return nil, errors.New("oauth token required for passthrough auth mode")
-		}
+		klog.V(5).Infof("No bearer token in context, falling back to kubeconfig credentials")
 		return m.kubernetes, nil
 	}
 

--- a/pkg/kubernetes/token_exchange_test.go
+++ b/pkg/kubernetes/token_exchange_test.go
@@ -14,22 +14,20 @@ type TokenExchangeRoutingSuite struct {
 }
 
 func (s *TokenExchangeRoutingSuite) TestResolveClusterAuthMode() {
-	s.Run("returns passthrough when OAuth is required", func() {
+	s.Run("defaults to passthrough", func() {
+		cfg := config.Default()
+		s.Equal(api.ClusterAuthPassthrough, cfg.ResolveClusterAuthMode())
+	})
+
+	s.Run("defaults to passthrough regardless of require_oauth", func() {
 		cfg := config.Default()
 		cfg.RequireOAuth = true
 		s.Equal(api.ClusterAuthPassthrough, cfg.ResolveClusterAuthMode())
 	})
 
-	s.Run("returns kubeconfig when OAuth is not required", func() {
-		cfg := config.Default()
-		cfg.RequireOAuth = false
-		s.Equal(api.ClusterAuthKubeconfig, cfg.ResolveClusterAuthMode())
-	})
-
-	s.Run("returns explicit mode when set", func() {
+	s.Run("returns explicit kubeconfig when set", func() {
 		cfg := config.Default()
 		cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
-		cfg.RequireOAuth = true
 		s.Equal(api.ClusterAuthKubeconfig, cfg.ResolveClusterAuthMode())
 	})
 }
@@ -59,22 +57,8 @@ func (s *TokenExchangeRoutingSuite) TestStsExchangeTokenInContextRouting() {
 		s.Equal("Bearer original-token", auth)
 	})
 
-	s.Run("auto-detect defaults to kubeconfig when OAuth not required", func() {
+	s.Run("auto-detect defaults to passthrough", func() {
 		cfg := config.Default()
-		cfg.RequireOAuth = false
-		cfg.ClusterAuthMode = "" // auto-detect
-
-		ctx := context.Background()
-		result, err := stsExchangeTokenInContext(ctx, cfg, nil, nil, "original-token", nil)
-		s.Require().NoError(err)
-
-		auth, _ := result.Value(OAuthAuthorizationHeader).(string)
-		s.Equal("", auth)
-	})
-
-	s.Run("auto-detect defaults to passthrough when OAuth required", func() {
-		cfg := config.Default()
-		cfg.RequireOAuth = true
 		cfg.ClusterAuthMode = "" // auto-detect
 
 		ctx := context.Background()


### PR DESCRIPTION
This PR restores the v0.0.60 auth-forwarding behavior that regressed after the Entra ID / OBO work (#953). The Authorization header is always forwarded to the cluster when present and kubeconfig credentials are used as fallback when absent. `require_oauth` controls only whether the token is mandatory and validated, not whether it is forwarded.

 - **Default behavior**: The server forwards the Authorization header to the Kubernetes cluster when present, and uses kubeconfig credentials when absent. No configuration is needed for this.

 - **`require_oauth = true`**: Makes the Authorization header mandatory and validates the token (expiry, audience, and optionally OIDC signature verification if `authorization_url` is set). Requests without a valid token are rejected.

 - **`cluster_auth_mode = "kubeconfig"`**: Forces the server to always use kubeconfig credentials, ignoring any Authorization header. Use this when cluster authentication is managed separately (e.g., via a ServiceAccount).

### Notes beyond strict v0.0.60 restoration

- The HTTP authorization middleware now also extracts the `Authorization: Bearer …` header into the request context when `require_oauth=false`. v0.0.60 did not do this in the HTTP layer — it relied solely on the MCP middleware, which left SSE clients + raw tokens broken (SSE transport does not propagate headers via `req.GetExtra().Header`). This addition is small, additive hardening that makes raw-token forwarding work for SSE clients as well, consistent with the existing `require_oauth=true` handling of the same transport gap.

- `Manager.Derived()` no longer returns the `"oauth token required"` error when invoked with no Bearer token in context under `require_oauth=true`; it falls back to kubeconfig instead. In the HTTP flow this path is unreachable (the authorization middleware already returns 401 first), so dependents are unaffected. Restoring this defense-in-depth guard and broadening integration coverage is tracked as a follow-up.