### PR TITLE
feat(resources): add statusOnly parameter to resources_get

### DIFF
--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -362,6 +362,77 @@ func (s *ResourcesSuite) TestResourcesGet() {
 			s.Equalf("default", decodedNamespace.GetName(), "invalid namespace name, expected default, got %v", decodedNamespace.GetName())
 		})
 	})
+	s.Run("resources_get with statusOnly returns only status", func() {
+		result, err := s.CallTool("resources_get", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"name":       "default",
+			"statusOnly": true,
+		})
+		s.Run("no error", func() {
+			s.Nilf(err, "call tool failed %v", err)
+			s.Falsef(result.IsError, "call tool failed")
+		})
+		var decoded map[string]interface{}
+		err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decoded)
+		s.Run("has yaml content", func() {
+			s.Nilf(err, "invalid tool result content %v", err)
+		})
+		s.Run("contains status phase field", func() {
+			_, hasPhase := decoded["phase"]
+			s.Truef(hasPhase, "expected status to contain phase field, got %v", decoded)
+		})
+		s.Run("does not contain metadata", func() {
+			_, hasMetadata := decoded["metadata"]
+			s.Falsef(hasMetadata, "status-only response should not contain metadata")
+		})
+		s.Run("does not contain kind", func() {
+			_, hasKind := decoded["kind"]
+			s.Falsef(hasKind, "status-only response should not contain kind")
+		})
+	})
+	s.Run("resources_get with statusOnly false returns full resource", func() {
+		result, err := s.CallTool("resources_get", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"name":       "default",
+			"statusOnly": false,
+		})
+		s.Run("no error", func() {
+			s.Nilf(err, "call tool failed %v", err)
+			s.Falsef(result.IsError, "call tool failed")
+		})
+		var decodedNamespace unstructured.Unstructured
+		err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedNamespace)
+		s.Run("returns full resource", func() {
+			s.Nilf(err, "invalid tool result content %v", err)
+			s.Equalf("default", decodedNamespace.GetName(), "expected default namespace, got %v", decodedNamespace.GetName())
+		})
+	})
+	s.Run("resources_get with statusOnly on resource without status returns empty object", func() {
+		kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
+		_, _ = kc.CoreV1().ConfigMaps("default").Create(s.T().Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "cm-status-only-test"},
+			Data:       map[string]string{"key": "value"},
+		}, metav1.CreateOptions{})
+		result, err := s.CallTool("resources_get", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"namespace":  "default",
+			"name":       "cm-status-only-test",
+			"statusOnly": true,
+		})
+		s.Run("no error", func() {
+			s.Nilf(err, "call tool failed %v", err)
+			s.Falsef(result.IsError, "call tool failed")
+		})
+		s.Run("returns empty object", func() {
+			var decoded map[string]interface{}
+			err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decoded)
+			s.Nilf(err, "invalid tool result content %v", err)
+			s.Emptyf(decoded, "expected empty status for ConfigMap, got %v", decoded)
+		})
+	})
 }
 
 func (s *ResourcesSuite) TestResourcesGetDenied() {

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -467,6 +467,10 @@
         "namespace": {
           "description": "Optional Namespace to retrieve the namespaced resource from (ignored in case of cluster scoped resources). If not provided, will get resource from configured namespace",
           "type": "string"
+        },
+        "statusOnly": {
+          "description": "Return only the status field of the resource instead of the full object (Optional)",
+          "type": "boolean"
         }
       },
       "required": [

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -568,6 +568,10 @@
         "namespace": {
           "description": "Optional Namespace to retrieve the namespaced resource from (ignored in case of cluster scoped resources). If not provided, will get resource from configured namespace",
           "type": "string"
+        },
+        "statusOnly": {
+          "description": "Return only the status field of the resource instead of the full object (Optional)",
+          "type": "boolean"
         }
       },
       "required": [

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -502,6 +502,10 @@
         "namespace": {
           "description": "Optional Namespace to retrieve the namespaced resource from (ignored in case of cluster scoped resources). If not provided, will get resource from configured namespace",
           "type": "string"
+        },
+        "statusOnly": {
+          "description": "Return only the status field of the resource instead of the full object (Optional)",
+          "type": "boolean"
         }
       },
       "required": [

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -487,6 +487,10 @@
         "namespace": {
           "description": "Optional Namespace to retrieve the namespaced resource from (ignored in case of cluster scoped resources). If not provided, will get resource from configured namespace",
           "type": "string"
+        },
+        "statusOnly": {
+          "description": "Return only the status field of the resource instead of the full object (Optional)",
+          "type": "boolean"
         }
       },
       "required": [

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -81,6 +81,10 @@ func initResources(o api.Openshift) []api.ServerTool {
 						Type:        "string",
 						Description: "Name of the resource",
 					},
+					"statusOnly": {
+						Type:        "boolean",
+						Description: "Return only the status field of the resource instead of the full object (Optional)",
+					},
 				},
 				Required: []string{"apiVersion", "kind", "name"},
 			},
@@ -252,10 +256,28 @@ func resourcesGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("", fmt.Errorf("name is not a string")), nil
 	}
 
+	var statusOnly bool
+	if v, ok := params.GetArguments()["statusOnly"]; ok {
+		b, ok := v.(bool)
+		if !ok {
+			return api.NewToolCallResult("", fmt.Errorf("statusOnly is not a boolean")), nil
+		}
+		statusOnly = b
+	}
+
 	ret, err := kubernetes.NewCore(params).ResourcesGet(params, gvk, ns, n)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get resource: %w", err)), nil
 	}
+
+	if statusOnly {
+		status, ok := ret.Object["status"]
+		if !ok || status == nil {
+			return api.NewToolCallResult(output.MarshalYaml(map[string]interface{}{})), nil
+		}
+		return api.NewToolCallResult(output.MarshalYaml(status)), nil
+	}
+
 	return api.NewToolCallResult(output.MarshalYaml(ret)), nil
 }
 


### PR DESCRIPTION
Add an optional boolean `statusOnly` parameter to the `resources_get` tool.
When set to true, only the `.status` field of the Kubernetes resource is
returned instead of the full object. When the resource has no status field,
an empty object is returned. Default behavior is unchanged.

Changes:
- `pkg/toolsets/core/resources.go`: schema definition and handler logic
- `pkg/mcp/resources_test.go`: three test scenarios (status returned,
  explicit false, missing status field)

Closes #876