### PR TITLE
chore(config): polish #1151 follow-up and add structured-output spec

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Living documentation for implemented and planned features:
 | Spec | Description | Status |
 |------|-------------|--------|
 | **[Validation](specs/validation.md)** | Pre-execution validation layer (resource existence, schema, RBAC) | Implemented |
+| **[Structured Tool Output](specs/structured-output.md)** | Conventions for tools that emit `structuredContent` | Implemented |
 
 ## Advanced Topics
 

--- a/docs/specs/structured-output.md
+++ b/docs/specs/structured-output.md
@@ -1,0 +1,206 @@
+# Structured Tool Output Conventions
+
+Per the [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#structured-content),
+tools may return a `structuredContent` field alongside the regular text content
+block, allowing MCP clients to consume typed data without parsing prose. This
+document defines the repo-wide conventions a new structured emitter should
+follow so the same choices don't need to be re-derived in every PR.
+
+## Helper selection
+
+Two helpers live in [`pkg/api/toolsets.go`](../../pkg/api/toolsets.go). Pick by
+asking: *is the human-readable text the same string as `json.Marshal(structured)`?*
+
+### `api.NewToolCallResultStructured(structured, err)`
+
+Use when the text representation **is** the JSON serialization of the structured
+value. The helper marshals `structured` and reuses the result as the text
+content, so the two are guaranteed to stay aligned.
+
+```go
+return api.NewToolCallResultStructured(payload, nil), nil
+```
+
+Good fit for tools that emit raw typed data with no separate prose framing.
+
+### `api.NewToolCallResultFull(text, structured, err)`
+
+Use when the text representation **differs** from the JSON serialization — for
+example, prose framing, a YAML serialization, a table, or any other
+human-tailored format. Both Content and StructuredContent are passed
+independently and you own keeping them consistent.
+
+```go
+return api.NewToolCallResultFull(humanReadable, payload, nil), nil
+```
+
+Good fit for tools whose existing text format is worth preserving for backwards
+compatibility or LLM readability.
+
+### `api.NewToolCallResult(text, err)`
+
+Text-only. No structured content. Use for tools that have no structured payload
+to emit (e.g., a YAML dump where the YAML *is* the user-facing output and there
+is no separate typed view).
+
+## Two recipes
+
+### Recipe 1 — Kubernetes resource list tools
+
+Tools that list or fetch Kubernetes resources should route through the existing
+output layer. `output.Output.PrintObjStructured` (defined in
+[`pkg/output/output.go`](../../pkg/output/output.go)) returns a `*PrintResult`
+with both the text rendering (table or YAML) and a structured view extracted
+from the underlying object.
+
+The current list-tool callers — e.g. `namespacesList` in
+[`pkg/toolsets/core/namespaces.go`](../../pkg/toolsets/core/namespaces.go) —
+still use `PrintObj` + `NewToolCallResult` and emit no structured content.
+When converting one of them, the pattern is:
+
+```go
+func namespacesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+    ret, err := kubernetes.NewCore(params).NamespacesList(
+        params, api.ListOptions{AsTable: params.ListOutput.AsTable()},
+    )
+    if err != nil {
+        return api.NewToolCallResult("", fmt.Errorf("failed to list namespaces: %w", err)), nil
+    }
+    printed, err := params.ListOutput.PrintObjStructured(ret)
+    if err != nil {
+        return api.NewToolCallResult("", fmt.Errorf("failed to format namespaces: %w", err)), nil
+    }
+    return api.NewToolCallResultFull(printed.Text, printed.Structured, nil), nil
+}
+```
+
+For the table output format, `tableToStructured` produces a
+`[]map[string]any` keyed by the server-sent column headers; for YAML it returns
+the cleaned-up object or list of objects. No tool-specific extractor is
+required.
+
+> **Status:** the recipe is the intended pattern but has no in-tree adopter
+> yet. The first converted list tool (tracked in #920) will become the
+> canonical reference. Until then, mirror the snippet above.
+
+### Recipe 2 — Bespoke / non-Kubernetes data
+
+Tools whose payload is neither a Kubernetes object nor a list of them should
+declare a small typed Go struct and pass it through `NewToolCallResultFull`
+alongside whatever human-readable framing they already produce. The
+`configuration_contexts_list` tool
+([`pkg/toolsets/config/configuration.go`](../../pkg/toolsets/config/configuration.go))
+is the reference example:
+
+```go
+type ContextInfo struct {
+    Name    string `json:"name"`
+    Server  string `json:"server"`
+    Default bool   `json:"default"`
+}
+
+type ContextsListResult struct {
+    DefaultContext string        `json:"defaultContext"`
+    Contexts       []ContextInfo `json:"contexts"`
+}
+```
+
+The struct, its field names, and its `json` tags are part of the tool's public
+wire contract — see "Field naming" below.
+
+## Ordering discipline
+
+List-shaped structured emitters must produce a deterministic order. Two
+clients consuming the same input shouldn't see entries shuffled. The default
+convention is **lexicographic** sort on a stable key (the entry name, the
+resource name, etc.):
+
+```go
+names := make([]string, 0, len(items))
+for name := range items {
+    names = append(names, name)
+}
+sort.Strings(names)
+```
+
+Use numeric ordering only where it is intrinsic to the data (e.g., port
+numbers, indexes). When mixing numeric-looking strings (`cluster-2`,
+`cluster-10`), lexicographic order yields `cluster-10 < cluster-2`; that is
+the contract — tests should pin a middle index to catch any drift.
+
+For Kubernetes resource lists, ordering is delegated to the output layer:
+Tables preserve the API server's order; YAML preserves the list's `Items`
+order. Tool authors are not expected to re-sort.
+
+## Field naming
+
+Top-level keys in the structured payload follow camelCase, matching the MCP
+ecosystem's general JSON style. Keys should be descriptive nouns; reserve
+abbreviations for cases that are already industry-standard (`url`, `uid`,
+`id`).
+
+`configuration_contexts_list` sets the precedent:
+
+```json
+{
+  "defaultContext": "fake-context",
+  "contexts": [
+    { "name": "cluster-0", "server": "unknown", "default": false }
+  ]
+}
+```
+
+The container key is the resource's plural name (`contexts`); the marker for
+the "default / current / focused" entry is a `default` bool on the entry
+itself plus a `defaultContext` top-level scalar pointing at it by name, so
+clients can resolve the default without re-scanning the list.
+
+## `outputSchema` stance
+
+The MCP spec lets a tool declare an `outputSchema` (JSON Schema) describing
+its `structuredContent` shape. As of this writing the spec marks declaration
+as SHOULD-level, not MUST.
+
+This repo takes an **opportunistic** stance:
+
+- **Declare `outputSchema`** when the tool has a stable, hand-authored
+  typed struct (Recipe 2 above). The struct already pins the shape; the
+  schema is a near-mechanical translation.
+- **Skip `outputSchema`** for Kubernetes resource list tools (Recipe 1).
+  Their structured shape depends on the queried GVK, the server's column
+  metadata, and any future API extensions, so a static schema would either be
+  too loose to be useful or too tight to remain accurate.
+
+When in doubt, leave it off and add it later in a follow-up PR — declaring
+nothing is preferable to declaring something inaccurate.
+
+> **Wiring note:** `api.Tool` (see
+> [`pkg/api/toolsets.go`](../../pkg/api/toolsets.go)) carries `InputSchema` but
+> does not yet expose an `OutputSchema` field. Adding the field, surfacing it
+> through the MCP go-sdk transport, and generating it from typed structs is a
+> follow-up; until then this section is forward-looking guidance.
+
+## Wire-contract discipline
+
+Once a tool emits `structuredContent`, its JSON shape is public API and
+clients may depend on the field names. To keep the contract visible to future
+maintainers:
+
+- Define the structured payload as a named, exported Go type whose `json:`
+  tags are the wire keys. `ContextInfo` and `ContextsListResult` in
+  `pkg/toolsets/config/configuration.go` are the reference.
+- Add a doc comment on the type stating that it is part of the tool's wire
+  contract, so reviewers know not to rename `json:` tags casually.
+- Cover the structured shape in tests: assert the top-level keys, assert the
+  type of nested entries, and pin at least one middle index for list-shaped
+  payloads (to catch off-by-one or duplicate-skip bugs that a length check
+  alone would miss).
+
+## Empty / nil results
+
+If a tool has no structured payload to emit on a given call — for example, a
+list endpoint that returned zero items where a clearer human message is more
+useful than an empty array — return text-only via `api.NewToolCallResult` and
+leave `StructuredContent` nil. Do **not** pass an empty slice / map / struct;
+a typed nil leaking into the `any` interface would create a non-nil interface
+value, which is a footgun for downstream nil checks.

--- a/docs/specs/structured-output.md
+++ b/docs/specs/structured-output.md
@@ -80,8 +80,11 @@ the cleaned-up object or list of objects. No tool-specific extractor is
 required.
 
 > **Status:** the recipe is the intended pattern but has no in-tree adopter
-> yet. The first converted list tool (tracked in #920) will become the
-> canonical reference. Until then, mirror the snippet above.
+> yet. The first converted list tool — tracked in #920 (MCP Apps), which
+> retrofits several core tools with this pattern — will become the canonical
+> reference. If that conversion uncovers a wrinkle (error-wrap style, params
+> plumbing, a dedicated helper, etc.), please thread the change back into
+> this section so the snippet doesn't quietly diverge from the live code.
 
 ### Recipe 2 — Bespoke / non-Kubernetes data
 

--- a/pkg/mcp/configuration_test.go
+++ b/pkg/mcp/configuration_test.go
@@ -81,7 +81,7 @@ func (s *ConfigurationSuite) TestContextsList() {
 			s.Equal(true, last["default"])
 			lastServer, ok := last["server"].(string)
 			s.Require().True(ok, "expected server string")
-			s.Regexp(`^https?://(127\.0\.0\.1|localhost):\d{1,5}$`, lastServer, "expected real server URL for fake-context, got %v", lastServer)
+			s.Regexp(`^https?://(127\.0\.0\.1|localhost):\d+$`, lastServer, "expected real server URL for fake-context, got %v", lastServer)
 		})
 	})
 }

