### PR TITLE
chore(deps): pin gen-crd-api-reference-docs via replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,3 +166,12 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )
+
+// tektoncd/pipeline v1.12.0 pins gen-crd-api-reference-docs to a pseudo-version
+// whose commit (6bbddc29119c) exists on GitHub but is not reachable from any
+// branch, tag, or PR ref in the upstream repo. proxy.golang.org and
+// `GOPROXY=direct` both 404, which breaks `go list -m all` and IDE indexing.
+// Pinned here to a real tag so module resolution succeeds; the tool itself is
+// not imported by any compiled code in this repo.
+// Track: https://github.com/tektoncd/pipeline/issues/9997
+replace github.com/ahmetb/gen-crd-api-reference-docs => github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
## Summary

`tektoncd/pipeline v1.12.0` transitively requires `gen-crd-api-reference-docs@v0.3.1-0.20260316152250-6bbddc29119c`. The commit exists on GitHub but is **not reachable from any branch, tag, or PR ref** in the upstream `ahmetb/gen-crd-api-reference-docs` repo, so both `proxy.golang.org` and `GOPROXY=direct` return 404.

This breaks `go list -m all` and IDE module indexing (GoLand/IntelliJ flag the entire project as broken). `go build` and `go test` were unaffected because nothing in this repo imports the package — it's only used for docs generation in upstream tekton.

## Fix

Add a `replace` directive pinning `gen-crd-api-reference-docs` to the tagged `v0.3.0` so module resolution succeeds. The package isn't compiled into our binary, so the specific version doesn't matter — only that it resolves.

The root cause is tracked upstream at [tektoncd/pipeline#9997](https://github.com/tektoncd/pipeline/issues/9997). The `replace` can be removed once tekton ships a patched release.

## Reproduction

```bash
go list -m all
# go: github.com/ahmetb/gen-crd-api-reference-docs@v0.3.1-0.20260316152250-6bbddc29119c:
#   invalid version: unknown revision 6bbddc29119c
```

After this change, `go list -m all` succeeds and IDE indexing completes cleanly.

## Test plan

- [x] `make tidy` succeeds
- [x] `go list -m all` resolves cleanly
- [x] `go build ./...` succeeds
- [ ] IntelliJ project indexing completes without errors