### PR TITLE
Use patched Go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/kubernetes-mcp-server
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary
- update the module Go directive from 1.25.7 to 1.26.2

## Why
`govulncheck ./...` reported reachable public Go standard-library advisories in `crypto/x509`, `crypto/tls`, `archive/tar`, `html/template`, `os`, and `net/url`. Those findings are fixed by Go 1.26.1/1.26.2. After this change, `govulncheck` no longer reports the standard-library findings.

`govulncheck` still reports GO-2026-4730 and GO-2023-1901 in `github.com/tektoncd/pipeline@v1.11.1`; both currently show `Fixed in: N/A`, so I left that separate from this toolchain-only fix.

## Verification
- `go test ./...`
- `govulncheck ./...` -> standard-library findings removed; only the two no-fixed-version Tekton findings remain
- `go version` -> `go1.26.2`