### PR TITLE
feat: introduce Feature Gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This MCP server enables AI assistants (like Claude, Gemini, Cursor, and others) 
     - `kubernetes/` - Kubernetes client management, authentication, and access control.
     - `mcp/` - Model Context Protocol (MCP) server implementation with tool registration and STDIO/HTTP support.
     - `output/` - output formatting and rendering.
+    - `features/` - Feature gate definitions and lifecycle management.
     - `toolsets/` - Toolset registration and management for MCP tools.
     - `version/` - Version information management.
 - `.github/` – GitHub-related configuration (Actions workflows, issue templates...).
@@ -47,6 +48,85 @@ When adding a new tool:
 2. Create a `ServerTool` struct with the tool definition and handler.
 3. Add the tool to an appropriate toolset (or create a new toolset if needed).
 4. Register the toolset in `pkg/toolsets/` if it's a new toolset.
+
+### Feature gates
+
+The project uses a feature gate framework based on `k8s.io/component-base/featuregate` to control the availability of features based on their maturity level (Alpha, Beta, GA, Deprecated). Feature gates live in `pkg/features/`.
+
+#### Defining a new feature gate
+
+1. Add a `featuregate.Feature` constant in `pkg/features/features.go` with a comment summarizing the feature:
+    ```go
+    const (
+        // MyFeature enables the new behavior for XYZ, improving
+        // performance when handling large-scale resources.
+        MyFeature featuregate.Feature = "MyFeature"
+    )
+    ```
+
+2. Add its versioned lifecycle to `defaultFeatureGates` in the same file:
+    ```go
+    var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+        MyFeature: {
+            {Version: version.MajorMinor(0, 1), Default: false, PreRelease: featuregate.Alpha},
+            {Version: version.MajorMinor(0, 5), Default: true, PreRelease: featuregate.Beta},
+            {Version: version.MajorMinor(1, 0), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+        },
+    }
+    ```
+    Features registered in `init()` via `DefaultMutableFeatureGate.AddVersioned()` are automatically available to the CLI flag, TOML config, and SIGHUP reload.
+
+#### Checking a feature gate
+
+Use the package-level helper anywhere in the codebase:
+```go
+import "github.com/containers/kubernetes-mcp-server/pkg/features"
+
+if features.Enabled(features.MyFeature) {
+    // feature-gated code
+}
+```
+
+#### Configuring feature gates
+
+Feature gates can be set via:
+
+* **CLI flag:** `--feature-gates MyFeature=true,OtherFeature=false`
+* **TOML config file** (supports SIGHUP reload):
+    ```toml
+    [feature_gates]
+    MyFeature = true
+    ```
+
+CLI flags override config file values.
+
+#### Testing with feature gates
+
+Use `k8s.io/component-base/featuregate/testing` for safe, per-test overrides with automatic cleanup:
+```go
+import (
+    featuregatetesting "k8s.io/component-base/featuregate/testing"
+    "github.com/containers/kubernetes-mcp-server/pkg/features"
+)
+
+func (s *MySuite) TestWithFeature() {
+    featuregatetesting.SetFeatureGateDuringTest(s.T(), features.DefaultMutableFeatureGate, features.MyFeature, true)
+    // test code that depends on MyFeature being enabled
+}
+```
+
+#### Maturity Lifecycle
+
+| Stage | Default | User can override | Notes |
+|-------|---------|-------------------|-------|
+| Alpha | `false` | Yes | Opt-in, may be incomplete |
+| Beta | `true` | Yes | Enabled by default, well-tested |
+| GA | `true` | No (`LockToDefault: true`) | Permanently enabled |
+| Deprecated | `false` | No (`LockToDefault: true`) | Permanently disabled, pending removal |
+
+#### Thread safety
+
+`features.Enabled()` is lock-free (reads from `atomic.Value`). `features.ApplyFeatureGates()` (used during config reload) acquires an internal mutex and publishes via `atomic.Store`, so concurrent reads never see partial state. SIGHUP reloads are further serialized by the server's `reloadMu`.
 
 ## Building
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Living documentation for implemented and planned features:
 | **[Validation](specs/validation.md)** | Pre-execution validation layer (resource existence, schema, RBAC) | Implemented |
 
 ## Advanced Topics