--- a/pkg/mcp/configuration_test.go
+++ b/pkg/mcp/configuration_test.go
@@ -25,9 +25,11 @@ func (s *ConfigurationSuite) SetupTest() {
 	mockServer := test.NewMockServer()
 	s.T().Cleanup(mockServer.Close)
 	kubeconfig := mockServer.Kubeconfig()
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 11; i++ {
 		// Add multiple fake contexts to force configuration_contexts_list tool to appear
-		// and test minification in configuration_view tool
+		// and test minification in configuration_view tool. cluster-10 is included
+		// so TestContextsList can assert the lexicographic ordering contract
+		// (cluster-10 sorts before cluster-2).
 		name := fmt.Sprintf("cluster-%d", i)
 		kubeconfig.Contexts[name] = clientcmdapi.NewContext()
 		kubeconfig.Clusters[name+"-cluster"] = clientcmdapi.NewCluster()
@@ -48,7 +50,7 @@ func (s *ConfigurationSuite) TestContextsList() {
 		s.Require().NotNil(toolResult, "Expected tool result from call")
 		s.Lenf(toolResult.Content, 1, "invalid tool result content length %v", len(toolResult.Content))
 		s.Run("contains context count", func() {
-			s.Regexpf(`^Available Kubernetes contexts \(11 total`, toolResult.Content[0].(*mcp.TextContent).Text, "invalid tool count result content %v", toolResult.Content[0].(*mcp.TextContent).Text)
+			s.Regexpf(`^Available Kubernetes contexts \(12 total`, toolResult.Content[0].(*mcp.TextContent).Text, "invalid tool count result content %v", toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 		s.Run("contains default context name", func() {
 			s.Regexpf(`^Available Kubernetes contexts \(\d+ total, default: fake-context\)`, toolResult.Content[0].(*mcp.TextContent).Text, "invalid tool context default result content %v", toolResult.Content[0].(*mcp.TextContent).Text)
@@ -60,15 +62,26 @@ func (s *ConfigurationSuite) TestContextsList() {
 			s.Equal("fake-context", structured["defaultContext"])
 			items, ok := structured["contexts"].([]interface{})
 			s.Require().True(ok, "expected contexts array")
-			s.Len(items, 11)
+			s.Len(items, 12)
 			first, ok := items[0].(map[string]interface{})
 			s.Require().True(ok, "expected context entry object")
 			s.Equal("cluster-0", first["name"])
 			s.Equal(false, first["default"])
-			last, ok := items[10].(map[string]interface{})
+			s.Equal("unknown", first["server"], "cluster-0 has no server, expected the unknown placeholder")
+			// Lock lexicographic ordering: cluster-10 sorts between cluster-1
+			// and cluster-2, so items[2] must be "cluster-10". This catches
+			// off-by-one or duplicate-skip bugs in the sort/append loop that a
+			// length-only assertion would miss.
+			middle, ok := items[2].(map[string]interface{})
+			s.Require().True(ok, "expected context entry object")
+			s.Equal("cluster-10", middle["name"], "expected lexicographic ordering: items[2] should be cluster-10 (cluster-10 < cluster-2 lexicographically)")
+			last, ok := items[11].(map[string]interface{})
 			s.Require().True(ok, "expected context entry object")
 			s.Equal("fake-context", last["name"])
 			s.Equal(true, last["default"])
+			lastServer, ok := last["server"].(string)
+			s.Require().True(ok, "expected server string")
+			s.Regexp(`^https?://(127\.0\.0\.1|localhost):\d{1,5}$`, lastServer, "expected real server URL for fake-context, got %v", lastServer)
 		})
 	})
 }
@@ -127,23 +140,23 @@ func (s *ConfigurationSuite) TestConfigurationView() {
 			s.Nilf(err, "invalid tool result content %v", err)
 		})
 		s.Run("returns additional context info", func() {
-			s.Lenf(decoded.Contexts, 11, "invalid context count, expected 12, got %v", len(decoded.Contexts))
+			s.Lenf(decoded.Contexts, 12, "invalid context count, expected 12, got %v", len(decoded.Contexts))
 			s.Equalf("cluster-0", decoded.Contexts[0].Name, "cluster-0 not found: %v", decoded.Contexts)
 			s.Equalf("cluster-0-cluster", decoded.Contexts[0].Context.Cluster, "cluster-0-cluster not found: %v", decoded.Contexts)
 			s.Equalf("cluster-0-auth", decoded.Contexts[0].Context.AuthInfo, "cluster-0-auth not found: %v", decoded.Contexts)
-			s.Equalf("fake", decoded.Contexts[10].Context.Cluster, "fake not found: %v", decoded.Contexts)
-			s.Equalf("fake", decoded.Contexts[10].Context.AuthInfo, "fake not found: %v", decoded.Contexts)
-			s.Equalf("fake-context", decoded.Contexts[10].Name, "fake-context not found: %v", decoded.Contexts)
+			s.Equalf("fake", decoded.Contexts[11].Context.Cluster, "fake not found: %v", decoded.Contexts)
+			s.Equalf("fake", decoded.Contexts[11].Context.AuthInfo, "fake not found: %v", decoded.Contexts)
+			s.Equalf("fake-context", decoded.Contexts[11].Name, "fake-context not found: %v", decoded.Contexts)
 		})
 		s.Run("returns cluster info", func() {
-			s.Lenf(decoded.Clusters, 11, "invalid cluster count, expected 2, got %v", len(decoded.Clusters))
+			s.Lenf(decoded.Clusters, 12, "invalid cluster count, expected 12, got %v", len(decoded.Clusters))
 			s.Equalf("cluster-0-cluster", decoded.Clusters[0].Name, "cluster-0-cluster not found: %v", decoded.Clusters)
-			s.Equalf("fake", decoded.Clusters[10].Name, "fake not found: %v", decoded.Clusters)
+			s.Equalf("fake", decoded.Clusters[11].Name, "fake not found: %v", decoded.Clusters)
 		})
 		s.Run("configuration_view with minified=false returns auth info", func() {
-			s.Lenf(decoded.AuthInfos, 11, "invalid auth info count, expected 2, got %v", len(decoded.AuthInfos))
+			s.Lenf(decoded.AuthInfos, 12, "invalid auth info count, expected 12, got %v", len(decoded.AuthInfos))
 			s.Equalf("cluster-0-auth", decoded.AuthInfos[0].Name, "cluster-0-auth not found: %v", decoded.AuthInfos)
-			s.Equalf("fake", decoded.AuthInfos[10].Name, "fake not found: %v", decoded.AuthInfos)
+			s.Equalf("fake", decoded.AuthInfos[11].Name, "fake not found: %v", decoded.AuthInfos)
 		})
 	})
 }

