### PR TITLE
fix(http): complete hot-reload surface for HTTP middleware config

### DIFF
--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -5,11 +5,17 @@ import "sync/atomic"
 // StaticConfigState holds the current StaticConfig and allows atomic, lock-free reads.
 // This enables hot-reloading of configuration via SIGHUP while ensuring all consumers
 // (e.g., HTTP middleware) always see the latest config snapshot.
+//
+// Non-nil invariant: once constructed via NewStaticConfigState with a non-nil
+// *StaticConfig, Load always returns a non-nil pointer. Store silently ignores
+// nil to preserve this invariant for downstream consumers that dereference
+// without a nil check.
 type StaticConfigState struct {
 	ref atomic.Pointer[StaticConfig]
 }
 
 // NewStaticConfigState creates a new StaticConfigState initialized with the given config.
+// cfg must be non-nil; passing nil violates the non-nil invariant of Load.
 func NewStaticConfigState(cfg *StaticConfig) *StaticConfigState {
 	s := &StaticConfigState{}
 	s.ref.Store(cfg)
@@ -17,11 +23,17 @@ func NewStaticConfigState(cfg *StaticConfig) *StaticConfigState {
 }
 
 // Load returns the current StaticConfig. Safe for concurrent use.
+// Guaranteed non-nil when the state was constructed via NewStaticConfigState
+// with a non-nil config; Store(nil) is a no-op.
 func (s *StaticConfigState) Load() *StaticConfig {
 	return s.ref.Load()
 }
 
 // Store atomically replaces the current StaticConfig.
+// nil is silently ignored to preserve the non-nil invariant of Load.
 func (s *StaticConfigState) Store(cfg *StaticConfig) {
+	if cfg == nil {
+		return
+	}
 	s.ref.Store(cfg)
 }

--- a/pkg/config/state_test.go
+++ b/pkg/config/state_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type StaticConfigStateSuite struct {
+	suite.Suite
+}
+
+func TestStaticConfigState(t *testing.T) {
+	suite.Run(t, new(StaticConfigStateSuite))
+}
+
+func (s *StaticConfigStateSuite) TestLoadStore() {
+	s.Run("load returns initial config", func() {
+		cfg := &StaticConfig{Port: "8080"}
+		state := NewStaticConfigState(cfg)
+		s.Equal(cfg, state.Load())
+	})
+
+	s.Run("store replaces config", func() {
+		cfg1 := &StaticConfig{Port: "8080"}
+		cfg2 := &StaticConfig{Port: "9090"}
+		state := NewStaticConfigState(cfg1)
+		state.Store(cfg2)
+		s.Equal(cfg2, state.Load())
+	})
+
+	s.Run("store ignores nil", func() {
+		cfg := &StaticConfig{Port: "8080"}
+		state := NewStaticConfigState(cfg)
+		state.Store(nil)
+		s.Equal(cfg, state.Load(), "Store(nil) must not clobber the current snapshot")
+	})
+
+	s.Run("concurrent load/store is safe", func() {
+		state := NewStaticConfigState(&StaticConfig{Port: "8080"})
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				state.Store(&StaticConfig{Port: "9090"})
+			}()
+			go func() {
+				defer wg.Done()
+				cfg := state.Load()
+				s.NotNil(cfg)
+			}()
+		}
+		wg.Wait()
+	})
+}

