### PR TITLE
chore(ci): group dependabot updates for k8s, otel, and golang.org/x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,23 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Bundle related ecosystem bumps into single grouped PRs to reduce review
churn and ensure dependencies that must move together actually do.

### Groups added (gomod)

- **`kubernetes`** — `k8s.io/*` + `sigs.k8s.io/*`
  Released in lockstep by the K8s release team and share the same Go
  toolchain constraint (e.g. the recent 0.36.0 bump opened 7 separate
  PRs that all require Go 1.26).
- **`opentelemetry`** — `go.opentelemetry.io/*`
  All OTel modules ship from a coordinated release; version skew
  between them is a known footgun.
- **`golang-x`** — `golang.org/x/*`
  Frequent low-risk updates that benefit from batching.

### Groups added (github-actions)

- Single `*` group — actions updates are mostly digest/patch bumps and
  don't warrant separate PRs.

### Notes

- `applies-to` defaults to `version-updates`, so security advisories
  will still come as individual PRs (intentional).
- Existing open dependabot PRs (#1094–#1100, etc.) won't be auto-grouped;
  commenting `@dependabot recreate` on one of them after merge will
  recreate them as a single grouped PR.