### PR TITLE
feat: Add namespace support to resources_create_or_update as in kubectl apply -n namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 - **resources_create_or_update** - Create or update a Kubernetes resource in the current cluster by providing a YAML or JSON representation of the resource
 (common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)
-  - `resource` (`string`) **(required)** - A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec
+  - `resource` (`string`) **(required)** - A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion, kind, metadata, and spec. For namespaced resources, include metadata.namespace to specify the target namespace; if omitted, the configured default namespace is used
 
 - **resources_delete** - Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name
 (common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -534,6 +534,26 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdate() {
 		})
 	})
 
+	s.Run("resources_create_or_update respects namespace from resource metadata", func() {
+		configMapYaml := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a-cm-ns-from-metadata\n  namespace: ns-1\ndata:\n  key: value\n"
+		result, err := s.CallTool("resources_create_or_update", map[string]interface{}{
+			"resource": configMapYaml,
+		})
+		s.Run("returns success", func() {
+			s.Nilf(err, "call tool failed %v", err)
+			s.Falsef(result.IsError, "call tool should not fail, got: %v", result.Content)
+		})
+		s.Run("creates ConfigMap in the namespace specified in the resource metadata", func() {
+			cm, cmErr := client.CoreV1().ConfigMaps("ns-1").Get(s.T().Context(), "a-cm-ns-from-metadata", metav1.GetOptions{})
+			s.Require().Nilf(cmErr, "ConfigMap not found in ns-1 namespace")
+			s.Equalf("ns-1", cm.Namespace, "ConfigMap should be in the namespace from the resource metadata")
+		})
+		s.Run("does not create ConfigMap in the default namespace", func() {
+			_, cmErr := client.CoreV1().ConfigMaps("default").Get(s.T().Context(), "a-cm-ns-from-metadata", metav1.GetOptions{})
+			s.Errorf(cmErr, "ConfigMap should not exist in the default namespace")
+		})
+	})
+
 	s.Run("resources_create_or_update strips status from resource", func() {
 		configMapWithStatusYaml := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a-cm-with-status\n  namespace: default\ndata:\n  key: value\nstatus:\n  conditions:\n  - type: Ready\n    status: \"True\"\n"
 		result, err := s.CallTool("resources_create_or_update", map[string]interface{}{"resource": configMapWithStatusYaml})

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -99,7 +99,7 @@ func initResources(o api.Openshift) []api.ServerTool {
 				Properties: map[string]*jsonschema.Schema{
 					"resource": {
 						Type:        "string",
-						Description: "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion,kind,metadata, and spec",
+						Description: "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion, kind, metadata, and spec. For namespaced resources, include metadata.namespace to specify the target namespace; if omitted, the configured default namespace is used",
 					},
 				},
 				Required: []string{"resource"},


### PR DESCRIPTION
Closes: #536 

## Root Cause

The `resource` parameter description in `pkg/toolsets/core/resources.go` only said:

> "A JSON or YAML containing a representation of the Kubernetes resource. Should include top-level fields such as apiVersion, kind, metadata, and spec"

No mention of `metadata.namespace` or default namespace fallback behavior.

## Changes

### 1. Tool description update

**File:** `pkg/toolsets/core/resources.go:102`

Updated the `resource` parameter description to include namespace guidance:

```diff
- "A JSON or YAML containing a representation of the Kubernetes resource.
-  Should include top-level fields such as apiVersion,kind,metadata, and spec"
+ "A JSON or YAML containing a representation of the Kubernetes resource.
+  Should include top-level fields such as apiVersion, kind, metadata, and spec.
+  For namespaced resources, include metadata.namespace to specify the target
+  namespace; if omitted, the configured default namespace is used"
```

### 2. Test proving non-default namespace is respected

**File:** `pkg/mcp/resources_test.go`

Added subtest `resources_create_or_update respects namespace from resource metadata` inside `TestResourcesCreateOrUpdate`. Existing tests all used `namespace: default`, which coincides with the envtest default, they would pass even if namespace handling was broken.

The new test:

- Creates a ConfigMap with `metadata.namespace: ns-1` (a non-default namespace already set up in `common_test.go:136`)
- Asserts the ConfigMap exists in `ns-1` with the correct namespace value
- Asserts the ConfigMap does **not** exist in `default`, proving the namespace was not silently ignored

## References

- Issue: [#536](https://github.com/containers/kubernetes-mcp-server/issues/536)
- Prior PR (rejected): [#941](https://github.com/containers/kubernetes-mcp-server/pull/941)
- Maintainer guidance: [comment on #536](https://github.com/containers/kubernetes-mcp-server/issues/536#issuecomment-4133990566)