### PR TITLE
refactor(test): consolidate http test server shutdown

### DIFF
--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -325,8 +325,7 @@ func (s *AuthorizationSuite) TestAuthorizationUnauthorizedTokenExchangeFailure()
 	})
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 func (s *AuthorizationSuite) TestAuthorizationRequireOAuthFalse() {
@@ -340,8 +339,7 @@ func (s *AuthorizationSuite) TestAuthorizationRequireOAuthFalse() {
 	})
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 func (s *AuthorizationSuite) TestAuthorizationRawToken() {
@@ -365,8 +363,7 @@ func (s *AuthorizationSuite) TestAuthorizationRawToken() {
 		})
 		s.mcpClient.Close()
 		s.mcpClient = nil
-		s.StopServer()
-		s.Require().NoError(s.WaitForShutdown())
+		s.stopRunningServer()
 	}
 }
 
@@ -397,8 +394,7 @@ func (s *AuthorizationSuite) TestAuthorizationOidcToken() {
 	})
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 // TestAuthorizationOidcTokenExchange verifies RFC 8693 / On-Behalf-Of token
@@ -507,8 +503,7 @@ func (s *AuthorizationSuite) TestAuthorizationOidcTokenExchange() {
 			} else {
 				s.Require().NoError(session.Close(), "Expected SSE session to close cleanly")
 			}
-			s.StopServer()
-			s.Require().NoError(s.WaitForShutdown())
+			s.stopRunningServer()
 		})
 	}
 }
@@ -536,8 +531,7 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughWarning() {
 	})
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 func (s *AuthorizationSuite) TestAuthorizationPassthroughWarningOnce() {
@@ -560,8 +554,7 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughWarningOnce() {
 		count := strings.Count(logs, "Bearer token forwarded without local validation")
 		s.Equal(1, count, "Expected warning to fire exactly once, got %d", count)
 	})
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 func (s *AuthorizationSuite) TestAuthorizationPassthroughRejectedWithoutSkipFlag() {
@@ -597,8 +590,7 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughRejectedWithoutSkipFlag
 		s.mcpClient.Close()
 		s.mcpClient = nil
 	}
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 func (s *AuthorizationSuite) TestAuthorizationExemptEndpointsFromOAuth() {
@@ -663,8 +655,7 @@ func (s *AuthorizationSuite) TestAuthorizationRawPassthroughStreamableHTTP() {
 
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 // TestAuthorizationRawPassthroughSSE is the SSE counterpart to
@@ -717,8 +708,7 @@ func (s *AuthorizationSuite) TestAuthorizationRawPassthroughSSE() {
 	})
 
 	s.Require().NoError(session.Close(), "Expected SSE session to close cleanly")
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 // TestAuthorizationClusterAuthModeKubeconfigDropsClientToken verifies that
@@ -765,8 +755,7 @@ func (s *AuthorizationSuite) TestAuthorizationClusterAuthModeKubeconfigDropsClie
 
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 // TestAuthorizationPassthroughOpaqueToken verifies that in passthrough mode
@@ -813,8 +802,7 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughOpaqueToken() {
 
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 // TestAuthorizationPassthroughMalformedJWT verifies that a syntactically invalid
@@ -837,8 +825,7 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughMalformedJWT() {
 
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 // TestAuthorizationPassthroughMissingHeader verifies that the Bearer header
@@ -862,8 +849,7 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughMissingHeader() {
 		})
 	})
 
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 // TestAuthorizationPassthroughExpiredToken verifies that expired JWTs are
@@ -908,8 +894,7 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughExpiredToken() {
 
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 // TestAuthorizationPassthroughClusterIssuedJWT verifies that JWTs issued by the
@@ -958,8 +943,7 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughClusterIssuedJWT() {
 
 	s.mcpClient.Close()
 	s.mcpClient = nil
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 // TestAuthorizationPassthroughOIDCPathUnaffected verifies that the passthrough
@@ -983,8 +967,7 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughOIDCPathUnaffected() {
 			"Expected HTTP 401 for opaque token with authorization_url set — passthrough must not bypass OIDC validation")
 	})
 
-	s.StopServer()
-	s.Require().NoError(s.WaitForShutdown())
+	s.stopRunningServer()
 }
 
 func TestAuthorization(t *testing.T) {

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -363,10 +363,8 @@ func (s *AuthorizationSuite) TestAuthorizationRawToken() {
 				s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initial request to not be nil")
 			})
 		})
-		if s.mcpClient.Session != nil {
-			_ = s.mcpClient.Session.Close()
-			s.mcpClient.Session = nil
-		}
+		s.mcpClient.Close()
+		s.mcpClient = nil
 		s.StopServer()
 		s.Require().NoError(s.WaitForShutdown())
 	}

