### PR TITLE
feat: add field-level redaction for denied_resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,13 +228,8 @@ group = "rbac.authorization.k8s.io"
 version = "v1"
 kind = "ClusterRole"
 
-# Allow Secrets but redact their values (keys and metadata remain visible)
-[[redacted_resources]]
-group = ""
-version = "v1"
-kind = "Secret"
-fields = ["data.*", "stringData.*"]
-mode = "hashed"
+# Redact Secret values (data, stringData, and last-applied-configuration)
+redact_secrets = "hashed"
 
 [telemetry]
 endpoint = "http://localhost:4317"
@@ -246,7 +241,7 @@ For comprehensive TOML configuration documentation, including:
 - Drop-in configuration files for modular settings
 - Dynamic configuration reload via SIGHUP
 - Denied resources for restricting access to sensitive resource types
-- Redacted resources for field-level redaction of sensitive values
+- Built-in Secret value redaction
 - Server instructions for MCP Tool Search
 - [Custom MCP prompts](docs/prompts.md)
 - OAuth/OIDC authentication for HTTP mode ([Keycloak](docs/KEYCLOAK_OIDC_SETUP.md), [Microsoft Entra ID](docs/ENTRA_ID_SETUP.md))

--- a/README.md
+++ b/README.md
@@ -222,11 +222,19 @@ log_level = 2
 read_only = true
 toolsets = ["core", "config", "helm", "kubevirt"]
 
-# Deny access to sensitive resources
+# Deny access to sensitive resources (fully blocked)
 [[denied_resources]]
+group = "rbac.authorization.k8s.io"
+version = "v1"
+kind = "ClusterRole"
+
+# Allow Secrets but redact their values (keys and metadata remain visible)
+[[redacted_resources]]
 group = ""
 version = "v1"
 kind = "Secret"
+fields = ["data.*", "stringData.*"]
+mode = "hashed"
 
 [telemetry]
 endpoint = "http://localhost:4317"
@@ -238,6 +246,7 @@ For comprehensive TOML configuration documentation, including:
 - Drop-in configuration files for modular settings
 - Dynamic configuration reload via SIGHUP
 - Denied resources for restricting access to sensitive resource types
+- Redacted resources for field-level redaction of sensitive values
 - Server instructions for MCP Tool Search
 - [Custom MCP prompts](docs/prompts.md)
 - OAuth/OIDC authentication for HTTP mode ([Keycloak](docs/KEYCLOAK_OIDC_SETUP.md), [Microsoft Entra ID](docs/ENTRA_ID_SETUP.md))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -410,67 +410,25 @@ version = "v1"
 kind = "ClusterRoleBinding"
 ```
 
-### Redacted Resources
+### Secret Redaction
 
-Instead of fully denying a resource, you can allow access but redact sensitive fields. This is useful for resources like Secrets where the agent needs to see metadata (name, namespace, keys, type, ownership) but should not see actual values.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `redacted_resources` | array | `[]` | List of resources with field-level redaction. |
-
-Each entry in `redacted_resources` supports the following fields:
+Enable built-in redaction of Secret values. When enabled, the server automatically redacts `data.*` and `stringData.*` values in all Secret resources, and strips the `kubectl.kubernetes.io/last-applied-configuration` annotation (which would otherwise contain unredacted Secret data). Secrets are matched by `kind: Secret` regardless of API version.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `group` | string | required | API group (e.g. `""` for core, `"apps"` for apps/v1) |
-| `version` | string | required | API version (e.g. `"v1"`) |
-| `kind` | string | required | Resource kind (e.g. `"Secret"`) |
-| `fields` | array | required | Dot-separated field paths to redact |
-| `mode` | string | `"opaque"` | How to redact values: `"opaque"` or `"hashed"` |
+| `redact_secrets` | string | `""` | Secret redaction mode: `"opaque"`, `"hashed"`, or `""` (disabled). |
 
 **Example — redact Secret values while keeping metadata and key names visible:**
 ```toml
-[[redacted_resources]]
-group = ""
-version = "v1"
-kind = "Secret"
-fields = ["data.*", "stringData.*"]
-mode = "hashed"
+redact_secrets = "hashed"
 ```
-
-**Path syntax:**
-
-Fields are specified as dot-separated paths with `*` wildcard support. The wildcard adapts to the type it encounters — it iterates keys in a map and items in an array.
-
-| Path | Behavior |
-|------|----------|
-| `data.*` | Redact all values in a map (keys remain visible) |
-| `spec.credentials` | Redact a single field |
-| `spec.template.spec.containers.*.env.*.value` | Traverse arrays and maps to reach nested fields |
 
 **Redaction modes:**
 
-- `opaque` (default): replaces values with `[REDACTED]`
+- `opaque`: replaces values with `[REDACTED]`
 - `hashed`: replaces values with `[REDACTED:gen_<id>:<hash>]`
 
 Hashed mode uses HMAC-SHA256 with a random salt generated once at server startup. This allows the agent to detect when two different resources reference the same value (e.g. two services using the same connection string) without exposing the actual content. The salt is never persisted and changes on restart. A generation ID is included so consumers can detect when the salt changed and know that hashes from different generations are not comparable.
-
-**More examples:**
-```toml
-# ConfigMap with sensitive data
-[[redacted_resources]]
-group = ""
-version = "v1"
-kind = "ConfigMap"
-fields = ["data.*"]
-
-# CRD with embedded credentials
-[[redacted_resources]]
-group = "db.example.com"
-version = "v1"
-kind = "DatabaseConnection"
-fields = ["spec.credentials.*", "spec.connectionString"]
-```
 
 ### Server Instructions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -410,6 +410,68 @@ version = "v1"
 kind = "ClusterRoleBinding"
 ```
 
+### Redacted Resources
+
+Instead of fully denying a resource, you can allow access but redact sensitive fields. This is useful for resources like Secrets where the agent needs to see metadata (name, namespace, keys, type, ownership) but should not see actual values.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `redacted_resources` | array | `[]` | List of resources with field-level redaction. |
+
+Each entry in `redacted_resources` supports the following fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `group` | string | required | API group (e.g. `""` for core, `"apps"` for apps/v1) |
+| `version` | string | required | API version (e.g. `"v1"`) |
+| `kind` | string | required | Resource kind (e.g. `"Secret"`) |
+| `fields` | array | required | Dot-separated field paths to redact |
+| `mode` | string | `"opaque"` | How to redact values: `"opaque"` or `"hashed"` |
+
+**Example — redact Secret values while keeping metadata and key names visible:**
+```toml
+[[redacted_resources]]
+group = ""
+version = "v1"
+kind = "Secret"
+fields = ["data.*", "stringData.*"]
+mode = "hashed"
+```
+
+**Path syntax:**
+
+Fields are specified as dot-separated paths with `*` wildcard support. The wildcard adapts to the type it encounters — it iterates keys in a map and items in an array.
+
+| Path | Behavior |
+|------|----------|
+| `data.*` | Redact all values in a map (keys remain visible) |
+| `spec.credentials` | Redact a single field |
+| `spec.template.spec.containers.*.env.*.value` | Traverse arrays and maps to reach nested fields |
+
+**Redaction modes:**
+
+- `opaque` (default): replaces values with `[REDACTED]`
+- `hashed`: replaces values with `[REDACTED:gen_<id>:<hash>]`
+
+Hashed mode uses HMAC-SHA256 with a random salt generated once at server startup. This allows the agent to detect when two different resources reference the same value (e.g. two services using the same connection string) without exposing the actual content. The salt is never persisted and changes on restart. A generation ID is included so consumers can detect when the salt changed and know that hashes from different generations are not comparable.
+
+**More examples:**
+```toml
+# ConfigMap with sensitive data
+[[redacted_resources]]
+group = ""
+version = "v1"
+kind = "ConfigMap"
+fields = ["data.*"]
+
+# CRD with embedded credentials
+[[redacted_resources]]
+group = "db.example.com"
+version = "v1"
+kind = "DatabaseConnection"
+fields = ["spec.credentials.*", "spec.connectionString"]
+```
+
 ### Server Instructions
 
 Provide hints to MCP clients (like Claude Code) about when to use this server's tools. Useful for clients that support **MCP Tool Search**.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -58,26 +58,15 @@ type GroupVersionKind struct {
 	Kind    string `json:"kind,omitempty" toml:"kind,omitempty"`
 }
 
-// RedactedResource defines a resource type whose specific fields should be redacted
-// rather than having the entire resource denied. This allows agents to see resource
-// metadata while sensitive field values are replaced with redaction markers.
-type RedactedResource struct {
-	Group   string   `json:"group" toml:"group"`
-	Version string   `json:"version" toml:"version"`
-	Kind    string   `json:"kind" toml:"kind"`
-	Fields  []string `json:"fields" toml:"fields"`
-	Mode    string   `json:"mode,omitempty" toml:"mode,omitempty"`
-}
-
 type DeniedResourcesProvider interface {
 	// GetDeniedResources returns a list of GroupVersionKinds that are denied.
 	GetDeniedResources() []GroupVersionKind
 }
 