-
+- **[Feature Gates](configuration.md#feature-gates)** - Control feature availability based on maturity level (Alpha, Beta, GA)
 - **[MCP Logging](logging.md)** - Structured logging to MCP clients with automatic K8s error categorization and secret redaction
 - **[OpenTelemetry Observability](OTEL.md)** - Distributed tracing and metrics configuration
 - **[MCP Prompts](prompts.md)** - Custom workflow templates for AI assistants

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,6 +281,27 @@ read_only = true
 disable_destructive = true
 ```
 
+### Feature Gates
+
+Feature gates control the availability of features based on their maturity level (Alpha, Beta, GA). They allow new or experimental features to be introduced behind a gate that users can opt into before the feature is enabled by default.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `feature_gates` | map of string -> bool | Enable or disable individual feature gates. |
+
+Feature gates can also be set via the `--feature-gates` CLI flag (format: `Feature1=true,Feature2=false`). CLI flags override config file values.
+
+**Example:**
+```toml
+[feature_gates]
+MyFeature = true
+AnotherFeature = false
+```
+
+Feature gates support dynamic reload via SIGHUP - changes to the `[feature_gates]` section take effect without restarting the server.
+
+Run `kubernetes-mcp-server --help` to see the list of available feature gates and their default states in the `--feature-gates` flag description.
+
 ### Toolsets
 
 Toolsets group related tools together. Enable only the toolsets you need to reduce context size and improve LLM tool selection accuracy.

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	k8s.io/apimachinery v0.35.4
 	k8s.io/cli-runtime v0.35.4
 	k8s.io/client-go v0.35.4
+	k8s.io/component-base v0.35.4
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
 	k8s.io/kubectl v0.35.4
@@ -157,7 +158,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.35.4 // indirect
-	k8s.io/component-base v0.35.4 // indirect
 	knative.dev/pkg v0.0.0-20260318013857-98d5a706d4fd // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/features"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
@@ -57,6 +58,10 @@ type StaticConfig struct {
 	ToolOverrides map[string]ToolOverride `toml:"tool_overrides,omitempty"`
 	// Prompt configuration
 	Prompts []api.Prompt `toml:"prompts,omitempty"`
+
+	// FeatureGates is a map of feature gate names to their enabled/disabled state.
+	// Feature gates control the availability of features based on their maturity level.
+	FeatureGates map[string]bool `toml:"feature_gates,omitempty"`
 
 	// Authorization-related fields
 	// RequireOAuth indicates whether the server requires OAuth for authentication.
@@ -366,6 +371,10 @@ func ReadToml(configData []byte, opts ...ReadConfigOpt) (*StaticConfig, error) {
 		return nil, err
 	}
 
+	if err := features.ApplyFeatureGates(config.FeatureGates); err != nil {
+		return nil, err
+	}
+
 	return config, nil
 }
 
@@ -538,6 +547,9 @@ func (c *StaticConfig) Validate() error {
 		return err
 	}
 	if err := c.HTTP.Validate(); err != nil {
+		return err
+	}
+	if err := features.ValidateFeatureGates(c.FeatureGates); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/features/feature_gate.go
+++ b/pkg/features/feature_gate.go
@@ -1,0 +1,62 @@
+package features
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-base/featuregate"
+
+	pkgversion "github.com/containers/kubernetes-mcp-server/pkg/version"
+)
+
+var (
+	// DefaultMutableFeatureGate is a mutable version of DefaultFeatureGate.
+	// Only top-level command setup, tests, and the feature registration init()
+	// should use this. Everything else should use DefaultFeatureGate.
+	DefaultMutableFeatureGate featuregate.MutableVersionedFeatureGate = newDefaultFeatureGate()
+
+	// DefaultFeatureGate is a shared global FeatureGate.
+	// Callers should use this to check whether a given feature is enabled.
+	DefaultFeatureGate featuregate.FeatureGate = DefaultMutableFeatureGate
+)
+
+func newDefaultFeatureGate() featuregate.MutableVersionedFeatureGate {
+	ver, err := version.Parse(pkgversion.Version)
+	if err != nil {
+		// Fallback to 0.0 if the version string is not semver-parseable.
+		ver = version.MajorMinor(0, 0)
+	}
+	// Use only major.minor for the emulation version.
+	emulationVersion := version.MajorMinor(ver.Major(), ver.Minor())
+	return featuregate.NewVersionedFeatureGate(emulationVersion)
+}
+
+// Enabled returns true if the given feature is enabled in the DefaultFeatureGate.
+func Enabled(f featuregate.Feature) bool {
+	return DefaultFeatureGate.Enabled(f)
+}
+
+// ApplyFeatureGates applies the given feature gate overrides to the DefaultMutableFeatureGate.
+// This is the single entry point for applying feature gates from config or CLI.
+// It is thread-safe: the underlying SetFromMap acquires an internal mutex and
+// publishes changes via atomic.Store, so concurrent Enabled() calls are safe.
+func ApplyFeatureGates(gates map[string]bool) error {
+	if len(gates) == 0 {
+		return nil
+	}
+	return DefaultMutableFeatureGate.SetFromMap(gates)
+}
+
+// ValidateFeatureGates validates that the given feature gate map contains only
+// known features with valid values, without mutating the DefaultMutableFeatureGate.
+// It performs a dry-run by applying gates to a deep copy of the gate.
+func ValidateFeatureGates(gates map[string]bool) error {
+	if len(gates) == 0 {
+		return nil
+	}
+	copy := DefaultMutableFeatureGate.DeepCopy()
+	if err := copy.SetFromMap(gates); err != nil {
+		return fmt.Errorf("invalid feature gates: %w", err)
+	}
+	return nil
+}

--- a/pkg/features/feature_gate_test.go
+++ b/pkg/features/feature_gate_test.go
@@ -1,0 +1,147 @@
+package features
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-base/featuregate"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testFeatureAlpha featuregate.Feature = "TestFeatureAlpha"
+	testFeatureBeta  featuregate.Feature = "TestFeatureBeta"
+)
+
+type FeatureGateSuite struct {
+	suite.Suite
+}
+
+func (s *FeatureGateSuite) SetupSuite() {
+	// Register test features once. AddVersioned is idempotent for identical specs.
+	err := DefaultMutableFeatureGate.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
+		testFeatureAlpha: {
+			{Version: version.MajorMinor(0, 0), Default: false, PreRelease: featuregate.Alpha},
+		},
+		testFeatureBeta: {
+			{Version: version.MajorMinor(0, 0), Default: true, PreRelease: featuregate.Beta},
+		},
+	})
+	s.Require().NoError(err)
+}
+
+func (s *FeatureGateSuite) TestDefaultFeatureGateIsNotNull() {
+	s.NotNil(DefaultFeatureGate, "DefaultFeatureGate should not be nil")
+	s.NotNil(DefaultMutableFeatureGate, "DefaultMutableFeatureGate should not be nil")
+}
+
+func (s *FeatureGateSuite) TestAlphaFeatureDefaultDisabled() {
+	s.Run("alpha feature is disabled by default", func() {
+		featuregatetesting.SetFeatureGateDuringTest(s.T(), DefaultMutableFeatureGate, testFeatureAlpha, false)
+		s.False(Enabled(testFeatureAlpha))
+	})
+}
+
+func (s *FeatureGateSuite) TestBetaFeatureDefaultEnabled() {
+	s.Run("beta feature is enabled by default", func() {
+		featuregatetesting.SetFeatureGateDuringTest(s.T(), DefaultMutableFeatureGate, testFeatureBeta, true)
+		s.True(Enabled(testFeatureBeta))
+	})
+}
+
+func (s *FeatureGateSuite) TestSetFeatureGateDuringTest() {
+	s.Run("can enable alpha feature during test", func() {
+		featuregatetesting.SetFeatureGateDuringTest(s.T(), DefaultMutableFeatureGate, testFeatureAlpha, true)
+		s.True(Enabled(testFeatureAlpha))
+	})
+	s.Run("can disable beta feature during test", func() {
+		featuregatetesting.SetFeatureGateDuringTest(s.T(), DefaultMutableFeatureGate, testFeatureBeta, false)
+		s.False(Enabled(testFeatureBeta))
+	})
+}
+
+func (s *FeatureGateSuite) TestApplyFeatureGates() {
+	s.Run("applies feature gate overrides", func() {
+		featuregatetesting.SetFeatureGateDuringTest(s.T(), DefaultMutableFeatureGate, testFeatureAlpha, false)
+		err := ApplyFeatureGates(map[string]bool{
+			string(testFeatureAlpha): true,
+		})
+		s.Require().NoError(err)
+		s.True(Enabled(testFeatureAlpha))
+	})
+	s.Run("returns nil for empty map", func() {
+		s.Nil(ApplyFeatureGates(map[string]bool{}))
+	})
+	s.Run("returns nil for nil map", func() {
+		s.Nil(ApplyFeatureGates(nil))
+	})
+}
+
+func (s *FeatureGateSuite) TestValidateFeatureGates() {
+	s.Run("validates known features", func() {
+		err := ValidateFeatureGates(map[string]bool{
+			string(testFeatureAlpha): true,
+		})
+		s.NoError(err)
+	})
+	s.Run("returns error for unknown feature", func() {
+		err := ValidateFeatureGates(map[string]bool{
+			"CompletelyUnknown": true,
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "CompletelyUnknown")
+	})
+	s.Run("does not mutate the default gate", func() {
+		featuregatetesting.SetFeatureGateDuringTest(s.T(), DefaultMutableFeatureGate, testFeatureAlpha, false)
+		_ = ValidateFeatureGates(map[string]bool{
+			string(testFeatureAlpha): true,
+		})
+		s.False(Enabled(testFeatureAlpha), "ValidateFeatureGates should not mutate the default gate")
+	})
+	s.Run("returns nil for empty map", func() {
+		s.Nil(ValidateFeatureGates(map[string]bool{}))
+	})
+	s.Run("returns nil for nil map", func() {
+		s.Nil(ValidateFeatureGates(nil))
+	})
+}
+
+func (s *FeatureGateSuite) TestAllAlphaToggle() {
+	s.Run("AllAlpha enables all alpha features", func() {
+		featuregatetesting.SetFeatureGatesDuringTest(s.T(), DefaultMutableFeatureGate, map[featuregate.Feature]bool{
+			"AllAlpha": true,
+		})
+		s.True(Enabled(testFeatureAlpha))
+	})
+	s.Run("AllAlpha does not affect beta features", func() {
+		featuregatetesting.SetFeatureGatesDuringTest(s.T(), DefaultMutableFeatureGate, map[featuregate.Feature]bool{
+			"AllAlpha": true,
+		})
+		s.True(Enabled(testFeatureBeta), "beta feature should remain enabled")
+	})
+}
+
+func (s *FeatureGateSuite) TestKnownFeatures() {
+	known := DefaultFeatureGate.KnownFeatures()
+	s.NotEmpty(known, "KnownFeatures should include at least AllAlpha/AllBeta")
+}
+
+// TestUnknownFeatureGateError tests error handling for unknown features using
+// a separate feature gate instance to avoid poisoning the shared DefaultMutableFeatureGate.
+// The upstream SetFromMap stores raw entries into enabledRaw before validation,
+// so an unknown feature would corrupt the global gate for subsequent tests.
+func (s *FeatureGateSuite) TestUnknownFeatureGateError() {
+	s.Run("ApplyFeatureGates with unknown feature returns error via validate", func() {
+		err := ValidateFeatureGates(map[string]bool{
+			"UnknownFeature": true,
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "UnknownFeature")
+	})
+}
+
+func TestFeatureGate(t *testing.T) {
+	suite.Run(t, new(FeatureGateSuite))
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,42 @@
+package features
+
+import (
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-base/featuregate"
+)
+
+// Feature gate constants should be listed in alphabetical, case-sensitive
+// (upper before any lower case character) order to reduce merge conflicts.
+const (
+// Add feature gate constants here, for example:
+// MyFeature featuregate.Feature = "MyFeature"
+)
+
+func init() {
+	if err := DefaultMutableFeatureGate.AddVersioned(defaultFeatureGates); err != nil {
+		panic(err)
+	}
+}
+
+// defaultFeatureGates contains the default feature gate definitions for this server.
+// Each entry maps a Feature to its VersionedSpecs, which define the maturity
+// lifecycle (Alpha -> Beta -> GA) across project versions.
+//
+// Entries should use version.MajorMinor(major, minor) for the Version field.
+// Use version 0.0 for features that should be available regardless of emulation version.
+//
+// Example:
+//
+//	var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+//		MyFeature: {
+//			{Version: version.MajorMinor(0, 1), Default: false, PreRelease: featuregate.Alpha},
+//			{Version: version.MajorMinor(0, 5), Default: true, PreRelease: featuregate.Beta},
+//			{Version: version.MajorMinor(1, 0), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+//		},
+//	}
+var defaultFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+	// Add feature gate versioned specs here.
+}
+
+// Ensure version import is used (will be used when real features are added).
+var _ = version.MajorMinor

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/features"
 	internalhttp "github.com/containers/kubernetes-mcp-server/pkg/http"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcp"
@@ -86,6 +87,7 @@ const (
 	flagTLSCert              = "tls-cert"
 	flagTLSKey               = "tls-key"
 	flagRequireTLS           = "require-tls"
+	flagFeatureGates         = "feature-gates"
 )
 
 type MCPServerOptions struct {
@@ -110,6 +112,7 @@ type MCPServerOptions struct {
 	TLSCert              string
 	TLSKey               string
 	RequireTLS           bool
+	FeatureGates         string
 
 	ConfigPath   string
 	ConfigDir    string
@@ -176,6 +179,7 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&o.TLSCert, flagTLSCert, o.TLSCert, "Path to TLS certificate file for HTTPS. Must be used together with --tls-key.")
 	cmd.Flags().StringVar(&o.TLSKey, flagTLSKey, o.TLSKey, "Path to TLS private key file for HTTPS. Must be used together with --tls-cert.")
 	cmd.Flags().BoolVar(&o.RequireTLS, flagRequireTLS, o.RequireTLS, "Require TLS for server and all outbound connections")
+	cmd.Flags().StringVar(&o.FeatureGates, flagFeatureGates, o.FeatureGates, "A set of feature=bool pairs that describe feature gates for alpha/experimental features. Options are:\n"+strings.Join(features.DefaultFeatureGate.KnownFeatures(), "\n"))
 
 	return cmd
 }
@@ -261,6 +265,11 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 	if cmd.Flag(flagRequireTLS).Changed {
 		m.StaticConfig.RequireTLS = m.RequireTLS
+	}
+	if cmd.Flag(flagFeatureGates).Changed {
+		if err := features.DefaultMutableFeatureGate.Set(m.FeatureGates); err != nil {
+			klog.Warningf("Failed to set feature gates from flag: %v", err)
+		}
 	}
 }
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/features"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/metrics"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
@@ -541,6 +542,14 @@ func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 		WithTokenExchangeStrategies(tokenexchange.GetRegisteredStrategies()).
 		Validate(); err != nil {
 		return fmt.Errorf("configuration reload rejected: %w", err)
+	}
+
+	// Apply feature gates from new config. This is thread-safe:
+	// SetFromMap acquires an internal mutex and publishes via atomic.Store.
+	// Callede after Validate (which dry-runs the gates) and before applyToolsets,
+	// so feature-fated tools see the new state when the toolset surface is built.
+	if err := features.ApplyFeatureGates(newConfig.FeatureGates); err != nil {
+		return fmt.Errorf("failed to apply feature gates: %w", err)
 	}
 
 	// Build a candidate Configuration view. applyToolsets will install it


### PR DESCRIPTION

## What
This PR introduces a generic feature gate framework (`pkg/features/`) based on `k8s.io/component-base/featuregate`.
Feature gates allow controlling feature availability based on maturity level (Alpha, Beta, GA, Deprecated) and can be configured via:
- CLI flag: `--feature-gates Feature1=true,Feature2=false`
- TOML config: `[feature_gates]` section (supports SIGHUP reload)

## Why

I'm working on enabling Kubernetes MCP in a large environment with many, big clusters. The scale of operations (and the nature of my environment) requires variety of features that we want to introduce gradually. Feature gating will help in managing a lifecycle of features. Some strong candidates from existing codebase:
1. StructuredContent

**Maturity:** Alpha (default: off)

**Description:** The `StructuredContent` field on `ToolCallResult` provides richer MCP UI rendering by including a JSON-serializable structured payload alongside the text Content. This is a newer MCP spec addition and not all clients support it yet.

**Current state:** Unconditionally included in tool call results when set by a tool handler. Defined in `pkg/api/toolsets.go` (`ToolCallResult.StructuredContent`) and serialized in `pkg/mcp/tools_gosdk.go`.

**Risk:** Low. Tools already produce a text Content fallback per MCP spec, so disabling structured content is a graceful degradation.

2. Elicitation

**Maturity:** Alpha (default: off)

**Description:** Elicitation enables interactive user confirmation prompts via the MCP protocol. The server can ask the user to confirm or deny an action before proceeding. This depends on MCP client support and already has fallback logic for clients that don't implement it (`ErrElicitationNotSupported`).

**Current state:** Wired in `pkg/mcp/elicit.go` (`sessionElicitor`), used by `pkg/kubernetes/confirmation_validator.go` for kube-level confirmation rules, and by `pkg/confirmation/` for tool-level rules. Clients that don't support elicitation get an error that is handled gracefully.

**Risk:** Low. The fallback path already exists for clients without elicitation support.  

Among the new features that could be gated behind feature gates is https://github.com/containers/kubernetes-mcp-server/pull/711 that I would like to work on.

## How

- **Separate `pkg/features/` package** — mirrors the Kubernetes convention (`k8s.io/apiserver/pkg/util/feature`, `k8s.io/kubernetes/pkg/features`). Keeps the gate instance and feature definitions together, avoids import cycles.
- **TOML `[feature_gates]` table** — uses `map[string]bool` which naturally maps to a TOML table. Follows the existing `StaticConfig` pattern. Applied via `SetFromMap` which is the canonical featuregate API.
- **Config reload support** — SIGHUP reload re-applies the feature_gates map from the new config. Since `SetFromMap` replaces the full state atomically, features removed from config revert to their defaults.
- **CLI overrides config** — the `--feature-gates` flag is applied in `loadFlags` after config file loading, matching the existing pattern where CLI flags take precedence.
- **No existing features gated yet** — the framework is introduced with an example/placeholder. Actual features can be gated as needed in subsequent PRs.