### PR TITLE
refactor(kubernetes)!: return separate stdout and stderr from PodsExec

### DIFF
--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -262,16 +262,16 @@ func (c *Core) PodsTop(ctx context.Context, options api.PodsTopOptions) (*metric
 	return convertedMetrics, metricsv1beta1api.Convert_v1beta1_PodMetricsList_To_metrics_PodMetricsList(versionedMetrics, convertedMetrics, nil)
 }
 
-func (c *Core) PodsExec(ctx context.Context, namespace, name, container string, command []string) (string, error) {
+func (c *Core) PodsExec(ctx context.Context, namespace, name, container string, command []string) (string, string, error) {
 	namespace = c.NamespaceOrDefault(namespace)
 	pods := c.CoreV1().Pods(namespace)
 	pod, err := pods.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	// https://github.com/kubernetes/kubectl/blob/5366de04e168bcbc11f5e340d131a9ca8b7d0df4/pkg/cmd/exec/exec.go#L350-L352
 	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
-		return "", fmt.Errorf("cannot exec into a container in a completed pod; current phase is %s", pod.Status.Phase)
+		return "", "", fmt.Errorf("cannot exec into a container in a completed pod; current phase is %s", pod.Status.Phase)
 	}
 	container = resolveContainer(pod, container)
 	podExecOptions := &v1.PodExecOptions{
@@ -291,34 +291,28 @@ func (c *Core) PodsExec(ctx context.Context, namespace, name, container string, 
 	execRequest.VersionedParams(podExecOptions, ParameterCodec)
 	restConfig, err := c.ToRESTConfig()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	spdyExec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", execRequest.URL())
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	webSocketExec, err := remotecommand.NewWebSocketExecutor(restConfig, "GET", execRequest.URL().String())
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	executor, err := remotecommand.NewFallbackExecutor(webSocketExec, spdyExec, func(err error) bool {
 		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
 	})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	stdout := bytes.NewBuffer(make([]byte, 0))
 	stderr := bytes.NewBuffer(make([]byte, 0))
 	if err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdout: stdout, Stderr: stderr, Tty: false,
 	}); err != nil {
-		return "", err
+		return "", "", err
 	}
-	if stdout.Len() > 0 {
-		return stdout.String(), nil
-	}
-	if stderr.Len() > 0 {
-		return stderr.String(), nil
-	}
-	return "", nil
+	return stdout.String(), stderr.String(), nil
 }

--- a/pkg/toolsets/core/pods.go
+++ b/pkg/toolsets/core/pods.go
@@ -366,13 +366,20 @@ func podsExec(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		}
 		command = append(command, s)
 	}
-	ret, err := kubernetes.NewCore(params).PodsExec(params, ns, name, container, command)
+	stdout, stderr, err := kubernetes.NewCore(params).PodsExec(params, ns, name, container, command)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to exec in pod %s in namespace %s: %w", name, ns, err)), nil
-	} else if ret == "" {
+	}
+
+	// Prefer stdout, fallback to stderr, or indicate no output
+	ret := stdout
+	if ret == "" && stderr != "" {
+		ret = stderr
+	}
+	if ret == "" {
 		ret = fmt.Sprintf("The executed command in pod %s in namespace %s has not produced any output", name, ns)
 	}
-	return api.NewToolCallResult(ret, err), nil
+	return api.NewToolCallResult(ret, nil), nil
 }
 
 func podsLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {


### PR DESCRIPTION
Changes:
  - Update PodsExec() signature to return (stdout, stderr, error)
  - Simplify output handling by always returning both streams
  - Update pods_exec handler to prefer stdout, fallback to stderr
  - Fix bug where error was incorrectly passed to result twice

This enables better integration with ovn-kubernetes-mcp[1] which needs separate stdout/stderr streams for network debugging tools.

[1] - https://github.com/ovn-kubernetes/ovn-kubernetes-mcp