-// RedactedResourcesProvider provides access to resources that should have specific fields redacted.
-type RedactedResourcesProvider interface {
-	// GetRedactedResources returns the list of resources with field-level redaction configured.
-	GetRedactedResources() []RedactedResource
+// SecretRedactionProvider provides access to the Secret redaction mode.
+type SecretRedactionProvider interface {
+	// GetRedactSecrets returns the Secret redaction mode ("opaque", "hashed", or "" for disabled).
+	GetRedactSecrets() string
 }
 
 type StsConfigProvider interface {
@@ -113,7 +102,7 @@ type BaseConfig interface {
 	ClusterProvider
 	ConfirmationRulesProvider
 	DeniedResourcesProvider
-	RedactedResourcesProvider
+	SecretRedactionProvider
 	ExtendedConfigProvider
 	StsConfigProvider
 	ValidationEnabledProvider

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -58,9 +58,26 @@ type GroupVersionKind struct {
 	Kind    string `json:"kind,omitempty" toml:"kind,omitempty"`
 }
 
+// RedactedResource defines a resource type whose specific fields should be redacted
+// rather than having the entire resource denied. This allows agents to see resource
+// metadata while sensitive field values are replaced with redaction markers.
+type RedactedResource struct {
+	Group   string   `json:"group" toml:"group"`
+	Version string   `json:"version" toml:"version"`
+	Kind    string   `json:"kind" toml:"kind"`
+	Fields  []string `json:"fields" toml:"fields"`
+	Mode    string   `json:"mode,omitempty" toml:"mode,omitempty"`
+}
+
 type DeniedResourcesProvider interface {
 	// GetDeniedResources returns a list of GroupVersionKinds that are denied.
 	GetDeniedResources() []GroupVersionKind
+}
+
+// RedactedResourcesProvider provides access to resources that should have specific fields redacted.
+type RedactedResourcesProvider interface {
+	// GetRedactedResources returns the list of resources with field-level redaction configured.
+	GetRedactedResources() []RedactedResource
 }
 
 type StsConfigProvider interface {
@@ -96,6 +113,7 @@ type BaseConfig interface {
 	ClusterProvider
 	ConfirmationRulesProvider
 	DeniedResourcesProvider
+	RedactedResourcesProvider
 	ExtendedConfigProvider
 	StsConfigProvider
 	ValidationEnabledProvider

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,8 +33,13 @@ type ToolOverride struct {
 // StaticConfig is the configuration for the server.
 // It allows to configure server specific settings and tools to be enabled or disabled.
 type StaticConfig struct {
-	DeniedResources   []api.GroupVersionKind `toml:"denied_resources"`
-	RedactedResources []api.RedactedResource `toml:"redacted_resources"`
+	DeniedResources []api.GroupVersionKind `toml:"denied_resources"`
+	// RedactSecrets controls built-in Secret value redaction.
+	// When set, Secret data/stringData values and the last-applied-configuration
+	// annotation are redacted in all tool outputs.
+	// Valid values: "opaque" (replaces with [REDACTED]), "hashed" (deterministic hash),
+	// or empty string (disabled).
+	RedactSecrets string `toml:"redact_secrets,omitempty"`
 
 	LogLevel   int    `toml:"log_level,omitzero"`
 	LogFile    string `toml:"log_file,omitempty"`
@@ -384,8 +389,8 @@ func (c *StaticConfig) GetDeniedResources() []api.GroupVersionKind {
 	return c.DeniedResources
 }
 
-func (c *StaticConfig) GetRedactedResources() []api.RedactedResource {
-	return c.RedactedResources
+func (c *StaticConfig) GetRedactSecrets() string {
+	return c.RedactSecrets
 }
 
 func (c *StaticConfig) GetKubeConfigPath() string {
@@ -556,43 +561,18 @@ func (c *StaticConfig) Validate() error {
 	if err := c.HTTP.Validate(); err != nil {
 		return err
 	}
-	if err := c.validateRedactedResources(); err != nil {
+	if err := c.validateRedactSecrets(); err != nil {
 		return err
 	}
 	return nil
 }
 
-// validateRedactedResources validates the redacted_resources configuration:
-//   - version must be set
-//   - kind must be set (cannot redact fields on an entire group/version)
-//   - fields must not be empty and must contain valid dot-separated paths
-//   - mode must be "opaque", "hashed", or empty (defaults to opaque)
-func (c *StaticConfig) validateRedactedResources() error {
-	for i, rr := range c.RedactedResources {
-		if rr.Version == "" {
-			return fmt.Errorf("redacted_resources[%d]: version must be set", i)
-		}
-		if rr.Kind == "" {
-			return fmt.Errorf("redacted_resources[%d]: kind must be set", i)
-		}
-		if len(rr.Fields) == 0 {
-			return fmt.Errorf("redacted_resources[%d]: fields must not be empty", i)
-		}
-		for j, field := range rr.Fields {
-			if field == "" {
-				return fmt.Errorf("redacted_resources[%d]: fields[%d] must not be empty", i, j)
-			}
-			segments := strings.Split(field, ".")
-			for _, seg := range segments {
-				if seg == "" {
-					return fmt.Errorf("redacted_resources[%d]: fields[%d] %q contains empty path segment", i, j, field)
-				}
-			}
-		}
-		mode := rr.Mode
-		if mode != "" && mode != redaction.RedactionModeOpaque && mode != redaction.RedactionModeHashed {
-			return fmt.Errorf("redacted_resources[%d]: invalid mode %q, must be %q or %q", i, mode, redaction.RedactionModeOpaque, redaction.RedactionModeHashed)
-		}
+// validateRedactSecrets validates the redact_secrets configuration.
+// Valid values: "", "opaque", "hashed".
+func (c *StaticConfig) validateRedactSecrets() error {
+	mode := c.RedactSecrets
+	if mode != "" && mode != redaction.RedactionModeOpaque && mode != redaction.RedactionModeHashed {
+		return fmt.Errorf("invalid redact_secrets %q: must be %q or %q", mode, redaction.RedactionModeOpaque, redaction.RedactionModeHashed)
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/redaction"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"k8s.io/klog/v2"
@@ -32,7 +33,8 @@ type ToolOverride struct {
 // StaticConfig is the configuration for the server.
 // It allows to configure server specific settings and tools to be enabled or disabled.
 type StaticConfig struct {
-	DeniedResources []api.GroupVersionKind `toml:"denied_resources"`
+	DeniedResources   []api.GroupVersionKind `toml:"denied_resources"`
+	RedactedResources []api.RedactedResource `toml:"redacted_resources"`
 
 	LogLevel   int    `toml:"log_level,omitzero"`
 	LogFile    string `toml:"log_file,omitempty"`
@@ -382,6 +384,10 @@ func (c *StaticConfig) GetDeniedResources() []api.GroupVersionKind {
 	return c.DeniedResources
 }
 
+func (c *StaticConfig) GetRedactedResources() []api.RedactedResource {
+	return c.RedactedResources
+}
+
 func (c *StaticConfig) GetKubeConfigPath() string {
 	return c.KubeConfig
 }
@@ -549,6 +555,44 @@ func (c *StaticConfig) Validate() error {
 	}
 	if err := c.HTTP.Validate(); err != nil {
 		return err
+	}
+	if err := c.validateRedactedResources(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateRedactedResources validates the redacted_resources configuration:
+//   - version must be set
+//   - kind must be set (cannot redact fields on an entire group/version)
+//   - fields must not be empty and must contain valid dot-separated paths
+//   - mode must be "opaque", "hashed", or empty (defaults to opaque)
+func (c *StaticConfig) validateRedactedResources() error {
+	for i, rr := range c.RedactedResources {
+		if rr.Version == "" {
+			return fmt.Errorf("redacted_resources[%d]: version must be set", i)
+		}
+		if rr.Kind == "" {
+			return fmt.Errorf("redacted_resources[%d]: kind must be set", i)
+		}
+		if len(rr.Fields) == 0 {
+			return fmt.Errorf("redacted_resources[%d]: fields must not be empty", i)
+		}
+		for j, field := range rr.Fields {
+			if field == "" {
+				return fmt.Errorf("redacted_resources[%d]: fields[%d] must not be empty", i, j)
+			}
+			segments := strings.Split(field, ".")
+			for _, seg := range segments {
+				if seg == "" {
+					return fmt.Errorf("redacted_resources[%d]: fields[%d] %q contains empty path segment", i, j, field)
+				}
+			}
+		}
+		mode := rr.Mode
+		if mode != "" && mode != redaction.RedactionModeOpaque && mode != redaction.RedactionModeHashed {
+			return fmt.Errorf("redacted_resources[%d]: invalid mode %q, must be %q or %q", i, mode, redaction.RedactionModeOpaque, redaction.RedactionModeHashed)
+		}
 	}
 	return nil
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -639,147 +639,31 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 	})
 }
 
-func (s *ValidateSuite) TestRedactedResources() {
-	s.Run("missing version is rejected", func() {
-		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:  "",
-				Kind:   "Secret",
-				Fields: []string{"data.*"},
-			},
-		}
-		err := cfg.Validate()
-		s.Require().Error(err)
-		s.Contains(err.Error(), "version must be set")
-	})
-
-	s.Run("missing kind is rejected", func() {
-		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Fields:  []string{"data.*"},
-			},
-		}
-		err := cfg.Validate()
-		s.Require().Error(err)
-		s.Contains(err.Error(), "kind must be set")
-	})
-
-	s.Run("empty fields is rejected", func() {
-		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-			},
-		}
-		err := cfg.Validate()
-		s.Require().Error(err)
-		s.Contains(err.Error(), "fields must not be empty")
-	})
-
-	s.Run("empty field path is rejected", func() {
-		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{""},
-			},
-		}
-		err := cfg.Validate()
-		s.Require().Error(err)
-		s.Contains(err.Error(), "fields[0] must not be empty")
-	})
-
-	s.Run("field path with empty segment is rejected", func() {
-		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data..key"},
-			},
-		}
-		err := cfg.Validate()
-		s.Require().Error(err)
-		s.Contains(err.Error(), "contains empty path segment")
-	})
-
+func (s *ValidateSuite) TestRedactSecrets() {
 	s.Run("invalid mode is rejected", func() {
 		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data.*"},
-				Mode:    "invalid-mode",
-			},
-		}
+		cfg.RedactSecrets = "invalid-mode"
 		err := cfg.Validate()
 		s.Require().Error(err)
-		s.Contains(err.Error(), "invalid mode")
+		s.Contains(err.Error(), "invalid redact_secrets")
 		s.Contains(err.Error(), "invalid-mode")
 	})
 
 	s.Run("opaque mode is accepted", func() {
 		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data.*"},
-				Mode:    "opaque",
-			},
-		}
+		cfg.RedactSecrets = "opaque"
 		s.NoError(cfg.Validate())
 	})
 
 	s.Run("hashed mode is accepted", func() {
 		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data.*"},
-				Mode:    "hashed",
-			},
-		}
+		cfg.RedactSecrets = "hashed"
 		s.NoError(cfg.Validate())
 	})
 
-	s.Run("empty mode defaults to opaque and is accepted", func() {
+	s.Run("empty mode is accepted", func() {
 		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data.*"},
-			},
-		}
-		s.NoError(cfg.Validate())
-	})
-
-	s.Run("valid multi-segment field path is accepted", func() {
-		cfg := s.validConfig()
-		cfg.RedactedResources = []api.RedactedResource{
-			{
-				Group:   "apps",
-				Version: "v1",
-				Kind:    "Deployment",
-				Fields:  []string{"spec.template.spec.containers.*.env.*.value"},
-			},
-		}
+		cfg.RedactSecrets = ""
 		s.NoError(cfg.Validate())
 	})
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -639,6 +639,151 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 	})
 }
 
+func (s *ValidateSuite) TestRedactedResources() {
+	s.Run("missing version is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:  "",
+				Kind:   "Secret",
+				Fields: []string{"data.*"},
+			},
+		}
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "version must be set")
+	})
+
+	s.Run("missing kind is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Fields:  []string{"data.*"},
+			},
+		}
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "kind must be set")
+	})
+
+	s.Run("empty fields is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+			},
+		}
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "fields must not be empty")
+	})
+
+	s.Run("empty field path is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{""},
+			},
+		}
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "fields[0] must not be empty")
+	})
+
+	s.Run("field path with empty segment is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data..key"},
+			},
+		}
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "contains empty path segment")
+	})
+
+	s.Run("invalid mode is rejected", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data.*"},
+				Mode:    "invalid-mode",
+			},
+		}
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid mode")
+		s.Contains(err.Error(), "invalid-mode")
+	})
+
+	s.Run("opaque mode is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data.*"},
+				Mode:    "opaque",
+			},
+		}
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("hashed mode is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data.*"},
+				Mode:    "hashed",
+			},
+		}
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("empty mode defaults to opaque and is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data.*"},
+			},
+		}
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("valid multi-segment field path is accepted", func() {
+		cfg := s.validConfig()
+		cfg.RedactedResources = []api.RedactedResource{
+			{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+				Fields:  []string{"spec.template.spec.containers.*.env.*.value"},
+			},
+		}
+		s.NoError(cfg.Validate())
+	})
+}
+
 func TestValidate(t *testing.T) {
 	suite.Run(t, new(ValidateSuite))
 }

--- a/pkg/kubernetes/core.go
+++ b/pkg/kubernetes/core.go
@@ -12,37 +12,27 @@ type Core struct {
 	redactor *redaction.Redactor
 }
 
