### PR TITLE
fix(auth): propagate certificate_authority to token exchange HTTP client

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -72,6 +72,7 @@ type StsConfigProvider interface {
 	GetStsAuthStyle() string
 	GetStsClientCertFile() string
 	GetStsClientKeyFile() string
+	GetCertificateAuthority() string
 }
 
 // ValidationEnabledProvider provides access to validation enabled setting.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -424,6 +424,10 @@ func (c *StaticConfig) GetStsClientKeyFile() string {
 	return c.StsClientKeyFile
 }
 
+func (c *StaticConfig) GetCertificateAuthority() string {
+	return c.CertificateAuthority
+}
+
 func (c *StaticConfig) IsValidationEnabled() bool {
 	return c.ValidationEnabled
 }

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -90,6 +90,7 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(snap *oauth.Snapshot) *tok
 		AuthStyle:      authStyle,
 		ClientCertFile: p.baseConfig.GetStsClientCertFile(),
 		ClientKeyFile:  p.baseConfig.GetStsClientKeyFile(),
+		CAFile:         p.baseConfig.GetCertificateAuthority(),
 	}
 	if err := cfg.Validate(); err != nil {
 		klog.Warningf("STS config validation failed, token exchange will be attempted per-request but will likely fail with the same error: %v", err)

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -173,6 +173,7 @@ func strategyBasedTokenExchange(
 			AuthStyle:      authStyle,
 			ClientCertFile: baseConfig.GetStsClientCertFile(),
 			ClientKeyFile:  baseConfig.GetStsClientKeyFile(),
+			CAFile:         baseConfig.GetCertificateAuthority(),
 		}
 		if err := cfg.Validate(); err != nil {
 			return ctx, fmt.Errorf("token exchange config validation: %w", err)


### PR DESCRIPTION
Fixes: #1108 

The token exchange config (used by rfc8693, keycloak-v1, entra-obo) was not receiving the certificate_authority setting, causing TLS failures when the OIDC token endpoint uses a private CA. The CAFile field on TargetTokenExchangeConfig was already handled correctly by HTTPClient() but was never populated from config.