### PR TITLE
feat(config): structure context list output

### DIFF
--- a/pkg/mcp/configuration_test.go
+++ b/pkg/mcp/configuration_test.go
@@ -54,6 +54,22 @@ func (s *ConfigurationSuite) TestContextsList() {
 			s.Regexpf(`^Available Kubernetes contexts \(\d+ total, default: fake-context\)`, toolResult.Content[0].(*mcp.TextContent).Text, "invalid tool context default result content %v", toolResult.Content[0].(*mcp.TextContent).Text)
 			s.Regexpf(`(?m)^\*fake-context -> http:\/\/127\.0\.0\.1:\d*$`, toolResult.Content[0].(*mcp.TextContent).Text, "invalid tool context default result content %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
+		s.Run("returns structured contexts", func() {
+			structured, ok := toolResult.StructuredContent.(map[string]interface{})
+			s.Require().True(ok, "expected structured context result")
+			s.Equal("fake-context", structured["defaultContext"])
+			items, ok := structured["contexts"].([]interface{})
+			s.Require().True(ok, "expected contexts array")
+			s.Len(items, 11)
+			first, ok := items[0].(map[string]interface{})
+			s.Require().True(ok, "expected context entry object")
+			s.Equal("cluster-0", first["name"])
+			s.Equal(false, first["default"])
+			last, ok := items[10].(map[string]interface{})
+			s.Require().True(ok, "expected context entry object")
+			s.Equal("fake-context", last["name"])
+			s.Equal(true, last["default"])
+		})
 	})
 }
 

--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"k8s.io/utils/ptr"
@@ -10,6 +11,17 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 )
+
+type contextInfo struct {
+	Name    string `json:"name"`
+	Server  string `json:"server"`
+	Default bool   `json:"default"`
+}
+
+type contextsListResult struct {
+	DefaultContext string        `json:"defaultContext"`
+	Contexts       []contextInfo `json:"contexts"`
+}
 
 func initConfiguration() []api.ServerTool {
 	tools := []api.ServerTool{
@@ -105,20 +117,35 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	result += "Format: [*] CONTEXT_NAME -> SERVER_URL\n"
 	result += " (* indicates the default context used in tools if context is not set)\n\n"
 	result += "Contexts:\n---------\n"
-	for context, server := range contexts {
+	contextNames := make([]string, 0, len(contexts))
+	for context := range contexts {
+		contextNames = append(contextNames, context)
+	}
+	sort.Strings(contextNames)
+
+	structured := contextsListResult{
+		DefaultContext: defaultContext,
+		Contexts:       make([]contextInfo, 0, len(contexts)),
+	}
+	for _, context := range contextNames {
+		server := contexts[context]
 		marker := " "
 		if context == defaultContext {
 			marker = "*"
 		}
 
 		result += fmt.Sprintf("%s%s -> %s\n", marker, context, server)
+		structured.Contexts = append(structured.Contexts, contextInfo{
+			Name:    context,
+			Server:  server,
+			Default: context == defaultContext,
+		})
 	}
 	result += "---------\n\n"
 
 	result += "To use a specific context with any tool, set the 'context' parameter in the tool call arguments"
 
-	// TODO: Review output format, current is not parseable and might not be ideal for LLM consumption
-	return api.NewToolCallResult(result, nil), nil
+	return api.NewToolCallResultFull(result, structured, nil), nil
 }
 
 func configurationView(params api.ToolHandlerParams) (*api.ToolCallResult, error) {


### PR DESCRIPTION
## What
Tiny DX fix: `configuration_contexts_list` keeps the same text output, but now also returns `structuredContent` with `defaultContext` and a sorted `contexts` list. Small win, less text parsing.

## Repro
On `main`, use any normal kubeconfig with at least one context, local kind/minikube is enough. Call `configuration_contexts_list`; the context list is only in `content[0].text`, while `structuredContent` is empty, so clients have to parse the prose. Kinda meh.

The added MCP test reproduces it: the new structured-content assertion fails on `main` before the handler change, and passes with this patch. No cloud-provider quota or hard API ceiling involved here, this is local kubeconfig data.

## Checks
- `go test ./pkg/mcp -run TestConfiguration/TestContextsList -count=1`
- `go test ./pkg/toolsets/config ./pkg/api -count=1`
- `make build`

No exact matching issue found. Related background: #777 and #960 added structured-content plumbing.