-func NewCore(client api.KubernetesClient) *Core {
+// NewCore creates a Core wrapper around a Kubernetes client.
+// If redactSecretsMode is non-empty ("opaque" or "hashed"), Secret values
+// are automatically redacted in ResourcesGet, ResourcesList, and
+// ResourcesCreateOrUpdate responses. The redaction covers data.*,
+// stringData.*, and strips the last-applied-configuration annotation.
+func NewCore(client api.KubernetesClient, redactSecretsMode string) *Core {
 	return &Core{
 		KubernetesClient: client,
+		redactor:         redaction.NewSecretRedactor(redactSecretsMode),
 	}
 }
 
-// NewCoreWithRedaction creates a Core with field-level redaction enabled.
-// The redactor is applied automatically in ResourcesGet, ResourcesList, and
-// ResourcesCreateOrUpdate. Toolsets that call the dynamic client directly
-// should use RedactResources/RedactResourceList to apply redaction manually.
-func NewCoreWithRedaction(client api.KubernetesClient, redactedResources []api.RedactedResource) *Core {
-	c := &Core{
-		KubernetesClient: client,
-	}
-	if len(redactedResources) > 0 {
-		c.redactor = redaction.NewRedactor(redactedResources)
-	}
-	return c
-}
-
-// RedactResource applies field-level redaction to a single unstructured resource.
-// This is exported for toolsets that bypass the Core wrapper and call the dynamic client directly.
-// It is a no-op if no redactor is configured.
+// RedactResource applies Secret redaction to a single unstructured resource.
+// It is a no-op if no redactor is configured or the resource is not a Secret.
 func (c *Core) RedactResource(obj *unstructured.Unstructured) {
 	if c.redactor != nil {
 		c.redactor.Apply(obj)
 	}
 }
 
-// RedactResourceList applies field-level redaction to all items in an unstructured list.
-// This is exported for toolsets that bypass the Core wrapper and call the dynamic client directly.
+// RedactResourceList applies Secret redaction to all items in an unstructured list.
 // It is a no-op if no redactor is configured.
 func (c *Core) RedactResourceList(list *unstructured.UnstructuredList) {
 	if c.redactor != nil {

--- a/pkg/kubernetes/core.go
+++ b/pkg/kubernetes/core.go
@@ -1,13 +1,51 @@
 package kubernetes
 
-import "github.com/containers/kubernetes-mcp-server/pkg/api"
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/redaction"
+)
 
 type Core struct {
 	api.KubernetesClient
+	redactor *redaction.Redactor
 }
 
 func NewCore(client api.KubernetesClient) *Core {
 	return &Core{
 		KubernetesClient: client,
+	}
+}
+
+// NewCoreWithRedaction creates a Core with field-level redaction enabled.
+// The redactor is applied automatically in ResourcesGet, ResourcesList, and
+// ResourcesCreateOrUpdate. Toolsets that call the dynamic client directly
+// should use RedactResources/RedactResourceList to apply redaction manually.
+func NewCoreWithRedaction(client api.KubernetesClient, redactedResources []api.RedactedResource) *Core {
+	c := &Core{
+		KubernetesClient: client,
+	}
+	if len(redactedResources) > 0 {
+		c.redactor = redaction.NewRedactor(redactedResources)
+	}
+	return c
+}
+
+// RedactResource applies field-level redaction to a single unstructured resource.
+// This is exported for toolsets that bypass the Core wrapper and call the dynamic client directly.
+// It is a no-op if no redactor is configured.
+func (c *Core) RedactResource(obj *unstructured.Unstructured) {
+	if c.redactor != nil {
+		c.redactor.Apply(obj)
+	}
+}
+
+// RedactResourceList applies field-level redaction to all items in an unstructured list.
+// This is exported for toolsets that bypass the Core wrapper and call the dynamic client directly.
+// It is a no-op if no redactor is configured.
+func (c *Core) RedactResourceList(list *unstructured.UnstructuredList) {
+	if c.redactor != nil {
+		c.redactor.ApplyToList(list)
 	}
 }

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -39,7 +39,12 @@ func (c *Core) ResourcesList(ctx context.Context, gvk *schema.GroupVersionKind, 
 	if options.AsTable {
 		return c.resourcesListAsTable(ctx, gvk, gvr, namespace, options)
 	}
-	return c.DynamicClient().Resource(*gvr).Namespace(namespace).List(ctx, options.ListOptions)
+	ret, err := c.DynamicClient().Resource(*gvr).Namespace(namespace).List(ctx, options.ListOptions)
+	if err != nil {
+		return nil, err
+	}
+	c.RedactResourceList(ret)
+	return ret, nil
 }
 
 func (c *Core) ResourcesGet(ctx context.Context, gvk *schema.GroupVersionKind, namespace, name string) (*unstructured.Unstructured, error) {
@@ -52,7 +57,12 @@ func (c *Core) ResourcesGet(ctx context.Context, gvk *schema.GroupVersionKind, n
 	if namespaced, nsErr := c.isNamespaced(gvk); nsErr == nil && namespaced {
 		namespace = c.NamespaceOrDefault(namespace)
 	}
-	return c.DynamicClient().Resource(*gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	ret, err := c.DynamicClient().Resource(*gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	c.RedactResource(ret)
+	return ret, nil
 }
 
 func (c *Core) ResourcesCreateOrUpdate(ctx context.Context, resource string) ([]*unstructured.Unstructured, error) {
@@ -133,6 +143,11 @@ func (c *Core) ResourcesScale(
 // resourcesListAsTable retrieves a list of resources in a table format.
 // It's almost identical to the dynamic.DynamicClient implementation, but it uses a specific Accept header to request the table format.
 // dynamic.DynamicClient does not provide a way to set the HTTP header (TODO: create an issue to request this feature)
+//
+// Note: field-level redaction is not applied to table-format responses because the
+// server returns computed column values (e.g. key count for Secrets), not the raw
+// resource fields that redaction rules target. If custom resources expose sensitive
+// data in their table columns, use the non-table list format instead.
 func (c *Core) resourcesListAsTable(ctx context.Context, gvk *schema.GroupVersionKind, gvr *schema.GroupVersionResource, namespace string, options api.ListOptions) (runtime.Unstructured, error) {
 	var url []string
 	if len(gvr.Group) == 0 {
@@ -197,6 +212,7 @@ func (c *Core) resourcesCreateOrUpdate(ctx context.Context, resources []*unstruc
 		if rErr != nil {
 			return nil, rErr
 		}
+		c.RedactResource(resources[i])
 		// Clear the cache to ensure the next operation is performed on the latest exposed APIs (will change after the CRD creation)
 		if gvk.Kind == "CustomResourceDefinition" {
 			c.RESTMapper().Reset()

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -1029,6 +1029,190 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 	})
 }
 
+func (s *ResourcesSuite) TestResourcesGetRedacted() {
+	s.Require().NoError(toml.Unmarshal([]byte(`
+		[[redacted_resources]]
+		version = "v1"
+		kind = "Secret"
+		fields = ["data.*", "stringData.*"]
+		mode = "opaque"
+	`), s.Cfg), "Expected to parse redacted resources config")
+	s.InitMcpClient()
+	kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
+	_, _ = kc.CoreV1().Secrets("default").Create(s.T().Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "redacted-secret"},
+		Data: map[string][]byte{
+			"DATABASE_PASSWORD": []byte("supersecret"),
+			"API_KEY":           []byte("myapikey"),
+		},
+	}, metav1.CreateOptions{})
+	s.Run("resources_get redacts secret data fields", func() {
+		result, err := s.CallTool("resources_get", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"namespace":  "default",
+			"name":       "redacted-secret",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		var decodedSecret unstructured.Unstructured
+		err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedSecret)
+		s.Require().NoError(err, "invalid tool result content")
+		s.Run("data values are redacted", func() {
+			data, found, _ := unstructured.NestedMap(decodedSecret.Object, "data")
+			s.Truef(found, "data field should be present")
+			s.Equal("[REDACTED]", data["DATABASE_PASSWORD"], "DATABASE_PASSWORD should be redacted")
+			s.Equal("[REDACTED]", data["API_KEY"], "API_KEY should be redacted")
+		})
+		s.Run("metadata is preserved", func() {
+			s.Equal("redacted-secret", decodedSecret.GetName())
+			s.Equal("default", decodedSecret.GetNamespace())
+			s.Equal("Secret", decodedSecret.GetKind())
+		})
+	})
+	s.Run("resources_get (not redacted) returns unmodified resource", func() {
+		kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
+		_, _ = kc.CoreV1().ConfigMaps("default").Create(s.T().Context(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "not-redacted-configmap"},
+			Data:       map[string]string{"visible-key": "visible-value"},
+		}, metav1.CreateOptions{})
+		result, err := s.CallTool("resources_get", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"namespace":  "default",
+			"name":       "not-redacted-configmap",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		var decodedCM unstructured.Unstructured
+		err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedCM)
+		s.Require().NoError(err, "invalid tool result content")
+		data, found, _ := unstructured.NestedMap(decodedCM.Object, "data")
+		s.Truef(found, "data field should be present")
+		s.Equal("visible-value", data["visible-key"], "ConfigMap data should not be redacted")
+	})
+}
+
+func (s *ResourcesSuite) TestResourcesGetRedactedHashed() {
+	s.Require().NoError(toml.Unmarshal([]byte(`
+		[[redacted_resources]]
+		version = "v1"
+		kind = "Secret"
+		fields = ["data.*"]
+		mode = "hashed"
+	`), s.Cfg), "Expected to parse redacted resources config")
+	s.InitMcpClient()
+	kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
+	_, _ = kc.CoreV1().Secrets("default").Create(s.T().Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "hashed-redacted-secret"},
+		Data: map[string][]byte{
+			"PASSWORD": []byte("samevalue"),
+			"TOKEN":    []byte("samevalue"),
+		},
+	}, metav1.CreateOptions{})
+	s.Run("resources_get produces hashed redaction markers", func() {
+		result, err := s.CallTool("resources_get", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"namespace":  "default",
+			"name":       "hashed-redacted-secret",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		var decodedSecret unstructured.Unstructured
+		err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedSecret)
+		s.Require().NoError(err, "invalid tool result content")
+		data, found, _ := unstructured.NestedMap(decodedSecret.Object, "data")
+		s.Truef(found, "data field should be present")
+		passwordVal, _ := data["PASSWORD"].(string)
+		tokenVal, _ := data["TOKEN"].(string)
+		s.Run("values have hashed redaction prefix", func() {
+			s.Truef(strings.HasPrefix(passwordVal, "[REDACTED:gen_"), "PASSWORD should have hashed prefix, got %s", passwordVal)
+			s.Truef(strings.HasPrefix(tokenVal, "[REDACTED:gen_"), "TOKEN should have hashed prefix, got %s", tokenVal)
+		})
+		s.Run("same input values produce same hash", func() {
+			s.Equalf(passwordVal, tokenVal, "same input values should produce same hash")
+		})
+	})
+}
+
+func (s *ResourcesSuite) TestResourcesListRedacted() {
+	s.Require().NoError(toml.Unmarshal([]byte(`
+		[[redacted_resources]]
+		version = "v1"
+		kind = "Secret"
+		fields = ["data.*"]
+		mode = "opaque"
+	`), s.Cfg), "Expected to parse redacted resources config")
+	s.InitMcpClient()
+	kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
+	_, _ = kc.CoreV1().Secrets("default").Create(s.T().Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "list-redacted-secret",
+			Labels: map[string]string{"test": "redaction"},
+		},
+		Data: map[string][]byte{
+			"SECRET_KEY": []byte("topsecret"),
+		},
+	}, metav1.CreateOptions{})
+	s.Run("resources_list redacts secret data in listed items", func() {
+		result, err := s.CallTool("resources_list", map[string]interface{}{
+			"apiVersion":    "v1",
+			"kind":          "Secret",
+			"namespace":     "default",
+			"labelSelector": "test=redaction",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		var decodedSecrets []unstructured.Unstructured
+		err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedSecrets)
+		s.Require().NoError(err, "invalid tool result content")
+		s.Require().Lenf(decodedSecrets, 1, "expected 1 secret, got %d", len(decodedSecrets))
+		s.Run("data values are redacted", func() {
+			data, found, _ := unstructured.NestedMap(decodedSecrets[0].Object, "data")
+			s.Truef(found, "data field should be present")
+			s.Equal("[REDACTED]", data["SECRET_KEY"], "SECRET_KEY should be redacted")
+		})
+		s.Run("metadata is preserved", func() {
+			s.Equal("list-redacted-secret", decodedSecrets[0].GetName())
+			s.Equal("default", decodedSecrets[0].GetNamespace())
+		})
+	})
+}
+
+func (s *ResourcesSuite) TestResourcesCreateOrUpdateRedacted() {
+	s.Require().NoError(toml.Unmarshal([]byte(`
+		[[redacted_resources]]
+		version = "v1"
+		kind = "Secret"
+		fields = ["data.*"]
+		mode = "opaque"
+	`), s.Cfg), "Expected to parse redacted resources config")
+	s.InitMcpClient()
+	// Secret created with stringData; Kubernetes converts stringData to base64-encoded data server-side,
+	// so the returned object contains data.* fields that match the redaction rule.
+	s.Run("resources_create_or_update returns redacted secret", func() {
+		secretYaml := "apiVersion: v1\nkind: Secret\nmetadata:\n  name: created-redacted-secret\n  namespace: default\nstringData:\n  MY_SECRET: sensitive-value\n"
+		result, err := s.CallTool("resources_create_or_update", map[string]interface{}{"resource": secretYaml})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(result.IsError, "call tool failed: %v", result.Content)
+		var decodedResources []unstructured.Unstructured
+		err = yaml.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &decodedResources)
+		s.Require().NoError(err, "invalid tool result content")
+		s.Require().Lenf(decodedResources, 1, "expected 1 resource, got %d", len(decodedResources))
+		s.Run("returned data is redacted", func() {
+			data, found, _ := unstructured.NestedMap(decodedResources[0].Object, "data")
+			s.Truef(found, "data field should be present")
+			for key, val := range data {
+				s.Equalf("[REDACTED]", val, "data key %s should be redacted, got %v", key, val)
+			}
+		})
+		s.Run("metadata is preserved", func() {
+			s.Equal("created-redacted-secret", decodedResources[0].GetName())
+		})
+	})
+}
+
 func TestResources(t *testing.T) {
 	suite.Run(t, new(ResourcesSuite))
 }

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -1031,12 +1031,8 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 
 func (s *ResourcesSuite) TestResourcesGetRedacted() {
 	s.Require().NoError(toml.Unmarshal([]byte(`
-		[[redacted_resources]]
-		version = "v1"
-		kind = "Secret"
-		fields = ["data.*", "stringData.*"]
-		mode = "opaque"
-	`), s.Cfg), "Expected to parse redacted resources config")
+		redact_secrets = "opaque"
+	`), s.Cfg), "Expected to parse redact_secrets config")
 	s.InitMcpClient()
 	kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
 	_, _ = kc.CoreV1().Secrets("default").Create(s.T().Context(), &corev1.Secret{
@@ -1070,7 +1066,7 @@ func (s *ResourcesSuite) TestResourcesGetRedacted() {
 			s.Equal("Secret", decodedSecret.GetKind())
 		})
 	})
-	s.Run("resources_get (not redacted) returns unmodified resource", func() {
+	s.Run("non-matching resource is not redacted", func() {
 		kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
 		_, _ = kc.CoreV1().ConfigMaps("default").Create(s.T().Context(), &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: "not-redacted-configmap"},
@@ -1095,12 +1091,8 @@ func (s *ResourcesSuite) TestResourcesGetRedacted() {
 
 func (s *ResourcesSuite) TestResourcesGetRedactedHashed() {
 	s.Require().NoError(toml.Unmarshal([]byte(`
-		[[redacted_resources]]
-		version = "v1"
-		kind = "Secret"
-		fields = ["data.*"]
-		mode = "hashed"
-	`), s.Cfg), "Expected to parse redacted resources config")
+		redact_secrets = "hashed"
+	`), s.Cfg), "Expected to parse redact_secrets config")
 	s.InitMcpClient()
 	kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
 	_, _ = kc.CoreV1().Secrets("default").Create(s.T().Context(), &corev1.Secret{
@@ -1138,12 +1130,8 @@ func (s *ResourcesSuite) TestResourcesGetRedactedHashed() {
 
 func (s *ResourcesSuite) TestResourcesListRedacted() {
 	s.Require().NoError(toml.Unmarshal([]byte(`
-		[[redacted_resources]]
-		version = "v1"
-		kind = "Secret"
-		fields = ["data.*"]
-		mode = "opaque"
-	`), s.Cfg), "Expected to parse redacted resources config")
+		redact_secrets = "opaque"
+	`), s.Cfg), "Expected to parse redact_secrets config")
 	s.InitMcpClient()
 	kc := kubernetes.NewForConfigOrDie(envTestRestConfig)
 	_, _ = kc.CoreV1().Secrets("default").Create(s.T().Context(), &corev1.Secret{
@@ -1182,12 +1170,8 @@ func (s *ResourcesSuite) TestResourcesListRedacted() {
 
 func (s *ResourcesSuite) TestResourcesCreateOrUpdateRedacted() {
 	s.Require().NoError(toml.Unmarshal([]byte(`
-		[[redacted_resources]]
-		version = "v1"
-		kind = "Secret"
-		fields = ["data.*"]
-		mode = "opaque"
-	`), s.Cfg), "Expected to parse redacted resources config")
+		redact_secrets = "opaque"
+	`), s.Cfg), "Expected to parse redact_secrets config")
 	s.InitMcpClient()
 	// Secret created with stringData; Kubernetes converts stringData to base64-encoded data server-side,
 	// so the returned object contains data.* fields that match the redaction rule.

--- a/pkg/redaction/redact.go
+++ b/pkg/redaction/redact.go
@@ -2,11 +2,8 @@ package redaction
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -14,63 +11,50 @@ const (
 	RedactionModeOpaque = "opaque"
 	// RedactionModeHashed replaces values with [REDACTED:gen_<id>:<hash>].
 	RedactionModeHashed = "hashed"
+
+	// lastAppliedConfigAnnotation is the kubectl annotation that stores the full
+	// previous resource manifest, which would include unredacted Secret data.
+	lastAppliedConfigAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
 )
 
-// Redactor applies field-level redaction to Kubernetes resources based on configuration.
+// Redactor applies built-in Secret value redaction to Kubernetes resources.
+// It redacts data.*, stringData.*, and strips the last-applied-configuration
+// annotation from Secret resources regardless of API group or version.
 type Redactor struct {
-	rules []redactionRule
-	salt  *Salt
+	mode string
+	salt *Salt
 }
 
-type redactionRule struct {
-	group         string
-	version       string
-	kind          string
-	fieldSegments []string // parsed dot-path segments e.g. ["data", "*"]
-	redactionMode string
-}
-
-// NewRedactor creates a Redactor from the redacted resources configuration.
-func NewRedactor(redactedResources []api.RedactedResource) *Redactor {
-	var rules []redactionRule
-	for _, r := range redactedResources {
-		mode := r.Mode
-		if mode == "" {
-			mode = RedactionModeOpaque
-		}
-		for _, field := range r.Fields {
-			rules = append(rules, redactionRule{
-				group:         r.Group,
-				version:       r.Version,
-				kind:          r.Kind,
-				fieldSegments: strings.Split(field, "."),
-				redactionMode: mode,
-			})
-		}
+// NewSecretRedactor creates a Redactor that redacts Secret values.
+// The mode must be "opaque" or "hashed". If mode is empty, returns nil (no redaction).
+func NewSecretRedactor(mode string) *Redactor {
+	if mode == "" {
+		return nil
 	}
 	return &Redactor{
-		rules: rules,
-		salt:  GlobalSalt(),
+		mode: mode,
+		salt: GlobalSalt(),
 	}
 }
 
-// Apply redacts fields in the given unstructured object based on its GVK.
+// Apply redacts Secret values in the given unstructured object.
+// Non-Secret resources are left untouched.
 // The object is modified in place.
 func (r *Redactor) Apply(obj *unstructured.Unstructured) {
-	if obj == nil || len(r.rules) == 0 {
+	if obj == nil || r == nil {
 		return
 	}
-	gvk := obj.GroupVersionKind()
-	for _, rule := range r.rules {
-		if matchesGVK(rule, gvk) {
-			r.walkValue(obj.Object, rule.fieldSegments, rule.redactionMode)
-		}
+	// Match kind=Secret regardless of API group or version.
+	// This avoids version-pinning bypasses (e.g. v1 vs v1beta1).
+	if obj.GetKind() != "Secret" {
+		return
 	}
+	r.redactSecretFields(obj)
 }
 
-// ApplyToList redacts fields in all items of an unstructured list.
+// ApplyToList redacts Secret values in all items of an unstructured list.
 func (r *Redactor) ApplyToList(list *unstructured.UnstructuredList) {
-	if list == nil || len(r.rules) == 0 {
+	if list == nil || r == nil {
 		return
 	}
 	for i := range list.Items {
@@ -78,132 +62,49 @@ func (r *Redactor) ApplyToList(list *unstructured.UnstructuredList) {
 	}
 }
 
-// matchesGVK checks whether a redaction rule applies to the given GVK.
-// Note: config validation (validateRedactedResources) ensures that entries with
-// redacted_fields always have kind set, so the empty-kind branch below is only
-// reachable for plain deny entries that have no field-level redaction.
-func matchesGVK(rule redactionRule, gvk schema.GroupVersionKind) bool {
-	if rule.group != gvk.Group || rule.version != gvk.Version {
-		return false
-	}
-	if rule.kind == "" {
-		return true
-	}
-	return rule.kind == gvk.Kind
-}
-
-// walkValue is the unified entry point that dispatches based on the runtime type of val.
-// It handles maps, slices, and scalars at each level of the path.
-func (r *Redactor) walkValue(val interface{}, segments []string, mode string) {
-	switch v := val.(type) {
-	case map[string]interface{}:
-		r.walkMap(v, segments, mode)
-	case []interface{}:
-		r.walkSlice(v, segments, mode)
-	}
-}
-
-// walkMap traverses a map along the given path segments.
-// - Named segment: navigate to that key
-// - "*" wildcard: iterate ALL keys in the map
-func (r *Redactor) walkMap(obj map[string]interface{}, segments []string, mode string) {
-	if len(segments) == 0 || obj == nil {
-		return
-	}
-
-	segment := segments[0]
-	remaining := segments[1:]
-
-	if segment == "*" {
-		// Wildcard on a map: iterate all keys
-		for key, val := range obj {
-			if len(remaining) == 0 {
-				// Leaf: redact this value
-				obj[key] = r.redactLeaf(val, mode)
+// redactSecretFields redacts the data and stringData maps and strips the
+// last-applied-configuration annotation which would contain unredacted values.
+func (r *Redactor) redactSecretFields(obj *unstructured.Unstructured) {
+	// Redact data.*
+	r.redactMapField(obj.Object, "data")
+	// Redact stringData.*
+	r.redactMapField(obj.Object, "stringData")
+	// Strip the last-applied-configuration annotation to prevent bypass
+	annotations := obj.GetAnnotations()
+	if annotations != nil {
+		if _, exists := annotations[lastAppliedConfigAnnotation]; exists {
+			delete(annotations, lastAppliedConfigAnnotation)
+			if len(annotations) == 0 {
+				// Remove the annotations key entirely if empty
+				if md, ok := obj.Object["metadata"].(map[string]interface{}); ok {
+					delete(md, "annotations")
+				}
 			} else {
-				// Non-leaf: recurse into the value
-				r.walkValue(val, remaining, mode)
+				obj.SetAnnotations(annotations)
 			}
 		}
-		return
 	}
+}
 
-	// Named segment: navigate to specific key
-	val, exists := obj[segment]
+// redactMapField redacts all values in a top-level map field of the object.
+// Keys are preserved; values are replaced with the redaction marker.
+func (r *Redactor) redactMapField(obj map[string]interface{}, field string) {
+	val, exists := obj[field]
 	if !exists {
 		return
 	}
-
-	if len(remaining) == 0 {
-		// Leaf: redact this field
-		obj[segment] = r.redactLeaf(val, mode)
+	m, ok := val.(map[string]interface{})
+	if !ok {
 		return
 	}
-
-	// Non-leaf: recurse into the value (works for both maps and slices)
-	r.walkValue(val, remaining, mode)
-}
-
-// walkSlice traverses a slice along the given path segments.
-// - "*" wildcard: iterate ALL items in the slice
-// - Named segment on a slice is invalid and skipped
-func (r *Redactor) walkSlice(arr []interface{}, segments []string, mode string) {
-	if len(segments) == 0 {
-		return
-	}
-
-	segment := segments[0]
-	remaining := segments[1:]
-
-	if segment == "*" {
-		// Wildcard on a slice: iterate all items
-		for i, item := range arr {
-			if len(remaining) == 0 {
-				// Leaf: redact each item
-				arr[i] = r.redactLeaf(item, mode)
-			} else {
-				// Non-leaf: recurse into each item
-				r.walkValue(item, remaining, mode)
-			}
-		}
-		return
-	}
-
-	// Named segment on a slice: not meaningful, skip
-}
-
-// redactLeaf replaces a value at a leaf position.
-// For map values, it preserves the keys and redacts each inner value individually.
-// For slice values, it redacts each element individually.
-// For scalar values, it returns the redaction marker directly.
-// If a leaf contains deeply nested structures (e.g. a map whose values are themselves
-// maps), the inner values are collapsed to their fmt string representation and then
-// redacted as scalars. This is intentional: leaf positions should not contain further
-// traversable structure in typical Kubernetes resources.
-func (r *Redactor) redactLeaf(val interface{}, mode string) interface{} {
-	switch v := val.(type) {
-	case map[string]interface{}:
-		// Preserve keys, redact values
-		redacted := make(map[string]interface{}, len(v))
-		for key, innerVal := range v {
-			redacted[key] = r.redactScalar(innerVal, mode)
-		}
-		return redacted
-	case []interface{}:
-		// Redact each element
-		redacted := make([]interface{}, len(v))
-		for i, item := range v {
-			redacted[i] = r.redactScalar(item, mode)
-		}
-		return redacted
-	default:
-		return r.redactScalar(val, mode)
+	for key, v := range m {
+		m[key] = r.redactScalar(v)
 	}
 }
 
-// redactScalar replaces a single scalar value with the redaction marker.
-func (r *Redactor) redactScalar(val interface{}, mode string) string {
-	if mode == RedactionModeHashed {
+// redactScalar replaces a single value with the redaction marker.
+func (r *Redactor) redactScalar(val interface{}) string {
+	if r.mode == RedactionModeHashed {
 		valStr := fmt.Sprintf("%v", val)
 		return fmt.Sprintf("[REDACTED:gen_%s:%s]", r.salt.GenerationID(), r.salt.Hash(valStr))
 	}

--- a/pkg/redaction/redact.go
+++ b/pkg/redaction/redact.go
@@ -1,0 +1,211 @@
+package redaction
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	// RedactionModeOpaque replaces values with [REDACTED].
+	RedactionModeOpaque = "opaque"
+	// RedactionModeHashed replaces values with [REDACTED:gen_<id>:<hash>].
+	RedactionModeHashed = "hashed"
+)
+
+// Redactor applies field-level redaction to Kubernetes resources based on configuration.
+type Redactor struct {
+	rules []redactionRule
+	salt  *Salt
+}
+
+type redactionRule struct {
+	group         string
+	version       string
+	kind          string
+	fieldSegments []string // parsed dot-path segments e.g. ["data", "*"]
+	redactionMode string
+}
+
+// NewRedactor creates a Redactor from the redacted resources configuration.
+func NewRedactor(redactedResources []api.RedactedResource) *Redactor {
+	var rules []redactionRule
+	for _, r := range redactedResources {
+		mode := r.Mode
+		if mode == "" {
+			mode = RedactionModeOpaque
+		}
+		for _, field := range r.Fields {
+			rules = append(rules, redactionRule{
+				group:         r.Group,
+				version:       r.Version,
+				kind:          r.Kind,
+				fieldSegments: strings.Split(field, "."),
+				redactionMode: mode,
+			})
+		}
+	}
+	return &Redactor{
+		rules: rules,
+		salt:  GlobalSalt(),
+	}
+}
+
+// Apply redacts fields in the given unstructured object based on its GVK.
+// The object is modified in place.
+func (r *Redactor) Apply(obj *unstructured.Unstructured) {
+	if obj == nil || len(r.rules) == 0 {
+		return
+	}
+	gvk := obj.GroupVersionKind()
+	for _, rule := range r.rules {
+		if matchesGVK(rule, gvk) {
+			r.walkValue(obj.Object, rule.fieldSegments, rule.redactionMode)
+		}
+	}
+}
+
+// ApplyToList redacts fields in all items of an unstructured list.
+func (r *Redactor) ApplyToList(list *unstructured.UnstructuredList) {
+	if list == nil || len(r.rules) == 0 {
+		return
+	}
+	for i := range list.Items {
+		r.Apply(&list.Items[i])
+	}
+}
+
+// matchesGVK checks whether a redaction rule applies to the given GVK.
+// Note: config validation (validateRedactedResources) ensures that entries with
+// redacted_fields always have kind set, so the empty-kind branch below is only
+// reachable for plain deny entries that have no field-level redaction.
+func matchesGVK(rule redactionRule, gvk schema.GroupVersionKind) bool {
+	if rule.group != gvk.Group || rule.version != gvk.Version {
+		return false
+	}
+	if rule.kind == "" {
+		return true
+	}
+	return rule.kind == gvk.Kind
+}
+
+// walkValue is the unified entry point that dispatches based on the runtime type of val.
+// It handles maps, slices, and scalars at each level of the path.
+func (r *Redactor) walkValue(val interface{}, segments []string, mode string) {
+	switch v := val.(type) {
+	case map[string]interface{}:
+		r.walkMap(v, segments, mode)
+	case []interface{}:
+		r.walkSlice(v, segments, mode)
+	}
+}
+
+// walkMap traverses a map along the given path segments.
+// - Named segment: navigate to that key
+// - "*" wildcard: iterate ALL keys in the map
+func (r *Redactor) walkMap(obj map[string]interface{}, segments []string, mode string) {
+	if len(segments) == 0 || obj == nil {
+		return
+	}
+
+	segment := segments[0]
+	remaining := segments[1:]
+
+	if segment == "*" {
+		// Wildcard on a map: iterate all keys
+		for key, val := range obj {
+			if len(remaining) == 0 {
+				// Leaf: redact this value
+				obj[key] = r.redactLeaf(val, mode)
+			} else {
+				// Non-leaf: recurse into the value
+				r.walkValue(val, remaining, mode)
+			}
+		}
+		return
+	}
+
+	// Named segment: navigate to specific key
+	val, exists := obj[segment]
+	if !exists {
+		return
+	}
+
+	if len(remaining) == 0 {
+		// Leaf: redact this field
+		obj[segment] = r.redactLeaf(val, mode)
+		return
+	}
+
+	// Non-leaf: recurse into the value (works for both maps and slices)
+	r.walkValue(val, remaining, mode)
+}
+
+// walkSlice traverses a slice along the given path segments.
+// - "*" wildcard: iterate ALL items in the slice
+// - Named segment on a slice is invalid and skipped
+func (r *Redactor) walkSlice(arr []interface{}, segments []string, mode string) {
+	if len(segments) == 0 {
+		return
+	}
+
+	segment := segments[0]
+	remaining := segments[1:]
+
+	if segment == "*" {
+		// Wildcard on a slice: iterate all items
+		for i, item := range arr {
+			if len(remaining) == 0 {
+				// Leaf: redact each item
+				arr[i] = r.redactLeaf(item, mode)
+			} else {
+				// Non-leaf: recurse into each item
+				r.walkValue(item, remaining, mode)
+			}
+		}
+		return
+	}
+
+	// Named segment on a slice: not meaningful, skip
+}
+
+// redactLeaf replaces a value at a leaf position.
+// For map values, it preserves the keys and redacts each inner value individually.
+// For slice values, it redacts each element individually.
+// For scalar values, it returns the redaction marker directly.
+// If a leaf contains deeply nested structures (e.g. a map whose values are themselves
+// maps), the inner values are collapsed to their fmt string representation and then
+// redacted as scalars. This is intentional: leaf positions should not contain further
+// traversable structure in typical Kubernetes resources.
+func (r *Redactor) redactLeaf(val interface{}, mode string) interface{} {
+	switch v := val.(type) {
+	case map[string]interface{}:
+		// Preserve keys, redact values
+		redacted := make(map[string]interface{}, len(v))
+		for key, innerVal := range v {
+			redacted[key] = r.redactScalar(innerVal, mode)
+		}
+		return redacted
+	case []interface{}:
+		// Redact each element
+		redacted := make([]interface{}, len(v))
+		for i, item := range v {
+			redacted[i] = r.redactScalar(item, mode)
+		}
+		return redacted
+	default:
+		return r.redactScalar(val, mode)
+	}
+}
+
+// redactScalar replaces a single scalar value with the redaction marker.
+func (r *Redactor) redactScalar(val interface{}, mode string) string {
+	if mode == RedactionModeHashed {
+		valStr := fmt.Sprintf("%v", val)
+		return fmt.Sprintf("[REDACTED:gen_%s:%s]", r.salt.GenerationID(), r.salt.Hash(valStr))
+	}
+	return "[REDACTED]"
+}

--- a/pkg/redaction/redact_test.go
+++ b/pkg/redaction/redact_test.go
@@ -1,0 +1,498 @@
+package redaction
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type RedactorSuite struct {
+	suite.Suite
+}
+
+func (s *RedactorSuite) TestSecretDataOpaque() {
+	redactor := NewRedactor([]api.RedactedResource{
+		{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Secret",
+			Fields:  []string{"data.*", "stringData.*"},
+			Mode:    "opaque",
+		},
+	})
+
+	s.Run("redacts data and stringData values", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name":      "my-secret",
+					"namespace": "default",
+				},
+				"type": "Opaque",
+				"data": map[string]interface{}{
+					"DATABASE_PASSWORD": "c2VjcmV0cGFzc3dvcmQ=",
+					"API_KEY":           "bXlhcGlrZXk=",
+				},
+				"stringData": map[string]interface{}{
+					"config.yaml": "sensitive: true\npassword: hunter2",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
+		data := obj.Object["data"].(map[string]interface{})
+		s.Equal("[REDACTED]", data["DATABASE_PASSWORD"])
+		s.Equal("[REDACTED]", data["API_KEY"])
+
+		stringData := obj.Object["stringData"].(map[string]interface{})
+		s.Equal("[REDACTED]", stringData["config.yaml"])
+	})
+
+	s.Run("preserves metadata and type", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name":      "my-secret",
+					"namespace": "default",
+				},
+				"type": "Opaque",
+				"data": map[string]interface{}{
+					"KEY": "value",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
+		metadata := obj.Object["metadata"].(map[string]interface{})
+		s.Equal("my-secret", metadata["name"])
+		s.Equal("default", metadata["namespace"])
+		s.Equal("Opaque", obj.Object["type"])
+	})
+}
+
+func (s *RedactorSuite) TestSecretDataHashed() {
+	redactor := NewRedactor([]api.RedactedResource{
+		{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Secret",
+			Fields:  []string{"data.*"},
+			Mode:    "hashed",
+		},
+	})
+
+	s.Run("produces hashed redaction markers", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "my-secret",
+				},
+				"data": map[string]interface{}{
+					"PASSWORD": "secret123",
+					"TOKEN":    "secret123",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
+		data := obj.Object["data"].(map[string]interface{})
+		passwordVal := data["PASSWORD"].(string)
+		tokenVal := data["TOKEN"].(string)
+
+		s.True(strings.HasPrefix(passwordVal, "[REDACTED:gen_"))
+		s.True(strings.HasPrefix(tokenVal, "[REDACTED:gen_"))
+	})
+
+	s.Run("same input values produce same hash", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "my-secret",
+				},
+				"data": map[string]interface{}{
+					"PASSWORD": "secret123",
+					"TOKEN":    "secret123",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
+		data := obj.Object["data"].(map[string]interface{})
+		s.Equal(data["PASSWORD"], data["TOKEN"])
+	})
+}
+
+func (s *RedactorSuite) TestDeploymentEnvValues() {
+	redactor := NewRedactor([]api.RedactedResource{
+		{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+			Fields:  []string{"spec.template.spec.containers.*.env.*.value"},
+			Mode:    "opaque",
+		},
+	})
+
+	s.Run("redacts plain env values", func() {
+		obj := s.deploymentWithEnv()
+		redactor.Apply(obj)
+
+		env := s.getContainerEnv(obj, 0)
+
+		env0 := env[0].(map[string]interface{})
+		s.Equal("PORT", env0["name"])
+		s.Equal("[REDACTED]", env0["value"])
+
+		env1 := env[1].(map[string]interface{})
+		s.Equal("NODE_ENV", env1["name"])
+		s.Equal("[REDACTED]", env1["value"])
+	})
+
+	s.Run("preserves secretKeyRef entries", func() {
+		obj := s.deploymentWithEnv()
+		redactor.Apply(obj)
+
+		env := s.getContainerEnv(obj, 0)
+
+		env2 := env[2].(map[string]interface{})
+		s.Equal("DB_PASSWORD", env2["name"])
+		s.Nil(env2["value"], "secretKeyRef env should not have value field added")
+		secretRef := env2["valueFrom"].(map[string]interface{})["secretKeyRef"].(map[string]interface{})
+		s.Equal("db-secret", secretRef["name"])
+		s.Equal("password", secretRef["key"])
+	})
+}
+
+func (s *RedactorSuite) TestNoMatchingGVK() {
+	s.Run("non-matching GVK is not redacted", func() {
+		redactor := NewRedactor([]api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data.*"},
+			},
+		})
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"data": map[string]interface{}{
+					"config": "visible-value",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
+		data := obj.Object["data"].(map[string]interface{})
+		s.Equal("visible-value", data["config"])
+	})
+}
+
+func (s *RedactorSuite) TestEmptyRedactedFields() {
+	s.Run("no fields configured means no redaction", func() {
+		redactor := NewRedactor([]api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+			},
+		})
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"data": map[string]interface{}{
+					"PASSWORD": "should-stay",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+		data := obj.Object["data"].(map[string]interface{})
+		s.Equal("should-stay", data["PASSWORD"])
+	})
+}
+
+func (s *RedactorSuite) TestDefaultsToOpaque() {
+	s.Run("empty mode defaults to opaque redaction", func() {
+		redactor := NewRedactor([]api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data.*"},
+			},
+		})
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"data": map[string]interface{}{
+					"KEY": "value",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+		data := obj.Object["data"].(map[string]interface{})
+		s.Equal("[REDACTED]", data["KEY"])
+	})
+}
+
+func (s *RedactorSuite) TestApplyToList() {
+	s.Run("redacts all items in list", func() {
+		redactor := NewRedactor([]api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data.*"},
+			},
+		})
+
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]interface{}{"name": "secret-1"},
+						"data":       map[string]interface{}{"KEY": "value1"},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]interface{}{"name": "secret-2"},
+						"data":       map[string]interface{}{"KEY": "value2"},
+					},
+				},
+			},
+		}
+
+		redactor.ApplyToList(list)
+
+		for _, item := range list.Items {
+			data := item.Object["data"].(map[string]interface{})
+			s.Equal("[REDACTED]", data["KEY"])
+		}
+	})
+}
+
+func (s *RedactorSuite) TestInitContainers() {
+	s.Run("redacts both init and main container env values", func() {
+		redactor := NewRedactor([]api.RedactedResource{
+			{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+				Fields: []string{
+					"spec.template.spec.containers.*.env.*.value",
+					"spec.template.spec.initContainers.*.env.*.value",
+				},
+			},
+		})
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "app"},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"initContainers": []interface{}{
+								map[string]interface{}{
+									"name": "init",
+									"env": []interface{}{
+										map[string]interface{}{
+											"name":  "INIT_SECRET",
+											"value": "init-secret-val",
+										},
+									},
+								},
+							},
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name": "main",
+									"env": []interface{}{
+										map[string]interface{}{
+											"name":  "APP_SECRET",
+											"value": "app-secret-val",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
+		spec := obj.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})
+
+		initEnv := spec["initContainers"].([]interface{})[0].(map[string]interface{})["env"].([]interface{})[0].(map[string]interface{})
+		s.Equal("INIT_SECRET", initEnv["name"])
+		s.Equal("[REDACTED]", initEnv["value"])
+
+		mainEnv := spec["containers"].([]interface{})[0].(map[string]interface{})["env"].([]interface{})[0].(map[string]interface{})
+		s.Equal("APP_SECRET", mainEnv["name"])
+		s.Equal("[REDACTED]", mainEnv["value"])
+	})
+}
+
+func (s *RedactorSuite) TestHashedGenerationID() {
+	s.Run("hashed value contains generation ID", func() {
+		redactor := NewRedactor([]api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data.*"},
+				Mode:    "hashed",
+			},
+		})
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"data": map[string]interface{}{
+					"KEY": "value",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
+		data := obj.Object["data"].(map[string]interface{})
+		val := data["KEY"].(string)
+
+		genID := redactor.salt.GenerationID()
+		s.Contains(val, "gen_"+genID)
+	})
+}
+
+func (s *RedactorSuite) TestMissingField() {
+	s.Run("non-existent field path does not panic", func() {
+		redactor := NewRedactor([]api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"nonexistent.path.*"},
+			},
+		})
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"data": map[string]interface{}{
+					"KEY": "should-remain",
+				},
+			},
+		}
+
+		s.NotPanics(func() {
+			redactor.Apply(obj)
+		})
+
+		data := obj.Object["data"].(map[string]interface{})
+		s.Equal("should-remain", data["KEY"])
+	})
+}
+
+func (s *RedactorSuite) TestNilObject() {
+	s.Run("nil object does not panic", func() {
+		redactor := NewRedactor([]api.RedactedResource{
+			{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Secret",
+				Fields:  []string{"data.*"},
+			},
+		})
+
+		s.NotPanics(func() {
+			redactor.Apply(nil)
+		})
+	})
+}
+
+// Helper to create a deployment with env vars for testing
+func (s *RedactorSuite) deploymentWithEnv() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name": "web-app",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "app",
+								"image": "myapp:latest",
+								"env": []interface{}{
+									map[string]interface{}{
+										"name":  "PORT",
+										"value": "3000",
+									},
+									map[string]interface{}{
+										"name":  "NODE_ENV",
+										"value": "production",
+									},
+									map[string]interface{}{
+										"name": "DB_PASSWORD",
+										"valueFrom": map[string]interface{}{
+											"secretKeyRef": map[string]interface{}{
+												"name": "db-secret",
+												"key":  "password",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Helper to extract container env from a deployment
+func (s *RedactorSuite) getContainerEnv(obj *unstructured.Unstructured, containerIndex int) []interface{} {
+	containers := obj.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})
+	return containers[containerIndex].(map[string]interface{})["env"].([]interface{})
+}
+
+func TestRedactor(t *testing.T) {
+	suite.Run(t, new(RedactorSuite))
+}

--- a/pkg/redaction/redact_test.go
+++ b/pkg/redaction/redact_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -14,15 +13,7 @@ type RedactorSuite struct {
 }
 
 func (s *RedactorSuite) TestSecretDataOpaque() {
-	redactor := NewRedactor([]api.RedactedResource{
-		{
-			Group:   "",
-			Version: "v1",
-			Kind:    "Secret",
-			Fields:  []string{"data.*", "stringData.*"},
-			Mode:    "opaque",
-		},
-	})
+	redactor := NewSecretRedactor("opaque")
 
 	s.Run("redacts data and stringData values", func() {
 		obj := &unstructured.Unstructured{
@@ -80,15 +71,7 @@ func (s *RedactorSuite) TestSecretDataOpaque() {
 }
 
 func (s *RedactorSuite) TestSecretDataHashed() {
-	redactor := NewRedactor([]api.RedactedResource{
-		{
-			Group:   "",
-			Version: "v1",
-			Kind:    "Secret",
-			Fields:  []string{"data.*"},
-			Mode:    "hashed",
-		},
-	})
+	redactor := NewSecretRedactor("hashed")
 
 	s.Run("produces hashed redaction markers", func() {
 		obj := &unstructured.Unstructured{
@@ -137,57 +120,9 @@ func (s *RedactorSuite) TestSecretDataHashed() {
 	})
 }
 
-func (s *RedactorSuite) TestDeploymentEnvValues() {
-	redactor := NewRedactor([]api.RedactedResource{
-		{
-			Group:   "apps",
-			Version: "v1",
-			Kind:    "Deployment",
-			Fields:  []string{"spec.template.spec.containers.*.env.*.value"},
-			Mode:    "opaque",
-		},
-	})
-
-	s.Run("redacts plain env values", func() {
-		obj := s.deploymentWithEnv()
-		redactor.Apply(obj)
-
-		env := s.getContainerEnv(obj, 0)
-
-		env0 := env[0].(map[string]interface{})
-		s.Equal("PORT", env0["name"])
-		s.Equal("[REDACTED]", env0["value"])
-
-		env1 := env[1].(map[string]interface{})
-		s.Equal("NODE_ENV", env1["name"])
-		s.Equal("[REDACTED]", env1["value"])
-	})
-
-	s.Run("preserves secretKeyRef entries", func() {
-		obj := s.deploymentWithEnv()
-		redactor.Apply(obj)
-
-		env := s.getContainerEnv(obj, 0)
-
-		env2 := env[2].(map[string]interface{})
-		s.Equal("DB_PASSWORD", env2["name"])
-		s.Nil(env2["value"], "secretKeyRef env should not have value field added")
-		secretRef := env2["valueFrom"].(map[string]interface{})["secretKeyRef"].(map[string]interface{})
-		s.Equal("db-secret", secretRef["name"])
-		s.Equal("password", secretRef["key"])
-	})
-}
-
-func (s *RedactorSuite) TestNoMatchingGVK() {
-	s.Run("non-matching GVK is not redacted", func() {
-		redactor := NewRedactor([]api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data.*"},
-			},
-		})
+func (s *RedactorSuite) TestNonSecretNotRedacted() {
+	s.Run("ConfigMap is not redacted", func() {
+		redactor := NewSecretRedactor("opaque")
 
 		obj := &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -204,71 +139,104 @@ func (s *RedactorSuite) TestNoMatchingGVK() {
 		data := obj.Object["data"].(map[string]interface{})
 		s.Equal("visible-value", data["config"])
 	})
-}
 
-func (s *RedactorSuite) TestEmptyRedactedFields() {
-	s.Run("no fields configured means no redaction", func() {
-		redactor := NewRedactor([]api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-			},
-		})
+	s.Run("Deployment is not redacted", func() {
+		redactor := NewSecretRedactor("opaque")
 
 		obj := &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "Secret",
-				"data": map[string]interface{}{
-					"PASSWORD": "should-stay",
-				},
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata":   map[string]interface{}{"name": "app"},
 			},
 		}
 
 		redactor.Apply(obj)
-		data := obj.Object["data"].(map[string]interface{})
-		s.Equal("should-stay", data["PASSWORD"])
+		s.Equal("Deployment", obj.GetKind())
 	})
 }
 
-func (s *RedactorSuite) TestDefaultsToOpaque() {
-	s.Run("empty mode defaults to opaque redaction", func() {
-		redactor := NewRedactor([]api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data.*"},
-			},
-		})
+func (s *RedactorSuite) TestLastAppliedConfigStripped() {
+	s.Run("strips last-applied-configuration annotation", func() {
+		redactor := NewSecretRedactor("opaque")
 
 		obj := &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "my-secret",
+					"annotations": map[string]interface{}{
+						"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"v1","data":{"PASSWORD":"c2VjcmV0"},"kind":"Secret"}`,
+						"other-annotation": "keep-this",
+					},
+				},
 				"data": map[string]interface{}{
-					"KEY": "value",
+					"PASSWORD": "c2VjcmV0",
 				},
 			},
 		}
 
 		redactor.Apply(obj)
+
+		annotations := obj.GetAnnotations()
+		s.NotContains(annotations, "kubectl.kubernetes.io/last-applied-configuration")
+		s.Equal("keep-this", annotations["other-annotation"])
+	})
+
+	s.Run("removes annotations key when last-applied-configuration is the only annotation", func() {
+		redactor := NewSecretRedactor("opaque")
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "my-secret",
+					"annotations": map[string]interface{}{
+						"kubectl.kubernetes.io/last-applied-configuration": `{"data":{"KEY":"val"}}`,
+					},
+				},
+				"data": map[string]interface{}{
+					"KEY": "val",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
+		metadata := obj.Object["metadata"].(map[string]interface{})
+		_, hasAnnotations := metadata["annotations"]
+		s.False(hasAnnotations, "annotations should be removed entirely when empty")
+	})
+}
+
+func (s *RedactorSuite) TestVersionAgnosticMatching() {
+	s.Run("matches Secret regardless of API version", func() {
+		redactor := NewSecretRedactor("opaque")
+
+		// Hypothetical v1beta1 Secret
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1beta1",
+				"kind":       "Secret",
+				"metadata":   map[string]interface{}{"name": "my-secret"},
+				"data": map[string]interface{}{
+					"PASSWORD": "plaintext",
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
 		data := obj.Object["data"].(map[string]interface{})
-		s.Equal("[REDACTED]", data["KEY"])
+		s.Equal("[REDACTED]", data["PASSWORD"])
 	})
 }
 
 func (s *RedactorSuite) TestApplyToList() {
-	s.Run("redacts all items in list", func() {
-		redactor := NewRedactor([]api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data.*"},
-			},
-		})
+	s.Run("redacts all Secret items in list", func() {
+		redactor := NewSecretRedactor("opaque")
 
 		list := &unstructured.UnstructuredList{
 			Items: []unstructured.Unstructured{
@@ -298,83 +266,44 @@ func (s *RedactorSuite) TestApplyToList() {
 			s.Equal("[REDACTED]", data["KEY"])
 		}
 	})
-}
 
-func (s *RedactorSuite) TestInitContainers() {
-	s.Run("redacts both init and main container env values", func() {
-		redactor := NewRedactor([]api.RedactedResource{
-			{
-				Group:   "apps",
-				Version: "v1",
-				Kind:    "Deployment",
-				Fields: []string{
-					"spec.template.spec.containers.*.env.*.value",
-					"spec.template.spec.initContainers.*.env.*.value",
+	s.Run("skips non-Secret items in mixed list", func() {
+		redactor := NewSecretRedactor("opaque")
+
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]interface{}{"name": "secret-1"},
+						"data":       map[string]interface{}{"KEY": "secret-value"},
+					},
 				},
-			},
-		})
-
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "apps/v1",
-				"kind":       "Deployment",
-				"metadata":   map[string]interface{}{"name": "app"},
-				"spec": map[string]interface{}{
-					"template": map[string]interface{}{
-						"spec": map[string]interface{}{
-							"initContainers": []interface{}{
-								map[string]interface{}{
-									"name": "init",
-									"env": []interface{}{
-										map[string]interface{}{
-											"name":  "INIT_SECRET",
-											"value": "init-secret-val",
-										},
-									},
-								},
-							},
-							"containers": []interface{}{
-								map[string]interface{}{
-									"name": "main",
-									"env": []interface{}{
-										map[string]interface{}{
-											"name":  "APP_SECRET",
-											"value": "app-secret-val",
-										},
-									},
-								},
-							},
-						},
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata":   map[string]interface{}{"name": "config-1"},
+						"data":       map[string]interface{}{"KEY": "visible-value"},
 					},
 				},
 			},
 		}
 
-		redactor.Apply(obj)
+		redactor.ApplyToList(list)
 
-		spec := obj.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})
+		secretData := list.Items[0].Object["data"].(map[string]interface{})
+		s.Equal("[REDACTED]", secretData["KEY"])
 
-		initEnv := spec["initContainers"].([]interface{})[0].(map[string]interface{})["env"].([]interface{})[0].(map[string]interface{})
-		s.Equal("INIT_SECRET", initEnv["name"])
-		s.Equal("[REDACTED]", initEnv["value"])
-
-		mainEnv := spec["containers"].([]interface{})[0].(map[string]interface{})["env"].([]interface{})[0].(map[string]interface{})
-		s.Equal("APP_SECRET", mainEnv["name"])
-		s.Equal("[REDACTED]", mainEnv["value"])
+		configMapData := list.Items[1].Object["data"].(map[string]interface{})
+		s.Equal("visible-value", configMapData["KEY"])
 	})
 }
 
 func (s *RedactorSuite) TestHashedGenerationID() {
 	s.Run("hashed value contains generation ID", func() {
-		redactor := NewRedactor([]api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data.*"},
-				Mode:    "hashed",
-			},
-		})
+		redactor := NewSecretRedactor("hashed")
 
 		obj := &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -396,23 +325,34 @@ func (s *RedactorSuite) TestHashedGenerationID() {
 	})
 }
 
-func (s *RedactorSuite) TestMissingField() {
-	s.Run("non-existent field path does not panic", func() {
-		redactor := NewRedactor([]api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"nonexistent.path.*"},
+func (s *RedactorSuite) TestMissingDataField() {
+	s.Run("Secret without data field does not panic", func() {
+		redactor := NewSecretRedactor("opaque")
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]interface{}{"name": "empty-secret"},
 			},
+		}
+
+		s.NotPanics(func() {
+			redactor.Apply(obj)
 		})
+	})
+}
+
+func (s *RedactorSuite) TestSecretWithoutMetadata() {
+	s.Run("Secret without metadata key does not panic", func() {
+		redactor := NewSecretRedactor("opaque")
 
 		obj := &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Secret",
 				"data": map[string]interface{}{
-					"KEY": "should-remain",
+					"KEY": "value",
 				},
 			},
 		}
@@ -422,20 +362,62 @@ func (s *RedactorSuite) TestMissingField() {
 		})
 
 		data := obj.Object["data"].(map[string]interface{})
-		s.Equal("should-remain", data["KEY"])
+		s.Equal("[REDACTED]", data["KEY"])
+	})
+}
+
+func (s *RedactorSuite) TestNonStringDataValues() {
+	s.Run("non-string data values are redacted without panic", func() {
+		redactor := NewSecretRedactor("opaque")
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]interface{}{"name": "weird-secret"},
+				"data": map[string]interface{}{
+					"string-val":  "normal",
+					"numeric-val": 42,
+					"bool-val":    true,
+					"nil-val":     nil,
+				},
+			},
+		}
+
+		s.NotPanics(func() {
+			redactor.Apply(obj)
+		})
+
+		data := obj.Object["data"].(map[string]interface{})
+		for key, val := range data {
+			s.Equal("[REDACTED]", val, "data key %s should be redacted", key)
+		}
+	})
+
+	s.Run("hashed mode handles non-string values deterministically", func() {
+		redactor := NewSecretRedactor("hashed")
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"data": map[string]interface{}{
+					"num1": 42,
+					"num2": 42,
+				},
+			},
+		}
+
+		redactor.Apply(obj)
+
+		data := obj.Object["data"].(map[string]interface{})
+		s.Equal(data["num1"], data["num2"], "same numeric values should produce same hash")
 	})
 }
 
 func (s *RedactorSuite) TestNilObject() {
 	s.Run("nil object does not panic", func() {
-		redactor := NewRedactor([]api.RedactedResource{
-			{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Secret",
-				Fields:  []string{"data.*"},
-			},
-		})
+		redactor := NewSecretRedactor("opaque")
 
 		s.NotPanics(func() {
 			redactor.Apply(nil)
@@ -443,54 +425,25 @@ func (s *RedactorSuite) TestNilObject() {
 	})
 }
 
-// Helper to create a deployment with env vars for testing
-func (s *RedactorSuite) deploymentWithEnv() *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "web-app",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "app",
-								"image": "myapp:latest",
-								"env": []interface{}{
-									map[string]interface{}{
-										"name":  "PORT",
-										"value": "3000",
-									},
-									map[string]interface{}{
-										"name":  "NODE_ENV",
-										"value": "production",
-									},
-									map[string]interface{}{
-										"name": "DB_PASSWORD",
-										"valueFrom": map[string]interface{}{
-											"secretKeyRef": map[string]interface{}{
-												"name": "db-secret",
-												"key":  "password",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
+func (s *RedactorSuite) TestNilRedactor() {
+	s.Run("nil redactor does not panic", func() {
+		redactor := NewSecretRedactor("")
+		s.Nil(redactor)
 
-// Helper to extract container env from a deployment
-func (s *RedactorSuite) getContainerEnv(obj *unstructured.Unstructured, containerIndex int) []interface{} {
-	containers := obj.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})
-	return containers[containerIndex].(map[string]interface{})["env"].([]interface{})
+		// Calling Apply on nil should not panic
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"data":       map[string]interface{}{"KEY": "value"},
+			},
+		}
+
+		s.NotPanics(func() {
+			var r *Redactor
+			r.Apply(obj)
+		})
+	})
 }
 
 func TestRedactor(t *testing.T) {

--- a/pkg/redaction/salt.go
+++ b/pkg/redaction/salt.go
@@ -1,0 +1,61 @@
+package redaction
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+)
+
+// Salt holds a random salt and generation ID for consistent hashing within a server session.
+// The salt is generated once at initialization and stays in memory — it is never persisted.
+// After a server restart a new salt and generation ID are created, so hashes are not
+// comparable across restarts. The generation ID is included in redacted values so that
+// consumers can detect when the salt changed.
+type Salt struct {
+	bytes        []byte
+	generationID string
+}
+
+var (
+	globalSalt     *Salt
+	globalSaltOnce sync.Once
+)
+
+// GlobalSalt returns the process-wide Salt, creating it on the first call.
+func GlobalSalt() *Salt {
+	globalSaltOnce.Do(func() {
+		globalSalt = newSalt()
+	})
+	return globalSalt
+}
+
+func newSalt() *Salt {
+	saltBytes := make([]byte, 32)
+	if _, err := rand.Read(saltBytes); err != nil {
+		panic(fmt.Sprintf("failed to generate redaction salt: %v", err))
+	}
+	genID := make([]byte, 4)
+	if _, err := rand.Read(genID); err != nil {
+		panic(fmt.Sprintf("failed to generate redaction generation ID: %v", err))
+	}
+	return &Salt{
+		bytes:        saltBytes,
+		generationID: hex.EncodeToString(genID),
+	}
+}
+
+// Hash returns a truncated HMAC-SHA256 of the given value using this salt.
+// The result is a 16-character hex string.
+func (s *Salt) Hash(value string) string {
+	mac := hmac.New(sha256.New, s.bytes)
+	mac.Write([]byte(value))
+	return hex.EncodeToString(mac.Sum(nil))[:16]
+}
+
+// GenerationID returns the short random ID for this salt generation.
+func (s *Salt) GenerationID() string {
+	return s.generationID
+}

--- a/pkg/redaction/salt_test.go
+++ b/pkg/redaction/salt_test.go
@@ -1,0 +1,61 @@
+package redaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SaltSuite struct {
+	suite.Suite
+}
+
+func (s *SaltSuite) TestNewSalt() {
+	s.Run("generates 32-byte key and 8-char generation ID", func() {
+		salt := newSalt()
+		s.Require().NotNil(salt)
+		s.Len(salt.bytes, 32)
+		s.Len(salt.generationID, 8, "4 bytes = 8 hex chars")
+	})
+}
+
+func (s *SaltSuite) TestHashConsistency() {
+	s.Run("same value produces same hash with same salt", func() {
+		salt := newSalt()
+		hash1 := salt.Hash("my-secret-value")
+		hash2 := salt.Hash("my-secret-value")
+		s.Equal(hash1, hash2)
+		s.Len(hash1, 16)
+	})
+}
+
+func (s *SaltSuite) TestHashDifference() {
+	s.Run("different values produce different hashes", func() {
+		salt := newSalt()
+		hash1 := salt.Hash("value-a")
+		hash2 := salt.Hash("value-b")
+		s.NotEqual(hash1, hash2)
+	})
+}
+
+func (s *SaltSuite) TestDifferentSalts() {
+	s.Run("different salts produce different hashes for same value", func() {
+		s1 := newSalt()
+		s2 := newSalt()
+		hash1 := s1.Hash("same-value")
+		hash2 := s2.Hash("same-value")
+		s.NotEqual(hash1, hash2)
+	})
+}
+
+func (s *SaltSuite) TestGlobalSaltSingleton() {
+	s.Run("returns the same instance on repeated calls", func() {
+		salt1 := GlobalSalt()
+		salt2 := GlobalSalt()
+		s.Equal(salt1, salt2)
+	})
+}
+
+func TestSalt(t *testing.T) {
+	suite.Run(t, new(SaltSuite))
+}

--- a/pkg/toolsets/config/configuration.go
+++ b/pkg/toolsets/config/configuration.go
@@ -99,7 +99,7 @@ func initConfiguration() []api.ServerTool {
 }
 
 func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	contexts, err := kubernetes.NewCore(params).ConfigurationContextsList()
+	contexts, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ConfigurationContextsList()
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list contexts: %w", err)), nil
 	}
@@ -108,7 +108,7 @@ func contextsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("No contexts found in kubeconfig", nil), nil
 	}
 
-	defaultContext, err := kubernetes.NewCore(params).ConfigurationContextsDefault()
+	defaultContext, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ConfigurationContextsDefault()
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get default context: %w", err)), nil
 	}
@@ -154,7 +154,7 @@ func configurationView(params api.ToolHandlerParams) (*api.ToolCallResult, error
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get configuration: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCore(params).ConfigurationView(minify)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ConfigurationView(minify)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get configuration: %w", err)), nil
 	}

--- a/pkg/toolsets/core/events.go
+++ b/pkg/toolsets/core/events.go
@@ -41,7 +41,7 @@ func eventsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list events in all namespaces: %w", err)), nil
 	}
