### PR TITLE
fix(tests): fix sporadic http test failures

### DIFF
--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -363,8 +363,10 @@ func (s *AuthorizationSuite) TestAuthorizationRawToken() {
 				s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initial request to not be nil")
 			})
 		})
-		_ = s.mcpClient.Session.Close()
-		s.mcpClient.Session = nil
+		if s.mcpClient.Session != nil {
+			_ = s.mcpClient.Session.Close()
+			s.mcpClient.Session = nil
+		}
 		s.StopServer()
 		s.Require().NoError(s.WaitForShutdown())
 	}

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -51,6 +51,17 @@ func (s *BaseHttpSuite) SetupTest() {
 }
 
 func (s *BaseHttpSuite) StartServer() {
+	// Stop any previous running servers to avoid resource leaks when StartServer is called multiple times
+	if s.StopServer != nil {
+		s.StopServer()
+		_ = s.WaitForShutdown()
+	}
+	if s.mcpServer != nil {
+		s.mcpServer.Close()
+	}
+	if s.timeoutCancel != nil {
+		s.timeoutCancel()
+	}
 
 	tcpAddr, err := test.RandomPortAddress()
 	s.Require().NoError(err, "Expected no error getting random port address")
@@ -169,7 +180,7 @@ func testCase(t *testing.T, test func(c *httpContext)) {
 
 func testCaseWithContext(t *testing.T, httpCtx *httpContext, test func(c *httpContext)) {
 	httpCtx.beforeEach(t)
-	t.Cleanup(func() { httpCtx.afterEach(t) })
+	defer httpCtx.afterEach(t)
 	test(httpCtx)
 }
 


### PR DESCRIPTION
Commit https://github.com/containers/kubernetes-mcp-server/commit/a38a72012075b3e7f41bef87ccc7020697e6df77 introduced `-race` in the `make test` that resulted in some sporadic test failures in `pkg/http`. This PR fixes:
- `TestHealthCheck` that calls `testCase` and `testCaseWithContext` sequentially on the same `t`. Both registered cleanup via `t.Cleanup()`, which defers execution until entire test finishes. That resulted in a race on `klog`.
- `TestMetadataGenerationFallback` calls `s.StartServer()` many times within a single test method. Each call overwrote `s.StopServer`, `s.WaitForShutdown` and `s.mcpServer` without stopping the previous server,. Under `-race`, the slower execution amplified the resource contention, causing the new server to fail to start in time.
- `TestAuthorizationRawToken` - nil pointer dereference. 