### PR TITLE
fix(auth): propagate config reload to HTTP authorization middleware

### DIFF
--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -1,0 +1,27 @@
+package config
+
+import "sync/atomic"
+
+// StaticConfigState holds the current StaticConfig and allows atomic, lock-free reads.
+// This enables hot-reloading of configuration via SIGHUP while ensuring all consumers
+// (e.g., HTTP middleware) always see the latest config snapshot.
+type StaticConfigState struct {
+	ref atomic.Pointer[StaticConfig]
+}
+
+// NewStaticConfigState creates a new StaticConfigState initialized with the given config.
+func NewStaticConfigState(cfg *StaticConfig) *StaticConfigState {
+	s := &StaticConfigState{}
+	s.ref.Store(cfg)
+	return s
+}
+
+// Load returns the current StaticConfig. Safe for concurrent use.
+func (s *StaticConfigState) Load() *StaticConfig {
+	return s.ref.Load()
+}
+
+// Store atomically replaces the current StaticConfig.
+func (s *StaticConfigState) Store(cfg *StaticConfig) {
+	s.ref.Store(cfg)
+}

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -53,7 +53,7 @@ func write401(w http.ResponseWriter, wwwAuthenticateHeader, errorType, message s
 //	         - The token is then validated against the OIDC Provider.
 //
 //	         see TestAuthorizationOidcToken
-func AuthorizationMiddleware(staticConfig *config.StaticConfig, oauthState *oauth.State) func(http.Handler) http.Handler {
+func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oauth.State) func(http.Handler) http.Handler {
 	var skipJWTWarningOnce sync.Once
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -67,6 +67,9 @@ func AuthorizationMiddleware(staticConfig *config.StaticConfig, oauthState *oaut
 				next.ServeHTTP(w, r)
 				return
 			}
+			// Load the latest config snapshot on every request so that
+			// SIGHUP-reloaded auth settings take effect immediately.
+			staticConfig := cfgState.Load()
 			if !staticConfig.RequireOAuth {
 				// Always extract the Authorization header so it can be forwarded
 				// to the cluster, even without OAuth validation.

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -103,11 +103,13 @@ func statsHandler(mcpServer *mcp.Server) http.HandlerFunc {
 	}
 }
 
-func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.StaticConfig, oauthState *oauth.State) error {
+func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticConfigState, oauthState *oauth.State) error {
+	// Read startup-time settings that cannot change at runtime (port, TLS, timeouts).
+	staticConfig := cfgState.Load()
 	mux := http.NewServeMux()
 
 	wrappedMux := RequestMiddleware(staticConfig.TrustProxyHeaders)(
-		AuthorizationMiddleware(staticConfig, oauthState)(
+		AuthorizationMiddleware(cfgState, oauthState)(
 			MaxBodyMiddleware(staticConfig.HTTP.MaxBodyBytes)(mux),
 		),
 	)
@@ -143,7 +145,7 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, staticConfig *config.Stat
 	})
 	mux.HandleFunc(statsEndpoint, statsHandler(mcpServer))
 	mux.Handle(metricsEndpoint, mcpServer.GetMetrics().PrometheusHandler())
-	mux.Handle("/.well-known/", WellKnownHandler(staticConfig, oauthState))
+	mux.Handle("/.well-known/", WellKnownHandler(cfgState, oauthState))
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -66,7 +66,9 @@ func (s *BaseHttpSuite) StartServer() {
 	timeoutCtx, s.timeoutCancel = context.WithTimeout(s.T().Context(), 10*time.Second)
 	group, gc := errgroup.WithContext(timeoutCtx)
 	cancelCtx, s.StopServer = context.WithCancel(gc)
-	group.Go(func() error { return Serve(cancelCtx, s.mcpServer, s.StaticConfig, s.OAuthState) })
+	group.Go(func() error {
+		return Serve(cancelCtx, s.mcpServer, config.NewStaticConfigState(s.StaticConfig), s.OAuthState)
+	})
 	s.WaitForShutdown = group.Wait
 	s.Require().NoError(test.WaitForServer(tcpAddr), "HTTP server did not start in time")
 	s.Require().NoError(test.WaitForHealthz(tcpAddr), "HTTP server /healthz endpoint did not respond with non-404 in time")
@@ -133,7 +135,9 @@ func (c *httpContext) beforeEach(t *testing.T) {
 	timeoutCtx, c.timeoutCancel = context.WithTimeout(t.Context(), 10*time.Second)
 	group, gc := errgroup.WithContext(timeoutCtx)
 	cancelCtx, c.StopServer = context.WithCancel(gc)
-	group.Go(func() error { return Serve(cancelCtx, mcpServer, c.StaticConfig, c.OAuthState) })
+	group.Go(func() error {
+		return Serve(cancelCtx, mcpServer, config.NewStaticConfigState(c.StaticConfig), c.OAuthState)
+	})
 	c.WaitForShutdown = group.Wait
 	// Wait for HTTP server to start (using net)
 	for i := 0; i < 10; i++ {

--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -84,7 +84,7 @@ func (g *DefaultMetadataGenerator) GenerateProtectedResourceMetadata(oidcConfig 
 
 type WellKnown struct {
 	oauthState        *oauth.State
-	staticConfig      *config.StaticConfig
+	cfgState          *config.StaticConfigState
 	metadataGenerator WellKnownMetadataGenerator
 	// Cache for openid-configuration to avoid repeated fetches (TTL: oidcConfigCacheTTL)
 	oidcConfigCache     map[string]interface{}
@@ -96,19 +96,19 @@ type WellKnown struct {
 
 var _ http.Handler = &WellKnown{}
 
-func WellKnownHandler(staticConfig *config.StaticConfig, oauthState *oauth.State) http.Handler {
-	return WellKnownHandlerWithGenerator(staticConfig, oauthState, &DefaultMetadataGenerator{})
+func WellKnownHandler(cfgState *config.StaticConfigState, oauthState *oauth.State) http.Handler {
+	return WellKnownHandlerWithGenerator(cfgState, oauthState, &DefaultMetadataGenerator{})
 }
 
 // WellKnownHandlerWithGenerator creates a WellKnown handler with a custom metadata generator.
 // This allows customizing how metadata is generated for different OIDC providers.
-func WellKnownHandlerWithGenerator(staticConfig *config.StaticConfig, oauthState *oauth.State, generator WellKnownMetadataGenerator) http.Handler {
+func WellKnownHandlerWithGenerator(cfgState *config.StaticConfigState, oauthState *oauth.State, generator WellKnownMetadataGenerator) http.Handler {
 	if generator == nil {
 		generator = &DefaultMetadataGenerator{}
 	}
 	return &WellKnown{
 		oauthState:        oauthState,
-		staticConfig:      staticConfig,
+		cfgState:          cfgState,
 		metadataGenerator: generator,
 	}
 }
@@ -129,7 +129,7 @@ func (w *WellKnown) wellKnownHTTPClient() *http.Client {
 	if snap != nil && snap.HTTPClient != nil {
 		return snap.HTTPClient
 	}
-	return config.NewTLSEnforcingClient(nil, w.staticConfig.IsRequireTLS)
+	return config.NewTLSEnforcingClient(nil, w.cfgState.Load().IsRequireTLS)
 }
 
 func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -330,12 +330,13 @@ func (w *WellKnown) generateProtectedResourceMetadata(request *http.Request) (ma
 // Uses server_url from config when set. Falls back to X-Forwarded-* headers only
 // when trust_proxy_headers is explicitly enabled. Otherwise uses request.Host directly.
 func (w *WellKnown) buildResourceURL(request *http.Request) string {
-	if w.staticConfig != nil && w.staticConfig.ServerURL != "" {
-		return strings.TrimSuffix(w.staticConfig.ServerURL, "/")
+	cfg := w.cfgState.Load()
+	if cfg != nil && cfg.ServerURL != "" {
+		return strings.TrimSuffix(cfg.ServerURL, "/")
 	}
 	scheme := "https"
 	host := request.Host
-	if w.staticConfig != nil && w.staticConfig.TrustProxyHeaders {
+	if cfg != nil && cfg.TrustProxyHeaders {
 		if request.TLS == nil && !strings.HasPrefix(request.Header.Get("X-Forwarded-Proto"), "https") {
 			scheme = "http"
 		}

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -353,14 +353,16 @@ func (m *MCPServerOptions) Run() error {
 		}
 	}()
 
+	cfgState := config.NewStaticConfigState(m.StaticConfig)
+
 	// Set up SIGHUP handler for configuration reload
 	if m.ConfigPath != "" || m.ConfigDir != "" {
-		_ = m.setupSIGHUPHandler(mcpServer, oauthState)
+		_ = m.setupSIGHUPHandler(mcpServer, oauthState, cfgState)
 	}
 
 	if m.StaticConfig.Port != "" {
 		ctx := context.Background()
-		return internalhttp.Serve(ctx, mcpServer, m.StaticConfig, oauthState)
+		return internalhttp.Serve(ctx, mcpServer, cfgState, oauthState)
 	}
 
 	ctx := context.Background()
@@ -374,7 +376,7 @@ func (m *MCPServerOptions) Run() error {
 // setupSIGHUPHandler sets up a signal handler to reload configuration on SIGHUP.
 // Returns a stop function that should be called to clean up the handler.
 // The stop function waits for the handler goroutine to finish.
-func (m *MCPServerOptions) setupSIGHUPHandler(mcpServer *mcp.Server, oauthState *internaloauth.State) (stop func()) {
+func (m *MCPServerOptions) setupSIGHUPHandler(mcpServer *mcp.Server, oauthState *internaloauth.State, cfgState *config.StaticConfigState) (stop func()) {
 	sigHupCh := make(chan os.Signal, 1)
 	done := make(chan struct{})
 	signal.Notify(sigHupCh, syscall.SIGHUP)
@@ -392,11 +394,14 @@ func (m *MCPServerOptions) setupSIGHUPHandler(mcpServer *mcp.Server, oauthState 
 			}
 
 			// Apply the new configuration to the MCP server first — if this fails,
-			// we skip the OAuth state update to avoid inconsistent state.
+			// we skip the OAuth state and config state updates to avoid inconsistent state.
 			if err := mcpServer.ReloadConfiguration(newConfig); err != nil {
 				klog.Errorf("Failed to apply reloaded configuration: %v", err)
 				continue
 			}
+
+			// Publish the new config so the HTTP auth middleware picks it up.
+			cfgState.Store(newConfig)
 
 			// Check if OAuth-relevant config changed and update the shared state
 			currentSnapshot := oauthState.Load()

--- a/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
@@ -80,7 +80,8 @@ func (s *SIGHUPSuite) InitServer(configPath, configDir string) {
 		ConfigDir:  configDir,
 	}
 	oauthState := oauth.NewState(&oauth.Snapshot{})
-	s.stopSIGHUP = opts.setupSIGHUPHandler(s.server, oauthState)
+	cfgState := config.NewStaticConfigState(cfg)
+	s.stopSIGHUP = opts.setupSIGHUPHandler(s.server, oauthState, cfgState)
 }
 
 func (s *SIGHUPSuite) TestSIGHUPReloadsConfigFromFile() {


### PR DESCRIPTION
Fixes: #1104 

The SIGHUP handler creates a new StaticConfig on reload and updates the MCP server internals and OIDC provider, but the HTTP authorization middleware continued reading from the original pointer making auth setting changes (require_oauth, oauth_audience, skip_jwt_verification) silently ineffective after reload.

Wrap StaticConfig in an atomic pointer (StaticConfigState), matching the existing oauth.State pattern. The middleware calls Load() per-request so SIGHUP-reloaded auth settings take effect immediately.