-	eventMap, err := kubernetes.NewCore(params).EventsList(params, namespace)
+	eventMap, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).EventsList(params, namespace)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list events in all namespaces: %w", err)), nil
 	}

--- a/pkg/toolsets/core/health_check.go
+++ b/pkg/toolsets/core/health_check.go
@@ -472,7 +472,7 @@ func gatherClusterOperatorDiagnostics(params api.PromptHandlerParams) (string, e
 		Kind:    "ClusterOperator",
 	}
 
-	operatorList, err := kubernetes.NewCore(params).ResourcesList(params, gvk, "", api.ListOptions{})
+	operatorList, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesList(params, gvk, "", api.ListOptions{})
 	if err != nil {
 		// Not an OpenShift cluster
 		return "", err

--- a/pkg/toolsets/core/health_check.go
+++ b/pkg/toolsets/core/health_check.go
@@ -472,7 +472,7 @@ func gatherClusterOperatorDiagnostics(params api.PromptHandlerParams) (string, e
 		Kind:    "ClusterOperator",
 	}
 
-	operatorList, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesList(params, gvk, "", api.ListOptions{})
+	operatorList, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ResourcesList(params, gvk, "", api.ListOptions{})
 	if err != nil {
 		// Not an OpenShift cluster
 		return "", err

--- a/pkg/toolsets/core/namespaces.go
+++ b/pkg/toolsets/core/namespaces.go
@@ -49,7 +49,7 @@ func initNamespaces(o api.Openshift) []api.ServerTool {
 }
 
 func namespacesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ret, err := kubernetes.NewCore(params).NamespacesList(params, api.ListOptions{AsTable: params.ListOutput.AsTable()})
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).NamespacesList(params, api.ListOptions{AsTable: params.ListOutput.AsTable()})
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list namespaces: %w", err)), nil
 	}
