### PR TITLE
fix(test): use BaseDefault() in ToolsetsSuite to avoid downstream config leaking

### DIFF
--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -40,7 +40,7 @@ type ToolsetsSuite struct {
 func (s *ToolsetsSuite) SetupTest() {
 	s.originalToolsets = toolsets.Toolsets()
 	s.MockServer = test.NewMockServer()
-	s.Cfg = configuration.Default()
+	s.Cfg = configuration.BaseDefault()
 	s.Cfg.KubeConfig = s.KubeconfigFile(s.T())
 	s.updateJson = os.Getenv(updateJsonEnvVar) != ""
 }


### PR DESCRIPTION
`ToolsetsSuite.SetupTest()` used `config.Default()` which inherits downstream overrides (e.g.`ReadOnly: true`). This caused tools without `ReadOnlyHint` to be filtered out, breaking snapshot comparisons. Switch to `BaseDefault()` consistent with `BaseMcpSuite`.