### PR TITLE
fix(validation)!: reject kubeconfig auth mode with require_oauth at startup

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -648,6 +648,9 @@ func (c *StaticConfig) ValidateClusterAuthMode() error {
 	if c.ClusterAuthMode != "" && c.ClusterAuthMode != api.ClusterAuthPassthrough && c.ClusterAuthMode != api.ClusterAuthKubeconfig {
 		return fmt.Errorf("invalid cluster_auth_mode %q: must be %q or %q", c.ClusterAuthMode, api.ClusterAuthPassthrough, api.ClusterAuthKubeconfig)
 	}
+	if c.ClusterAuthMode == api.ClusterAuthKubeconfig && c.RequireOAuth {
+		return fmt.Errorf("cluster_auth_mode %q is not compatible with require_oauth=true: all authenticated users would share a single cluster identity, breaking per-user audit trails; use passthrough or token exchange to preserve user identity on the cluster", api.ClusterAuthKubeconfig)
+	}
 	hasTokenExchange := c.TokenExchangeStrategy != "" || c.StsAudience != ""
 	if c.ClusterAuthMode == api.ClusterAuthKubeconfig && hasTokenExchange {
 		return fmt.Errorf("token exchange settings (token_exchange_strategy/sts_audience) are incompatible with cluster_auth_mode %q (exchanged token would be unused)", api.ClusterAuthKubeconfig)

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -545,6 +545,23 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 		s.NoError(cfg.Validate())
 	})
 
+	s.Run("kubeconfig with require_oauth is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = true
+		cfg.SkipJWTVerification = true
+		cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "is not compatible with require_oauth=true")
+	})
+
+	s.Run("kubeconfig without require_oauth is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RequireOAuth = false
+		cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+		s.NoError(cfg.Validate())
+	})
+
 	s.Run("invalid cluster_auth_mode is rejected", func() {
 		cfg := s.validConfig()
 		cfg.ClusterAuthMode = "bogus"


### PR DESCRIPTION
`cluster_auth_mode="kubeconfig"` with `require_oauth=true` is an invalid combination: all users would share a single cluster identity, breaking per-user audit trails. Previously this failed at runtime with a confusing `oauth token required` error. Catch it at config validation with a clear message instead.