@@ -57,7 +57,7 @@ func namespacesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 }
 
 func projectsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	ret, err := kubernetes.NewCore(params).ProjectsList(params, api.ListOptions{AsTable: params.ListOutput.AsTable()})
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ProjectsList(params, api.ListOptions{AsTable: params.ListOutput.AsTable()})
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list projects: %w", err)), nil
 	}

--- a/pkg/toolsets/core/nodes.go
+++ b/pkg/toolsets/core/nodes.go
@@ -114,7 +114,7 @@ func nodesLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 			return api.NewToolCallResult("", fmt.Errorf("failed to parse tailLines parameter: %w", err)), nil
 		}
 	}
-	ret, err := kubernetes.NewCore(params).NodesLog(params, name, query, tailInt)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).NodesLog(params, name, query, tailInt)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get node log for %s: %w", name, err)), nil
 	} else if ret == "" {
@@ -128,7 +128,7 @@ func nodesStatsSummary(params api.ToolHandlerParams) (*api.ToolCallResult, error
 	if !ok || name == "" {
 		return api.NewToolCallResult("", errors.New("failed to get node stats summary, missing argument name")), nil
 	}
-	ret, err := kubernetes.NewCore(params).NodesStatsSummary(params, name)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).NodesStatsSummary(params, name)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get node stats summary for %s: %w", name, err)), nil
 	}