--- a/pkg/http/authorization_reload_test.go
+++ b/pkg/http/authorization_reload_test.go
@@ -1,0 +1,55 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
+)
+
+// AuthorizationMiddlewareReloadSuite verifies that config changes published via
+// *config.StaticConfigState.Store take effect on the NEXT request served by an
+// already-constructed AuthorizationMiddleware — i.e. the middleware re-reads
+// the config snapshot per request instead of capturing it at wiring time.
+// Regression guard for issue #1106 / PR #1105.
+type AuthorizationMiddlewareReloadSuite struct {
+	suite.Suite
+}
+
+func TestAuthorizationMiddlewareReload(t *testing.T) {
+	suite.Run(t, new(AuthorizationMiddlewareReloadSuite))
+}
+
+func (s *AuthorizationMiddlewareReloadSuite) TestRequireOAuthFlipObservedPerRequest() {
+	s.Run("unauthenticated request: 200 when require_oauth=false, 401 after cfgState.Store flips it to true", func() {
+		cfgState := config.NewStaticConfigState(&config.StaticConfig{RequireOAuth: false})
+		oauthState := oauth.NewState(&oauth.Snapshot{})
+
+		next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		handler := AuthorizationMiddleware(cfgState, oauthState)(next)
+
+		// Pre-reload: require_oauth=false → unauthenticated request passes.
+		req1 := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+		rr1 := httptest.NewRecorder()
+		handler.ServeHTTP(rr1, req1)
+		s.Equal(http.StatusOK, rr1.Code, "pre-reload: require_oauth=false must allow unauthenticated requests")
+
+		// Simulate a SIGHUP reload flipping require_oauth to true.
+		cfgState.Store(&config.StaticConfig{RequireOAuth: true})
+
+		// Post-reload: same unauthenticated request must now be rejected.
+		req2 := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+		rr2 := httptest.NewRecorder()
+		handler.ServeHTTP(rr2, req2)
+		s.Equal(http.StatusUnauthorized, rr2.Code,
+			"post-reload: require_oauth=true must reject unauthenticated requests")
+		s.Contains(rr2.Header().Get("WWW-Authenticate"), `realm="Kubernetes MCP Server"`,
+			"401 response must carry WWW-Authenticate challenge")
+	})
+}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -104,17 +104,17 @@ func statsHandler(mcpServer *mcp.Server) http.HandlerFunc {
 }
 
 func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticConfigState, oauthState *oauth.State) error {
-	// Read startup-time settings that cannot change at runtime (port, TLS, timeouts).
+	// Only fields read below are startup-only; middleware reloads via cfgState.
 	staticConfig := cfgState.Load()
 	mux := http.NewServeMux()
 
-	wrappedMux := RequestMiddleware(staticConfig.TrustProxyHeaders)(
-		AuthorizationMiddleware(cfgState, oauthState)(
-			MaxBodyMiddleware(staticConfig.HTTP.MaxBodyBytes)(mux),
-		),
+	// Middlewares read config per request from cfgState so SIGHUP reloads
+	// take effect immediately. Listed outermost-first (request flow order).
+	wrappedMux := chain(mux,
+		RequestMiddleware(cfgState),
+		AuthorizationMiddleware(cfgState, oauthState),
+		MaxBodyMiddleware(cfgState),
 	)
-
-	// Wrap with metrics middleware
 	instrumentedHandler := metricsMiddleware(wrappedMux, mcpServer)
 
 	// Note: WriteTimeout is intentionally omitted - it would kill SSE streams.

--- a/pkg/http/middleware.go
+++ b/pkg/http/middleware.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/telemetry"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -19,6 +20,21 @@ import (
 
 // httpTracer is the tracer used for HTTP request spans
 var httpTracer = otel.Tracer("kubernetes-mcp-server/http")
+
+// Middleware decorates an http.Handler. It is the shape returned by
+// RequestMiddleware, AuthorizationMiddleware, and MaxBodyMiddleware so they
+// can be composed via chain.
+type Middleware func(http.Handler) http.Handler
+
+// chain composes middlewares into a single handler, applied in the order
+// listed: the first middleware is the outermost (runs first on inbound,
+// last on outbound). Reads top-down like the request flow.
+func chain(handler http.Handler, middlewares ...Middleware) http.Handler {
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](handler)
+	}
+	return handler
+}
 
 // getClientIP extracts the client IP address from the request.
 // When trustProxy is true, it checks X-Forwarded-For and X-Real-IP headers first
@@ -63,9 +79,11 @@ func getHTTPRoute(path string) string {
 }
 
 // RequestMiddleware creates OpenTelemetry spans for HTTP requests.
