### PR TITLE
fix(auth): restore Derived() require_oauth guard and broaden raw-token coverage

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -84,6 +84,11 @@ type RequireTLSProvider interface {
 	IsRequireTLS() bool
 }
 
+// RequireOAuthProvider provides access to require_oauth setting.
+type RequireOAuthProvider interface {
+	IsRequireOAuth() bool
+}
+
 type BaseConfig interface {
 	ClusterAuthProvider
 	ClusterProvider
@@ -93,4 +98,5 @@ type BaseConfig interface {
 	StsConfigProvider
 	ValidationEnabledProvider
 	RequireTLSProvider
+	RequireOAuthProvider
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -440,6 +440,10 @@ func (c *StaticConfig) IsRequireTLS() bool {
 	return c.RequireTLS
 }
 
+func (c *StaticConfig) IsRequireOAuth() bool {
+	return c.RequireOAuth
+}
+
 // WithProviderStrategies sets the known cluster-provider strategies for
 // validation. Callers that have access to the provider registry should chain
 // this before Validate so that cluster_provider_strategy is checked:

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -552,6 +552,24 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid cluster_auth_mode")
 	})
+
+	s.Run("token_exchange_strategy without require_oauth is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = false
+		cfg.TokenExchangeStrategy = "rfc8693"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "token exchange requires require_oauth=true")
+	})
+
+	s.Run("sts_audience without require_oauth is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = false
+		cfg.StsAudience = "backend-audience"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "token exchange requires require_oauth=true")
+	})
 }
 
 func TestValidate(t *testing.T) {

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/klog/v2/textlogger"
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
 )
 
 // bearerRoundTripper adds a static Authorization: Bearer header to every
@@ -620,10 +621,11 @@ func (s *AuthorizationSuite) TestAuthorizationExemptEndpointsFromOAuth() {
 	}
 }
 