--- a/pkg/http/http_mcp_test.go
+++ b/pkg/http/http_mcp_test.go
@@ -71,8 +71,7 @@ func (s *McpTransportSuite) TestStreamableHttpTransport() {
 			s.Run("Can close Streamable HTTP client", func() {
 				s.Require().NoError(session.Close(), "Expected no error closing Streamable HTTP MCP client")
 			})
-			s.StopServer()
-			s.Require().NoError(s.WaitForShutdown())
+			s.stopRunningServer()
 		})
 	}
 }

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -83,19 +83,16 @@ func (s *BaseHttpSuite) TearDownTest() {
 
 // stopRunningServer cancels the running HTTP server, waits for the Serve goroutine to return,
 // and releases the associated resources. Safe to call when no server has been started yet
-// and idempotent across repeated invocations.
+// and idempotent across repeated invocations. StartServer assigns mcpServer, timeoutCancel,
+// StopServer and WaitForShutdown as a group, so checking StopServer alone is sufficient.
 func (s *BaseHttpSuite) stopRunningServer() {
 	if s.StopServer == nil {
 		return
 	}
 	s.StopServer()
 	s.Require().NoError(s.WaitForShutdown(), "HTTP server did not shut down gracefully")
-	if s.mcpServer != nil {
-		s.mcpServer.Close()
-	}
-	if s.timeoutCancel != nil {
-		s.timeoutCancel()
-	}
+	s.mcpServer.Close()
+	s.timeoutCancel()
 	s.StopServer = nil
 	s.WaitForShutdown = nil
 	s.mcpServer = nil

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -51,17 +51,8 @@ func (s *BaseHttpSuite) SetupTest() {
 }
 
 func (s *BaseHttpSuite) StartServer() {
-	// Stop any previous running servers to avoid resource leaks when StartServer is called multiple times
-	if s.StopServer != nil {
-		s.StopServer()
-		_ = s.WaitForShutdown()
-	}
-	if s.mcpServer != nil {
-		s.mcpServer.Close()
-	}
-	if s.timeoutCancel != nil {
-		s.timeoutCancel()
-	}
+	// Stop any previously started server so multiple StartServer calls in the same test do not leak resources.
+	s.stopRunningServer()
 
 	tcpAddr, err := test.RandomPortAddress()
 	s.Require().NoError(err, "Expected no error getting random port address")
@@ -87,12 +78,28 @@ func (s *BaseHttpSuite) StartServer() {
 
 func (s *BaseHttpSuite) TearDownTest() {
 	s.MockServer.Close()
-	if s.mcpServer != nil {
-		s.mcpServer.Close()
+	s.stopRunningServer()
+}
+
+// stopRunningServer cancels the running HTTP server, waits for the Serve goroutine to return,
+// and releases the associated resources. Safe to call when no server has been started yet
+// and idempotent across repeated invocations.
+func (s *BaseHttpSuite) stopRunningServer() {
+	if s.StopServer == nil {
+		return
 	}
 	s.StopServer()
 	s.Require().NoError(s.WaitForShutdown(), "HTTP server did not shut down gracefully")
-	s.timeoutCancel()
+	if s.mcpServer != nil {
+		s.mcpServer.Close()
+	}
+	if s.timeoutCancel != nil {
+		s.timeoutCancel()
+	}
+	s.StopServer = nil
+	s.WaitForShutdown = nil
+	s.mcpServer = nil
+	s.timeoutCancel = nil
 }
 
 type httpContext struct {


### PR DESCRIPTION
## Summary

Follow-up to #1161 addressing two review findings:

- Extract `BaseHttpSuite.stopRunningServer()` shared by `StartServer`'s cleanup-of-previous-server path and `TearDownTest`. Centralising the sequence (`StopServer → WaitForShutdown → mcpServer.Close → timeoutCancel`) removes a divergent ordering between the two call sites — the new order also matches what `Serve` itself does (calls `mcpServer.Shutdown` mid-graceful-shutdown), so closing `mcpServer` only after `WaitForShutdown` returns avoids tearing down rate-limiter/provider while in-flight requests could still touch them. The helper also asserts `WaitForShutdown` via `Require.NoError`, surfacing prior-server shutdown errors that `StartServer` previously discarded with `_ = s.WaitForShutdown()`.
- Normalise `TestAuthorizationRawToken` cleanup to `s.mcpClient.Close(); s.mcpClient = nil`, matching sibling tests at lines 326, 341, 398. `McpClient.Close()` already nil-guards `Session`, so the inline `if s.mcpClient.Session != nil` guard added in #1161 is redundant.

## Test plan

- [x] `go test -race -count=3 ./pkg/http/...` passes
- [x] `go vet ./pkg/http/...` clean