### PR TITLE
docs(agents): expand downstream test guidance + refactor TOML idioms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,10 +236,88 @@ func FieldString(obj *unstructured.Unstructured, path string) string {
 
 #### Test Configuration and Downstream Compatibility
 
-This project supports downstream builds that override default configuration via `pkg/config/config_default_overrides.go` (e.g., `ReadOnly`, `Toolsets`, `ToolOverrides`). Tests must work correctly regardless of what downstream overrides are active.
+Downstream builds may override defaults at two layers, and tests must work
+regardless of which overrides are active:
 
-- **`BaseMcpSuite.SetupTest()` uses `config.BaseDefault()`** (not `config.Default()`) as the starting point for `s.Cfg`, so the suite config reflects pure upstream defaults without downstream overrides
-- **When creating a secondary config** (e.g., for reload tests), inherit runtime-sensitive fields from `s.Cfg` instead of relying on `config.Default()`:
+1. **Static config overrides** — `pkg/config/config_default_overrides.go`
+   exposes a stub `defaultOverrides()` that downstream forks populate to
+   change defaults such as `ReadOnly`, `Toolsets`, or `ToolOverrides`.
+2. **Per-toolset overrides** — toolsets like `kiali` and `kubevirt` carry an
+   `internal/defaults/defaults_override.go` stub that downstream uses to
+   rebrand the toolset name and description (e.g. `kiali` → `ossm`).
+
+The rules below keep the test suite portable across both layers.
+
+##### Start from `BaseDefault()`, not `Default()`
+
+`BaseMcpSuite.SetupTest()` initializes `s.Cfg` from `config.BaseDefault()`
+(pure upstream defaults), then layers test-specific tweaks like
+`ListOutput = "yaml"` on top. Any custom suite (`ToolsetsSuite`, etc.) must
+do the same — using `config.Default()` would let downstream overrides leak
+into the test environment.
+
+##### Prefer merging TOML into `s.Cfg`
+
+The dominant pattern across the test suite is to unmarshal TOML directly
+into the existing `s.Cfg`. This keeps the configuration visible inline
+(matching how a real config file looks) and automatically preserves the
+runtime fields the suite already set (`KubeConfig`, `ListOutput`,
+`ReadOnly`, etc.):
+
+```go
+s.Require().NoError(toml.Unmarshal([]byte(`
+    toolsets = [ "kubevirt" ]
+`), s.Cfg), "Expected to parse toolsets config")
+```
+
+See `pkg/mcp/kubevirt_test.go`, `pkg/mcp/pods_exec_test.go`, and
+`pkg/mcp/helm_test.go` for representative examples.
+
+##### When `config.ReadToml` is required
+
+`toml.Unmarshal` only does a single decode pass. Fields like
+`toolset_configs` and `cluster_provider_configs` are typed as
+`map[string]toml.Primitive` and need a second parse phase that uses the
+TOML metadata returned by `config.ReadToml`. If your TOML uses one of those
+sections, `toml.Unmarshal` will leave them unparsed and `GetToolsetConfig`
+/ `GetProviderConfig` will return nothing.
+
+In that case, use `ReadToml` and restore the runtime fields explicitly:
+
+```go
+kubeConfig := s.Cfg.KubeConfig
+listOutput := s.Cfg.ListOutput
+readOnly := s.Cfg.ReadOnly
+cfg, err := config.ReadToml([]byte(tomlStr))
+s.Require().NoError(err)
+s.Cfg = cfg
+s.Cfg.KubeConfig = kubeConfig
+s.Cfg.ListOutput = listOutput
+s.Cfg.ReadOnly = readOnly
+```
+
+`pkg/mcp/kiali_test.go` and the `TestToolHandlerReceivesToolsetConfig`
+case in `pkg/mcp/mcp_config_provider_test.go` follow this pattern.
+
+Note that the **TOML key under `[toolset_configs.<key>]` is the literal
+name the toolset registers its parser under, not the toolset's exposed
+name**. The Kiali toolset registers its parser as `"kiali"`
+(see `pkg/kiali/config.go`), so even when downstream rebrands the
+toolset to `ossm`, the section is still `[toolset_configs.kiali]`
+and `params.GetToolsetConfig("kiali")` is the correct lookup. Resolve
+the *toolset name* dynamically via `GetName()` (see below), but keep
+the *toolset_configs key* hardcoded — using the dynamic name there will
+silently produce `(nil, false)`.
+
+##### Inherit runtime fields when building secondary configs
+
+Reload tests sometimes need a separate `*StaticConfig` derived from
+`config.Default()`. This is the deliberate exception to the "start from
+`BaseDefault()`" rule above: a reload simulates the SIGHUP path the
+running server takes, which goes through `Default()` and therefore sees
+any downstream overrides. Carry across the runtime fields from `s.Cfg`
+so the candidate config still points at the test kubeconfig and respects
+the suite's `ReadOnly` value (see `pkg/mcp/mcp_reload_test.go`):
 
 ```go
 candidateStatic := config.Default()
@@ -247,7 +325,10 @@ candidateStatic.KubeConfig = s.Cfg.KubeConfig
 candidateStatic.ReadOnly = s.Cfg.ReadOnly
 ```
 
-- **Append to `s.Cfg.Toolsets`** rather than hardcoding toolset lists, so additional default toolsets from downstream are preserved:
+##### Append to `s.Cfg.Toolsets`, never reset it
+
+Hardcoding the toolset list assumes upstream defaults and breaks downstream
+builds that ship a different default set:
 
 ```go
 // Good - preserves whatever the suite already has
@@ -257,31 +338,39 @@ s.Cfg.Toolsets = append(s.Cfg.Toolsets, "helm")
 s.Cfg.Toolsets = []string{"core", "config", "helm"}
 ```
 
-- **When parsing TOML into a new config**, preserve suite fields that the TOML doesn't intend to override (see `confirmation_test.go:cfgFromTOML` for a helper pattern):
+##### Resolve toolset names through the toolset's `GetName()`
+
+When a test invokes a tool from a rebrandable toolset, ask the toolset for
+its current name rather than hardcoding the upstream string. `kiali_test.go`
+does this so the same test works whether the toolset is exposed as `kiali`
+upstream or `ossm` downstream:
 
 ```go
-kubeConfig := s.Cfg.KubeConfig
-listOutput := s.Cfg.ListOutput
-readOnly := s.Cfg.ReadOnly
-cfg, err := config.ReadToml([]byte(tomlStr))
-s.Cfg = cfg
-s.Cfg.KubeConfig = kubeConfig
-s.Cfg.ListOutput = listOutput
-s.Cfg.ReadOnly = readOnly
+s.toolsetName = (&kialiToolset.Toolset{}).GetName()
+// ...
+s.CallTool(fmt.Sprintf("%s_get_trace_details", s.toolsetName), …)
 ```
 
-- **Never hardcode assumptions** about default values for fields that downstream may override (`ReadOnly`, `Toolsets`, `ToolOverrides`, `ListOutput`)
+##### Never hardcode override-prone defaults
+
+`ReadOnly`, `Toolsets`, `ToolOverrides`, `ListOutput`, and toolset names
+are all subject to downstream override. Read them from `s.Cfg` or resolve
+them at runtime — never assume the upstream value.
 
 #### Examples from the Codebase
 
 Good examples of these patterns can be found in:
 - `internal/test/unstructured_test.go` - demonstrates proper use of testify/suite, nested subtests, and edge case testing
-- `pkg/mcp/kubevirt_test.go` - shows behavior-based testing of the MCP layer
+- `pkg/mcp/kubevirt_test.go` - merges TOML into `s.Cfg` for toolset selection; behavior-based MCP-layer testing
 - `pkg/kubernetes/manager_test.go` - illustrates testing with proper setup/teardown and subtests
-- `pkg/mcp/confirmation_test.go` - shows the `cfgFromTOML` helper pattern for preserving suite config across TOML reloads
-- `pkg/mcp/mcp_config_provider_test.go` - demonstrates inheriting `ReadOnly` from suite config
+- `pkg/mcp/pods_exec_test.go` - inline TOML for `denied_resources` configuration
+- `pkg/mcp/confirmation_test.go` - inline TOML for `confirmation_rules` and `confirmation_fallback`
+- `pkg/mcp/helm_test.go` - appends to `s.Cfg.Toolsets` instead of resetting it
+- `pkg/mcp/kiali_test.go` - resolves the toolset name dynamically via `GetName()` and uses `ReadToml` for `toolset_configs`
 - `pkg/mcp/toolsets_test.go` - uses `BaseDefault()` in `ToolsetsSuite.SetupTest()` to avoid downstream config leaking
 - `pkg/mcp/mcp_reload_test.go` - inherits `ReadOnly` from `s.Cfg` when building candidate configs for reload tests
+- `pkg/mcp/mcp_config_provider_test.go` - demonstrates inheriting `ReadOnly` from suite config when `toolset_configs` requires `ReadToml`
+- `pkg/mcp/require_tls_test.go` - shows both patterns side by side: `CoreRequireTLSSuite` merges plain `require_tls` into `s.Cfg`, while `KialiRequireTLSSuite` keeps `ReadToml` for `[toolset_configs.kiali]`
 
 ## Linting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,12 +234,54 @@ func FieldString(obj *unstructured.Unstructured, path string) string {
 }
 ```
 
+#### Test Configuration and Downstream Compatibility
+
+This project supports downstream builds that override default configuration via `pkg/config/config_default_overrides.go` (e.g., `ReadOnly`, `Toolsets`, `ToolOverrides`). Tests must work correctly regardless of what downstream overrides are active.
+
+- **`BaseMcpSuite.SetupTest()` uses `config.BaseDefault()`** (not `config.Default()`) as the starting point for `s.Cfg`, so the suite config reflects pure upstream defaults without downstream overrides
+- **When creating a secondary config** (e.g., for reload tests), inherit runtime-sensitive fields from `s.Cfg` instead of relying on `config.Default()`:
+
+```go
+candidateStatic := config.Default()
+candidateStatic.KubeConfig = s.Cfg.KubeConfig
+candidateStatic.ReadOnly = s.Cfg.ReadOnly
+```
+
+- **Append to `s.Cfg.Toolsets`** rather than hardcoding toolset lists, so additional default toolsets from downstream are preserved:
+
+```go
+// Good - preserves whatever the suite already has
+s.Cfg.Toolsets = append(s.Cfg.Toolsets, "helm")
+
+// Bad - assumes upstream defaults
+s.Cfg.Toolsets = []string{"core", "config", "helm"}
+```
+
+- **When parsing TOML into a new config**, preserve suite fields that the TOML doesn't intend to override (see `confirmation_test.go:cfgFromTOML` for a helper pattern):
+
+```go
+kubeConfig := s.Cfg.KubeConfig
+listOutput := s.Cfg.ListOutput
+readOnly := s.Cfg.ReadOnly
+cfg, err := config.ReadToml([]byte(tomlStr))
+s.Cfg = cfg
+s.Cfg.KubeConfig = kubeConfig
+s.Cfg.ListOutput = listOutput
+s.Cfg.ReadOnly = readOnly
+```
+
+- **Never hardcode assumptions** about default values for fields that downstream may override (`ReadOnly`, `Toolsets`, `ToolOverrides`, `ListOutput`)
+
 #### Examples from the Codebase
 
 Good examples of these patterns can be found in:
 - `internal/test/unstructured_test.go` - demonstrates proper use of testify/suite, nested subtests, and edge case testing
 - `pkg/mcp/kubevirt_test.go` - shows behavior-based testing of the MCP layer
 - `pkg/kubernetes/manager_test.go` - illustrates testing with proper setup/teardown and subtests
+- `pkg/mcp/confirmation_test.go` - shows the `cfgFromTOML` helper pattern for preserving suite config across TOML reloads
+- `pkg/mcp/mcp_config_provider_test.go` - demonstrates inheriting `ReadOnly` from suite config
+- `pkg/mcp/toolsets_test.go` - uses `BaseDefault()` in `ToolsetsSuite.SetupTest()` to avoid downstream config leaking
+- `pkg/mcp/mcp_reload_test.go` - inherits `ReadOnly` from `s.Cfg` when building candidate configs for reload tests
 
 ## Linting
 

--- a/pkg/mcp/confirmation_test.go
+++ b/pkg/mcp/confirmation_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
-	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/confirmation"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
@@ -13,21 +13,6 @@ import (
 
 type ConfirmationRulesSuite struct {
 	BaseMcpSuite
-}
-
-// cfgFromTOML parses a TOML config string and preserves the KubeConfig, ListOutput,
-// and ReadOnly from the base test setup so that the test environment remains functional.
-func (s *ConfirmationRulesSuite) cfgFromTOML(tomlStr string) {
-	s.T().Helper()
-	kubeConfig := s.Cfg.KubeConfig
-	listOutput := s.Cfg.ListOutput
-	readOnly := s.Cfg.ReadOnly
-	cfg, err := config.ReadToml([]byte(tomlStr))
-	s.Require().NoError(err, "failed to parse TOML config")
-	s.Cfg = cfg
-	s.Cfg.KubeConfig = kubeConfig
-	s.Cfg.ListOutput = listOutput
-	s.Cfg.ReadOnly = readOnly
 }
 
 func (s *ConfirmationRulesSuite) TestNoRulesConfigured() {
@@ -41,11 +26,11 @@ func (s *ConfirmationRulesSuite) TestNoRulesConfigured() {
 }
 
 func (s *ConfirmationRulesSuite) TestToolRuleMatchUserAccepts() {
-	s.cfgFromTOML(`
+	s.Require().NoError(toml.Unmarshal([]byte(`
 [[confirmation_rules]]
 tool = "pods_list"
 message = "List pods?"
-`)
+`), s.Cfg), "Expected to parse confirmation rules config")
 	s.InitMcpClient(test.WithElicitationHandler(
 		func(_ context.Context, req *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
 			return &mcp.ElicitResult{Action: "accept"}, nil
@@ -60,11 +45,11 @@ message = "List pods?"
 }
 
 func (s *ConfirmationRulesSuite) TestToolRuleMatchUserDeclines() {
-	s.cfgFromTOML(`
+	s.Require().NoError(toml.Unmarshal([]byte(`
 [[confirmation_rules]]
 tool = "pods_list"
 message = "List pods?"
-`)
+`), s.Cfg), "Expected to parse confirmation rules config")
 	s.InitMcpClient(test.WithElicitationHandler(
 		func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
 			return &mcp.ElicitResult{Action: "decline"}, nil
@@ -80,13 +65,13 @@ message = "List pods?"
 }
 
 func (s *ConfirmationRulesSuite) TestToolRuleNoElicitationSupportFallbackDeny() {
-	s.cfgFromTOML(`
+	s.Require().NoError(toml.Unmarshal([]byte(`
 confirmation_fallback = "deny"
 
 [[confirmation_rules]]
 tool = "pods_list"
 message = "List pods?"
-`)
+`), s.Cfg), "Expected to parse confirmation rules config")
 	// No elicitation handler = client does not support elicitation
 	s.InitMcpClient()
 	result, err := s.CallTool("pods_list", map[string]any{})
@@ -99,13 +84,13 @@ message = "List pods?"
 }
 
 func (s *ConfirmationRulesSuite) TestToolRuleNoElicitationSupportFallbackAllow() {
-	s.cfgFromTOML(`
+	s.Require().NoError(toml.Unmarshal([]byte(`
 confirmation_fallback = "allow"
 
 [[confirmation_rules]]
 tool = "pods_list"
 message = "List pods?"
-`)
+`), s.Cfg), "Expected to parse confirmation rules config")
 	// No elicitation handler = client does not support elicitation
 	s.InitMcpClient()
 	result, err := s.CallTool("pods_list", map[string]any{})
@@ -117,11 +102,11 @@ message = "List pods?"
 }
 
 func (s *ConfirmationRulesSuite) TestDestructiveRuleMatchesDestructiveTools() {
-	s.cfgFromTOML(`
+	s.Require().NoError(toml.Unmarshal([]byte(`
 [[confirmation_rules]]
 destructive = true
 message = "Destructive operation."
-`)
+`), s.Cfg), "Expected to parse confirmation rules config")
 	s.InitMcpClient(test.WithElicitationHandler(
 		func(_ context.Context, req *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
 			return &mcp.ElicitResult{Action: "accept"}, nil
@@ -137,7 +122,7 @@ message = "Destructive operation."
 }
 
 func (s *ConfirmationRulesSuite) TestMultipleToolRulesMatchMergedPrompt() {
-	s.cfgFromTOML(`
+	s.Require().NoError(toml.Unmarshal([]byte(`
 [[confirmation_rules]]
 tool = "pods_list"
 message = "Listing pods."
@@ -145,7 +130,7 @@ message = "Listing pods."
 [[confirmation_rules]]
 tool = "pods_list"
 message = "Are you sure?"
-`)
+`), s.Cfg), "Expected to parse confirmation rules config")
 	var receivedMessage string
 	s.InitMcpClient(test.WithElicitationHandler(
 		func(_ context.Context, req *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
@@ -164,13 +149,13 @@ message = "Are you sure?"
 }
 
 func (s *ConfirmationRulesSuite) TestToolRuleDoesNotMatchOtherTools() {
-	s.cfgFromTOML(`
+	s.Require().NoError(toml.Unmarshal([]byte(`
 confirmation_fallback = "deny"
 
 [[confirmation_rules]]
 tool = "namespaces_list"
 message = "Listing namespaces."
-`)
+`), s.Cfg), "Expected to parse confirmation rules config")
 	// No elicitation handler = client does not support elicitation
 	s.InitMcpClient()
 	result, err := s.CallTool("pods_list", map[string]any{})

--- a/pkg/mcp/kiali_test.go
+++ b/pkg/mcp/kiali_test.go
@@ -24,14 +24,22 @@ func (s *KialiSuite) SetupTest() {
 	s.BaseMcpSuite.SetupTest()
 	s.mockServer = test.NewMockServer()
 	s.mockServer.Config().BearerToken = "token-xyz"
-	kubeConfig := s.Cfg.KubeConfig
 	s.toolsetName = (&kialiToolset.Toolset{}).GetName()
-	s.Cfg = test.Must(config.ReadToml([]byte(fmt.Sprintf(`
+	// toolset_configs requires the two-phase parsing performed by config.ReadToml,
+	// so we replace s.Cfg and restore the runtime fields the suite already set.
+	kubeConfig := s.Cfg.KubeConfig
+	listOutput := s.Cfg.ListOutput
+	readOnly := s.Cfg.ReadOnly
+	cfg, err := config.ReadToml([]byte(fmt.Sprintf(`
 		toolsets = ["%s"]
 		[toolset_configs.kiali]
 		url = "%s"
-	`, s.toolsetName, s.mockServer.Config().Host))))
+	`, s.toolsetName, s.mockServer.Config().Host)))
+	s.Require().NoError(err, "failed to parse kiali toolset config")
+	s.Cfg = cfg
 	s.Cfg.KubeConfig = kubeConfig
+	s.Cfg.ListOutput = listOutput
+	s.Cfg.ReadOnly = readOnly
 }
 
 func (s *KialiSuite) TearDownTest() {

--- a/pkg/mcp/mcp_config_provider_test.go
+++ b/pkg/mcp/mcp_config_provider_test.go
@@ -90,15 +90,21 @@ func (s *McpConfigProviderSuite) TestToolHandlerReceivesToolsetConfig() {
 	toolsets.Clear()
 	toolsets.Register(testToolset)
 
+	// toolset_configs requires the two-phase parsing performed by config.ReadToml,
+	// so we replace s.Cfg and restore the runtime fields the suite already set.
+	kubeConfig := s.Cfg.KubeConfig
+	listOutput := s.Cfg.ListOutput
+	readOnly := s.Cfg.ReadOnly
 	cfg, err := config.ReadToml([]byte(`
 		toolsets = ["config-provider-test"]
 		[toolset_configs.kiali]
 		url = "http://kiali.example/"
 	`))
-	s.Require().NoError(err)
-	cfg.KubeConfig = s.Cfg.KubeConfig
-	cfg.ReadOnly = s.Cfg.ReadOnly
+	s.Require().NoError(err, "Expected to parse config")
 	s.Cfg = cfg
+	s.Cfg.KubeConfig = kubeConfig
+	s.Cfg.ListOutput = listOutput
+	s.Cfg.ReadOnly = readOnly
 
 	s.InitMcpClient()
 

--- a/pkg/mcp/mcp_toolset_prompts_test.go
+++ b/pkg/mcp/mcp_toolset_prompts_test.go
@@ -3,11 +3,11 @@ package mcp
 import (
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
-	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 )
 
@@ -247,7 +247,7 @@ func (s *McpToolsetPromptsSuite) TestConfigPromptsOverrideToolsetPrompts() {
 	toolsets.Register(testToolset)
 
 	// Add config prompt with same name
-	cfg, err := config.ReadToml([]byte(`
+	s.Require().NoError(toml.Unmarshal([]byte(`
 toolsets = ["test-toolset"]
 
 [[prompts]]
@@ -257,11 +257,7 @@ description = "Config version"
 [[prompts.messages]]
 role = "user"
 content = "From config"
-	`))
-	s.Require().NoError(err)
-	// Preserve kubeconfig from SetupTest
-	cfg.KubeConfig = s.Cfg.KubeConfig
-	s.Cfg = cfg
+	`), s.Cfg), "Expected to parse config")
 
 	s.InitMcpClient()
 

--- a/pkg/mcp/require_tls_test.go
+++ b/pkg/mcp/require_tls_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	kialiToolset "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali"
@@ -39,15 +40,21 @@ func (s *KialiRequireTLSSuite) TearDownTest() {
 }
 
 func (s *KialiRequireTLSSuite) setupConfig(requireTLS bool) {
-	kubeConfig := s.Cfg.KubeConfig
+	// toolset_configs requires the two-phase parsing performed by config.ReadToml,
+	// so we replace s.Cfg and restore the runtime fields the suite already set.
 	// Parse config without require_tls to bypass Layer 1 (config-time) URL validation,
 	// then enable require_tls to test Layer 2 (runtime) TLSEnforcingTransport enforcement.
+	kubeConfig := s.Cfg.KubeConfig
+	listOutput := s.Cfg.ListOutput
+	readOnly := s.Cfg.ReadOnly
 	s.Cfg = test.Must(config.ReadToml([]byte(fmt.Sprintf(`
 		toolsets = ["%s"]
 		[toolset_configs.kiali]
 		url = "%s"
 	`, s.toolsetName, s.mockServer.Config().Host))))
 	s.Cfg.KubeConfig = kubeConfig
+	s.Cfg.ListOutput = listOutput
+	s.Cfg.ReadOnly = readOnly
 	s.Cfg.RequireTLS = requireTLS
 }
 
@@ -105,12 +112,9 @@ type CoreRequireTLSSuite struct {
 }
 
 func (s *CoreRequireTLSSuite) TestRequireTLS_CoreToolsStillWork() {
-	kubeConfig := s.Cfg.KubeConfig
-	s.Cfg = test.Must(config.ReadToml([]byte(`
+	s.Require().NoError(toml.Unmarshal([]byte(`
 		require_tls = true
-		list_output = "yaml"
-	`)))
-	s.Cfg.KubeConfig = kubeConfig
+	`), s.Cfg), "Expected to parse require_tls config")
 	s.InitMcpClient()
 
 	s.Run("namespaces_list succeeds with require_tls enabled", func() {


### PR DESCRIPTION
## Summary

Builds on @matzew's #1140 (cherry-picked as the first commit) and:

- **Refactors test config idioms** — converts `confirmation_test.go` and `mcp_toolset_prompts_test.go` from the `config.ReadToml` + manual restore pattern to the dominant `toml.Unmarshal([]byte(...), s.Cfg)` MERGE idiom used by ~25 other test files. The merge approach automatically preserves runtime fields the suite already populated, so no `cfgFromTOML` helper is needed.
- **Documents the legitimate `ReadToml` exception** — `kiali_test.go` and `mcp_config_provider_test.go::TestToolHandlerReceivesToolsetConfig` keep `ReadToml` because their TOML uses `[toolset_configs.kiali]`, which is typed `map[string]toml.Primitive` and requires the second-phase parse `ReadToml` performs with TOML metadata. Both files now carry an inline comment explaining the constraint.
- **Expands AGENTS.md** to cover (1) the second downstream override layer (per-toolset `internal/defaults/defaults_override.go`, e.g. `kiali` → `ossm`), (2) the merge-first TOML idiom, (3) when `ReadToml` is still required, and (4) the `(&toolset.Toolset{}).GetName()` pattern from `kiali_test.go` for resolving toolset names dynamically.

## Verification

- `go test ./pkg/mcp/... ./pkg/config/...` passes on upstream.
- Re-ran the same suites with `pkg/config/config_default_overrides.go` and `pkg/toolsets/kiali/internal/defaults/defaults_override.go` patched to match `openshift/main` (`ReadOnly: true`, `Toolsets: ["core", "config"]`, `kiali → ossm`). All four touched suites (`TestConfirmationRules`, `TestKiali`, `TestMcpConfigProvider`, `TestMcpToolsetPromptsSuite`) still pass. The only failure under the simulated downstream merge is the pre-existing `TestToolsets/TestGranularToolsetsTools/Toolset_ossm` snapshot-file-missing failure, which reproduces without any of these changes.

## Test plan

- [x] Verify `go test ./pkg/mcp/... ./pkg/config/...` is green on upstream
- [x] Verify the four refactored suites stay green when downstream override files are patched in locally
- [ ] Reviewer to confirm the AGENTS.md guidance reads correctly

Closes #1140

Co-Authored-By: Matthias Wessendorf <mwessend@redhat.com>