@@ -144,7 +144,7 @@ func nodesTop(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		nodesTopOptions.LabelSelector = v
 	}
 
-	nodeMetrics, err := kubernetes.NewCore(params).NodesTop(params, nodesTopOptions)
+	nodeMetrics, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).NodesTop(params, nodesTopOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get nodes top: %w", err)), nil
 	}

--- a/pkg/toolsets/core/pods.go
+++ b/pkg/toolsets/core/pods.go
@@ -269,7 +269,7 @@ func podsListInAllNamespaces(params api.ToolHandlerParams) (*api.ToolCallResult,
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in all namespaces: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).PodsListInAllNamespaces(params, resourceListOptions)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).PodsListInAllNamespaces(params, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in all namespaces: %w", err)), nil
 	}
@@ -287,7 +287,7 @@ func podsListInNamespace(params api.ToolHandlerParams) (*api.ToolCallResult, err
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).PodsListInNamespace(params, ns, resourceListOptions)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).PodsListInNamespace(params, ns, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace %s: %w", ns, err)), nil
 	}
@@ -301,7 +301,7 @@ func podsGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).PodsGet(params, ns, name)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).PodsGet(params, ns, name)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod %s in namespace %s: %w", name, ns, err)), nil
 	}
@@ -315,7 +315,7 @@ func podsDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to delete pod: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCore(params).PodsDelete(params, ns, name)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).PodsDelete(params, ns, name)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to delete pod %s in namespace %s: %w", name, ns, err)), nil
 	}
