### PR TITLE
feat(auth): add accept_opaque_tokens for non-JWT bearer token passthrough

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -482,6 +482,7 @@ Configure OAuth/OIDC authentication for HTTP mode deployments.
 | `oauth_audience` | string | `""` | Valid audience for OAuth tokens (for offline JWT claim validation). |
 | `authorization_url` | string | `""` | URL of the OIDC authorization server for token validation and STS exchange. |
 | `skip_jwt_verification` | boolean | `false` | When `true`, allows JWTs without cryptographic signature verification when `require_oauth` is enabled but no `authorization_url` is configured. Only use behind a trusted reverse proxy that already verifies tokens. When `false` (default), the server refuses to start in this configuration. |
+| `accept_opaque_tokens` | boolean | `false` | When `true`, accepts non-JWT bearer tokens (e.g., OpenShift OAuth `sha256~...` tokens) and passes them through to the Kubernetes API server for validation. Use with `cluster_auth_mode = "passthrough"` for per-user RBAC with OpenShift OAuth or similar non-JWT token providers. |
 | `disable_dynamic_client_registration` | boolean | `false` | When `true`, disables dynamic client registration in `.well-known` endpoints. |
 | `oauth_scopes` | string[] | `[]` | Supported client scopes for the OAuth flow. |
 | `sts_client_id` | string | `""` | OAuth client ID for backend token exchange. |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,6 +72,12 @@ type StaticConfig struct {
 	// that performs token verification. When false (default), the server refuses to
 	// start if require_oauth is true and authorization_url is empty.
 	SkipJWTVerification bool `toml:"skip_jwt_verification,omitempty"`
+	// AcceptOpaqueTokens allows the server to accept non-JWT bearer tokens
+	// (e.g., OpenShift OAuth tokens like "sha256~...") when require_oauth is enabled.
+	// Opaque tokens are not validated by the MCP server — they are passed through
+	// to the Kubernetes API server which validates them directly.
+	// This enables passthrough of OpenShift OAuth tokens for per-user RBAC.
+	AcceptOpaqueTokens bool `toml:"accept_opaque_tokens,omitempty"`
 	// DisableDynamicClientRegistration indicates whether dynamic client registration is disabled.
 	// If true, the .well-known endpoints will not expose the registration endpoint.
 	DisableDynamicClientRegistration bool `toml:"disable_dynamic_client_registration,omitempty"`
@@ -570,6 +576,11 @@ func (c *StaticConfig) validateSkipJWTVerification() error {
 	if !c.RequireOAuth || c.AuthorizationURL != "" {
 		return nil
 	}
+	if c.AcceptOpaqueTokens {
+		klog.Warningf("accept_opaque_tokens is enabled: non-JWT bearer tokens (e.g., OpenShift OAuth) will be accepted " +
+			"without server-side validation and passed through to the Kubernetes API for validation.")
+		return nil
+	}
 	if c.SkipJWTVerification {
 		klog.Warningf("skip_jwt_verification is enabled: JWTs will be accepted without cryptographic signature verification. " +
 			"Only use this behind a trusted reverse proxy that performs token verification.")
@@ -578,7 +589,8 @@ func (c *StaticConfig) validateSkipJWTVerification() error {
 	return fmt.Errorf("require_oauth is enabled but authorization_url is not configured: " +
 		"JWTs cannot be cryptographically verified without an OIDC provider. " +
 		"Set authorization_url to an OIDC issuer, or set skip_jwt_verification=true " +
-		"if the server is behind a trusted reverse proxy that verifies tokens")
+		"if the server is behind a trusted reverse proxy that verifies tokens, " +
+		"or set accept_opaque_tokens=true to accept non-JWT tokens (e.g., OpenShift OAuth)")
 }
 
 // validateTokenExchange validates token-exchange-related fields:

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -529,6 +529,31 @@ func (s *ValidateSuite) TestSkipJWTVerification() {
 	})
 }
 