-// When trustProxy is true, X-Forwarded-* and X-Real-IP headers are used for
-// client IP and scheme detection. Only enable when behind a trusted reverse proxy.
-func RequestMiddleware(trustProxy bool) func(http.Handler) http.Handler {
+// The trust_proxy_headers config flag is read per request from cfgState so
+// SIGHUP-reloaded values take effect immediately. When enabled, X-Forwarded-*
+// and X-Real-IP headers are used for client IP and scheme detection. Only
+// enable when behind a trusted reverse proxy.
+func RequestMiddleware(cfgState *config.StaticConfigState) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Skip tracing for health checks
@@ -73,6 +91,8 @@ func RequestMiddleware(trustProxy bool) func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
+
+			trustProxy := cfgState.Load().TrustProxyHeaders
 
 			// Skip all tracing work if telemetry is not enabled
 			if !telemetry.Enabled() {
@@ -212,7 +232,9 @@ func (lrw *loggingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) 
 // MaxBodyMiddleware limits the size of incoming request bodies.
 // It wraps the request body with http.MaxBytesReader to enforce the limit.
 // Requests exceeding the limit receive a 413 Request Entity Too Large response.
-func MaxBodyMiddleware(maxBytes int64) func(http.Handler) http.Handler {
+// The max_body_bytes limit is read per request from cfgState so SIGHUP-reloaded
+// values take effect immediately.
+func MaxBodyMiddleware(cfgState *config.StaticConfigState) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Skip for methods that typically don't have bodies
@@ -221,6 +243,7 @@ func MaxBodyMiddleware(maxBytes int64) func(http.Handler) http.Handler {
 				return
 			}
 
+			maxBytes := cfgState.Load().HTTP.MaxBodyBytes
 			// Skip if maxBytes is 0 or negative (disabled)
 			if maxBytes <= 0 {
 				next.ServeHTTP(w, r)

--- a/pkg/http/middleware_test.go
+++ b/pkg/http/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/telemetry"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
@@ -17,6 +18,18 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// cfgStateWithTrustProxy returns a *config.StaticConfigState initialized with
+// only TrustProxyHeaders set — used by tests that drive RequestMiddleware.
+func cfgStateWithTrustProxy(trustProxy bool) *config.StaticConfigState {
+	return config.NewStaticConfigState(&config.StaticConfig{TrustProxyHeaders: trustProxy})
+}
+
+// cfgStateWithMaxBody returns a *config.StaticConfigState initialized with
+// only HTTP.MaxBodyBytes set — used by tests that drive MaxBodyMiddleware.
+func cfgStateWithMaxBody(maxBytes int64) *config.StaticConfigState {
+	return config.NewStaticConfigState(&config.StaticConfig{HTTP: config.HTTPConfig{MaxBodyBytes: maxBytes}})
+}
 
 type HTTPTraceContextPropagationSuite struct {
 	suite.Suite
@@ -54,7 +67,7 @@ func (s *HTTPTraceContextPropagationSuite) TestRequestMiddlewareExtractsTraceCon
 			w.WriteHeader(http.StatusOK)
 		})
 
-		middleware := RequestMiddleware(false)(handler)
+		middleware := RequestMiddleware(cfgStateWithTrustProxy(false))(handler)
 
 		req := httptest.NewRequest("GET", "/test", nil)
 		req.Header.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
@@ -81,7 +94,7 @@ func (s *HTTPTraceContextPropagationSuite) TestRequestMiddlewareExtractsTraceCon
 			w.WriteHeader(http.StatusOK)
 		})
 
-		middleware := RequestMiddleware(false)(handler)
+		middleware := RequestMiddleware(cfgStateWithTrustProxy(false))(handler)
 
 		req := httptest.NewRequest("GET", "/test", nil)
 		rr := httptest.NewRecorder()
@@ -98,7 +111,7 @@ func (s *HTTPTraceContextPropagationSuite) TestRequestMiddlewareExtractsTraceCon
 			w.WriteHeader(http.StatusOK)
 		})
 
-		middleware := RequestMiddleware(false)(handler)
+		middleware := RequestMiddleware(cfgStateWithTrustProxy(false))(handler)
 
 		req := httptest.NewRequest("GET", "/healthz", nil)
 		req.Header.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
@@ -125,7 +138,7 @@ func (s *HTTPTraceContextPropagationSuite) TestRequestMiddlewareExtractsTraceCon
 			innerHandler.ServeHTTP(w, r)
 		})
 
-		middleware := RequestMiddleware(false)(intermediateHandler)
+		middleware := RequestMiddleware(cfgStateWithTrustProxy(false))(intermediateHandler)
 
 		req := httptest.NewRequest("GET", "/test", nil)
 		req.Header.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