@@ -333,7 +333,7 @@ func podsTop(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pods top: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCore(params).PodsTop(params, podsTopOptions)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).PodsTop(params, podsTopOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pods top: %w", err)), nil
 	}
@@ -366,7 +366,7 @@ func podsExec(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		}
 		command = append(command, s)
 	}
-	ret, err := kubernetes.NewCore(params).PodsExec(params, ns, name, container, command)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).PodsExec(params, ns, name, container, command)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to exec in pod %s in namespace %s: %w", name, ns, err)), nil
 	} else if ret == "" {
@@ -385,7 +385,7 @@ func podsLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod log: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCore(params).PodsLog(params.Context, ns, name, container, previousBool, tailInt)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).PodsLog(params.Context, ns, name, container, previousBool, tailInt)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod %s log in namespace %s: %w", name, ns, err)), nil
 	} else if ret == "" {
@@ -403,7 +403,7 @@ func podsRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to run pod: %w", err)), nil
 	}
-	resources, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).PodsRun(params, ns, name, image, port)
+	resources, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).PodsRun(params, ns, name, image, port)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to run pod %s in namespace %s: %w", name, ns, err)), nil
 	}

--- a/pkg/toolsets/core/pods.go
+++ b/pkg/toolsets/core/pods.go
@@ -269,7 +269,7 @@ func podsListInAllNamespaces(params api.ToolHandlerParams) (*api.ToolCallResult,
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in all namespaces: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCore(params).PodsListInAllNamespaces(params, resourceListOptions)
+	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).PodsListInAllNamespaces(params, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in all namespaces: %w", err)), nil
 	}
