### PR TITLE
fix(test): inherit ReadOnly from suite config in reload test

### DIFF
--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -409,6 +409,7 @@ func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
 	// returns the bad tool and the convert phase fails.
 	candidateStatic := config.Default()
 	candidateStatic.KubeConfig = s.Cfg.KubeConfig
+	candidateStatic.ReadOnly = s.Cfg.ReadOnly
 	candidate := &Configuration{
 		StaticConfig: candidateStatic,
 		toolsets:     []api.Toolset{brokenToolset{}},


### PR DESCRIPTION
The TestReloadFailureLeavesConfigurationIntact test built a candidate config from config.Default() without inheriting ReadOnly from the suite config. When downstream overrides set ReadOnly: true, the brokenToolset tool (which has no ReadOnlyHint) gets filtered out before reaching the convert phase, causing the test to pass unexpectedly.

Inherit ReadOnly from s.Cfg to match the pattern used by other tests.