### PR TITLE
feat(api): add MCP resource

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,8 +318,13 @@ The `docs/specs/` directory contains feature specifications (living documentatio
 ### Documentation conventions
 
 - Use **lowercase filenames** for new documentation files (e.g., `configuration.md`, `prompts.md`)
-- The toolsets table in `README.md` and `docs/configuration.md` is **auto-generated** - use `make update-readme-tools` to update it
-- Both files use markers (`<!-- AVAILABLE-TOOLSETS-START -->` / `<!-- AVAILABLE-TOOLSETS-END -->`) for the generated content
+- The toolsets table, tools, prompts, resources, and resource templates in `README.md` and `docs/configuration.md` are **auto-generated** - use `make update-readme-tools` to update them after modifying toolsets
+- Both files use marker pairs for the generated content:
+  - `<!-- AVAILABLE-TOOLSETS-START -->` / `<!-- AVAILABLE-TOOLSETS-END -->` (toolset summary table)
+  - `<!-- AVAILABLE-TOOLSETS-TOOLS-START -->` / `<!-- AVAILABLE-TOOLSETS-TOOLS-END -->` (tool details)
+  - `<!-- AVAILABLE-TOOLSETS-PROMPTS-START -->` / `<!-- AVAILABLE-TOOLSETS-PROMPTS-END -->` (prompt details)
+  - `<!-- AVAILABLE-TOOLSETS-RESOURCES-START -->` / `<!-- AVAILABLE-TOOLSETS-RESOURCES-END -->` (resource details)
+  - `<!-- AVAILABLE-TOOLSETS-RESOURCES-TEMPLATES-START -->` / `<!-- AVAILABLE-TOOLSETS-RESOURCES-TEMPLATES-END -->` (resource template details)
 
 ## Distribution Methods
 

--- a/README.md
+++ b/README.md
@@ -597,6 +597,20 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 <!-- AVAILABLE-TOOLSETS-PROMPTS-END -->
 
+### Resources
+
+<!-- AVAILABLE-TOOLSETS-RESOURCES-START -->
+
+
+<!-- AVAILABLE-TOOLSETS-RESOURCES-END -->
+
+### Resource Templates
+
+<!-- AVAILABLE-TOOLSETS-RESOURCES-TEMPLATES-START -->
+
+
+<!-- AVAILABLE-TOOLSETS-RESOURCES-TEMPLATES-END -->
+
 ## Helm Chart
 
 A [Helm Chart](https://helm.sh) is available to simplify the deployment of the Kubernetes MCP server.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -311,6 +311,20 @@ Toolsets group related tools together. Enable only the toolsets you need to redu
 toolsets = ["core", "config", "helm", "kubevirt"]
 ```
 
+**Available Resources:**
+
+<!-- AVAILABLE-TOOLSETS-RESOURCES-START -->
+
+
+<!-- AVAILABLE-TOOLSETS-RESOURCES-END -->
+
+**Available Resource Templates:**
+
+<!-- AVAILABLE-TOOLSETS-RESOURCES-TEMPLATES-START -->
+
+
+<!-- AVAILABLE-TOOLSETS-RESOURCES-TEMPLATES-END -->
+
 ### Tool Filtering
 
 Fine-grained control over individual tools within enabled toolsets.

--- a/internal/test/mcp.go
+++ b/internal/test/mcp.go
@@ -327,6 +327,21 @@ func (m *McpClient) ListPrompts() (*mcp.ListPromptsResult, error) {
 	return m.Session.ListPrompts(m.ctx, &mcp.ListPromptsParams{})
 }
 
+// ListResources helper function to list available resources
+func (m *McpClient) ListResources() (*mcp.ListResourcesResult, error) {
+	return m.Session.ListResources(m.ctx, &mcp.ListResourcesParams{})
+}
+
+// ReadResource helper function to read a resource by URI
+func (m *McpClient) ReadResource(uri string) (*mcp.ReadResourceResult, error) {
+	return m.Session.ReadResource(m.ctx, &mcp.ReadResourceParams{URI: uri})
+}
+
+// ListResourceTemplates helper function to list available resource templates
+func (m *McpClient) ListResourceTemplates() (*mcp.ListResourceTemplatesResult, error) {
+	return m.Session.ListResourceTemplates(m.ctx, &mcp.ListResourceTemplatesParams{})
+}
+
 // GetPrompt helper function to get a prompt by name
 func (m *McpClient) GetPrompt(name string, arguments map[string]string) (*mcp.GetPromptResult, error) {
 	return m.Session.GetPrompt(m.ctx, &mcp.GetPromptParams{

--- a/internal/tools/update-readme/main.go
+++ b/internal/tools/update-readme/main.go
@@ -135,6 +135,50 @@ func main() {
 		toolsetPrompts.String(),
 	)
 
+	// Available Toolset Resources
+	toolsetResources := strings.Builder{}
+	for _, toolset := range toolsetsList {
+		resources := toolset.GetResources()
+		if len(resources) == 0 {
+			continue
+		}
+		toolsetResources.WriteString("<details>\n\n<summary>" + toolset.GetName() + "</summary>\n\n")
+		for _, resource := range resources {
+			fmt.Fprintf(&toolsetResources, "- **%s** - %s\n", resource.Resource.Name, resource.Resource.Description)
+			fmt.Fprintf(&toolsetResources, "  - URI: `%s`\n", resource.Resource.URI)
+			fmt.Fprintf(&toolsetResources, "  - MIME Type: `%s`\n", resource.Resource.MIMEType)
+		}
+		toolsetResources.WriteString("</details>\n\n")
+	}
+	updated = replaceBetweenMarkers(
+		updated,
+		"<!-- AVAILABLE-TOOLSETS-RESOURCES-START -->",
+		"<!-- AVAILABLE-TOOLSETS-RESOURCES-END -->",
+		toolsetResources.String(),
+	)
+
+	// Available Toolset Resource Templates
+	toolsetResourceTemplates := strings.Builder{}
+	for _, toolset := range toolsetsList {
+		templates := toolset.GetResourceTemplates()
+		if len(templates) == 0 {
+			continue
+		}
+		toolsetResourceTemplates.WriteString("<details>\n\n<summary>" + toolset.GetName() + "</summary>\n\n")
+		for _, template := range templates {
+			fmt.Fprintf(&toolsetResourceTemplates, "- **%s** - %s\n", template.ResourceTemplate.Name, template.ResourceTemplate.Description)
+			fmt.Fprintf(&toolsetResourceTemplates, "  - URI Template: `%s`\n", template.ResourceTemplate.URITemplate)
+			fmt.Fprintf(&toolsetResourceTemplates, "  - MIME Type: `%s`\n", template.ResourceTemplate.MIMEType)
+		}
+		toolsetResourceTemplates.WriteString("</details>\n\n")
+	}
+	updated = replaceBetweenMarkers(
+		updated,
+		"<!-- AVAILABLE-TOOLSETS-RESOURCES-TEMPLATES-START -->",
+		"<!-- AVAILABLE-TOOLSETS-RESOURCES-TEMPLATES-END -->",
+		toolsetResourceTemplates.String(),
+	)
+
 	if err := os.WriteFile(localReadmePath, []byte(updated), 0o644); err != nil {
 		panic(err)
 	}

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -47,6 +47,12 @@ type Toolset interface {
 	// GetPrompts returns the prompts provided by this toolset.
 	// Returns nil if the toolset doesn't provide any prompts.
 	GetPrompts() []ServerPrompt
+	// GetResources returns the resources provided by this toolset.
+	// Returns nil if the toolset doesn't provide any resources.
+	GetResources() []ServerResource
+	// GetResourceTemplates returns the resource templates provided by this toolset.
+	// Returns nil if the toolset doesn't provide any resource templates.
+	GetResourceTemplates() []ServerResourceTemplate
 }
 
 type ToolCallRequest interface {
@@ -101,6 +107,40 @@ func NewToolCallResultStructured(structured any, err error) *ToolCallResult {
 		}
 	}
 	return NewToolCallResultFull(content, structured, err)
+}
+
+// Resource represents the metadata of an MCP resource.
+type Resource struct {
+	URI         string
+	Name        string
+	Description string
+	MIMEType    string
+}
+
+// ResourceHandler is called when a client reads a resource.
+type ResourceHandler func(ctx context.Context) (content string, err error)
+
+// ServerResource represents a resource that can be registered with the MCP server.
+type ServerResource struct {
+	Resource Resource
+	Handler  ResourceHandler
+}
+
+// ResourceTemplate represents the metadata of an MCP resource template.
+type ResourceTemplate struct {
+	URITemplate string
+	Name        string
+	Description string
+	MIMEType    string
+}
+
+// ResourceTemplateHandler is called when a client reads a resource matching a template.
+type ResourceTemplateHandler func(ctx context.Context, uri string) (content string, err error)
+
+// ServerResourceTemplate represents a resource template that can be registered with the MCP server.
+type ServerResourceTemplate struct {
+	ResourceTemplate ResourceTemplate
+	Handler          ResourceTemplateHandler
 }
 
 type ToolHandlerParams struct {

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -117,8 +117,21 @@ type Resource struct {
 	MIMEType    string
 }
 
+// ResourceContent is the value returned by a resource handler.
+// Exactly one of Text or Blob must be set; both cannot be nil or both non-nil.
+type ResourceContent struct {
+	// MIMEType overrides Resource.MIMEType when set; otherwise Resource.MIMEType is used.
+	MIMEType string
+	// Text is the UTF-8 text content of the resource.
+	Text string
+	// Blob is the binary content of the resource.
+	Blob []byte
+}
+
 // ResourceHandler is called when a client reads a resource.
-type ResourceHandler func(ctx context.Context) (content string, err error)
+// Session state (auth, request context) is available on ctx via sessionInjectionMiddleware.
+// Handlers should return a ResourceContent with exactly one of Text or Blob set.
+type ResourceHandler func(ctx context.Context) (*ResourceContent, error)
 
 // ServerResource represents a resource that can be registered with the MCP server.
 type ServerResource struct {
@@ -135,7 +148,10 @@ type ResourceTemplate struct {
 }
 
 // ResourceTemplateHandler is called when a client reads a resource matching a template.
-type ResourceTemplateHandler func(ctx context.Context, uri string) (content string, err error)
+// Session state (auth, request context) is available on ctx via sessionInjectionMiddleware.
+// The uri parameter is the actual resource URI that matches the template.
+// Handlers should return a ResourceContent with exactly one of Text or Blob set.
+type ResourceTemplateHandler func(ctx context.Context, uri string) (*ResourceContent, error)
 
 // ServerResourceTemplate represents a resource template that can be registered with the MCP server.
 type ServerResourceTemplate struct {

--- a/pkg/mcp/elicit_test.go
+++ b/pkg/mcp/elicit_test.go
@@ -281,6 +281,14 @@ func (m *mockElicitToolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (m *mockElicitToolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (m *mockElicitToolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
 func TestElicitationSuite(t *testing.T) {
 	suite.Run(t, new(ElicitationSuite))
 }

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -65,15 +65,17 @@ func (c *Configuration) isToolApplicable(tool api.ServerTool) bool {
 }
 
 type Server struct {
-	mu             sync.RWMutex
-	configuration  *Configuration
-	server         *mcp.Server
-	enabledTools   []string
-	enabledPrompts []string
-	p              internalk8s.Provider
-	metrics        *metrics.Metrics // Metrics collection system
-	rateLimitDone  chan struct{}    // Closed to stop the rate limiter reaper goroutine
-	closeOnce      sync.Once
+	mu                       sync.RWMutex
+	configuration            *Configuration
+	server                   *mcp.Server
+	enabledTools             []string
+	enabledPrompts           []string
+	enabledResources         []string
+	enabledResourceTemplates []string
+	p                        internalk8s.Provider
+	metrics                  *metrics.Metrics // Metrics collection system
+	rateLimitDone            chan struct{}    // Closed to stop the rate limiter reaper goroutine
+	closeOnce                sync.Once
 }
 
 func NewServer(configuration Configuration, targetProvider internalk8s.Provider) (*Server, error) {
@@ -88,7 +90,7 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 			},
 			&mcp.ServerOptions{
 				Capabilities: &mcp.ServerCapabilities{
-					Resources: nil,
+					Resources: &mcp.ResourceCapabilities{ListChanged: !configuration.Stateless},
 					Prompts:   &mcp.PromptCapabilities{ListChanged: !configuration.Stateless},
 					Tools:     &mcp.ToolCapabilities{ListChanged: !configuration.Stateless},
 					Logging:   &mcp.LoggingCapabilities{},
@@ -147,11 +149,15 @@ func (s *Server) reloadToolsets() error {
 	// Collect applicable items
 	applicableTools := s.collectApplicableTools()
 	applicablePrompts := s.collectApplicablePrompts()
+	applicableResources := s.collectApplicableResources()
+	applicableResourceTemplates := s.collectApplicableResourceTemplates()
 
 	// Read the previous state with read lock - don't hold lock while calling external code
 	s.mu.RLock()
 	previousTools := s.enabledTools
 	previousPrompts := s.enabledPrompts
+	previousResources := s.enabledResources
+	previousResourceTemplates := s.enabledResourceTemplates
 	s.mu.RUnlock()
 
 	// Reload tools (calls s.server.AddTool/RemoveTools - external code, no lock held)
@@ -178,10 +184,36 @@ func (s *Server) reloadToolsets() error {
 		return err
 	}
 
+	// Reload resources
+	newResources, err := reloadItems(
+		previousResources,
+		applicableResources,
+		func(r api.ServerResource) string { return r.Resource.URI },
+		s.server.RemoveResources,
+		s.registerResource,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Reload resource templates
+	newResourceTemplates, err := reloadItems(
+		previousResourceTemplates,
+		applicableResourceTemplates,
+		func(rt api.ServerResourceTemplate) string { return rt.ResourceTemplate.URITemplate },
+		s.server.RemoveResourceTemplates,
+		s.registerResourceTemplate,
+	)
+	if err != nil {
+		return err
+	}
+
 	// Only hold write lock for the final assignment
 	s.mu.Lock()
 	s.enabledTools = newTools
 	s.enabledPrompts = newPrompts
+	s.enabledResources = newResources
+	s.enabledResourceTemplates = newResourceTemplates
 	s.mu.Unlock()
 
 	// Start new watch
@@ -282,6 +314,36 @@ func (s *Server) registerPrompt(prompt api.ServerPrompt) error {
 	return nil
 }
 
+// collectApplicableResources returns resources from all enabled toolsets
+func (s *Server) collectApplicableResources() []api.ServerResource {
+	resources := make([]api.ServerResource, 0)
+	for _, toolset := range s.configuration.Toolsets() {
+		resources = append(resources, toolset.GetResources()...)
+	}
+	return resources
+}
+
+// collectApplicableResourceTemplates returns resource templates from all enabled toolsets
+func (s *Server) collectApplicableResourceTemplates() []api.ServerResourceTemplate {
+	templates := make([]api.ServerResourceTemplate, 0)
+	for _, toolset := range s.configuration.Toolsets() {
+		templates = append(templates, toolset.GetResourceTemplates()...)
+	}
+	return templates
+}
+
+// registerResource registers a resource with the MCP server
+func (s *Server) registerResource(res api.ServerResource) error {
+	addResource(s.server, res)
+	return nil
+}
+
+// registerResourceTemplate registers a resource template with the MCP server
+func (s *Server) registerResourceTemplate(rt api.ServerResourceTemplate) error {
+	addResourceTemplate(s.server, rt)
+	return nil
+}
+
 // metricsMiddleware returns a metrics middleware with access to the server's metrics system
 func (s *Server) metricsMiddleware() func(mcp.MethodHandler) mcp.MethodHandler {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
@@ -356,6 +418,20 @@ func (s *Server) GetEnabledPrompts() []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.enabledPrompts
+}
+
+// GetEnabledResources returns the URIs of the currently enabled resources
+func (s *Server) GetEnabledResources() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.enabledResources
+}
+
+// GetEnabledResourceTemplates returns the URI templates of the currently enabled resource templates
+func (s *Server) GetEnabledResourceTemplates() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.enabledResourceTemplates
 }
 
 // ReloadConfiguration reloads the configuration and reinitializes the server.

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -314,20 +314,36 @@ func (s *Server) registerPrompt(prompt api.ServerPrompt) error {
 	return nil
 }
 
-// collectApplicableResources returns resources from all enabled toolsets
+// collectApplicableResources returns resources from all enabled toolsets after filtering and mutation
 func (s *Server) collectApplicableResources() []api.ServerResource {
+	filter := CompositeResourceFilter()
+	mutator := ComposeResourceMutators()
+
 	resources := make([]api.ServerResource, 0)
 	for _, toolset := range s.configuration.Toolsets() {
-		resources = append(resources, toolset.GetResources()...)
+		for _, resource := range toolset.GetResources() {
+			resource = mutator(resource)
+			if filter(resource) {
+				resources = append(resources, resource)
+			}
+		}
 	}
 	return resources
 }
 
-// collectApplicableResourceTemplates returns resource templates from all enabled toolsets
+// collectApplicableResourceTemplates returns resource templates from all enabled toolsets after filtering and mutation
 func (s *Server) collectApplicableResourceTemplates() []api.ServerResourceTemplate {
+	filter := CompositeResourceTemplateFilter()
+	mutator := ComposeResourceTemplateMutators()
+
 	templates := make([]api.ServerResourceTemplate, 0)
 	for _, toolset := range s.configuration.Toolsets() {
-		templates = append(templates, toolset.GetResourceTemplates()...)
+		for _, template := range toolset.GetResourceTemplates() {
+			template = mutator(template)
+			if filter(template) {
+				templates = append(templates, template)
+			}
+		}
 	}
 	return templates
 }
@@ -564,4 +580,60 @@ func ensureStructuredObject(v any) any {
 		return map[string]any{"items": v}
 	}
 	return v
+}
+
+// ResourceFilter is a function that takes a ServerResource and returns a boolean indicating whether to include it
+type ResourceFilter func(resource api.ServerResource) bool
+
+// CompositeResourceFilter combines multiple resource filters into a single filter using AND logic
+func CompositeResourceFilter(filters ...ResourceFilter) ResourceFilter {
+	return func(resource api.ServerResource) bool {
+		for _, f := range filters {
+			if !f(resource) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// ResourceMutator is a function that transforms a ServerResource
+type ResourceMutator func(resource api.ServerResource) api.ServerResource
+
+// ComposeResourceMutators combines multiple resource mutators into a pipeline
+func ComposeResourceMutators(mutators ...ResourceMutator) ResourceMutator {
+	return func(resource api.ServerResource) api.ServerResource {
+		for _, m := range mutators {
+			resource = m(resource)
+		}
+		return resource
+	}
+}
+
+// ResourceTemplateFilter is a function that takes a ServerResourceTemplate and returns a boolean indicating whether to include it
+type ResourceTemplateFilter func(template api.ServerResourceTemplate) bool
+
+// CompositeResourceTemplateFilter combines multiple resource template filters into a single filter using AND logic
+func CompositeResourceTemplateFilter(filters ...ResourceTemplateFilter) ResourceTemplateFilter {
+	return func(template api.ServerResourceTemplate) bool {
+		for _, f := range filters {
+			if !f(template) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// ResourceTemplateMutator is a function that transforms a ServerResourceTemplate
+type ResourceTemplateMutator func(template api.ServerResourceTemplate) api.ServerResourceTemplate
+
+// ComposeResourceTemplateMutators combines multiple resource template mutators into a pipeline
+func ComposeResourceTemplateMutators(mutators ...ResourceTemplateMutator) ResourceTemplateMutator {
+	return func(template api.ServerResourceTemplate) api.ServerResourceTemplate {
+		for _, m := range mutators {
+			template = m(template)
+		}
+		return template
+	}
 }

--- a/pkg/mcp/mcp_config_provider_test.go
+++ b/pkg/mcp/mcp_config_provider_test.go
@@ -217,10 +217,12 @@ type configProviderToolset struct {
 	prompts []api.ServerPrompt
 }
 
-func (t *configProviderToolset) GetName() string                           { return t.name }
-func (t *configProviderToolset) GetDescription() string                    { return "Test toolset for ConfigProvider" }
-func (t *configProviderToolset) GetTools(_ api.Openshift) []api.ServerTool { return t.tools }
-func (t *configProviderToolset) GetPrompts() []api.ServerPrompt            { return t.prompts }
+func (t *configProviderToolset) GetName() string                                    { return t.name }
+func (t *configProviderToolset) GetDescription() string                             { return "Test toolset for ConfigProvider" }
+func (t *configProviderToolset) GetTools(_ api.Openshift) []api.ServerTool          { return t.tools }
+func (t *configProviderToolset) GetPrompts() []api.ServerPrompt                     { return t.prompts }
+func (t *configProviderToolset) GetResources() []api.ServerResource                 { return nil }
+func (t *configProviderToolset) GetResourceTemplates() []api.ServerResourceTemplate { return nil }
 
 func TestMcpConfigProvider(t *testing.T) {
 	suite.Run(t, new(McpConfigProviderSuite))

--- a/pkg/mcp/mcp_toolset_prompts_test.go
+++ b/pkg/mcp/mcp_toolset_prompts_test.go
@@ -377,6 +377,14 @@ func (m *mockToolsetWithPrompts) GetPrompts() []api.ServerPrompt {
 	return m.prompts
 }
 
+func (m *mockToolsetWithPrompts) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (m *mockToolsetWithPrompts) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
 func TestMcpToolsetPromptsSuite(t *testing.T) {
 	suite.Run(t, new(McpToolsetPromptsSuite))
 }

--- a/pkg/mcp/resource.go
+++ b/pkg/mcp/resource.go
@@ -1,0 +1,58 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// addResource registers a resource with the MCP server.
+func addResource(server *mcp.Server, res api.ServerResource) {
+	server.AddResource(
+		&mcp.Resource{
+			URI:         res.Resource.URI,
+			Name:        res.Resource.Name,
+			Description: res.Resource.Description,
+			MIMEType:    res.Resource.MIMEType,
+		},
+		func(ctx context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			content, err := res.Handler(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return &mcp.ReadResourceResult{
+				Contents: []*mcp.ResourceContents{{
+					URI:      res.Resource.URI,
+					MIMEType: res.Resource.MIMEType,
+					Text:     content,
+				}},
+			}, nil
+		},
+	)
+}
+
+// addResourceTemplate registers a resource template with the MCP server.
+func addResourceTemplate(server *mcp.Server, rt api.ServerResourceTemplate) {
+	server.AddResourceTemplate(
+		&mcp.ResourceTemplate{
+			URITemplate: rt.ResourceTemplate.URITemplate,
+			Name:        rt.ResourceTemplate.Name,
+			Description: rt.ResourceTemplate.Description,
+			MIMEType:    rt.ResourceTemplate.MIMEType,
+		},
+		func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			content, err := rt.Handler(ctx, req.Params.URI)
+			if err != nil {
+				return nil, err
+			}
+			return &mcp.ReadResourceResult{
+				Contents: []*mcp.ResourceContents{{
+					URI:      req.Params.URI,
+					MIMEType: rt.ResourceTemplate.MIMEType,
+					Text:     content,
+				}},
+			}, nil
+		},
+	)
+}

--- a/pkg/mcp/resource.go
+++ b/pkg/mcp/resource.go
@@ -21,11 +21,16 @@ func addResource(server *mcp.Server, res api.ServerResource) {
 			if err != nil {
 				return nil, err
 			}
+			mimeType := res.Resource.MIMEType
+			if content.MIMEType != "" {
+				mimeType = content.MIMEType
+			}
 			return &mcp.ReadResourceResult{
 				Contents: []*mcp.ResourceContents{{
 					URI:      res.Resource.URI,
-					MIMEType: res.Resource.MIMEType,
-					Text:     content,
+					MIMEType: mimeType,
+					Text:     content.Text,
+					Blob:     content.Blob,
 				}},
 			}, nil
 		},
@@ -46,11 +51,16 @@ func addResourceTemplate(server *mcp.Server, rt api.ServerResourceTemplate) {
 			if err != nil {
 				return nil, err
 			}
+			mimeType := rt.ResourceTemplate.MIMEType
+			if content.MIMEType != "" {
+				mimeType = content.MIMEType
+			}
 			return &mcp.ReadResourceResult{
 				Contents: []*mcp.ResourceContents{{
 					URI:      req.Params.URI,
-					MIMEType: rt.ResourceTemplate.MIMEType,
-					Text:     content,
+					MIMEType: mimeType,
+					Text:     content.Text,
+					Blob:     content.Blob,
 				}},
 			}, nil
 		},

--- a/pkg/mcp/resource.go
+++ b/pkg/mcp/resource.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -20,6 +21,9 @@ func addResource(server *mcp.Server, res api.ServerResource) {
 			content, err := res.Handler(ctx)
 			if err != nil {
 				return nil, err
+			}
+			if content == nil {
+				return nil, errors.New("resource handler cannot be nil")
 			}
 			mimeType := res.Resource.MIMEType
 			if content.MIMEType != "" {
@@ -50,6 +54,9 @@ func addResourceTemplate(server *mcp.Server, rt api.ServerResourceTemplate) {
 			content, err := rt.Handler(ctx, req.Params.URI)
 			if err != nil {
 				return nil, err
+			}
+			if content == nil {
+				return nil, errors.New("resource template handler cannot be nil")
 			}
 			mimeType := rt.ResourceTemplate.MIMEType
 			if content.MIMEType != "" {

--- a/pkg/mcp/resource_filter_test.go
+++ b/pkg/mcp/resource_filter_test.go
@@ -1,0 +1,218 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/stretchr/testify/suite"
+)
+
+type ResourceFilterSuite struct {
+	suite.Suite
+}
+
+func (s *ResourceFilterSuite) TestResourceFilterType() {
+	s.Run("can be used as function", func() {
+		var filter ResourceFilter = func(resource api.ServerResource) bool {
+			return resource.Resource.Name == "included"
+		}
+		s.Run("returns true for included resource", func() {
+			r := api.ServerResource{Resource: api.Resource{Name: "included"}}
+			s.True(filter(r))
+		})
+		s.Run("returns false for excluded resource", func() {
+			r := api.ServerResource{Resource: api.Resource{Name: "excluded"}}
+			s.False(filter(r))
+		})
+	})
+}
+
+func (s *ResourceFilterSuite) TestCompositeResourceFilter() {
+	s.Run("returns true with no filters", func() {
+		filter := CompositeResourceFilter()
+		r := api.ServerResource{Resource: api.Resource{Name: "any"}}
+		s.True(filter(r))
+	})
+	s.Run("returns true if all filters return true", func() {
+		filter := CompositeResourceFilter(
+			func(_ api.ServerResource) bool { return true },
+			func(_ api.ServerResource) bool { return true },
+		)
+		r := api.ServerResource{Resource: api.Resource{Name: "test"}}
+		s.True(filter(r))
+	})
+	s.Run("returns false if any filter returns false", func() {
+		filter := CompositeResourceFilter(
+			func(_ api.ServerResource) bool { return true },
+			func(_ api.ServerResource) bool { return false },
+		)
+		r := api.ServerResource{Resource: api.Resource{Name: "test"}}
+		s.False(filter(r))
+	})
+	s.Run("short-circuits on first false", func() {
+		called := false
+		filter := CompositeResourceFilter(
+			func(_ api.ServerResource) bool { return false },
+			func(_ api.ServerResource) bool { called = true; return true },
+		)
+		r := api.ServerResource{Resource: api.Resource{Name: "test"}}
+		s.False(filter(r))
+		s.False(called)
+	})
+}
+
+func (s *ResourceFilterSuite) TestResourceMutatorType() {
+	s.Run("can be used as function", func() {
+		var mutator ResourceMutator = func(resource api.ServerResource) api.ServerResource {
+			resource.Resource.Name = "mutated-" + resource.Resource.Name
+			return resource
+		}
+		r := api.ServerResource{Resource: api.Resource{Name: "original"}}
+		result := mutator(r)
+		s.Equal("mutated-original", result.Resource.Name)
+	})
+}
+
+func (s *ResourceFilterSuite) TestComposeResourceMutators() {
+	s.Run("identity with no mutators", func() {
+		mutator := ComposeResourceMutators()
+		r := api.ServerResource{Resource: api.Resource{Name: "unchanged"}}
+		result := mutator(r)
+		s.Equal("unchanged", result.Resource.Name)
+	})
+	s.Run("applies single mutator", func() {
+		mutator := ComposeResourceMutators(
+			func(r api.ServerResource) api.ServerResource {
+				r.Resource.Description = "added"
+				return r
+			},
+		)
+		r := api.ServerResource{Resource: api.Resource{Name: "test"}}
+		result := mutator(r)
+		s.Equal("added", result.Resource.Description)
+	})
+	s.Run("chains mutators in order", func() {
+		mutator := ComposeResourceMutators(
+			func(r api.ServerResource) api.ServerResource {
+				r.Resource.Name = r.Resource.Name + "-first"
+				return r
+			},
+			func(r api.ServerResource) api.ServerResource {
+				r.Resource.Name = r.Resource.Name + "-second"
+				return r
+			},
+		)
+		r := api.ServerResource{Resource: api.Resource{Name: "start"}}
+		result := mutator(r)
+		s.Equal("start-first-second", result.Resource.Name)
+	})
+}
+
+type ResourceTemplateFilterSuite struct {
+	suite.Suite
+}
+
+func (s *ResourceTemplateFilterSuite) TestResourceTemplateFilterType() {
+	s.Run("can be used as function", func() {
+		var filter ResourceTemplateFilter = func(t api.ServerResourceTemplate) bool {
+			return t.ResourceTemplate.Name == "included"
+		}
+		s.Run("returns true for included template", func() {
+			t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "included"}}
+			s.True(filter(t))
+		})
+		s.Run("returns false for excluded template", func() {
+			t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "excluded"}}
+			s.False(filter(t))
+		})
+	})
+}
+
+func (s *ResourceTemplateFilterSuite) TestCompositeResourceTemplateFilter() {
+	s.Run("returns true with no filters", func() {
+		filter := CompositeResourceTemplateFilter()
+		t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "any"}}
+		s.True(filter(t))
+	})
+	s.Run("returns true if all filters return true", func() {
+		filter := CompositeResourceTemplateFilter(
+			func(_ api.ServerResourceTemplate) bool { return true },
+			func(_ api.ServerResourceTemplate) bool { return true },
+		)
+		t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "test"}}
+		s.True(filter(t))
+	})
+	s.Run("returns false if any filter returns false", func() {
+		filter := CompositeResourceTemplateFilter(
+			func(_ api.ServerResourceTemplate) bool { return true },
+			func(_ api.ServerResourceTemplate) bool { return false },
+		)
+		t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "test"}}
+		s.False(filter(t))
+	})
+	s.Run("short-circuits on first false", func() {
+		called := false
+		filter := CompositeResourceTemplateFilter(
+			func(_ api.ServerResourceTemplate) bool { return false },
+			func(_ api.ServerResourceTemplate) bool { called = true; return true },
+		)
+		t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "test"}}
+		s.False(filter(t))
+		s.False(called)
+	})
+}
+
+func (s *ResourceTemplateFilterSuite) TestResourceTemplateMutatorType() {
+	s.Run("can be used as function", func() {
+		var mutator ResourceTemplateMutator = func(t api.ServerResourceTemplate) api.ServerResourceTemplate {
+			t.ResourceTemplate.Name = "mutated-" + t.ResourceTemplate.Name
+			return t
+		}
+		t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "original"}}
+		result := mutator(t)
+		s.Equal("mutated-original", result.ResourceTemplate.Name)
+	})
+}
+
+func (s *ResourceTemplateFilterSuite) TestComposeResourceTemplateMutators() {
+	s.Run("identity with no mutators", func() {
+		mutator := ComposeResourceTemplateMutators()
+		t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "unchanged"}}
+		result := mutator(t)
+		s.Equal("unchanged", result.ResourceTemplate.Name)
+	})
+	s.Run("applies single mutator", func() {
+		mutator := ComposeResourceTemplateMutators(
+			func(t api.ServerResourceTemplate) api.ServerResourceTemplate {
+				t.ResourceTemplate.Description = "added"
+				return t
+			},
+		)
+		t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "test"}}
+		result := mutator(t)
+		s.Equal("added", result.ResourceTemplate.Description)
+	})
+	s.Run("chains mutators in order", func() {
+		mutator := ComposeResourceTemplateMutators(
+			func(t api.ServerResourceTemplate) api.ServerResourceTemplate {
+				t.ResourceTemplate.Name = t.ResourceTemplate.Name + "-first"
+				return t
+			},
+			func(t api.ServerResourceTemplate) api.ServerResourceTemplate {
+				t.ResourceTemplate.Name = t.ResourceTemplate.Name + "-second"
+				return t
+			},
+		)
+		t := api.ServerResourceTemplate{ResourceTemplate: api.ResourceTemplate{Name: "start"}}
+		result := mutator(t)
+		s.Equal("start-first-second", result.ResourceTemplate.Name)
+	})
+}
+
+func TestResourceFilter(t *testing.T) {
+	suite.Run(t, new(ResourceFilterSuite))
+}
+
+func TestResourceTemplateFilter(t *testing.T) {
+	suite.Run(t, new(ResourceTemplateFilterSuite))
+}

--- a/pkg/mcp/resource_test.go
+++ b/pkg/mcp/resource_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -40,8 +41,8 @@ func (s *ResourceSuite) TestResources() {
 					Description: "First",
 					MIMEType:    "text/plain",
 				},
-				Handler: func(_ context.Context) (string, error) {
-					return txt1, nil
+				Handler: func(_ context.Context) (*api.ResourceContent, error) {
+					return &api.ResourceContent{Text: txt1}, nil
 				},
 			},
 			{
@@ -51,8 +52,8 @@ func (s *ResourceSuite) TestResources() {
 					Description: "Second",
 					MIMEType:    "application/json",
 				},
-				Handler: func(_ context.Context) (string, error) {
-					return json2, nil
+				Handler: func(_ context.Context) (*api.ResourceContent, error) {
+					return &api.ResourceContent{Text: json2}, nil
 				},
 			},
 		},
@@ -79,11 +80,13 @@ func (s *ResourceSuite) TestResources() {
 	s.Run("each resource has correct content and mimeType", func() {
 		result1, err := s.ReadResource("test://example/resource1")
 		s.NoError(err)
+		s.Require().Len(result1.Contents, 1)
 		s.Equal(txt1, result1.Contents[0].Text)
 		s.Equal("text/plain", result1.Contents[0].MIMEType)
 
 		result2, err := s.ReadResource("test://example/resource2")
 		s.NoError(err)
+		s.Require().Len(result2.Contents, 1)
 		s.Equal(json2, result2.Contents[0].Text)
 		s.Equal("application/json", result2.Contents[0].MIMEType)
 	})
@@ -102,8 +105,8 @@ func (s *ResourceSuite) TestResourceTemplates() {
 					Description: txtFoo,
 					MIMEType:    "text/plain",
 				},
-				Handler: func(_ context.Context, uri string) (string, error) {
-					return "content for: " + uri, nil
+				Handler: func(_ context.Context, uri string) (*api.ResourceContent, error) {
+					return &api.ResourceContent{Text: "content for: " + uri}, nil
 				},
 			},
 		},
@@ -128,14 +131,62 @@ func (s *ResourceSuite) TestResourceTemplates() {
 		uri1 := "test://example/foo"
 		result1, err := s.ReadResource(uri1)
 		s.NoError(err)
+		s.Require().Len(result1.Contents, 1)
 		s.Equal(uri1, result1.Contents[0].URI)
 		s.Equal("content for: "+uri1, result1.Contents[0].Text)
 
 		uri2 := "test://example/bar"
 		result2, err := s.ReadResource(uri2)
 		s.NoError(err)
+		s.Require().Len(result2.Contents, 1)
 		s.Equal(uri2, result2.Contents[0].URI)
 		s.Equal("content for: "+uri2, result2.Contents[0].Text)
+	})
+}
+
+func (s *ResourceSuite) TestHandlerErrors() {
+	testToolset := &mockResourceToolset{
+		resources: []api.ServerResource{
+			{
+				Resource: api.Resource{
+					URI:      "test://example/error",
+					Name:     "Error Resource",
+					MIMEType: "text/plain",
+				},
+				Handler: func(_ context.Context) (*api.ResourceContent, error) {
+					return nil, errors.New("permission denied")
+				},
+			},
+		},
+		resourceTemplates: []api.ServerResourceTemplate{
+			{
+				ResourceTemplate: api.ResourceTemplate{
+					URITemplate: "test://example/template/{id}",
+					Name:        "Template with Error",
+					MIMEType:    "text/plain",
+				},
+				Handler: func(_ context.Context, uri string) (*api.ResourceContent, error) {
+					return nil, errors.New("permission denied")
+				},
+			},
+		},
+	}
+
+	toolsets.Clear()
+	toolsets.Register(testToolset)
+	s.Cfg.Toolsets = []string{"resource-test"}
+	s.InitMcpClient()
+
+	s.Run("static resource handler error propagates", func() {
+		result, err := s.ReadResource("test://example/error")
+		s.Error(err)
+		s.Nil(result)
+	})
+
+	s.Run("template resource handler error propagates", func() {
+		result, err := s.ReadResource("test://example/template/123")
+		s.Error(err)
+		s.Nil(result)
 	})
 }
 

--- a/pkg/mcp/resource_test.go
+++ b/pkg/mcp/resource_test.go
@@ -1,0 +1,158 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
+	"github.com/stretchr/testify/suite"
+)
+
+type ResourceSuite struct {
+	BaseMcpSuite
+	originalToolsets []api.Toolset
+}
+
+func (s *ResourceSuite) SetupTest() {
+	s.BaseMcpSuite.SetupTest()
+	s.originalToolsets = toolsets.Toolsets()
+}
+
+func (s *ResourceSuite) TearDownTest() {
+	s.BaseMcpSuite.TearDownTest()
+	toolsets.Clear()
+	for _, toolset := range s.originalToolsets {
+		toolsets.Register(toolset)
+	}
+}
+
+func (s *ResourceSuite) TestResources() {
+	txt1 := "Content 1"
+	json2 := `{"key": "value"}`
+
+	testToolset := &mockResourceToolset{
+		resources: []api.ServerResource{
+			{
+				Resource: api.Resource{
+					URI:         "test://example/resource1",
+					Name:        "Resource One",
+					Description: "First",
+					MIMEType:    "text/plain",
+				},
+				Handler: func(_ context.Context) (string, error) {
+					return txt1, nil
+				},
+			},
+			{
+				Resource: api.Resource{
+					URI:         "test://example/resource2",
+					Name:        "Resource Two",
+					Description: "Second",
+					MIMEType:    "application/json",
+				},
+				Handler: func(_ context.Context) (string, error) {
+					return json2, nil
+				},
+			},
+		},
+	}
+
+	toolsets.Clear()
+	toolsets.Register(testToolset)
+	s.Cfg.Toolsets = []string{"resource-test"}
+	s.InitMcpClient()
+
+	s.Run("all resources appear in list", func() {
+		result, err := s.ListResources()
+		s.NoError(err)
+		s.Require().Len(result.Resources, 2)
+
+		uris := make(map[string]bool)
+		for _, r := range result.Resources {
+			uris[r.URI] = true
+		}
+		s.True(uris["test://example/resource1"])
+		s.True(uris["test://example/resource2"])
+	})
+
+	s.Run("each resource has correct content and mimeType", func() {
+		result1, err := s.ReadResource("test://example/resource1")
+		s.NoError(err)
+		s.Equal(txt1, result1.Contents[0].Text)
+		s.Equal("text/plain", result1.Contents[0].MIMEType)
+
+		result2, err := s.ReadResource("test://example/resource2")
+		s.NoError(err)
+		s.Equal(json2, result2.Contents[0].Text)
+		s.Equal("application/json", result2.Contents[0].MIMEType)
+	})
+}
+
+func (s *ResourceSuite) TestResourceTemplates() {
+	uriTempl := "test://example/{name}"
+	txtFoo := "foo-dynamic-resource"
+
+	testToolset := &mockResourceToolset{
+		resourceTemplates: []api.ServerResourceTemplate{
+			{
+				ResourceTemplate: api.ResourceTemplate{
+					URITemplate: uriTempl,
+					Name:        txtFoo,
+					Description: txtFoo,
+					MIMEType:    "text/plain",
+				},
+				Handler: func(_ context.Context, uri string) (string, error) {
+					return "content for: " + uri, nil
+				},
+			},
+		},
+	}
+
+	toolsets.Clear()
+	toolsets.Register(testToolset)
+	s.Cfg.Toolsets = []string{"resource-test"}
+	s.InitMcpClient()
+
+	s.Run("template appears in list", func() {
+		result, err := s.ListResourceTemplates()
+		s.NoError(err)
+		s.Require().Len(result.ResourceTemplates, 1)
+		s.Equal(uriTempl, result.ResourceTemplates[0].URITemplate)
+		s.Equal(txtFoo, result.ResourceTemplates[0].Name)
+		s.Equal(txtFoo, result.ResourceTemplates[0].Description)
+		s.Equal("text/plain", result.ResourceTemplates[0].MIMEType)
+	})
+
+	s.Run("handler receives correct URI for different URIs", func() {
+		uri1 := "test://example/foo"
+		result1, err := s.ReadResource(uri1)
+		s.NoError(err)
+		s.Equal(uri1, result1.Contents[0].URI)
+		s.Equal("content for: "+uri1, result1.Contents[0].Text)
+
+		uri2 := "test://example/bar"
+		result2, err := s.ReadResource(uri2)
+		s.NoError(err)
+		s.Equal(uri2, result2.Contents[0].URI)
+		s.Equal("content for: "+uri2, result2.Contents[0].Text)
+	})
+}
+
+type mockResourceToolset struct {
+	resources         []api.ServerResource
+	resourceTemplates []api.ServerResourceTemplate
+}
+
+func (m *mockResourceToolset) GetName() string                           { return "resource-test" }
+func (m *mockResourceToolset) GetDescription() string                    { return "Test toolset for resources" }
+func (m *mockResourceToolset) GetTools(_ api.Openshift) []api.ServerTool { return nil }
+func (m *mockResourceToolset) GetPrompts() []api.ServerPrompt            { return nil }
+func (m *mockResourceToolset) GetResources() []api.ServerResource        { return m.resources }
+func (m *mockResourceToolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return m.resourceTemplates
+}
+
+func TestResourceSuite(t *testing.T) {
+	suite.Run(t, new(ResourceSuite))
+}

--- a/pkg/mcp/resource_test.go
+++ b/pkg/mcp/resource_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/stretchr/testify/suite"
 )
@@ -190,13 +192,167 @@ func (s *ResourceSuite) TestHandlerErrors() {
 	})
 }
 
+func (s *ResourceSuite) TestNilContentReturnsError() {
+	testToolset := &mockResourceToolset{
+		resources: []api.ServerResource{
+			{
+				Resource: api.Resource{
+					URI:      "test://example/nil-content",
+					Name:     "Nil Content Resource",
+					MIMEType: "text/plain",
+				},
+				Handler: func(_ context.Context) (*api.ResourceContent, error) {
+					return nil, nil
+				},
+			},
+		},
+		resourceTemplates: []api.ServerResourceTemplate{
+			{
+				ResourceTemplate: api.ResourceTemplate{
+					URITemplate: "test://example/nil-template/{id}",
+					Name:        "Nil Content Template",
+					MIMEType:    "text/plain",
+				},
+				Handler: func(_ context.Context, _ string) (*api.ResourceContent, error) {
+					return nil, nil
+				},
+			},
+		},
+	}
+
+	toolsets.Clear()
+	toolsets.Register(testToolset)
+	s.Cfg.Toolsets = []string{"resource-test"}
+	s.InitMcpClient()
+
+	s.Run("static resource nil content returns error", func() {
+		result, err := s.ReadResource("test://example/nil-content")
+		s.Error(err)
+		s.Nil(result)
+	})
+
+	s.Run("template resource nil content returns error", func() {
+		result, err := s.ReadResource("test://example/nil-template/123")
+		s.Error(err)
+		s.Nil(result)
+	})
+}
+
+func (s *ResourceSuite) TestReloadRemovesResources() {
+	testToolset := &mockResourceToolset{
+		resources: []api.ServerResource{
+			{
+				Resource: api.Resource{
+					URI:      "test://example/removable",
+					Name:     "Removable",
+					MIMEType: "text/plain",
+				},
+				Handler: func(_ context.Context) (*api.ResourceContent, error) {
+					return &api.ResourceContent{Text: "will be removed"}, nil
+				},
+			},
+		},
+		resourceTemplates: []api.ServerResourceTemplate{
+			{
+				ResourceTemplate: api.ResourceTemplate{
+					URITemplate: "test://example/removable/{id}",
+					Name:        "Removable Template",
+					MIMEType:    "text/plain",
+				},
+				Handler: func(_ context.Context, uri string) (*api.ResourceContent, error) {
+					return &api.ResourceContent{Text: "template: " + uri}, nil
+				},
+			},
+		},
+	}
+
+	emptyToolset := &mockResourceToolset{name: "resource-test-empty"}
+
+	toolsets.Clear()
+	toolsets.Register(testToolset)
+	toolsets.Register(emptyToolset)
+	s.Cfg.Toolsets = []string{"resource-test"}
+	s.InitMcpClient()
+
+	s.Run("resources present before reload", func() {
+		result, err := s.ListResources()
+		s.Require().NoError(err)
+		s.Require().Len(result.Resources, 1)
+		s.Equal("test://example/removable", result.Resources[0].URI)
+
+		tmpl, err := s.ListResourceTemplates()
+		s.Require().NoError(err)
+		s.Require().Len(tmpl.ResourceTemplates, 1)
+	})
+
+	s.Run("resources removed after reload", func() {
+		newConfig := config.Default()
+		newConfig.Toolsets = []string{"resource-test-empty"}
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+
+		err := s.mcpServer.ReloadConfiguration(newConfig)
+		s.Require().NoError(err)
+
+		result, err := s.ListResources()
+		s.Require().NoError(err)
+		s.Empty(result.Resources)
+
+		tmpl, err := s.ListResourceTemplates()
+		s.Require().NoError(err)
+		s.Empty(tmpl.ResourceTemplates)
+	})
+}
+
+func (s *ResourceSuite) TestReloadNotifiesResourceListChanged() {
+	testToolset := &mockResourceToolset{
+		resources: []api.ServerResource{
+			{
+				Resource: api.Resource{
+					URI:      "test://example/notify",
+					Name:     "Notify Resource",
+					MIMEType: "text/plain",
+				},
+				Handler: func(_ context.Context) (*api.ResourceContent, error) {
+					return &api.ResourceContent{Text: "notify"}, nil
+				},
+			},
+		},
+	}
+
+	emptyToolset := &mockResourceToolset{name: "resource-test-empty"}
+
+	toolsets.Clear()
+	toolsets.Register(testToolset)
+	toolsets.Register(emptyToolset)
+	s.Cfg.Toolsets = []string{"resource-test"}
+	s.InitMcpClient()
+
+	capture := s.StartCapturingNotifications()
+
+	newConfig := config.Default()
+	newConfig.Toolsets = []string{"resource-test-empty"}
+	newConfig.KubeConfig = s.Cfg.KubeConfig
+
+	err := s.mcpServer.ReloadConfiguration(newConfig)
+	s.Require().NoError(err)
+
+	notification := capture.RequireNotification(s.T(), 2*time.Second, "notifications/resources/list_changed")
+	s.NotNil(notification)
+}
+
 type mockResourceToolset struct {
+	name              string
 	resources         []api.ServerResource
 	resourceTemplates []api.ServerResourceTemplate
 }
 
-func (m *mockResourceToolset) GetName() string                           { return "resource-test" }
-func (m *mockResourceToolset) GetDescription() string                    { return "Test toolset for resources" }
+func (m *mockResourceToolset) GetName() string {
+	if m.name != "" {
+		return m.name
+	}
+	return "resource-test"
+}
+func (m *mockResourceToolset) GetDescription() string { return "Test toolset for resources" }
 func (m *mockResourceToolset) GetTools(_ api.Openshift) []api.ServerTool { return nil }
 func (m *mockResourceToolset) GetPrompts() []api.ServerPrompt            { return nil }
 func (m *mockResourceToolset) GetResources() []api.ServerResource        { return m.resources }

--- a/pkg/mcp/resource_test.go
+++ b/pkg/mcp/resource_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -66,17 +67,25 @@ func (s *ResourceSuite) TestResources() {
 	s.Cfg.Toolsets = []string{"resource-test"}
 	s.InitMcpClient()
 
-	s.Run("all resources appear in list", func() {
+	s.Run("all resources appear in list with correct metadata", func() {
 		result, err := s.ListResources()
 		s.NoError(err)
 		s.Require().Len(result.Resources, 2)
 
-		uris := make(map[string]bool)
+		byURI := make(map[string]*mcp.Resource)
 		for _, r := range result.Resources {
-			uris[r.URI] = true
+			byURI[r.URI] = r
 		}
-		s.True(uris["test://example/resource1"])
-		s.True(uris["test://example/resource2"])
+
+		s.Require().Contains(byURI, "test://example/resource1")
+		s.Equal("Resource One", byURI["test://example/resource1"].Name)
+		s.Equal("First", byURI["test://example/resource1"].Description)
+		s.Equal("text/plain", byURI["test://example/resource1"].MIMEType)
+
+		s.Require().Contains(byURI, "test://example/resource2")
+		s.Equal("Resource Two", byURI["test://example/resource2"].Name)
+		s.Equal("Second", byURI["test://example/resource2"].Description)
+		s.Equal("application/json", byURI["test://example/resource2"].MIMEType)
 	})
 
 	s.Run("each resource has correct content and mimeType", func() {
@@ -340,6 +349,130 @@ func (s *ResourceSuite) TestReloadNotifiesResourceListChanged() {
 	s.NotNil(notification)
 }
 
+func (s *ResourceSuite) TestBlobResource() {
+	blobData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+	testToolset := &mockResourceToolset{
+		resources: []api.ServerResource{
+			{
+				Resource: api.Resource{
+					URI:      "test://example/image",
+					Name:     "Image Resource",
+					MIMEType: "image/png",
+				},
+				Handler: func(_ context.Context) (*api.ResourceContent, error) {
+					return &api.ResourceContent{Blob: blobData}, nil
+				},
+			},
+		},
+	}
+
+	toolsets.Clear()
+	toolsets.Register(testToolset)
+	s.Cfg.Toolsets = []string{"resource-test"}
+	s.InitMcpClient()
+
+	s.Run("blob content is returned correctly", func() {
+		result, err := s.ReadResource("test://example/image")
+		s.NoError(err)
+		s.Require().Len(result.Contents, 1)
+		s.Equal("image/png", result.Contents[0].MIMEType)
+		s.Equal(blobData, result.Contents[0].Blob)
+		s.Empty(result.Contents[0].Text)
+	})
+}
+
+func (s *ResourceSuite) TestMIMETypeOverride() {
+	testToolset := &mockResourceToolset{
+		resources: []api.ServerResource{
+			{
+				Resource: api.Resource{
+					URI:      "test://example/override",
+					Name:     "Override Resource",
+					MIMEType: "text/plain",
+				},
+				Handler: func(_ context.Context) (*api.ResourceContent, error) {
+					return &api.ResourceContent{
+						Text:     `{"overridden": true}`,
+						MIMEType: "application/json",
+					}, nil
+				},
+			},
+		},
+		resourceTemplates: []api.ServerResourceTemplate{
+			{
+				ResourceTemplate: api.ResourceTemplate{
+					URITemplate: "test://example/tmpl-override/{id}",
+					Name:        "Override Template",
+					MIMEType:    "text/plain",
+				},
+				Handler: func(_ context.Context, uri string) (*api.ResourceContent, error) {
+					return &api.ResourceContent{
+						Text:     `{"uri": "` + uri + `"}`,
+						MIMEType: "application/json",
+					}, nil
+				},
+			},
+		},
+	}
+
+	toolsets.Clear()
+	toolsets.Register(testToolset)
+	s.Cfg.Toolsets = []string{"resource-test"}
+	s.InitMcpClient()
+
+	s.Run("handler MIMEType overrides resource-level MIMEType", func() {
+		result, err := s.ReadResource("test://example/override")
+		s.NoError(err)
+		s.Require().Len(result.Contents, 1)
+		s.Equal("application/json", result.Contents[0].MIMEType)
+		s.Equal(`{"overridden": true}`, result.Contents[0].Text)
+	})
+
+	s.Run("handler MIMEType overrides template-level MIMEType", func() {
+		result, err := s.ReadResource("test://example/tmpl-override/42")
+		s.NoError(err)
+		s.Require().Len(result.Contents, 1)
+		s.Equal("application/json", result.Contents[0].MIMEType)
+	})
+}
+
+func (s *ResourceSuite) TestInvalidURIPanics() {
+	badTemplateToolset := &mockResourceToolset{
+		name: "resource-test-bad",
+		resourceTemplates: []api.ServerResourceTemplate{
+			{
+				ResourceTemplate: api.ResourceTemplate{
+					URITemplate: "{{invalid",
+					Name:        "Bad Template",
+					MIMEType:    "text/plain",
+				},
+				Handler: func(_ context.Context, _ string) (*api.ResourceContent, error) {
+					return &api.ResourceContent{Text: "unreachable"}, nil
+				},
+			},
+		},
+	}
+
+	emptyToolset := &mockResourceToolset{name: "resource-test-empty"}
+
+	toolsets.Clear()
+	toolsets.Register(emptyToolset)
+	toolsets.Register(badTemplateToolset)
+	s.Cfg.Toolsets = []string{"resource-test-empty"}
+	s.InitMcpClient()
+
+	s.Run("invalid resource template URI panics", func() {
+		newConfig := config.Default()
+		newConfig.Toolsets = []string{"resource-test-bad"}
+		newConfig.KubeConfig = s.Cfg.KubeConfig
+
+		s.Panics(func() {
+			_ = s.mcpServer.ReloadConfiguration(newConfig)
+		})
+	})
+}
+
 type mockResourceToolset struct {
 	name              string
 	resources         []api.ServerResource
@@ -352,7 +485,7 @@ func (m *mockResourceToolset) GetName() string {
 	}
 	return "resource-test"
 }
-func (m *mockResourceToolset) GetDescription() string { return "Test toolset for resources" }
+func (m *mockResourceToolset) GetDescription() string                    { return "Test toolset for resources" }
 func (m *mockResourceToolset) GetTools(_ api.Openshift) []api.ServerTool { return nil }
 func (m *mockResourceToolset) GetPrompts() []api.ServerPrompt            { return nil }
 func (m *mockResourceToolset) GetResources() []api.ServerResource        { return m.resources }

--- a/pkg/toolsets/config/toolset.go
+++ b/pkg/toolsets/config/toolset.go
@@ -30,6 +30,14 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (t *Toolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/core/toolset.go
+++ b/pkg/toolsets/core/toolset.go
@@ -41,6 +41,14 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	)
 }
 
+func (t *Toolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/helm/toolset.go
+++ b/pkg/toolsets/helm/toolset.go
@@ -30,6 +30,14 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (t *Toolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kcp/toolset.go
+++ b/pkg/toolsets/kcp/toolset.go
@@ -29,6 +29,14 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (t *Toolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -41,6 +41,14 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (t *Toolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -34,6 +34,14 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return initVMTroubleshoot()
 }
 
+func (t *Toolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/tekton/toolset.go
+++ b/pkg/toolsets/tekton/toolset.go
@@ -33,6 +33,14 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return nil
 }
 
+func (t *Toolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -50,6 +50,46 @@ func (s *ToolsetsSuite) TestRegisterPanicsOnDuplicate() {
 	}, "Expected panic on duplicate toolset registration")
 }
 
+func (s *ToolsetsSuite) TestUniqueToolNames() {
+	toolNames := make(map[string]bool)
+	for _, toolset := range Toolsets() {
+		for _, tool := range toolset.GetTools(nil) {
+			s.Falsef(toolNames[tool.Tool.Name], "duplicate tool name: %s", tool.Tool.Name)
+			toolNames[tool.Tool.Name] = true
+		}
+	}
+}
+
+func (s *ToolsetsSuite) TestUniquePromptNames() {
+	promptNames := make(map[string]bool)
+	for _, toolset := range Toolsets() {
+		for _, prompt := range toolset.GetPrompts() {
+			s.Falsef(promptNames[prompt.Prompt.Name], "duplicate prompt name: %s", prompt.Prompt.Name)
+			promptNames[prompt.Prompt.Name] = true
+		}
+	}
+}
+
+func (s *ToolsetsSuite) TestUniqueResourceURIs() {
+	resourceURIs := make(map[string]bool)
+	for _, toolset := range Toolsets() {
+		for _, resource := range toolset.GetResources() {
+			s.Falsef(resourceURIs[resource.Resource.URI], "duplicate resource URI: %s", resource.Resource.URI)
+			resourceURIs[resource.Resource.URI] = true
+		}
+	}
+}
+
+func (s *ToolsetsSuite) TestUniqueResourceTemplateURITemplates() {
+	uriTemplates := make(map[string]bool)
+	for _, toolset := range Toolsets() {
+		for _, template := range toolset.GetResourceTemplates() {
+			s.Falsef(uriTemplates[template.ResourceTemplate.URITemplate], "duplicate resource template URI template: %s", template.ResourceTemplate.URITemplate)
+			uriTemplates[template.ResourceTemplate.URITemplate] = true
+		}
+	}
+}
+
 func (s *ToolsetsSuite) TestToolsetNames() {
 	s.Run("Returns empty list if no toolsets registered", func() {
 		s.Empty(ToolsetNames(), "Expected empty list of toolset names")

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -1,6 +1,7 @@
 package toolsets
 
 import (
+	"context"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -43,6 +44,10 @@ func (t *TestToolset) GetResourceTemplates() []api.ServerResourceTemplate { retu
 
 var _ api.Toolset = (*TestToolset)(nil)
 
+type fakeOpenshift struct{}
+
+func (f *fakeOpenshift) IsOpenShift(context.Context) bool { return false }
+
 func (s *ToolsetsSuite) TestRegisterPanicsOnDuplicate() {
 	Register(&TestToolset{name: "duplicate"})
 	s.Panics(func() {
@@ -52,8 +57,8 @@ func (s *ToolsetsSuite) TestRegisterPanicsOnDuplicate() {
 
 func (s *ToolsetsSuite) TestUniqueToolNames() {
 	toolNames := make(map[string]bool)
-	for _, toolset := range Toolsets() {
-		for _, tool := range toolset.GetTools(nil) {
+	for _, toolset := range s.originalToolsets {
+		for _, tool := range toolset.GetTools(&fakeOpenshift{}) {
 			s.Falsef(toolNames[tool.Tool.Name], "duplicate tool name: %s", tool.Tool.Name)
 			toolNames[tool.Tool.Name] = true
 		}
@@ -62,7 +67,7 @@ func (s *ToolsetsSuite) TestUniqueToolNames() {
 
 func (s *ToolsetsSuite) TestUniquePromptNames() {
 	promptNames := make(map[string]bool)
-	for _, toolset := range Toolsets() {
+	for _, toolset := range s.originalToolsets {
 		for _, prompt := range toolset.GetPrompts() {
 			s.Falsef(promptNames[prompt.Prompt.Name], "duplicate prompt name: %s", prompt.Prompt.Name)
 			promptNames[prompt.Prompt.Name] = true
@@ -72,7 +77,7 @@ func (s *ToolsetsSuite) TestUniquePromptNames() {
 
 func (s *ToolsetsSuite) TestUniqueResourceURIs() {
 	resourceURIs := make(map[string]bool)
-	for _, toolset := range Toolsets() {
+	for _, toolset := range s.originalToolsets {
 		for _, resource := range toolset.GetResources() {
 			s.Falsef(resourceURIs[resource.Resource.URI], "duplicate resource URI: %s", resource.Resource.URI)
 			resourceURIs[resource.Resource.URI] = true
@@ -82,7 +87,7 @@ func (s *ToolsetsSuite) TestUniqueResourceURIs() {
 
 func (s *ToolsetsSuite) TestUniqueResourceTemplateURITemplates() {
 	uriTemplates := make(map[string]bool)
-	for _, toolset := range Toolsets() {
+	for _, toolset := range s.originalToolsets {
 		for _, template := range toolset.GetResourceTemplates() {
 			s.Falsef(uriTemplates[template.ResourceTemplate.URITemplate], "duplicate resource template URI template: %s", template.ResourceTemplate.URITemplate)
 			uriTemplates[template.ResourceTemplate.URITemplate] = true

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -37,6 +37,10 @@ func (t *TestToolset) GetTools(_ api.Openshift) []api.ServerTool { return nil }
 
 func (t *TestToolset) GetPrompts() []api.ServerPrompt { return nil }
 
+func (t *TestToolset) GetResources() []api.ServerResource { return nil }
+
+func (t *TestToolset) GetResourceTemplates() []api.ServerResourceTemplate { return nil }
+
 var _ api.Toolset = (*TestToolset)(nil)
 
 func (s *ToolsetsSuite) TestRegisterPanicsOnDuplicate() {


### PR DESCRIPTION
Adds boilerplate for registering [MCP resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources) using the mcp-go-sdk.

xref: https://github.com/openshift/openshift-mcp-server/pull/159#discussion_r3095830141