+func (s *ValidateSuite) TestAcceptOpaqueTokens() {
+	s.Run("require_oauth with accept_opaque_tokens=true and no authorization_url is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = ""
+		cfg.AcceptOpaqueTokens = true
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("require_oauth with accept_opaque_tokens=true and authorization_url is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "https://example.com/auth"
+		cfg.AcceptOpaqueTokens = true
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("require_oauth=false with accept_opaque_tokens=true is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = false
+		cfg.AcceptOpaqueTokens = true
+		s.NoError(cfg.Validate())
+	})
+}
+
 func (s *ValidateSuite) TestClusterAuthMode() {
 	s.Run("passthrough without require_oauth is accepted", func() {
 		cfg := s.validConfig()

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -96,6 +96,22 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 
 			token := strings.TrimPrefix(authHeader, "Bearer ")
 
+			// Opaque token support (e.g., OpenShift OAuth tokens: "sha256~...")
+			// When accept_opaque_tokens is enabled and the token is not a JWT,
+			// pass it through without validation — the downstream Kubernetes API
+			// server will validate it directly.
+			if !isJWT(token) {
+				if staticConfig.AcceptOpaqueTokens {
+					klog.V(2).Infof("Accepting opaque (non-JWT) bearer token for passthrough: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+					ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+				klog.V(1).Infof("Authentication failed - opaque token rejected (accept_opaque_tokens not enabled): %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+				write401(w, wwwAuthenticateHeader, "invalid_token", "Unauthorized: Token format not supported")
+				return
+			}
+
 			claims, err := ParseJWTClaims(token)
 			if err == nil && claims == nil {
 				// Impossible case, but just in case
@@ -117,6 +133,14 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 					}
 					// No provider configured - require explicit opt-in via skip_jwt_verification
 					if !staticConfig.SkipJWTVerification {
+						// When accept_opaque_tokens is enabled, the server may legitimately
+						// start without an OIDC provider. JWTs arriving in this config are
+						// a client error (wrong token type), not a server misconfiguration.
+						if staticConfig.AcceptOpaqueTokens {
+							klog.V(1).Infof("Authentication rejected - JWT received but only opaque tokens are supported in this configuration: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+							write401(w, wwwAuthenticateHeader, "invalid_token", "Unauthorized: Invalid token")
+							return
+						}
 						klog.V(1).Infof("Authentication rejected - JWT verification not configured: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
 						http.Error(w, "JWT verification not configured - set authorization_url or skip_jwt_verification", http.StatusInternalServerError)
 						return
@@ -195,6 +219,11 @@ func (c *JWTClaims) ValidateWithProvider(ctx context.Context, audience string, p
 		}
 	}
 	return nil
+}
+
+// isJWT checks if a token looks like a JWT (three dot-separated base64 parts).
+func isJWT(token string) bool {
+	return strings.Count(token, ".") == 2
 }
 
 func ParseJWTClaims(token string) (*JWTClaims, error) {

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -769,6 +769,138 @@ func (s *AuthorizationSuite) TestAuthorizationClusterAuthModeKubeconfigDropsClie
 	s.Require().NoError(s.WaitForShutdown())
 }
 
+func (s *AuthorizationSuite) TestAuthorizationOpaqueTokenAccepted() {
+	// When accept_opaque_tokens=true, non-JWT tokens (e.g., OpenShift "sha256~...")
+	// should be accepted and passed through without validation.
+	s.MockServer.ResetHandlers()
+	s.StaticConfig.AcceptOpaqueTokens = true
+	s.StaticConfig.AuthorizationURL = ""
+	s.logBuffer.Reset()
+	s.StartServer()
+
+	opaqueToken := "sha256~ZxZCA-JzcWmicNGnISqK1SNwk3FgBz9rVpDmAxkZbeQ"
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + opaqueToken,
+	})
+
+	s.Run("MCP session is established with opaque token", func() {
+		s.Require().NotNil(s.mcpClient.Session, "Expected session for opaque token authentication")
+		s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initial request to not be nil")
+	})
+
+	s.Run("HTTP request returns 200 for opaque token", func() {
+		resp := s.HttpGet("Bearer " + opaqueToken)
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
+		s.NotEqual(http.StatusUnauthorized, resp.StatusCode, "Expected non-401 status for opaque token")
+	})
+
+	s.Run("logs acceptance of opaque token", func() {
+		s.Contains(s.logBuffer.String(), "Accepting opaque (non-JWT) bearer token",
+			"Expected log entry for opaque token acceptance")
+	})
+
+	s.mcpClient.Close()
+	s.mcpClient = nil
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
+}
+
+func (s *AuthorizationSuite) TestAuthorizationOpaqueTokenRejectedWithoutFlag() {
+	// When accept_opaque_tokens=false (default), non-JWT tokens should be rejected.
+	s.MockServer.ResetHandlers()
+	s.StaticConfig.AcceptOpaqueTokens = false
+	s.StaticConfig.SkipJWTVerification = true // Allow server to start without authorization_url
+	s.StaticConfig.AuthorizationURL = ""
+	s.logBuffer.Reset()
+	s.StartServer()
+
+	opaqueToken := "sha256~ZxZCA-JzcWmicNGnISqK1SNwk3FgBz9rVpDmAxkZbeQ"
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + opaqueToken,
+	})
+
+	s.Run("MCP session is rejected for opaque token without flag", func() {
+		s.Nil(s.mcpClient.Session, "Expected no session when accept_opaque_tokens is false")
+	})
+
+	s.Run("HTTP request returns 401 for opaque token", func() {
+		resp := s.HttpGet("Bearer " + opaqueToken)
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
+		s.Equal(http.StatusUnauthorized, resp.StatusCode, "Expected HTTP 401 for opaque token without flag")
+	})
+
+	s.Run("logs rejection of opaque token", func() {
+		s.Contains(s.logBuffer.String(), "opaque token rejected",
+			"Expected log entry for opaque token rejection")
+	})
+
+	if s.mcpClient != nil {
+		s.mcpClient.Close()
+		s.mcpClient = nil
+	}
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
+}
+
+func (s *AuthorizationSuite) TestAuthorizationJWTStillWorksWithOpaqueTokenFlag() {
+	// When accept_opaque_tokens=true, JWT tokens should still be validated normally.
+	s.MockServer.ResetHandlers()
+	s.StaticConfig.AcceptOpaqueTokens = true
+	s.StaticConfig.SkipJWTVerification = true
+	s.StaticConfig.AuthorizationURL = ""
+	s.logBuffer.Reset()
+	s.StartServer()
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + tokenBasicNotExpired,
+	})
+
+	s.Run("JWT token is still accepted alongside opaque token support", func() {
+		s.Require().NotNil(s.mcpClient.Session, "Expected session for JWT token")
+		s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initial request to not be nil")
+	})
+
+	s.mcpClient.Close()
+	s.mcpClient = nil
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
+}
+
+func (s *AuthorizationSuite) TestAuthorizationJWTRejectedWithOpaqueOnlyConfig() {
+	// When accept_opaque_tokens=true but skip_jwt_verification=false and no
+	// authorization_url, JWT tokens should get a 401 (not 500).
+	s.MockServer.ResetHandlers()
+	s.StaticConfig.AcceptOpaqueTokens = true
+	s.StaticConfig.SkipJWTVerification = false
+	s.StaticConfig.AuthorizationURL = ""
+	s.logBuffer.Reset()
+	s.StartServer()
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + tokenBasicNotExpired,
+	})
+
+	s.Run("MCP session is rejected for JWT in opaque-only config", func() {
+		s.Nil(s.mcpClient.Session, "Expected nil session for JWT in opaque-only config")
+	})
+
+	s.Run("HTTP request returns 401 (not 500) for JWT", func() {
+		resp := s.HttpGet("Bearer " + tokenBasicNotExpired)
+		s.T().Cleanup(func() { _ = resp.Body.Close() })
+		s.Equal(http.StatusUnauthorized, resp.StatusCode, "Expected HTTP 401, not 500, for JWT in opaque-only config")
+	})
+
+	s.Run("logs that only opaque tokens are supported", func() {
+		s.Contains(s.logBuffer.String(), "JWT received but only opaque tokens are supported",
+			"Expected log entry explaining JWT rejection in opaque-only config")
+	})
+
+	if s.mcpClient != nil {
+		s.mcpClient.Close()
+		s.mcpClient = nil
+	}
+	s.StopServer()
+	s.Require().NoError(s.WaitForShutdown())
+}
+
 func TestAuthorization(t *testing.T) {
 	suite.Run(t, new(AuthorizationSuite))
 }

