### PR TITLE
fix(helm-charts): make ServiceAccount token auto-mount configurable on Helm chart (security) 

### DIFF
--- a/charts/kubernetes-mcp-server/README.md
+++ b/charts/kubernetes-mcp-server/README.md
@@ -153,8 +153,9 @@ Each container accepts any valid Kubernetes container field including `image`, `
 | service.port | int | `8080` | This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports |
 | service.targetPort | string | `"http"` | Target port for the service. Useful when deploying with a proxy sidecar or exposing a different port. Set this to the sidecar's port to route traffic through the proxy before reaching the main container. |
 | service.type | string | `"ClusterIP"` | This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types |
-| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/ |
+| serviceAccount | object | `{"annotations":{},"automountToken":true,"create":true,"name":""}` | This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/ |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automountToken | bool | `true` | Whether to auto-mount the ServiceAccount token into the pod. Required for in-cluster Kubernetes API access (default). Set to false for OAuth passthrough deployments where the server uses the user's token instead of the ServiceAccount token. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
 | tls | object | `{"certFile":"tls.crt","enabled":false,"keyFile":"tls.key","mountPath":"/etc/tls","secretName":""}` | This is the recommended way to enable TLS instead of using extraArgs. |

--- a/charts/kubernetes-mcp-server/ci/sa-automount-test-values.yaml
+++ b/charts/kubernetes-mcp-server/ci/sa-automount-test-values.yaml
@@ -1,0 +1,11 @@
+# Test values that exercise the serviceAccount.automountToken toggle.
+# Validates that:
+# - Setting automountToken to false renders correctly in both
+#   the Deployment pod spec and the ServiceAccount resource
+
+ingress:
+  host: localhost
+
+serviceAccount:
+  create: true
+  automountToken: false

--- a/charts/kubernetes-mcp-server/templates/deployment.yaml
+++ b/charts/kubernetes-mcp-server/templates/deployment.yaml
@@ -28,6 +28,11 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kubernetes-mcp-server.serviceAccountName" . }}
+      {{- if hasKey .Values.serviceAccount "automountToken" }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+      {{- else }}
+      automountServiceAccountToken: true
+      {{- end }}
       securityContext:
         {{- tpl (toYaml (default .Values.defaultPodSecurityContext .Values.podSecurityContext)) . | nindent 8 }}
       {{- with .Values.initContainers }}

--- a/charts/kubernetes-mcp-server/templates/serviceaccount.yaml
+++ b/charts/kubernetes-mcp-server/templates/serviceaccount.yaml
@@ -10,4 +10,9 @@ metadata:
   annotations:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
+{{- if hasKey .Values.serviceAccount "automountToken" }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
+{{- else }}
+automountServiceAccountToken: true
+{{- end }}
 {{- end }}

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -28,6 +28,11 @@ serviceAccount:
   # -- The name of the service account to use.
   # -- If not set and create is true, a name is generated using the fullname template
   name: ""
+  # -- Whether to auto-mount the ServiceAccount token into the pod.
+  # Required for in-cluster Kubernetes API access (default).
+  # Set to false for OAuth passthrough deployments where the server
+  # uses the user's token instead of the ServiceAccount token.
+  automountToken: true
 
 # -- RBAC configuration for the MCP server.
 # -- Use these lists to add custom RBAC resources without modifying templates.


### PR DESCRIPTION
Add `serviceAccount.automountToken` value (`default: true`) to control whether the `ServiceAccount` token is mounted into the pod. Operators using OAuth passthrough mode can set this to false to reduce the attack surface when the server's own SA token is not needed (CWE-250).

- Set `automountServiceAccountToken` on both the Deployment pod spec and the `ServiceAccount` resource for defense-in-depth
- Use `hasKey` guard to correctly handle boolean false values (Go template `default` treats false as empty)
- Add CI test values exercising `automountToken: false`

Fixes https://github.com/containers/kubernetes-mcp-server/issues/1092 