### PR TITLE
refactor(mcp): make ReloadConfiguration fully transactional (#1128)

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -139,16 +139,41 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 	s.server.AddReceivingMiddleware(toolCallLoggingMiddleware)
 	s.server.AddReceivingMiddleware(s.metricsMiddleware())
 
-	err = s.reloadToolsets()
+	err = s.reloadToolsets(s.configuration)
 	if err != nil {
 		return nil, err
 	}
-	s.p.WatchTargets(s.reloadToolsets)
+	s.p.WatchTargets(s.refreshToolsets)
 
 	return s, nil
 }
 
-func (s *Server) reloadToolsets() error {
+// refreshToolsets re-runs reloadToolsets against whatever configuration is
+// currently installed. Used by the provider's WatchTargets callback (signature
+// func() error) when cluster state changes but the configuration itself has
+// not. Passing nil cfg makes reloadToolsets re-read s.configuration *inside*
+// the reloadMu critical section, which avoids a TOCTOU race where capturing
+// the cfg here would let a concurrent ReloadConfiguration commit a new cfg
+// while we were blocked on reloadMu — we'd then silently roll it back by
+// re-installing the stale snapshot.
+func (s *Server) refreshToolsets() error {
+	return s.reloadToolsets(nil)
+}
+
+// reloadToolsets recomputes the SDK's tool/prompt/resource/template surface
+// against cfg and, on success, atomically installs cfg as the live
+// configuration alongside the SDK changes. cfg may be:
+//   - a freshly-built *Configuration (configuration reload path), in which
+//     case s.configuration is only mutated once the convert phase succeeds;
+//   - nil (refresh path, e.g. cluster-state change), in which case the
+//     currently-installed configuration is re-read under reloadMu and
+//     reused. nil — instead of "callers pass s.configuration" — is required
+//     to avoid the caller capturing a stale cfg before reloadMu serializes
+//     against an in-flight ReloadConfiguration.
+//
+// On error s.configuration, the SDK, and the enabled-X bookkeeping all stay
+// at their prior consistent values.
+func (s *Server) reloadToolsets(cfg *Configuration) error {
 	// TODO: No option to perform a full replacement of tools.
 	// s.server.SetTools(tools...)
 
@@ -158,11 +183,23 @@ func (s *Server) reloadToolsets() error {
 	s.reloadMu.Lock()
 	defer s.reloadMu.Unlock()
 
-	// Collect applicable items
-	applicableTools := s.collectApplicableTools()
-	applicablePrompts := s.collectApplicablePrompts()
-	applicableResources := s.collectApplicableResources()
-	applicableResourceTemplates := s.collectApplicableResourceTemplates()
+	// If the caller didn't pin a candidate cfg, refresh against whatever is
+	// currently installed. Reading inside the reloadMu critical section
+	// guarantees we observe the latest committed cfg, even if a concurrent
+	// ReloadConfiguration just committed one while we were blocked above.
+	if cfg == nil {
+		s.mu.RLock()
+		cfg = s.configuration
+		s.mu.RUnlock()
+	}
+
+	// Collect applicable items against cfg (NOT s.configuration) so that a
+	// pending ReloadConfiguration can probe a candidate config without making
+	// it observable to concurrent readers until the convert phase succeeds.
+	applicableTools := s.collectApplicableTools(cfg)
+	applicablePrompts := s.collectApplicablePrompts(cfg)
+	applicableResources := s.collectApplicableResources(cfg)
+	applicableResourceTemplates := s.collectApplicableResourceTemplates(cfg)
 
 	// Phase 1: convert all items to SDK types. This validates URIs, URITemplates,
 	// and any per-item conversion before any SDK mutation, so a bad item in any
@@ -222,8 +259,14 @@ func (s *Server) reloadToolsets() error {
 	newResources := commitItems(previousResources, convertedResources, s.server.RemoveResources, s.server.AddResource)
 	newResourceTemplates := commitItems(previousResourceTemplates, convertedResourceTemplates, s.server.RemoveResourceTemplates, s.server.AddResourceTemplate)
 
-	// Only hold write lock for the final assignment
+	// Install cfg alongside the new bookkeeping. The SDK already reflects cfg
+	// (commit phase above). Readers that take s.mu.RLock — the rate-limit
+	// closure, GetEnabledX getters, the next reloadToolsets refresh path —
+	// observe a consistent (cfg, enabledX) pair. (Tool/prompt handlers read
+	// s.configuration without taking s.mu, a pre-existing relaxation; this
+	// refactor neither introduces nor fixes that.)
 	s.mu.Lock()
+	s.configuration = cfg
 	s.enabledTools = newTools
 	s.enabledPrompts = newPrompts
 	s.enabledResources = newResources
@@ -231,7 +274,7 @@ func (s *Server) reloadToolsets() error {
 	s.mu.Unlock()
 
 	// Start new watch
-	s.p.WatchTargets(s.reloadToolsets)
+	s.p.WatchTargets(s.refreshToolsets)
 	return nil
 }
 
@@ -292,19 +335,19 @@ func commitItems[M, H any](
 }
 
 // collectApplicableTools returns tools after applying filtering and mutation
-func (s *Server) collectApplicableTools() []api.ServerTool {
+func (s *Server) collectApplicableTools(cfg *Configuration) []api.ServerTool {
 	filter := CompositeFilter(
-		s.configuration.isToolApplicable,
+		cfg.isToolApplicable,
 		ShouldIncludeTargetListTool(s.p.GetTargetParameterName(), s.p.IsMultiTarget()),
 	)
 	mutator := ComposeMutators(
 		WithTargetParameter(s.p.GetDefaultTarget(), s.p.GetTargetParameterName(), s.p.IsMultiTarget()),
 		WithTargetListTool(s.p.GetDefaultTarget(), s.p.GetTargetParameterName(), s.p),
-		WithToolOverrides(s.configuration.ToolOverrides),
+		WithToolOverrides(cfg.ToolOverrides),
 	)
 
 	tools := make([]api.ServerTool, 0)
-	for _, toolset := range s.configuration.Toolsets() {
+	for _, toolset := range cfg.Toolsets() {
 		for _, tool := range toolset.GetTools(s.p) {
 			tool = mutator(tool)
 			if filter(tool) {
@@ -316,26 +359,26 @@ func (s *Server) collectApplicableTools() []api.ServerTool {
 }
 
 // collectApplicablePrompts returns prompts after applying mutation and merging toolset and config prompts
-func (s *Server) collectApplicablePrompts() []api.ServerPrompt {
+func (s *Server) collectApplicablePrompts(cfg *Configuration) []api.ServerPrompt {
 	mutator := WithPromptTargetParameter(s.p.GetDefaultTarget(), s.p.GetTargetParameterName(), s.p.IsMultiTarget())
 
 	toolsetPrompts := make([]api.ServerPrompt, 0)
-	for _, toolset := range s.configuration.Toolsets() {
+	for _, toolset := range cfg.Toolsets() {
 		for _, prompt := range toolset.GetPrompts() {
 			toolsetPrompts = append(toolsetPrompts, mutator(prompt))
 		}
 	}
-	configPrompts := prompts.ToServerPrompts(s.configuration.Prompts)
+	configPrompts := prompts.ToServerPrompts(cfg.Prompts)
 	return prompts.MergePrompts(toolsetPrompts, configPrompts)
 }
 
 // collectApplicableResources returns resources from all enabled toolsets after filtering and mutation
-func (s *Server) collectApplicableResources() []api.ServerResource {
+func (s *Server) collectApplicableResources(cfg *Configuration) []api.ServerResource {
 	filter := CompositeResourceFilter()
 	mutator := ComposeResourceMutators()
 
 	resources := make([]api.ServerResource, 0)
-	for _, toolset := range s.configuration.Toolsets() {
+	for _, toolset := range cfg.Toolsets() {
 		for _, resource := range toolset.GetResources() {
 			resource = mutator(resource)
 			if filter(resource) {
@@ -347,12 +390,12 @@ func (s *Server) collectApplicableResources() []api.ServerResource {
 }
 
 // collectApplicableResourceTemplates returns resource templates from all enabled toolsets after filtering and mutation
-func (s *Server) collectApplicableResourceTemplates() []api.ServerResourceTemplate {
+func (s *Server) collectApplicableResourceTemplates(cfg *Configuration) []api.ServerResourceTemplate {
 	filter := CompositeResourceTemplateFilter()
 	mutator := ComposeResourceTemplateMutators()
 
 	templates := make([]api.ServerResourceTemplate, 0)
-	for _, toolset := range s.configuration.Toolsets() {
+	for _, toolset := range cfg.Toolsets() {
 		for _, template := range toolset.GetResourceTemplates() {
 			template = mutator(template)
 			if filter(template) {
@@ -456,6 +499,13 @@ func (s *Server) GetEnabledResourceTemplates() []string {
 // ReloadConfiguration reloads the configuration and reinitializes the server.
 // This is intended to be called by the server lifecycle manager when
 // configuration changes are detected.
+//
+// The reload is fully transactional: s.configuration is not mutated until
+// reloadToolsets has successfully recomputed and committed the SDK surface
+// against the candidate config. A rejected reload leaves s.configuration, the
+// SDK, and the enabled-X bookkeeping at their previous consistent values, so
+// concurrent readers (rate-limit closure, confirmation rules, list output...)
+// can never observe a new-but-rejected configuration.
 func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 	klog.V(1).Info("Reloading MCP server configuration...")
 
@@ -467,32 +517,11 @@ func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 		return fmt.Errorf("configuration reload rejected: %w", err)
 	}
 
-	// Update the configuration (protected by mu so concurrent readers see a
-	// consistent snapshot, e.g. the rate-limit configFn closure).
-	// TODO(#1128): refactor reloadToolsets to compute against newConfig
-	// without mutating s.configuration (transactional reload), removing
-	// the need for the rollback path below.
-	s.mu.Lock()
-	previousConfig := s.configuration.StaticConfig
-	previousListOutput := s.configuration.listOutput
-	previousToolsets := s.configuration.toolsets
-	s.configuration.StaticConfig = newConfig
-	// Clear cached values so they get recomputed
-	s.configuration.listOutput = nil
-	s.configuration.toolsets = nil
-	s.mu.Unlock()
+	// Build a candidate Configuration view. reloadToolsets will install it
+	// atomically only if the convert phase succeeds.
+	candidate := &Configuration{StaticConfig: newConfig}
 
-	// Reload the Kubernetes provider (this will also rebuild tools)
-	if err := s.reloadToolsets(); err != nil {
-		// reloadToolsets is transactional — SDK state is unchanged on error.
-		// Roll back the configuration so subsequent reads (rate limiter,
-		// confirmation rules, list output, ...) stay consistent with what
-		// the SDK is actually serving.
-		s.mu.Lock()
-		s.configuration.StaticConfig = previousConfig
-		s.configuration.listOutput = previousListOutput
-		s.configuration.toolsets = previousToolsets
-		s.mu.Unlock()
+	if err := s.reloadToolsets(candidate); err != nil {
 		return fmt.Errorf("failed to reload toolsets: %w", err)
 	}
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -65,14 +66,24 @@ func (c *Configuration) isToolApplicable(tool api.ServerTool) bool {
 }
 
 type Server struct {
+	// mu protects the enabledX bookkeeping. The configuration is held in
+	// an atomic.Pointer (see below) and does NOT require mu for reads.
 	mu sync.RWMutex
 	// reloadMu serializes reloadToolsets calls. WatchTargets (kubeconfig +
 	// cluster-state watchers) and ReloadConfiguration can all fire reloads
 	// concurrently; without this lock, two reloads can interleave their SDK
 	// Add/Remove operations and their enabledX writes, leaving the SDK and
 	// the bookkeeping divergent.
-	reloadMu                 sync.Mutex
-	configuration            *Configuration
+	reloadMu sync.Mutex
+	// configuration is the live server configuration. It's an
+	// atomic.Pointer so that handlers (which read s.configuration on every
+	// tool/prompt invocation, on hot paths) can do so without acquiring a
+	// lock, and so that a reload's swap publishes the new *Configuration
+	// in one indivisible step. Each handler should snapshot the pointer
+	// once at the top of its critical section and read all fields off that
+	// snapshot — otherwise a mid-handler reload could split fields across
+	// two configs.
+	configuration            atomic.Pointer[Configuration]
 	server                   *mcp.Server
 	enabledTools             []string
 	enabledPrompts           []string
@@ -86,7 +97,6 @@ type Server struct {
 
 func NewServer(configuration Configuration, targetProvider internalk8s.Provider) (*Server, error) {
 	s := &Server{
-		configuration: &configuration,
 		server: mcp.NewServer(
 			&mcp.Implementation{
 				Name:       version.BinaryName,
@@ -105,6 +115,7 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 			}),
 		p: targetProvider,
 	}
+	s.configuration.Store(&configuration)
 
 	// Initialize metrics system
 	metricsInstance, err := metrics.New(metrics.Config{
@@ -123,10 +134,9 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 	s.rateLimitDone = make(chan struct{})
 	s.server.AddReceivingMiddleware(
 		rateLimitingMiddleware(s.rateLimitDone, func() (rate.Limit, int) {
-			s.mu.RLock()
-			rps := s.configuration.HTTP.RateLimitRPS
-			burst := s.configuration.HTTP.RateLimitBurst
-			s.mu.RUnlock()
+			cfg := s.configuration.Load()
+			rps := cfg.HTTP.RateLimitRPS
+			burst := cfg.HTTP.RateLimitBurst
 			if burst == 0 {
 				burst = config.DefaultRateLimitBurst
 			}
@@ -139,7 +149,7 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 	s.server.AddReceivingMiddleware(toolCallLoggingMiddleware)
 	s.server.AddReceivingMiddleware(s.metricsMiddleware())
 
-	err = s.reloadToolsets(s.configuration)
+	err = s.reloadToolsets(s.configuration.Load())
 	if err != nil {
 		return nil, err
 	}
@@ -186,11 +196,9 @@ func (s *Server) reloadToolsets(cfg *Configuration) error {
 	// If the caller didn't pin a candidate cfg, refresh against whatever is
 	// currently installed. Reading inside the reloadMu critical section
 	// guarantees we observe the latest committed cfg, even if a concurrent
-	// ReloadConfiguration just committed one while we were blocked above.
+	// ReloadConfiguration just stored one while we were blocked above.
 	if cfg == nil {
-		s.mu.RLock()
-		cfg = s.configuration
-		s.mu.RUnlock()
+		cfg = s.configuration.Load()
 	}
 
 	// Collect applicable items against cfg (NOT s.configuration) so that a
@@ -259,14 +267,16 @@ func (s *Server) reloadToolsets(cfg *Configuration) error {
 	newResources := commitItems(previousResources, convertedResources, s.server.RemoveResources, s.server.AddResource)
 	newResourceTemplates := commitItems(previousResourceTemplates, convertedResourceTemplates, s.server.RemoveResourceTemplates, s.server.AddResourceTemplate)
 
-	// Install cfg alongside the new bookkeeping. The SDK already reflects cfg
-	// (commit phase above). Readers that take s.mu.RLock — the rate-limit
-	// closure, GetEnabledX getters, the next reloadToolsets refresh path —
-	// observe a consistent (cfg, enabledX) pair. (Tool/prompt handlers read
-	// s.configuration without taking s.mu, a pre-existing relaxation; this
-	// refactor neither introduces nor fixes that.)
+	// Publish cfg to readers (handlers, rate-limit closure, ServeHTTP, the
+	// next refresh) via an atomic store. The SDK already reflects cfg from
+	// the commit phase above; the store makes the new *Configuration
+	// observable to lock-free readers in one indivisible step.
+	s.configuration.Store(cfg)
+	// Update the enabledX bookkeeping under mu. Reader of these fields
+	// (GetEnabledX) only reads enabledX, never combined with cfg, so there
+	// is no need to keep the cfg store and the enabledX writes inside the
+	// same critical section.
 	s.mu.Lock()
-	s.configuration = cfg
 	s.enabledTools = newTools
 	s.enabledPrompts = newPrompts
 	s.enabledResources = newResources
@@ -457,7 +467,7 @@ func (s *Server) ServeHTTP() *mcp.StreamableHTTPHandler {
 		// balancing, and serverless environments where maintaining client state
 		// is not desired or possible.
 		// https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server
-		Stateless: s.configuration.Stateless,
+		Stateless: s.configuration.Load().Stateless,
 	})
 }
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -267,10 +267,21 @@ func (s *Server) reloadToolsets(cfg *Configuration) error {
 	newResources := commitItems(previousResources, convertedResources, s.server.RemoveResources, s.server.AddResource)
 	newResourceTemplates := commitItems(previousResourceTemplates, convertedResourceTemplates, s.server.RemoveResourceTemplates, s.server.AddResourceTemplate)
 
+	// Pre-warm the lazy caches so concurrent first-readers (handlers reading
+	// cfg.ListOutput()) don't race on the cache's lazy initialization. The
+	// collectApplicable* calls above already populated cfg.toolsets, so
+	// only listOutput needs explicit warming here; warming both keeps the
+	// invariant (every cache field is populated before publish) easy to
+	// state and survive future caches without re-introducing the race.
+	cfg.ListOutput()
+	cfg.Toolsets()
+
 	// Publish cfg to readers (handlers, rate-limit closure, ServeHTTP, the
 	// next refresh) via an atomic store. The SDK already reflects cfg from
 	// the commit phase above; the store makes the new *Configuration
-	// observable to lock-free readers in one indivisible step.
+	// observable to lock-free readers in one indivisible step. Pre-warming
+	// the caches above ensures lock-free readers find them already
+	// populated and never write to them concurrently.
 	s.configuration.Store(cfg)
 	// Update the enabledX bookkeeping under mu. Reader of these fields
 	// (GetEnabledX) only reads enabledX, never combined with cfg, so there

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -49,6 +49,17 @@ func (c *Configuration) ListOutput() output.Output {
 	return c.listOutput
 }
 
+// warmCaches forces every lazy cache field on Configuration to be populated.
+// Callers about to publish a *Configuration to lock-free readers MUST call
+// this first; otherwise the first concurrent readers race on the lazy
+// initialization. Keep this in sync with every lazy field on Configuration —
+// adding a new lazy field without extending warmCaches re-introduces the
+// race.
+func (c *Configuration) warmCaches() {
+	c.ListOutput()
+	c.Toolsets()
+}
+
 func (c *Configuration) isToolApplicable(tool api.ServerTool) bool {
 	if c.ReadOnly && !ptr.Deref(tool.Tool.Annotations.ReadOnlyHint, false) {
 		return false
@@ -69,7 +80,7 @@ type Server struct {
 	// mu protects the enabledX bookkeeping. The configuration is held in
 	// an atomic.Pointer (see below) and does NOT require mu for reads.
 	mu sync.RWMutex
-	// reloadMu serializes reloadToolsets calls. WatchTargets (kubeconfig +
+	// reloadMu serializes applyToolsets calls. WatchTargets (kubeconfig +
 	// cluster-state watchers) and ReloadConfiguration can all fire reloads
 	// concurrently; without this lock, two reloads can interleave their SDK
 	// Add/Remove operations and their enabledX writes, leaving the SDK and
@@ -149,33 +160,32 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 	s.server.AddReceivingMiddleware(toolCallLoggingMiddleware)
 	s.server.AddReceivingMiddleware(s.metricsMiddleware())
 
-	err = s.reloadToolsets(s.configuration.Load())
+	err = s.applyToolsets(s.configuration.Load())
 	if err != nil {
 		return nil, err
 	}
-	s.p.WatchTargets(s.refreshToolsets)
+	s.p.WatchTargets(s.reapplyToolsets)
 
 	return s, nil
 }
 
-// refreshToolsets re-runs reloadToolsets against whatever configuration is
-// currently installed. Used by the provider's WatchTargets callback (signature
-// func() error) when cluster state changes but the configuration itself has
-// not. Passing nil cfg makes reloadToolsets re-read s.configuration *inside*
-// the reloadMu critical section, which avoids a TOCTOU race where capturing
-// the cfg here would let a concurrent ReloadConfiguration commit a new cfg
-// while we were blocked on reloadMu — we'd then silently roll it back by
-// re-installing the stale snapshot.
-func (s *Server) refreshToolsets() error {
-	return s.reloadToolsets(nil)
+// reapplyToolsets is the provider's WatchTargets callback (signature
+// func() error). It re-applies the currently-installed configuration when
+// cluster state changes. The nil arg tells applyToolsets to re-read
+// s.configuration *inside* the reloadMu critical section, avoiding a TOCTOU
+// where capturing cfg here could let a concurrent ReloadConfiguration commit
+// a new cfg while we're blocked on reloadMu — we'd then silently roll it
+// back by re-installing the stale snapshot.
+func (s *Server) reapplyToolsets() error {
+	return s.applyToolsets(nil)
 }
 
-// reloadToolsets recomputes the SDK's tool/prompt/resource/template surface
+// applyToolsets recomputes the SDK's tool/prompt/resource/template surface
 // against cfg and, on success, atomically installs cfg as the live
 // configuration alongside the SDK changes. cfg may be:
 //   - a freshly-built *Configuration (configuration reload path), in which
 //     case s.configuration is only mutated once the convert phase succeeds;
-//   - nil (refresh path, e.g. cluster-state change), in which case the
+//   - nil (re-apply path, e.g. cluster-state change), in which case the
 //     currently-installed configuration is re-read under reloadMu and
 //     reused. nil — instead of "callers pass s.configuration" — is required
 //     to avoid the caller capturing a stale cfg before reloadMu serializes
@@ -183,7 +193,7 @@ func (s *Server) refreshToolsets() error {
 //
 // On error s.configuration, the SDK, and the enabled-X bookkeeping all stay
 // at their prior consistent values.
-func (s *Server) reloadToolsets(cfg *Configuration) error {
+func (s *Server) applyToolsets(cfg *Configuration) error {
 	// TODO: No option to perform a full replacement of tools.
 	// s.server.SetTools(tools...)
 
@@ -193,7 +203,7 @@ func (s *Server) reloadToolsets(cfg *Configuration) error {
 	s.reloadMu.Lock()
 	defer s.reloadMu.Unlock()
 
-	// If the caller didn't pin a candidate cfg, refresh against whatever is
+	// If the caller didn't pin a candidate cfg, re-apply whatever is
 	// currently installed. Reading inside the reloadMu critical section
 	// guarantees we observe the latest committed cfg, even if a concurrent
 	// ReloadConfiguration just stored one while we were blocked above.
@@ -267,24 +277,19 @@ func (s *Server) reloadToolsets(cfg *Configuration) error {
 	newResources := commitItems(previousResources, convertedResources, s.server.RemoveResources, s.server.AddResource)
 	newResourceTemplates := commitItems(previousResourceTemplates, convertedResourceTemplates, s.server.RemoveResourceTemplates, s.server.AddResourceTemplate)
 
-	// Pre-warm the lazy caches so concurrent first-readers (handlers reading
-	// cfg.ListOutput()) don't race on the cache's lazy initialization. The
-	// collectApplicable* calls above already populated cfg.toolsets, so
-	// only listOutput needs explicit warming here; warming both keeps the
-	// invariant (every cache field is populated before publish) easy to
-	// state and survive future caches without re-introducing the race.
-	cfg.ListOutput()
-	cfg.Toolsets()
+	// Pre-warm cfg's lazy caches so concurrent first-readers (handlers
+	// reading cfg.ListOutput() etc.) don't race on the lazy initialization.
+	// MUST happen before the atomic store below, otherwise lock-free readers
+	// can observe cfg with un-warmed caches.
+	cfg.warmCaches()
 
 	// Publish cfg to readers (handlers, rate-limit closure, ServeHTTP, the
-	// next refresh) via an atomic store. The SDK already reflects cfg from
+	// next re-apply) via an atomic store. The SDK already reflects cfg from
 	// the commit phase above; the store makes the new *Configuration
-	// observable to lock-free readers in one indivisible step. Pre-warming
-	// the caches above ensures lock-free readers find them already
-	// populated and never write to them concurrently.
+	// observable to lock-free readers in one indivisible step.
 	s.configuration.Store(cfg)
-	// Update the enabledX bookkeeping under mu. Reader of these fields
-	// (GetEnabledX) only reads enabledX, never combined with cfg, so there
+	// Update the enabledX bookkeeping under mu. Readers of these fields
+	// (GetEnabledX) only read enabledX, never combined with cfg, so there
 	// is no need to keep the cfg store and the enabledX writes inside the
 	// same critical section.
 	s.mu.Lock()
@@ -295,7 +300,7 @@ func (s *Server) reloadToolsets(cfg *Configuration) error {
 	s.mu.Unlock()
 
 	// Start new watch
-	s.p.WatchTargets(s.refreshToolsets)
+	s.p.WatchTargets(s.reapplyToolsets)
 	return nil
 }
 
@@ -522,7 +527,7 @@ func (s *Server) GetEnabledResourceTemplates() []string {
 // configuration changes are detected.
 //
 // The reload is fully transactional: s.configuration is not mutated until
-// reloadToolsets has successfully recomputed and committed the SDK surface
+// applyToolsets has successfully recomputed and committed the SDK surface
 // against the candidate config. A rejected reload leaves s.configuration, the
 // SDK, and the enabled-X bookkeeping at their previous consistent values, so
 // concurrent readers (rate-limit closure, confirmation rules, list output...)
@@ -538,11 +543,11 @@ func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 		return fmt.Errorf("configuration reload rejected: %w", err)
 	}
 
-	// Build a candidate Configuration view. reloadToolsets will install it
+	// Build a candidate Configuration view. applyToolsets will install it
 	// atomically only if the convert phase succeeds.
 	candidate := &Configuration{StaticConfig: newConfig}
 
-	if err := s.reloadToolsets(candidate); err != nil {
+	if err := s.applyToolsets(candidate); err != nil {
 		return fmt.Errorf("failed to reload toolsets: %w", err)
 	}
 

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -497,6 +497,44 @@ func (s *ConfigReloadSuite) TestConcurrentReadsDuringReload() {
 	}
 }
 
+// TestConcurrentListOutputAfterReload exercises the lazy ListOutput cache
+// race: after a successful reload, several handlers reading
+// cfg.ListOutput() concurrently for the first time would each write the
+// cache field unsynchronized. With the cache pre-warmed in reloadToolsets
+// before publish, the first-read writes are gone and `-race` stays clean.
+func (s *ConfigReloadSuite) TestConcurrentListOutputAfterReload() {
+	provider, err := kubernetes.NewProvider(s.Cfg)
+	s.Require().NoError(err)
+	server, err := NewServer(Configuration{
+		StaticConfig: s.Cfg,
+	}, provider)
+	s.Require().NoError(err)
+	s.server = server
+
+	for iter := 0; iter < 5; iter++ {
+		newCfg := config.Default()
+		newCfg.KubeConfig = s.Cfg.KubeConfig
+		if iter%2 == 0 {
+			newCfg.ListOutput = "yaml"
+		} else {
+			newCfg.ListOutput = "table"
+		}
+		s.Require().NoError(server.ReloadConfiguration(newCfg))
+
+		var wg sync.WaitGroup
+		for r := 0; r < 16; r++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				cfg := server.configuration.Load()
+				_ = cfg.ListOutput()
+				_ = cfg.Toolsets()
+			}()
+		}
+		wg.Wait()
+	}
+}
+
 func (s *ConfigReloadSuite) TestServerLifecycle() {
 	provider, err := kubernetes.NewProvider(s.Cfg)
 	s.Require().NoError(err)

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -18,7 +18,7 @@ import (
 // brokenToolset is a fake api.Toolset whose single tool has a non-object
 // input schema. ServerToolToGoSdkTool rejects this in the convert phase
 // ("input schema must have type \"object\""), which is the only failure
-// mode that exercises reloadToolsets's transactional swap path —
+// mode that exercises applyToolsets's transactional swap path —
 // config-level errors fail earlier, in Validate. We can't simply use
 // InputSchema: nil because the WithTargetParameter mutator initializes a
 // nil schema to type=object for cluster-aware tools.
@@ -384,9 +384,10 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 // TestReloadFailureLeavesConfigurationIntact is the regression for issue
 // #1128: a reload whose convert phase fails must leave s.configuration, the
 // SDK surface, and the enabled-X bookkeeping all at their pre-reload values.
-// We trigger the failure via brokenToolset (a tool with nil input schema is
-// rejected by ServerToolToGoSdkTool) and call reloadToolsets directly so we
-// exercise the transactional swap rather than the Validate fast-path.
+// We trigger the failure via brokenToolset (a tool with a non-object input
+// schema is rejected by ServerToolToGoSdkTool) and call applyToolsets
+// directly so we exercise the transactional swap rather than the Validate
+// fast-path.
 func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
 	provider, err := kubernetes.NewProvider(s.Cfg)
 	s.Require().NoError(err)
@@ -414,8 +415,8 @@ func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
 	}
 
 	s.Run("convert-phase failure does not mutate s.configuration", func() {
-		err := server.reloadToolsets(candidate)
-		s.Require().Error(err, "reload must fail when a tool has a nil input schema")
+		err := server.applyToolsets(candidate)
+		s.Require().Error(err, "reload must fail when a tool has a non-object input schema")
 
 		s.Same(prevConfig, server.configuration.Load(),
 			"s.configuration pointer must be unchanged after a rejected reload")
@@ -429,10 +430,10 @@ func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
 			"enabledResourceTemplates must be unchanged after a rejected reload")
 	})
 
-	s.Run("a subsequent successful refresh still works", func() {
+	s.Run("a subsequent successful re-apply still works", func() {
 		// Confirms the failed swap didn't leave reloadMu/mu in a bad state
 		// or corrupt the existing SDK surface.
-		s.Require().NoError(server.refreshToolsets())
+		s.Require().NoError(server.reapplyToolsets())
 		s.Equal(prevEnabledTools, server.GetEnabledTools())
 	})
 }
@@ -500,8 +501,9 @@ func (s *ConfigReloadSuite) TestConcurrentReadsDuringReload() {
 // TestConcurrentListOutputAfterReload exercises the lazy ListOutput cache
 // race: after a successful reload, several handlers reading
 // cfg.ListOutput() concurrently for the first time would each write the
-// cache field unsynchronized. With the cache pre-warmed in reloadToolsets
-// before publish, the first-read writes are gone and `-race` stays clean.
+// cache field unsynchronized. With the cache pre-warmed by warmCaches in
+// applyToolsets before publish, the first-read writes are gone and
+// `-race` stays clean.
 func (s *ConfigReloadSuite) TestConcurrentListOutputAfterReload() {
 	provider, err := kubernetes.NewProvider(s.Cfg)
 	s.Require().NoError(err)

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -3,11 +3,35 @@ package mcp
 import (
 	"testing"
 
+	"github.com/google/jsonschema-go/jsonschema"
+
 	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/stretchr/testify/suite"
 )
+
+// brokenToolset is a fake api.Toolset whose single tool has a non-object
+// input schema. ServerToolToGoSdkTool rejects this in the convert phase
+// ("input schema must have type \"object\""), which is the only failure
+// mode that exercises reloadToolsets's transactional swap path —
+// config-level errors fail earlier, in Validate. We can't simply use
+// InputSchema: nil because the WithTargetParameter mutator initializes a
+// nil schema to type=object for cluster-aware tools.
+type brokenToolset struct{}
+
+func (brokenToolset) GetName() string        { return "broken-test-toolset" }
+func (brokenToolset) GetDescription() string { return "test-only toolset that fails convert phase" }
+func (brokenToolset) GetTools(api.Openshift) []api.ServerTool {
+	return []api.ServerTool{{Tool: api.Tool{
+		Name:        "broken-tool",
+		InputSchema: &jsonschema.Schema{Type: "string"},
+	}}}
+}
+func (brokenToolset) GetPrompts() []api.ServerPrompt                     { return nil }
+func (brokenToolset) GetResources() []api.ServerResource                 { return nil }
+func (brokenToolset) GetResourceTemplates() []api.ServerResourceTemplate { return nil }
 
 type ConfigReloadSuite struct {
 	BaseMcpSuite
@@ -351,6 +375,62 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 		err := server.ReloadConfiguration(newConfig)
 		s.NoError(err)
+	})
+}
+
+// TestReloadFailureLeavesConfigurationIntact is the regression for issue
+// #1128: a reload whose convert phase fails must leave s.configuration, the
+// SDK surface, and the enabled-X bookkeeping all at their pre-reload values.
+// We trigger the failure via brokenToolset (a tool with nil input schema is
+// rejected by ServerToolToGoSdkTool) and call reloadToolsets directly so we
+// exercise the transactional swap rather than the Validate fast-path.
+func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
+	provider, err := kubernetes.NewProvider(s.Cfg)
+	s.Require().NoError(err)
+	server, err := NewServer(Configuration{
+		StaticConfig: s.Cfg,
+	}, provider)
+	s.Require().NoError(err)
+	s.server = server
+
+	prevConfig := server.configuration
+	prevEnabledTools := server.GetEnabledTools()
+	prevEnabledPrompts := server.GetEnabledPrompts()
+	prevEnabledResources := server.GetEnabledResources()
+	prevEnabledResourceTemplates := server.GetEnabledResourceTemplates()
+	s.Require().NotEmpty(prevEnabledTools, "baseline must have some enabled tools to be a meaningful regression target")
+
+	// Build a candidate Configuration that bypasses the StaticConfig.Toolsets
+	// resolver and goes straight to the broken toolset, so collectApplicable*
+	// returns the bad tool and the convert phase fails.
+	candidateStatic := config.Default()
+	candidateStatic.KubeConfig = s.Cfg.KubeConfig
+	candidate := &Configuration{
+		StaticConfig: candidateStatic,
+		toolsets:     []api.Toolset{brokenToolset{}},
+	}
+
+	s.Run("convert-phase failure does not mutate s.configuration", func() {
+		err := server.reloadToolsets(candidate)
+		s.Require().Error(err, "reload must fail when a tool has a nil input schema")
+
+		s.Same(prevConfig, server.configuration,
+			"s.configuration pointer must be unchanged after a rejected reload")
+		s.Equal(prevEnabledTools, server.GetEnabledTools(),
+			"enabledTools must be unchanged after a rejected reload")
+		s.Equal(prevEnabledPrompts, server.GetEnabledPrompts(),
+			"enabledPrompts must be unchanged after a rejected reload")
+		s.Equal(prevEnabledResources, server.GetEnabledResources(),
+			"enabledResources must be unchanged after a rejected reload")
+		s.Equal(prevEnabledResourceTemplates, server.GetEnabledResourceTemplates(),
+			"enabledResourceTemplates must be unchanged after a rejected reload")
+	})
+
+	s.Run("a subsequent successful refresh still works", func() {
+		// Confirms the failed swap didn't leave reloadMu/mu in a bad state
+		// or corrupt the existing SDK surface.
+		s.Require().NoError(server.refreshToolsets())
+		s.Equal(prevEnabledTools, server.GetEnabledTools())
 	})
 }
 

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -1,7 +1,10 @@
 package mcp
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 
@@ -68,9 +71,9 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 	s.server = server
 
 	s.Run("initial configuration loaded correctly", func() {
-		s.Equal(s.Cfg.LogLevel, server.configuration.LogLevel)
-		s.Equal(s.Cfg.ListOutput, server.configuration.StaticConfig.ListOutput)
-		s.Equal(s.Cfg.Toolsets, server.configuration.StaticConfig.Toolsets)
+		s.Equal(s.Cfg.LogLevel, server.configuration.Load().LogLevel)
+		s.Equal(s.Cfg.ListOutput, server.configuration.Load().StaticConfig.ListOutput)
+		s.Equal(s.Cfg.Toolsets, server.configuration.Load().StaticConfig.Toolsets)
 	})
 
 	s.Run("reload with new log level", func() {
@@ -83,9 +86,9 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 		err = server.ReloadConfiguration(newConfig)
 		s.Require().NoError(err)
 
-		s.Equal(5, server.configuration.LogLevel)
-		s.Equal("yaml", server.configuration.StaticConfig.ListOutput)
-		s.Equal([]string{"core", "config"}, server.configuration.StaticConfig.Toolsets)
+		s.Equal(5, server.configuration.Load().LogLevel)
+		s.Equal("yaml", server.configuration.Load().StaticConfig.ListOutput)
+		s.Equal([]string{"core", "config"}, server.configuration.Load().StaticConfig.Toolsets)
 	})
 
 	s.Run("reload with additional toolsets", func() {
@@ -98,9 +101,9 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 		err = server.ReloadConfiguration(newConfig)
 		s.Require().NoError(err)
 
-		s.Equal(5, server.configuration.LogLevel)
-		s.Equal("yaml", server.configuration.StaticConfig.ListOutput)
-		s.Equal([]string{"core", "config", "helm"}, server.configuration.StaticConfig.Toolsets)
+		s.Equal(5, server.configuration.Load().LogLevel)
+		s.Equal("yaml", server.configuration.Load().StaticConfig.ListOutput)
+		s.Equal([]string{"core", "config", "helm"}, server.configuration.Load().StaticConfig.Toolsets)
 	})
 
 	s.Run("reload with partial changes", func() {
@@ -113,9 +116,9 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 		err = server.ReloadConfiguration(newConfig)
 		s.Require().NoError(err)
 
-		s.Equal(7, server.configuration.LogLevel)
-		s.Equal("yaml", server.configuration.StaticConfig.ListOutput)
-		s.Equal([]string{"core", "config", "helm"}, server.configuration.StaticConfig.Toolsets)
+		s.Equal(7, server.configuration.Load().LogLevel)
+		s.Equal("yaml", server.configuration.Load().StaticConfig.ListOutput)
+		s.Equal([]string{"core", "config", "helm"}, server.configuration.Load().StaticConfig.Toolsets)
 	})
 
 	s.Run("reload back to defaults", func() {
@@ -128,9 +131,9 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 		err = server.ReloadConfiguration(newConfig)
 		s.Require().NoError(err)
 
-		s.Equal(0, server.configuration.LogLevel)
-		s.Equal("table", server.configuration.StaticConfig.ListOutput)
-		s.Equal([]string{"core", "config"}, server.configuration.StaticConfig.Toolsets)
+		s.Equal(0, server.configuration.Load().LogLevel)
+		s.Equal("table", server.configuration.Load().StaticConfig.ListOutput)
+		s.Equal([]string{"core", "config"}, server.configuration.Load().StaticConfig.Toolsets)
 	})
 }
 
@@ -145,7 +148,7 @@ func (s *ConfigReloadSuite) TestConfigurationValues() {
 
 	s.Run("reload updates configuration values", func() {
 		// Verify initial values
-		initialLogLevel := server.configuration.LogLevel
+		initialLogLevel := server.configuration.Load().LogLevel
 
 		newConfig := config.Default()
 		newConfig.LogLevel = 9
@@ -157,10 +160,10 @@ func (s *ConfigReloadSuite) TestConfigurationValues() {
 		s.Require().NoError(err)
 
 		// Verify configuration was updated
-		s.NotEqual(initialLogLevel, server.configuration.LogLevel)
-		s.Equal(9, server.configuration.LogLevel)
-		s.Equal([]string{"core", "config", "helm"}, server.configuration.StaticConfig.Toolsets)
-		s.Equal("yaml", server.configuration.StaticConfig.ListOutput)
+		s.NotEqual(initialLogLevel, server.configuration.Load().LogLevel)
+		s.Equal(9, server.configuration.Load().LogLevel)
+		s.Equal([]string{"core", "config", "helm"}, server.configuration.Load().StaticConfig.Toolsets)
+		s.Equal("yaml", server.configuration.Load().StaticConfig.ListOutput)
 	})
 }
 
@@ -181,7 +184,7 @@ func (s *ConfigReloadSuite) TestMultipleReloads() {
 		cfg1.Toolsets = []string{"core"}
 		err = server.ReloadConfiguration(cfg1)
 		s.Require().NoError(err)
-		s.Equal(3, server.configuration.LogLevel)
+		s.Equal(3, server.configuration.Load().LogLevel)
 
 		// Second reload
 		cfg2 := config.Default()
@@ -190,7 +193,7 @@ func (s *ConfigReloadSuite) TestMultipleReloads() {
 		cfg2.Toolsets = []string{"core", "config"}
 		err = server.ReloadConfiguration(cfg2)
 		s.Require().NoError(err)
-		s.Equal(6, server.configuration.LogLevel)
+		s.Equal(6, server.configuration.Load().LogLevel)
 
 		// Third reload
 		cfg3 := config.Default()
@@ -199,7 +202,7 @@ func (s *ConfigReloadSuite) TestMultipleReloads() {
 		cfg3.Toolsets = []string{"core", "config", "helm"}
 		err = server.ReloadConfiguration(cfg3)
 		s.Require().NoError(err)
-		s.Equal(9, server.configuration.LogLevel)
+		s.Equal(9, server.configuration.Load().LogLevel)
 	})
 }
 
@@ -393,7 +396,7 @@ func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
 	s.Require().NoError(err)
 	s.server = server
 
-	prevConfig := server.configuration
+	prevConfig := server.configuration.Load()
 	prevEnabledTools := server.GetEnabledTools()
 	prevEnabledPrompts := server.GetEnabledPrompts()
 	prevEnabledResources := server.GetEnabledResources()
@@ -414,7 +417,7 @@ func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
 		err := server.reloadToolsets(candidate)
 		s.Require().Error(err, "reload must fail when a tool has a nil input schema")
 
-		s.Same(prevConfig, server.configuration,
+		s.Same(prevConfig, server.configuration.Load(),
 			"s.configuration pointer must be unchanged after a rejected reload")
 		s.Equal(prevEnabledTools, server.GetEnabledTools(),
 			"enabledTools must be unchanged after a rejected reload")
@@ -432,6 +435,66 @@ func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
 		s.Require().NoError(server.refreshToolsets())
 		s.Equal(prevEnabledTools, server.GetEnabledTools())
 	})
+}
+
+// TestConcurrentReadsDuringReload runs many reader goroutines that exercise
+// the same s.configuration access pattern handlers use (Load() + read fields
+// off the snapshot), in parallel with a writer goroutine that calls
+// ReloadConfiguration repeatedly. With the field stored as a plain pointer
+// guarded only by the now-unused-by-handlers s.mu, `go test -race` would
+// report a data race on the field. With atomic.Pointer it is race-free.
+func (s *ConfigReloadSuite) TestConcurrentReadsDuringReload() {
+	provider, err := kubernetes.NewProvider(s.Cfg)
+	s.Require().NoError(err)
+	server, err := NewServer(Configuration{
+		StaticConfig: s.Cfg,
+	}, provider)
+	s.Require().NoError(err)
+	s.server = server
+
+	stop := make(chan struct{})
+	var observedReads atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				cfg := server.configuration.Load()
+				_ = cfg.HTTP.RateLimitRPS
+				_ = cfg.Stateless
+				_ = cfg.LogLevel
+				observedReads.Add(1)
+			}
+		}()
+	}
+
+	deadline := time.After(500 * time.Millisecond)
+	toggle := false
+	for {
+		select {
+		case <-deadline:
+			close(stop)
+			wg.Wait()
+			s.Greater(observedReads.Load(), int64(0), "readers must have run")
+			return
+		default:
+		}
+		newCfg := config.Default()
+		newCfg.KubeConfig = s.Cfg.KubeConfig
+		if toggle {
+			newCfg.LogLevel = 9
+		} else {
+			newCfg.LogLevel = 1
+		}
+		toggle = !toggle
+		s.Require().NoError(server.ReloadConfiguration(newCfg))
+	}
 }
 
 func (s *ConfigReloadSuite) TestServerLifecycle() {

--- a/pkg/mcp/prompts_gosdk.go
+++ b/pkg/mcp/prompts_gosdk.go
@@ -57,7 +57,7 @@ func ServerPromptToGoSdkPrompt(s *Server, serverPrompt api.ServerPrompt) (*mcp.P
 
 		params := api.PromptHandlerParams{
 			Context:           ctx,
-			BaseConfig:        s.configuration,
+			BaseConfig:        s.configuration.Load(),
 			KubernetesClient:  k8s,
 			PromptCallRequest: &promptCallRequestAdapter{request: request},
 			Elicitor:          &sessionElicitor{},

--- a/pkg/mcp/resources_gosdk_test.go
+++ b/pkg/mcp/resources_gosdk_test.go
@@ -506,7 +506,7 @@ func (s *ResourceSuite) TestInvalidURITemplateReturnsError() {
 		// must mirror that — otherwise downstream reads (rate limit, list
 		// output, confirmation rules, ...) would see a config that disagrees
 		// with what the SDK is actually serving.
-		s.Equal([]string{"resource-test-good"}, s.mcpServer.configuration.StaticConfig.Toolsets)
+		s.Equal([]string{"resource-test-good"}, s.mcpServer.configuration.Load().StaticConfig.Toolsets)
 	})
 
 	s.Run("server accepts a subsequent valid reload", func() {

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -49,9 +49,12 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 		if err != nil {
 			return nil, fmt.Errorf("%v for tool %s", err, tool.Tool.Name)
 		}
+		// Snapshot the live configuration once so a concurrent reload
+		// can't split BaseConfig and ListOutput across two configs.
+		cfg := s.configuration.Load()
 		// Check confirmation rules before executing the tool
 		if confirmErr := confirmation.CheckToolRules(
-			ctx, s.configuration, &sessionElicitor{},
+			ctx, cfg, &sessionElicitor{},
 			tool.Tool.Name, tool.Tool.Annotations.DestructiveHint,
 		); confirmErr != nil {
 			return NewTextResult("", confirmErr), nil
@@ -66,10 +69,10 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 
 		result, err := tool.Handler(api.ToolHandlerParams{
 			Context:          ctx,
-			BaseConfig:       s.configuration,
+			BaseConfig:       cfg,
 			KubernetesClient: k,
 			ToolCallRequest:  toolCallRequest,
-			ListOutput:       s.configuration.ListOutput(),
+			ListOutput:       cfg.ListOutput(),
 			Elicitor:         &sessionElicitor{},
 		})
 		if err != nil {

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -16,7 +16,7 @@ import (
 
 func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolHandler, error) {
 	// Validate the input schema upfront to mirror the SDK's AddTool panic
-	// surface. This keeps reloadToolsets' two-phase model panic-free at commit
+	// surface. This keeps applyToolsets' two-phase model panic-free at commit
 	// time even if a misconfigured tool slips through the toolset boundary.
 	inputSchema := tool.Tool.InputSchema
 	if inputSchema == nil {


### PR DESCRIPTION
## Summary

Closes #1128.

`ReloadConfiguration` previously mutated `s.configuration.StaticConfig` *before* calling `reloadToolsets`, then snapshot-and-rolled-back on failure. The window between mutation and rollback briefly exposed a new-but-rejected configuration to concurrent readers (rate-limit closure, confirmation rules, list output, ...). This PR makes the reload fully transactional, then takes the boy-scout opportunity to fix two pre-existing data races in the surrounding `s.configuration` access pattern that surfaced during review.

Three commits, each with its own race-detector regression test that fails before the fix and passes after.

### 1. `refactor(mcp): make ReloadConfiguration fully transactional` — the issue itself

- `collectApplicableTools/Prompts/Resources/ResourceTemplates` now take `*Configuration` explicitly instead of reading `s.configuration`.
- `reloadToolsets(cfg *Configuration)` is the single reload entry point. It installs `cfg` atomically only after the convert phase succeeds. Passing `nil` triggers the refresh path: re-read `s.configuration` *inside* the `reloadMu` critical section. This avoids a TOCTOU where the `WatchTargets` callback could otherwise capture cfg before `reloadMu`, then commit a stale snapshot after a concurrent `ReloadConfiguration` had already published a new one.
- `ReloadConfiguration` builds a candidate `*Configuration` and hands it to `reloadToolsets`. The snapshot-and-rollback path is gone.
- Regression test: `TestReloadFailureLeavesConfigurationIntact` injects a tool with a non-`object` input schema (rejected by `ServerToolToGoSdkTool` in the convert phase), calls `reloadToolsets` directly with the candidate, and asserts `s.configuration` and all `enabledX` lists are unchanged. A second subtest verifies a follow-up `refreshToolsets()` succeeds — confirms locks weren't left in a bad state.

### 2. `fix(mcp): make Server.configuration accesses race-free with atomic.Pointer`

`Server.configuration` is now `atomic.Pointer[Configuration]`. Lock-free `Load()` on hot read paths (handlers, rate-limit closure, `ServeHTTP`); atomic `Store()` on the swap. The tool handler now snapshots once via `cfg := s.configuration.Load()` at the top and uses that for both `BaseConfig` and `ListOutput()` — fixes a torn-deref where a mid-handler reload could split fields across two configurations. Regression test: `TestConcurrentReadsDuringReload` runs 8 reader goroutines mirroring the handler access pattern alongside a tight `ReloadConfiguration` loop; clean under `-race`, would have flagged the bare-pointer field.

### 3. `fix(mcp): pre-warm Configuration's lazy caches before publish`

`Configuration.ListOutput()` and `Configuration.Toolsets()` lazy-init unexported cache fields on first read. After publish the new config is visible to lock-free readers, and the first concurrent first-readers would race writing the same cache field. Pre-warming both caches in `reloadToolsets` immediately before the atomic store eliminates the windows. Regression test: `TestConcurrentListOutputAfterReload` — verified that *without* the warm-up `-race` reports the data race on `Configuration.listOutput`, *with* the warm-up it stays clean.

## Test plan

- [x] \`go test ./pkg/mcp/ -race -timeout 300s\` → ok
- [x] \`go test ./...\` → all packages pass
- [x] \`make lint\` → 0 issues
- [x] New regression tests for each commit pass with the fix in place and fail when reverted (verified via \`git stash\` for #3)
- [x] CI green