### PR TITLE
feat(config): add sts_token_url and sts_subject_token_type fields

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -73,6 +73,8 @@ type StsConfigProvider interface {
 	GetStsClientCertFile() string
 	GetStsClientKeyFile() string
 	GetStsFederatedTokenFile() string
+	GetStsTokenURL() string
+	GetStsSubjectTokenType() string
 	GetCertificateAuthority() string
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,14 @@ type StaticConfig struct {
 	// StsFederatedTokenFile is the path to a file containing a JWT from an external identity
 	// provider (e.g., SPIRE JWT-SVID). Used with sts_auth_style="federated".
 	StsFederatedTokenFile string `toml:"sts_federated_token_file,omitempty"`
+	// StsTokenURL is the explicit token endpoint URL for STS token exchange.
+	// When set, this URL is used instead of the OIDC-discovered token endpoint,
+	// enabling token exchange with a dedicated STS gateway.
+	StsTokenURL string `toml:"sts_token_url,omitempty"`
+	// StsSubjectTokenType specifies the token type identifier for the subject token
+	// in the token exchange request (e.g., "urn:ietf:params:oauth:token-type:access_token"
+	// or "urn:ietf:params:oauth:token-type:jwt").
+	StsSubjectTokenType string `toml:"sts_subject_token_type,omitempty"`
 	// ClusterAuthMode determines how the MCP server authenticates to the cluster.
 	// Valid values: "passthrough" (forward Authorization header, with optional exchange), "kubeconfig" (use kubeconfig credentials).
 	// If empty, defaults to passthrough: forwards the token when present, falls back to kubeconfig when absent.
@@ -431,6 +439,14 @@ func (c *StaticConfig) GetStsClientKeyFile() string {
 
 func (c *StaticConfig) GetStsFederatedTokenFile() string {
 	return c.StsFederatedTokenFile
+}
+
+func (c *StaticConfig) GetStsTokenURL() string {
+	return c.StsTokenURL
+}
+
+func (c *StaticConfig) GetStsSubjectTokenType() string {
+	return c.StsSubjectTokenType
 }
 
 func (c *StaticConfig) GetCertificateAuthority() string {

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -57,14 +57,15 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(snap *oauth.Snapshot) *tok
 		return nil
 	}
 
-	var tokenURL string
-	if snap.OIDCProvider != nil {
+	// Prefer the explicit sts_token_url from config; fall back to OIDC discovery.
+	tokenURL := p.baseConfig.GetStsTokenURL()
+	if tokenURL == "" && snap.OIDCProvider != nil {
 		if endpoint := snap.OIDCProvider.Endpoint(); endpoint.TokenURL != "" {
 			tokenURL = endpoint.TokenURL
 		}
 	}
 	if tokenURL == "" {
-		klog.Warningf("token exchange strategy %q configured but OIDC provider returned empty token URL", strategy)
+		klog.Warningf("token exchange strategy %q configured but no token URL available (set sts_token_url or configure an OIDC provider)", strategy)
 		return nil
 	}
 
@@ -86,6 +87,7 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(snap *oauth.Snapshot) *tok
 		ClientID:           p.baseConfig.GetStsClientId(),
 		ClientSecret:       p.baseConfig.GetStsClientSecret(),
 		Audience:           p.baseConfig.GetStsAudience(),
+		SubjectTokenType:   p.baseConfig.GetStsSubjectTokenType(),
 		Scopes:             p.baseConfig.GetStsScopes(),
 		AuthStyle:          authStyle,
 		ClientCertFile:     p.baseConfig.GetStsClientCertFile(),

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -148,15 +148,15 @@ func strategyBasedTokenExchange(
 
 	cfg := cachedConfig
 	if cfg == nil {
-		// Build token URL from OIDC provider
-		var tokenURL string
-		if oidcProvider != nil {
+		// Prefer explicit sts_token_url; fall back to OIDC discovery.
+		tokenURL := baseConfig.GetStsTokenURL()
+		if tokenURL == "" && oidcProvider != nil {
 			if endpoint := oidcProvider.Endpoint(); endpoint.TokenURL != "" {
 				tokenURL = endpoint.TokenURL
 			}
 		}
 		if tokenURL == "" {
-			return ctx, fmt.Errorf("token exchange failed: no token URL available from OIDC provider")
+			return ctx, fmt.Errorf("token exchange failed: no token URL available (set sts_token_url or configure an OIDC provider)")
 		}
 
 		authStyle := baseConfig.GetStsAuthStyle()
@@ -169,6 +169,7 @@ func strategyBasedTokenExchange(
 			ClientID:           baseConfig.GetStsClientId(),
 			ClientSecret:       baseConfig.GetStsClientSecret(),
 			Audience:           baseConfig.GetStsAudience(),
+			SubjectTokenType:   baseConfig.GetStsSubjectTokenType(),
 			Scopes:             baseConfig.GetStsScopes(),
 			AuthStyle:          authStyle,
 			ClientCertFile:     baseConfig.GetStsClientCertFile(),


### PR DESCRIPTION
## Summary

- Adds `sts_token_url` config field to allow specifying an explicit STS token endpoint instead of relying on OIDC discovery
- Adds `sts_subject_token_type` config field for the RFC 8693 `subject_token_type` parameter
- When `sts_token_url` is set, it takes precedence over the OIDC-discovered token endpoint, enabling token exchange with a dedicated STS gateway

## Motivation

When running token exchange against a dedicated STS gateway (separate from the OIDC provider), the OIDC-discovered token endpoint points to the wrong service. For example, if Okta is the OIDC provider but token exchange should go to a custom `sts-gateway`, the current code always resolves to Okta's token endpoint.

This patch lets operators explicitly set `sts_token_url` in the TOML config to direct token exchange requests to the correct endpoint.

## Test plan

- [ ] `go build ./...` passes
- [ ] Existing tests pass (`make test`)
- [ ] Manual verification with `sts_token_url` set to a custom STS gateway endpoint
- [ ] Verify backward compatibility: when `sts_token_url` is unset, behavior is unchanged (falls back to OIDC discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)