-func (s *AuthorizationSuite) TestAuthorizationRawPassthrough() {
-	// When require_oauth=false, the server should extract the Authorization header
-	// from the HTTP request and forward it to the Kubernetes backend without any
-	// JWT validation. This is the default behavior — no cluster_auth_mode needed.
+// TestAuthorizationRawPassthroughStreamableHTTP verifies that when
+// require_oauth=false the server forwards the client's Authorization header
+// verbatim to the Kubernetes backend over the StreamableHTTP transport, which
+// propagates the bearer via request headers directly.
+func (s *AuthorizationSuite) TestAuthorizationRawPassthroughStreamableHTTP() {
 	s.MockServer.ResetHandlers()
 	rawK8sToken := "k8s-service-account-token-not-a-jwt"
 
@@ -657,6 +659,108 @@ func (s *AuthorizationSuite) TestAuthorizationRawPassthrough() {
 		s.Require().NotEmpty(got, "Expected backend to receive an Authorization header")
 		s.Equal("Bearer "+rawK8sToken, got,
 			"Backend must receive the original raw token passed in the Authorization header")
+	})
+
+	s.mcpClient.Close()
+	s.mcpClient = nil
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
+}
+
+// TestAuthorizationRawPassthroughSSE is the SSE counterpart to
+// TestAuthorizationRawPassthroughStreamableHTTP. SSE does not propagate HTTP
+// headers into the MCP RequestExtra, so the Authorization header must be
+// extracted by AuthorizationMiddleware (even in the require_oauth=false branch)
+// and bridged into the MCP context via authHeaderPropagationMiddleware.
+// SSE coverage: https://github.com/containers/kubernetes-mcp-server/issues/1043
+func (s *AuthorizationSuite) TestAuthorizationRawPassthroughSSE() {
+	s.MockServer.ResetHandlers()
+	rawK8sToken := "k8s-service-account-token-not-a-jwt"
+
+	var backendAuth atomic.Value
+	s.MockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			backendAuth.Store(auth)
+		}
+	}))
+
+	s.StaticConfig.RequireOAuth = false
+	s.StartServer()
+
+	httpClient := &http.Client{
+		Transport: &bearerRoundTripper{token: rawK8sToken, base: http.DefaultTransport},
+	}
+	sseClient := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1.33.7"}, nil)
+	transport := &mcp.SSEClientTransport{
+		Endpoint:   fmt.Sprintf("http://127.0.0.1:%s/sse", s.StaticConfig.Port),
+		HTTPClient: httpClient,
+	}
+	session, err := sseClient.Connect(s.T().Context(), transport, nil)
+	s.Require().NoError(err, "Expected no error connecting SSE MCP client")
+
+	s.Run("Initialize succeeds without OAuth", func() {
+		s.Require().NotNil(session.InitializeResult(), "Expected initial request to not be nil")
+	})
+	s.Run("Tool call forwards raw token to backend", func() {
+		toolResult, err := session.CallTool(s.T().Context(), &mcp.CallToolParams{
+			Name:      "events_list",
+			Arguments: map[string]any{},
+		})
+		s.Require().NoError(err, "Expected no error calling tool")
+		s.Require().NotNil(toolResult, "Expected tool result to not be nil")
+	})
+	s.Run("Backend receives the raw token", func() {
+		got, _ := backendAuth.Load().(string)
+		s.Require().NotEmpty(got, "Expected backend to receive an Authorization header")
+		s.Equal("Bearer "+rawK8sToken, got,
+			"Backend must receive the original raw token passed in the Authorization header")
+	})
+
+	s.Require().NoError(session.Close(), "Expected SSE session to close cleanly")
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
+}
+
+// TestAuthorizationClusterAuthModeKubeconfigDropsClientToken verifies that
+// when an operator explicitly opts into cluster_auth_mode="kubeconfig", a
+// client-sent Authorization header is cleared before the request reaches the
+// backend — so the backend authenticates as the kubeconfig principal, not the
+// client. This locks in the stsExchangeTokenInContext clear behavior at the
+// HTTP level (previously only covered by unit tests).
+func (s *AuthorizationSuite) TestAuthorizationClusterAuthModeKubeconfigDropsClientToken() {
+	s.MockServer.ResetHandlers()
+	clientToken := "client-sent-token-must-not-reach-backend"
+
+	var backendAuth atomic.Value
+	s.MockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Store every request's Authorization header (including empty) so we
+		// can assert the client token is never forwarded.
+		backendAuth.Store(r.Header.Get("Authorization"))
+	}))
+
+	s.StaticConfig.RequireOAuth = false
+	s.StaticConfig.ClusterAuthMode = api.ClusterAuthKubeconfig
+	s.StartServer()
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + clientToken,
+	})
+
+	s.Run("Initialize succeeds", func() {
+		s.Require().NotNil(s.mcpClient.Session, "Expected session for successful connection")
+		s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initial request to not be nil")
+	})
+	s.Run("Tool call succeeds via kubeconfig credentials", func() {
+		toolResult, err := s.mcpClient.Session.CallTool(s.T().Context(), &mcp.CallToolParams{
+			Name:      "events_list",
+			Arguments: map[string]any{},
+		})
+		s.Require().NoError(err, "Expected no error calling tool")
+		s.Require().NotNil(toolResult, "Expected tool result to not be nil")
+	})
+	s.Run("Backend does not receive the client-sent Authorization header", func() {
+		got, _ := backendAuth.Load().(string)
+		s.NotEqual("Bearer "+clientToken, got,
+			"Backend must not receive the client-sent token when cluster_auth_mode=kubeconfig")
 	})
 
 	s.mcpClient.Close()