--- a/pkg/http/authorization_test.go
+++ b/pkg/http/authorization_test.go
@@ -156,6 +156,44 @@ func TestJWTTokenValidateOffline(t *testing.T) {
 	})
 }
 
+func TestIsJWT(t *testing.T) {
+	t.Run("valid JWT format (3 dot-separated parts)", func(t *testing.T) {
+		if !isJWT(tokenBasicNotExpired) {
+			t.Error("expected tokenBasicNotExpired to be detected as JWT")
+		}
+	})
+	t.Run("valid JWT format (expired)", func(t *testing.T) {
+		if !isJWT(tokenBasicExpired) {
+			t.Error("expected tokenBasicExpired to be detected as JWT")
+		}
+	})
+	t.Run("OpenShift opaque token (sha256~...)", func(t *testing.T) {
+		if isJWT("sha256~ZxZCA-JzcWmicNGnISqK1SNwk3FgBz9rVpDmAxkZbeQ") {
+			t.Error("expected OpenShift opaque token to NOT be detected as JWT")
+		}
+	})
+	t.Run("random opaque token (no dots)", func(t *testing.T) {
+		if isJWT("abc123def456ghi789") {
+			t.Error("expected random token to NOT be detected as JWT")
+		}
+	})
+	t.Run("empty string", func(t *testing.T) {
+		if isJWT("") {
+			t.Error("expected empty string to NOT be detected as JWT")
+		}
+	})
+	t.Run("single dot (not JWT)", func(t *testing.T) {
+		if isJWT("part1.part2") {
+			t.Error("expected token with 1 dot to NOT be detected as JWT")
+		}
+	})
+	t.Run("three dots (not JWT)", func(t *testing.T) {
+		if isJWT("part1.part2.part3.part4") {
+			t.Error("expected token with 3 dots to NOT be detected as JWT")
+		}
+	})
+}
+
 func TestJWTClaimsGetScopes(t *testing.T) {
 	t.Run("no scopes", func(t *testing.T) {
 		claims, err := ParseJWTClaims(tokenBasicExpired)

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -79,6 +79,7 @@ const (
 	flagOAuthAudience        = "oauth-audience"
 	flagAuthorizationURL     = "authorization-url"
 	flagSkipJWTVerification  = "skip-jwt-verification"
+	flagAcceptOpaqueTokens   = "accept-opaque-tokens"
 	flagServerUrl            = "server-url"
 	flagCertificateAuthority = "certificate-authority"
 	flagDisableMultiCluster  = "disable-multi-cluster"
@@ -103,6 +104,7 @@ type MCPServerOptions struct {
 	OAuthAudience        string
 	AuthorizationURL     string
 	SkipJWTVerification  bool
+	AcceptOpaqueTokens   bool
 	CertificateAuthority string
 	ServerURL            string
 	DisableMultiCluster  bool
@@ -167,6 +169,8 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	_ = cmd.Flags().MarkHidden(flagAuthorizationURL)
 	cmd.Flags().BoolVar(&o.SkipJWTVerification, flagSkipJWTVerification, o.SkipJWTVerification, "Skip JWT cryptographic signature verification when require-oauth is enabled but no authorization-url is configured. Only use behind a trusted reverse proxy that verifies tokens.")
 	_ = cmd.Flags().MarkHidden(flagSkipJWTVerification)
+	cmd.Flags().BoolVar(&o.AcceptOpaqueTokens, flagAcceptOpaqueTokens, o.AcceptOpaqueTokens, "Accept non-JWT bearer tokens (e.g., OpenShift OAuth tokens) and pass them through to the Kubernetes API for validation. Use with cluster_auth_mode=passthrough for per-user RBAC with OpenShift OAuth.")
+	_ = cmd.Flags().MarkHidden(flagAcceptOpaqueTokens)
 	cmd.Flags().StringVar(&o.ServerURL, flagServerUrl, o.ServerURL, "Server URL of this application. Optional. If set, this url will be served in protected resource metadata endpoint and tokens will be validated with this audience. If not set, expected audience is kubernetes-mcp-server. Only valid if require-oauth is enabled.")
 	_ = cmd.Flags().MarkHidden(flagServerUrl)
 	cmd.Flags().StringVar(&o.CertificateAuthority, flagCertificateAuthority, o.CertificateAuthority, "Certificate authority path to verify certificates. Optional. Only valid if require-oauth is enabled.")
@@ -240,6 +244,9 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 	if cmd.Flag(flagSkipJWTVerification).Changed {
 		m.StaticConfig.SkipJWTVerification = m.SkipJWTVerification
+	}
+	if cmd.Flag(flagAcceptOpaqueTokens).Changed {
+		m.StaticConfig.AcceptOpaqueTokens = m.AcceptOpaqueTokens
 	}
 	if cmd.Flag(flagServerUrl).Changed {
 		m.StaticConfig.ServerURL = m.ServerURL


### PR DESCRIPTION
## Summary
- Add `accept_opaque_tokens` config option to accept non-JWT bearer tokens (e.g., OpenShift OAuth `sha256~...` tokens) when `require_oauth` is enabled
- Opaque tokens are passed through to the Kubernetes API server for validation instead of being rejected by the MCP server's JWT parsing
- Enables per-user RBAC with OpenShift OAuth or similar non-JWT token providers using `cluster_auth_mode=passthrough`

## Changes
- **`pkg/config/config.go`**: New `AcceptOpaqueTokens` field, validation in `validateSkipJWTVerification`
- **`pkg/http/authorization.go`**: Opaque token detection (`isJWT`), passthrough path in middleware, graceful 401 (not 500) when JWTs hit an opaque-only config
- **`pkg/kubernetes-mcp-server/cmd/root.go`**: `--accept-opaque-tokens` CLI flag (hidden, like other auth flags)
- **`docs/configuration.md`**: Documentation for the new option
- **Tests**: 4 integration tests (opaque accepted, opaque rejected, JWT still works with flag, JWT gets 401 not 500 in opaque-only config) + `isJWT` unit tests + config validation tests

## Test plan
- [x] `make build` passes
- [x] `go test ./pkg/http/ ./pkg/config/` -- all tests pass
- [x] New `TestAuthorizationOpaqueTokenAccepted` -- opaque token passthrough works
- [x] New `TestAuthorizationOpaqueTokenRejectedWithoutFlag` -- opaque tokens rejected without flag
- [x] New `TestAuthorizationJWTStillWorksWithOpaqueTokenFlag` -- JWT validation unaffected
- [x] New `TestAuthorizationJWTRejectedWithOpaqueOnlyConfig` -- JWTs return 401 (not 500) when only opaque tokens are configured