### PR TITLE
build(kubevirt): bump KubeVirt v1.8.2, CDI v1.65.0, Multus v4.2.4

### DIFF
--- a/build/kubevirt.mk
+++ b/build/kubevirt.mk
@@ -1,9 +1,9 @@
 # KubeVirt installation and management
 
 # KubeVirt version configuration
-KUBEVIRT_VERSION ?= v1.7.0
-CDI_VERSION ?= v1.64.0
-MULTUS_VERSION ?= v4.2.3
+KUBEVIRT_VERSION ?= v1.8.2
+CDI_VERSION ?= v1.65.0
+MULTUS_VERSION ?= v4.2.4
 
 # Detect if we're using a released version or main/latest
 KUBEVIRT_RELEASE_URL = https://github.com/kubevirt/kubevirt/releases/download/$(KUBEVIRT_VERSION)


### PR DESCRIPTION
## Summary
- Bump KubeVirt from v1.7.0 to v1.8.2
- Bump CDI from v1.64.0 to v1.65.0
- Bump Multus from v4.2.3 to v4.2.4