--- a/pkg/kubernetes/kubernetes_derived_test.go
+++ b/pkg/kubernetes/kubernetes_derived_test.go
@@ -268,23 +268,25 @@ users:
 			require_oauth = true
 		`)))
 
-		s.Run("with no authorization header falls back to kubeconfig", func() {
+		s.Run("with no authorization header returns error", func() {
 			testManager, err := NewKubeconfigManager(testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			derived, err := testManager.Derived(s.T().Context())
-			s.Require().NoError(err)
-			s.Equal(derived, testManager.kubernetes, "expected original client when no token")
+			s.Require().Error(err, "expected error when no token and RequireOAuth=true")
+			s.ErrorContains(err, "oauth token required")
+			s.Nil(derived, "expected nil derived kubernetes when no token and RequireOAuth=true")
 		})
 
-		s.Run("with invalid authorization header falls back to kubeconfig", func() {
+		s.Run("with invalid authorization header returns error", func() {
 			testManager, err := NewKubeconfigManager(testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			ctx := context.WithValue(s.T().Context(), HeaderKey("Authorization"), "invalid-token")
 			derived, err := testManager.Derived(ctx)
-			s.Require().NoError(err)
-			s.Equal(derived, testManager.kubernetes, "expected original client when invalid token")
+			s.Require().Error(err, "expected error when invalid token and RequireOAuth=true")
+			s.ErrorContains(err, "oauth token required")
+			s.Nil(derived, "expected nil derived kubernetes when invalid token and RequireOAuth=true")
 		})
 
 		s.Run("with valid bearer token creates derived kubernetes", func() {

--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -167,10 +167,16 @@ func (m *Manager) Derived(ctx context.Context) (*Kubernetes, error) {
 	authorization, ok := ctx.Value(OAuthAuthorizationHeader).(string)
 	hasToken := ok && strings.HasPrefix(authorization, "Bearer ")
 
-	// No token: fall back to kubeconfig credentials.
+	// No token: fall back to kubeconfig credentials, unless require_oauth=true.
 	// In kubeconfig mode, the token exchange layer clears the auth header before we get here,
 	// so this branch handles both "no token sent" and "kubeconfig mode cleared it".
+	// The require_oauth guard is defense-in-depth: the HTTP middleware already rejects
+	// token-less requests with 401, but this protects STDIO / internal paths and
+	// preserves the operator contract that require_oauth=true never falls through to kubeconfig.
 	if !hasToken {
+		if m.config.IsRequireOAuth() {
+			return nil, errors.New("oauth token required")
+		}
 		klog.V(5).Infof("No bearer token in context, falling back to kubeconfig credentials")
 		return m.kubernetes, nil
 	}


### PR DESCRIPTION
## Summary

Follow-up to #1084, closing #1087.

- Restore the `"oauth token required"` guard in `Manager.Derived()` for `require_oauth=true`, as defense-in-depth for STDIO / internal paths; HTTP middleware already rejects token-less requests with 401.
- Add an **SSE** counterpart to `TestAuthorizationRawPassthrough` — the raw-token-to-backend path on SSE is new relative to v0.0.60 and wasn't covered end-to-end.
- Add `TestAuthorizationClusterAuthModeKubeconfigDropsClientToken` to lock in the `stsExchangeTokenInContext` clear behavior at the HTTP level.
- Add `TestClusterAuthMode` assertions for the reworded `"token exchange requires require_oauth=true"` error, covering both `token_exchange_strategy` and `sts_audience` as triggers.
- Revert the two kubeconfig-derived test flips from #1084 back to asserting the error.

### API-surface note

Adds `IsRequireOAuth()` to the `BaseConfig` interface via a new `RequireOAuthProvider`. In-tree, only `*StaticConfig` satisfies `BaseConfig` (`RequireOAuth` already exists on it), so the new method is a trivial shim. Any out-of-tree `BaseConfig` implementer would need to add the method — mild, worth flagging.

## Test plan

- [x] `make test` passes (including new cases under `TestDerived`, `TestValidate/TestClusterAuthMode`, `TestAuthorization/TestAuthorizationRawPassthroughSSE`, and `TestAuthorization/TestAuthorizationClusterAuthModeKubeconfigDropsClientToken`).
- [x] `make lint` clean.
- [x] `TestAuthorization/TestAuthorizationRawPassthroughStreamableHTTP` still passes after splitting from the merged dual-transport test.
- [x] `TestDerived` `require_oauth=true` no-token / invalid-token cases now assert `"oauth token required"` rather than fallback.

## Related

- #1084 — primary fix
- #1087 — follow-up issue tracking these items
- #953 — Entra ID / OBO (regression source)
- #1078 — `skip_jwt_verification` (orthogonal, unchanged)