--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -12,15 +12,28 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 )
 
-type contextInfo struct {
+// ContextInfo describes a single kubeconfig context entry in the
+// configuration_contexts_list tool's structured content payload.
+//
+// This is part of the tool's public wire contract: the JSON field tags are
+// observed by MCP clients and must not be renamed without a coordinated
+// migration. See docs/specs/structured-output.md for the repo-wide
+// structured-content conventions.
+type ContextInfo struct {
 	Name    string `json:"name"`
 	Server  string `json:"server"`
 	Default bool   `json:"default"`
 }
 
-type contextsListResult struct {
+// ContextsListResult is the structured-content payload returned by the
+// configuration_contexts_list tool.
+//
+// This is part of the tool's public wire contract: the JSON field tags are
+// observed by MCP clients and must not be renamed without a coordinated
+// migration. See docs/specs/structured-output.md.
+type ContextsListResult struct {
 	DefaultContext string        `json:"defaultContext"`
-	Contexts       []contextInfo `json:"contexts"`
+	Contexts       []ContextInfo `json:"contexts"`
 }
 
 func initConfiguration() []api.ServerTool {
@@ -105,6 +118,8 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	}
 
 	if len(contexts) == 0 {
+		// Structured content is intentionally omitted (nil) on this branch — see
+		// docs/specs/structured-output.md "Empty / nil results".
 		return api.NewToolCallResult("No contexts found in kubeconfig", nil), nil
 	}
 
@@ -121,11 +136,14 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	for context := range contexts {
 		contextNames = append(contextNames, context)
 	}
+	// Lexicographic order is the documented contract — see
+	// docs/specs/structured-output.md "Ordering discipline". Note this places
+	// numeric-looking names like "cluster-10" before "cluster-2".
 	sort.Strings(contextNames)
 
-	structured := contextsListResult{
+	structured := ContextsListResult{
 		DefaultContext: defaultContext,
-		Contexts:       make([]contextInfo, 0, len(contexts)),
+		Contexts:       make([]ContextInfo, 0, len(contexts)),
 	}
 	for _, context := range contextNames {
 		server := contexts[context]
@@ -135,7 +153,7 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		}
 
 		result += fmt.Sprintf("%s%s -> %s\n", marker, context, server)
-		structured.Contexts = append(structured.Contexts, contextInfo{
+		structured.Contexts = append(structured.Contexts, ContextInfo{
 			Name:    context,
 			Server:  server,
 			Default: context == defaultContext,
@@ -145,6 +163,10 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 
 	result += "To use a specific context with any tool, set the 'context' parameter in the tool call arguments"
 
+	// TODO: Review the unstructured text fallback above (see #1151 review).
+	// Per the MCP spec the text block alongside structuredContent is SHOULD-
+	// level, so its format is still worth revisiting independently (e.g. for
+	// LLM legibility and parseability).
 	return api.NewToolCallResultFull(result, structured, nil), nil
 }
 

--- a/pkg/toolsets/config/configuration_test.go
+++ b/pkg/toolsets/config/configuration_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+)
+
+// The MCP-level integration suite (pkg/mcp/configuration_test.go) cannot
+// exercise the empty-kubeconfig branch of contextsList:
+//   - a kubeconfig with zero contexts fails provider initialization
+//     ("no current-context is set and no contexts are defined"), and
+//   - a kubeconfig with a single context filters the tool out entirely via
+//     ShouldIncludeTargetListTool because the provider is not multi-target.
+// This test covers the otherwise-unreachable empty branch by invoking the
+// handler with a minimal ClientConfig that returns a kubeconfig with no
+// contexts.
+
+type ContextsListEmptySuite struct {
+	suite.Suite
+}
+
+func (s *ContextsListEmptySuite) TestContextsListEmpty() {
+	params := api.ToolHandlerParams{
+		KubernetesClient: emptyContextsKubernetesClient{},
+	}
+
+	result, err := contextsList(params)
+
+	s.Require().NoError(err, "contextsList returned a transport error")
+	s.Require().NotNil(result, "expected non-nil result for empty kubeconfig")
+	s.NoError(result.Error, "expected no tool-level error for empty kubeconfig")
+	s.Equal("No contexts found in kubeconfig", result.Content)
+	s.Nil(result.StructuredContent, "structured content must be nil when no contexts are present")
+}
+
+func TestContextsListEmptySuite(t *testing.T) {
+	suite.Run(t, new(ContextsListEmptySuite))
+}
+
+// emptyContextsKubernetesClient is a minimal api.KubernetesClient that
+// returns a kubeconfig with no contexts. The embedded api.KubernetesClient
+// is left nil — contextsList only calls ToRawKubeConfigLoader on it for
+// the empty branch, so the other interface methods are never reached.
+type emptyContextsKubernetesClient struct {
+	api.KubernetesClient // intentionally nil; any unexpected method call will panic loudly.
+}
+
+func (emptyContextsKubernetesClient) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return emptyClientConfig{}
+}
+
+// emptyClientConfig is a clientcmd.ClientConfig that returns a kubeconfig
+// with no contexts. The non-RawConfig methods are stubbed because the
+// configuration_contexts_list handler does not invoke them on the empty
+// branch — `clientcmd.ClientConfig` cannot be embedded here because the
+// interface has a `ClientConfig()` method that would collide with the
+// embedded field's promoted name.
+type emptyClientConfig struct{}
+
+var _ clientcmd.ClientConfig = emptyClientConfig{}
+
+func (emptyClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return *clientcmdapi.NewConfig(), nil
+}
+
+func (emptyClientConfig) ClientConfig() (*rest.Config, error) { return nil, nil }
+
+func (emptyClientConfig) Namespace() (string, bool, error) { return "", false, nil }
+
+func (emptyClientConfig) ConfigAccess() clientcmd.ConfigAccess { return nil }

--- a/pkg/toolsets/config/configuration_test.go
+++ b/pkg/toolsets/config/configuration_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 )
+
+var errEmptyClientConfigStub = errors.New("emptyClientConfig: method not implemented (unreachable on the empty-contexts branch)")
 
 // The MCP-level integration suite (pkg/mcp/configuration_test.go) cannot
 // exercise the empty-kubeconfig branch of contextsList:
@@ -69,8 +72,12 @@ func (emptyClientConfig) RawConfig() (clientcmdapi.Config, error) {
 	return *clientcmdapi.NewConfig(), nil
 }
 
-func (emptyClientConfig) ClientConfig() (*rest.Config, error) { return nil, nil }
+func (emptyClientConfig) ClientConfig() (*rest.Config, error) {
+	return nil, errEmptyClientConfigStub
+}
 
-func (emptyClientConfig) Namespace() (string, bool, error) { return "", false, nil }
+func (emptyClientConfig) Namespace() (string, bool, error) {
+	return "", false, errEmptyClientConfigStub
+}
 
 func (emptyClientConfig) ConfigAccess() clientcmd.ConfigAccess { return nil }


### PR DESCRIPTION
## Summary

Follow-up to #1151 polishing the structured-content emission for
`configuration_contexts_list` and adding a repo-wide spec so the next
structured emitter (e.g. the #920 MCP Apps retrofits) doesn't have to
re-derive choices already made.

## What's done

### Production code — `pkg/toolsets/config/configuration.go`

- Restored the unstructured-text-fallback TODO removed during #1151
  (per @Cali0707's review): the text block alongside
  `structuredContent` is SHOULD-level per the MCP spec, so its format
  is still worth revisiting independently.
- Exported the structured payload types — `contextInfo` →
  `ContextInfo`, `contextsListResult` → `ContextsListResult` — with
  doc comments naming them as the tool's public wire contract.
- Added in-line comments anchoring the lexicographic ordering
  contract and the intentional nil `StructuredContent` on the empty
  branch.

### Tests

- New `pkg/toolsets/config/configuration_test.go` covers the
  previously-untested empty-kubeconfig branch. A header comment
  explains why this branch is unreachable from the MCP-level suite.
- `pkg/mcp/configuration_test.go`: bumped fake clusters from 10 to
  11 so `cluster-10` exists and exposes the surprising lexicographic
  ordering; added `server` assertions for both paths (the `"unknown"`
  placeholder and the real `http://127.0.0.1:port` URL); pinned
  `items[2] == "cluster-10"` as the middle-index ordering check;
  adjusted `TestConfigurationView` length assertions to 12.

### Docs

- New `docs/specs/structured-output.md` codifies repo-wide
  conventions: helper selection (`NewToolCallResultFull` vs
  `NewToolCallResultStructured`); two recipes (Kubernetes resource
  lists via `output.PrintObjStructured`; bespoke data via a typed
  struct); ordering discipline; field naming; an opportunistic
  `outputSchema` stance with a wiring note (`api.Tool` doesn't yet
  expose `OutputSchema`); wire-contract discipline and empty/nil
  result guidance.
- `docs/README.md`: index entry for the new spec.

## What's pending

- None for this issue. Out-of-scope items from #1153 (handler
  error-branch tests; MCP Apps viewer resource registration) remain
  tracked there.

Closes #1153