@@ -150,7 +163,7 @@ type MaxBodyMiddlewareSuite struct {
 
 func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 	s.Run("allows requests under limit", func() {
-		handler := MaxBodyMiddleware(100)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := MaxBodyMiddleware(cfgStateWithMaxBody(100))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			s.Require().NoError(err)
 			s.Equal("small body", string(body))
@@ -166,7 +179,7 @@ func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 
 	s.Run("rejects requests exceeding limit", func() {
 		handlerCalled := false
-		handler := MaxBodyMiddleware(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := MaxBodyMiddleware(cfgStateWithMaxBody(10))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			handlerCalled = true
 			// Attempt to read the body - this should fail
 			_, err := io.ReadAll(r.Body)
@@ -188,7 +201,7 @@ func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 
 	s.Run("skips GET requests", func() {
 		handlerCalled := false
-		handler := MaxBodyMiddleware(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := MaxBodyMiddleware(cfgStateWithMaxBody(10))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			handlerCalled = true
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -203,7 +216,7 @@ func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 
 	s.Run("skips HEAD requests", func() {
 		handlerCalled := false
-		handler := MaxBodyMiddleware(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := MaxBodyMiddleware(cfgStateWithMaxBody(10))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			handlerCalled = true
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -218,7 +231,7 @@ func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 
 	s.Run("skips OPTIONS requests", func() {
 		handlerCalled := false
-		handler := MaxBodyMiddleware(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := MaxBodyMiddleware(cfgStateWithMaxBody(10))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			handlerCalled = true
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -232,7 +245,7 @@ func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 	})
 
 	s.Run("skips when maxBytes is zero", func() {
-		handler := MaxBodyMiddleware(0)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := MaxBodyMiddleware(cfgStateWithMaxBody(0))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			s.Require().NoError(err)
 			s.Equal("large body that would exceed any limit", string(body))
@@ -247,7 +260,7 @@ func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 	})
 
 	s.Run("applies to PUT requests", func() {
-		handler := MaxBodyMiddleware(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := MaxBodyMiddleware(cfgStateWithMaxBody(10))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, err := io.ReadAll(r.Body)
 			if err != nil {
 				http.Error(w, "request too large", http.StatusRequestEntityTooLarge)
@@ -265,7 +278,7 @@ func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 	})
 
 	s.Run("applies to PATCH requests", func() {
-		handler := MaxBodyMiddleware(10)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := MaxBodyMiddleware(cfgStateWithMaxBody(10))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, err := io.ReadAll(r.Body)
 			if err != nil {
 				http.Error(w, "request too large", http.StatusRequestEntityTooLarge)
@@ -280,6 +293,34 @@ func (s *MaxBodyMiddlewareSuite) TestMaxBodyMiddleware() {
 		handler.ServeHTTP(rr, req)
 
 		s.Equal(http.StatusRequestEntityTooLarge, rr.Code)
+	})
+
+	// Regression for issue #1106: changes stored in cfgState must be observed
+	// on the NEXT request without rebuilding the middleware.
+	s.Run("picks up max_body_bytes change via cfgState.Store", func() {
+		cfgState := config.NewStaticConfigState(&config.StaticConfig{HTTP: config.HTTPConfig{MaxBodyBytes: 0}})
+
+		handler := MaxBodyMiddleware(cfgState)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "request too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req1 := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(strings.Repeat("x", 100)))
+		rr1 := httptest.NewRecorder()
+		handler.ServeHTTP(rr1, req1)
+		s.Equal(http.StatusOK, rr1.Code, "pre-reload: max_body_bytes=0 must allow any body size")
+
+		cfgState.Store(&config.StaticConfig{HTTP: config.HTTPConfig{MaxBodyBytes: 10}})
+
+		req2 := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(strings.Repeat("x", 100)))
+		rr2 := httptest.NewRecorder()
+		handler.ServeHTTP(rr2, req2)
+		s.Equal(http.StatusRequestEntityTooLarge, rr2.Code,
+			"post-reload: max_body_bytes=10 must reject oversized body")
 	})
 }
 
@@ -338,7 +379,7 @@ func (s *TrustProxyHeadersSuite) runRequest(trustProxy bool, mutate func(*http.R
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	middleware := RequestMiddleware(trustProxy)(handler)
+	middleware := RequestMiddleware(cfgStateWithTrustProxy(trustProxy))(handler)
 
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
 	req.RemoteAddr = "192.168.1.1:443"
@@ -455,3 +496,53 @@ func (s *TrustProxyHeadersSuite) TestURLScheme() {
 func TestTrustProxyHeaders(t *testing.T) {
 	suite.Run(t, new(TrustProxyHeadersSuite))
 }
+
+// TestReloadObserved verifies the middleware observes config changes on the
+// NEXT request after cfgState.Store — no wiring rebuild required. This is
+// the regression lock for issue #1106: RequestMiddleware and MaxBodyMiddleware
+// must read from *StaticConfigState per request so SIGHUP-reloaded values
+// (trust_proxy_headers, max_body_bytes) take effect without a restart.
+func (s *TrustProxyHeadersSuite) TestReloadObserved() {
+	s.Run("RequestMiddleware picks up trust_proxy_headers flip via cfgState.Store", func() {
+		s.spanRecorder.Reset()
+		cfgState := config.NewStaticConfigState(&config.StaticConfig{TrustProxyHeaders: false})
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		middleware := RequestMiddleware(cfgState)(handler)
+
+		// First request — trust_proxy=false: X-Forwarded-For must be ignored.
+		req1 := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+		req1.RemoteAddr = "192.168.1.1:443"
+		req1.Header.Set("X-Forwarded-For", "10.0.0.1")
+		middleware.ServeHTTP(httptest.NewRecorder(), req1)
+
+		// Flip config — simulates a SIGHUP reload.
+		cfgState.Store(&config.StaticConfig{TrustProxyHeaders: true})
+
+		// Second request — trust_proxy=true: X-Forwarded-For must now be honored.
+		req2 := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+		req2.RemoteAddr = "192.168.1.1:443"
+		req2.Header.Set("X-Forwarded-For", "10.0.0.1")
+		middleware.ServeHTTP(httptest.NewRecorder(), req2)
+
+		ended := s.spanRecorder.Ended()
+		s.Require().Len(ended, 2, "expected two spans")
+
+		firstAttrs := make(map[string]attribute.Value, len(ended[0].Attributes()))
+		for _, kv := range ended[0].Attributes() {
+			firstAttrs[string(kv.Key)] = kv.Value
+		}
+		secondAttrs := make(map[string]attribute.Value, len(ended[1].Attributes()))
+		for _, kv := range ended[1].Attributes() {
+			secondAttrs[string(kv.Key)] = kv.Value
+		}
+
+		s.Equal("192.168.1.1", firstAttrs["client.address"].AsString(),
+			"pre-reload request must ignore X-Forwarded-For (trust_proxy_headers=false)")
+		s.Equal("10.0.0.1", secondAttrs["client.address"].AsString(),
+			"post-reload request must honor X-Forwarded-For (trust_proxy_headers=true)")
+	})
+}
+

--- a/pkg/http/middleware_test.go
+++ b/pkg/http/middleware_test.go
@@ -545,4 +545,3 @@ func (s *TrustProxyHeadersSuite) TestReloadObserved() {
 			"post-reload request must honor X-Forwarded-For (trust_proxy_headers=true)")
 	})
 }
-

--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -331,12 +331,12 @@ func (w *WellKnown) generateProtectedResourceMetadata(request *http.Request) (ma
 // when trust_proxy_headers is explicitly enabled. Otherwise uses request.Host directly.
 func (w *WellKnown) buildResourceURL(request *http.Request) string {
 	cfg := w.cfgState.Load()
-	if cfg != nil && cfg.ServerURL != "" {
+	if cfg.ServerURL != "" {
 		return strings.TrimSuffix(cfg.ServerURL, "/")
 	}
 	scheme := "https"
 	host := request.Host
-	if cfg != nil && cfg.TrustProxyHeaders {
+	if cfg.TrustProxyHeaders {
 		if request.TLS == nil && !strings.HasPrefix(request.Header.Get("X-Forwarded-Proto"), "https") {
 			scheme = "http"
 		}


### PR DESCRIPTION
## Summary

Follow-up to #1105. The earlier fix propagated SIGHUP-reloaded config to `AuthorizationMiddleware` and `WellKnownHandler` via `config.StaticConfigState`, but `RequestMiddleware` and `MaxBodyMiddleware` were still bound to the startup snapshot. After a reload that flipped `trust_proxy_headers`, the well-known handler (per-request `Load()`) and `RequestMiddleware` (stale startup value) disagreed about whether to trust `X-Forwarded-*` headers.

## Changes

- **Per-request reload for the whole middleware chain** — `RequestMiddleware` and `MaxBodyMiddleware` now take `*config.StaticConfigState` and read `trust_proxy_headers` / `max_body_bytes` on every request, matching the pattern used by `AuthorizationMiddleware` and `WellKnownHandler`.
- **Readable chain composition** — introduced a small local `chain(handler, middlewares...)` helper in `pkg/http/middleware.go` so the middleware list in `Serve` reads top-down (outermost first) instead of nested inside-out.
- **`StaticConfigState` hardening** — documented the non-nil invariant on `Load()`, `Store(nil)` is now a no-op, and the redundant `cfg != nil` checks in `wellknown.buildResourceURL` are removed for style consistency with `authorization.go`.
- **Regression tests** — new `TestAuthorizationMiddlewareReload` locks in the #1105 behavior (200 → 401 after flipping `require_oauth` via `cfgState.Store`); new reload subtests in `TestTrustProxyHeaders` / `TestMaxBodyMiddleware` cover the extension; new `TestStaticConfigState` unit test (Load/Store round-trip, race-safe).

Closes #1106