@@ -287,7 +287,7 @@ func podsListInNamespace(params api.ToolHandlerParams) (*api.ToolCallResult, err
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCore(params).PodsListInNamespace(params, ns, resourceListOptions)
+	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).PodsListInNamespace(params, ns, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list pods in namespace %s: %w", ns, err)), nil
 	}
@@ -301,7 +301,7 @@ func podsGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCore(params).PodsGet(params, ns, name)
+	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).PodsGet(params, ns, name)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod %s in namespace %s: %w", name, ns, err)), nil
 	}
@@ -403,7 +403,7 @@ func podsRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to run pod: %w", err)), nil
 	}
-	resources, err := kubernetes.NewCore(params).PodsRun(params, ns, name, image, port)
+	resources, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).PodsRun(params, ns, name, image, port)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to run pod %s in namespace %s: %w", name, ns, err)), nil
 	}

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -221,7 +221,7 @@ func resourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("", fmt.Errorf("namespace is not a string")), nil
 	}
 
-	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesList(params, gvk, ns, resourceListOptions)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ResourcesList(params, gvk, ns, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list resources: %w", err)), nil
 	}
@@ -252,7 +252,7 @@ func resourcesGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("", fmt.Errorf("name is not a string")), nil
 	}
 
-	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesGet(params, gvk, ns, n)
+	ret, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ResourcesGet(params, gvk, ns, n)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get resource: %w", err)), nil
 	}
@@ -270,7 +270,7 @@ func resourcesCreateOrUpdate(params api.ToolHandlerParams) (*api.ToolCallResult,
 		return api.NewToolCallResult("", fmt.Errorf("resource is not a string")), nil
 	}
 
-	resources, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesCreateOrUpdate(params, r)
+	resources, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ResourcesCreateOrUpdate(params, r)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to create or update resources: %w", err)), nil
 	}
@@ -314,7 +314,7 @@ func resourcesDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) 
 		gracePeriodSecondsPtr = &gracePeriodSeconds
 	}
 
-	err = kubernetes.NewCore(params).ResourcesDelete(params, gvk, ns, n, gracePeriodSecondsPtr)
+	err = kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ResourcesDelete(params, gvk, ns, n, gracePeriodSecondsPtr)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to delete resource: %w", err)), nil
 	}
@@ -356,7 +356,7 @@ func resourcesScale(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		}
 	}
 
-	scale, err := kubernetes.NewCore(params).ResourcesScale(params.Context, gvk, ns, n, desiredScale, shouldScale)
+	scale, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ResourcesScale(params.Context, gvk, ns, n, desiredScale, shouldScale)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get/update resource scale: %w", err)), nil
 	}

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -221,7 +221,7 @@ func resourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("", fmt.Errorf("namespace is not a string")), nil
 	}
 
-	ret, err := kubernetes.NewCore(params).ResourcesList(params, gvk, ns, resourceListOptions)
+	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesList(params, gvk, ns, resourceListOptions)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list resources: %w", err)), nil
 	}
@@ -252,7 +252,7 @@ func resourcesGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("", fmt.Errorf("name is not a string")), nil
 	}
 
-	ret, err := kubernetes.NewCore(params).ResourcesGet(params, gvk, ns, n)
+	ret, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesGet(params, gvk, ns, n)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get resource: %w", err)), nil
 	}
@@ -270,7 +270,7 @@ func resourcesCreateOrUpdate(params api.ToolHandlerParams) (*api.ToolCallResult,
 		return api.NewToolCallResult("", fmt.Errorf("resource is not a string")), nil
 	}
 
-	resources, err := kubernetes.NewCore(params).ResourcesCreateOrUpdate(params, r)
+	resources, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesCreateOrUpdate(params, r)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to create or update resources: %w", err)), nil
 	}

--- a/pkg/toolsets/kubevirt/vm/create/tool.go
+++ b/pkg/toolsets/kubevirt/vm/create/tool.go
@@ -172,7 +172,7 @@ func create(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	}
 
 	// Create the VM in the cluster
-	resources, err := kubernetes.NewCore(params).ResourcesCreateOrUpdate(params, vmYaml)
+	resources, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesCreateOrUpdate(params, vmYaml)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to create VirtualMachine: %w", err)), nil
 	}

--- a/pkg/toolsets/kubevirt/vm/create/tool.go
+++ b/pkg/toolsets/kubevirt/vm/create/tool.go
@@ -172,7 +172,7 @@ func create(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	}
 
 	// Create the VM in the cluster
-	resources, err := kubernetes.NewCoreWithRedaction(params, params.BaseConfig.GetRedactedResources()).ResourcesCreateOrUpdate(params, vmYaml)
+	resources, err := kubernetes.NewCore(params, params.BaseConfig.GetRedactSecrets()).ResourcesCreateOrUpdate(params, vmYaml)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to create VirtualMachine: %w", err)), nil
 	}

--- a/pkg/toolsets/kubevirt/vm_troubleshoot.go
+++ b/pkg/toolsets/kubevirt/vm_troubleshoot.go
@@ -335,7 +335,7 @@ func fetchVirtLauncherPodLogs(ctx context.Context, client api.KubernetesClient, 
 		return "### virt-launcher Pod Logs\n\n*No virt-launcher pod found - no logs available*"
 	}
 
-	core := kubernetes.NewCore(client)
+	core := kubernetes.NewCore(client, "")
 	var result strings.Builder
 	result.WriteString("### virt-launcher Pod Logs\n\n")
 
@@ -357,7 +357,7 @@ func fetchVirtLauncherPodLogs(ctx context.Context, client api.KubernetesClient, 
 
 // fetchEvents fetches events related to the VM and returns them formatted
 func fetchEvents(ctx context.Context, client api.KubernetesClient, namespace, vmName string) string {
-	core := kubernetes.NewCore(client)
+	core := kubernetes.NewCore(client, "")
 	eventMap, err := core.EventsList(ctx, namespace)
 	if err != nil {
 		return fmt.Sprintf("### Events\n\n*Error listing events: %v*", err)


### PR DESCRIPTION
## Problem

When using kubernetes-mcp-server with AI agents, `denied_resources` is all-or-nothing — you either block an entire resource type or allow full access to it.

This is a problem for resources like Secrets: blocking them entirely means the agent can't see that a Secret exists, what keys it contains, its type, ownership, or annotations. But allowing full access exposes the actual secret values to the LLM context.

## Solution

Add a built-in `redact_secrets` configuration option that redacts Secret values while preserving metadata. This is a **hardcoded, Secret-specific** redaction that avoids the complexity and security risks of a generic field-walking approach.

### What gets redacted

When `redact_secrets` is set, the following fields are redacted on **all** Secret resources regardless of API version:

- `data.*` — all values replaced with redaction markers
- `stringData.*` — all values replaced with redaction markers
- `kubectl.kubernetes.io/last-applied-configuration` annotation — stripped entirely (it contains unredacted Secret data in plaintext)

Keys, metadata (name, namespace, labels, annotations, ownerReferences), and type are all preserved.

### Configuration

```toml
# Replace Secret values with [REDACTED]
redact_secrets = "opaque"

# Replace Secret values with deterministic HMAC-SHA256 hashes
# Allows agents to detect duplicate values without seeing actual content
redact_secrets = "hashed"
```

### Redaction modes

- **`opaque`** — values become `[REDACTED]`
- **`hashed`** — values become `[REDACTED:gen_<id>:<hash>]` where the hash is a deterministic HMAC-SHA256 with a per-session random salt. Same values produce the same hash within a session. The generation ID changes on restart so consumers know when hashes from different sessions are not comparable.

### Security properties

- **Fail-closed**: The redactor is a hardcoded list of fields (`data.*`, `stringData.*`, `last-applied-configuration`). There is no user-configurable field walker — nothing to misconfigure.
- **Version-agnostic**: Matches `kind=Secret` regardless of API group or version, preventing bypass via version pinning (e.g. `v1beta1`).
- **Annotation stripping**: `kubectl.kubernetes.io/last-applied-configuration` is removed because it stores the full previous manifest including unredacted Secret data.
- **Applied at the Core layer**: Redaction happens in the Kubernetes wrapper layer (`Core` struct), so all tool handlers benefit automatically without per-handler code.

### Example output (hashed mode)

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: web-ui
  namespace: production
type: Opaque
data:
  client_secret: '[REDACTED:gen_ee128e09:df2e09b64a1c8f37]'
  jira_api_token: '[REDACTED:gen_ee128e09:3f2501db82e4a90c]'
  sentry_dsn: '[REDACTED:gen_ee128e09:039c47e8f15b6d2a]'
```

The agent can see: the Secret exists, it has 3 keys (`client_secret`, `jira_api_token`, `sentry_dsn`), it's type `Opaque`, and it's owned by a SealedSecret controller. It cannot see any actual values.

### Changes

- **`pkg/redaction/`** — Rewrote from a 212-line generic field walker to a 110-line Secret-specific redactor
- **`pkg/config/`** — Replaced `[[redacted_resources]]` array-of-tables with `redact_secrets` string field
- **`pkg/kubernetes/core.go`** — Merged two `Core` constructors into one: `NewCore(client, redactSecretsMode)`
- **`pkg/toolsets/`** — Updated all 25 call sites across 9 files
- **`docs/configuration.md`** — Updated documentation