### PR TITLE
feat(kiali): add built-in MCP prompts to the Kiali toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,18 +594,18 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 <summary>kiali</summary>
 
-- **list-applications** - List applications in the mesh namespaces
+- **mesh-list-applications** - List applications in the mesh namespaces
   - `namespace` (`string`) - Optional namespace to filter applications (default: all namespaces)
 
 - **list-istio-config** - List Istio configuration resources in the mesh namespaces
   - `namespace` (`string`) - Optional namespace to filter Istio configuration (default: all namespaces)
 
-- **list-namespaces** - List all namespaces with their sidecar injection status and Istio labels
+- **mesh-list-namespaces** - List all namespaces with their sidecar injection status and Istio labels
 
-- **list-services** - List services in the mesh namespaces
+- **mesh-list-services** - List services in the mesh namespaces
   - `namespace` (`string`) - Optional namespace to filter services (default: all namespaces)
 
-- **list-workloads** - List workloads in the mesh namespaces
+- **mesh-list-workloads** - List workloads in the mesh namespaces
   - `namespace` (`string`) - Optional namespace to filter workloads (default: all namespaces)
 
 - **mesh-health-check** - Perform a comprehensive health assessment of the Istio service mesh including control plane and data plane status
@@ -614,11 +614,12 @@ In case multi-cluster support is enabled (default) and you have access to multip
 - **mesh-topology** - Show the mesh topology including control plane components and cluster connectivity
 
 - **traffic-topology** - Analyze the service mesh traffic topology showing service dependencies, traffic flow, and communication patterns
-  - `namespaces` (`string`) - Comma-separated list of namespaces to include in the graph (default: all mesh namespaces)
+  - `namespaces` (`string`) **(required)** - Comma-separated list of namespaces to include in the graph, or 'all' to include all mesh namespaces
 
 - **service-troubleshoot** - Investigate service errors using logs, traces, and Istio configuration to identify root causes
   - `namespace` (`string`) **(required)** - Namespace where the service is deployed
   - `service` (`string`) **(required)** - Name of the service to troubleshoot
+  - `workload` (`string`) - Optional workload or pod name to fetch logs from (if omitted, uses the service name)
 
 - **trace-analysis** - Investigate distributed traces for a service to identify latency bottlenecks, error sources, and slow spans
   - `namespace` (`string`) **(required)** - Namespace where the service is deployed

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ In case multi-cluster support is enabled (default) and you have access to multip
 - **mesh-topology** - Show the mesh topology including control plane components and cluster connectivity
 
 - **traffic-topology** - Analyze the service mesh traffic topology showing service dependencies, traffic flow, and communication patterns
-  - `namespaces` (`string`) **(required)** - Comma-separated list of namespaces to include in the graph, or 'all' to include all mesh namespaces
+  - `namespaces` (`string`) **(required)** - Comma-separated list of namespaces to include in the graph, or 'all' to include all accessible mesh namespaces
 
 - **service-troubleshoot** - Investigate service errors using logs, traces, and Istio configuration to identify root causes
   - `namespace` (`string`) **(required)** - Namespace where the service is deployed

--- a/README.md
+++ b/README.md
@@ -592,6 +592,45 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 <details>
 
+<summary>kiali</summary>
+
+- **list-applications** - List applications in the mesh namespaces
+  - `namespace` (`string`) - Optional namespace to filter applications (default: all namespaces)
+
+- **list-istio-config** - List Istio configuration resources in the mesh namespaces
+  - `namespace` (`string`) - Optional namespace to filter Istio configuration (default: all namespaces)
+
+- **list-namespaces** - List all namespaces with their sidecar injection status and Istio labels
+
+- **list-services** - List services in the mesh namespaces
+  - `namespace` (`string`) - Optional namespace to filter services (default: all namespaces)
+
+- **list-workloads** - List workloads in the mesh namespaces
+  - `namespace` (`string`) - Optional namespace to filter workloads (default: all namespaces)
+
+- **mesh-health-check** - Perform a comprehensive health assessment of the Istio service mesh including control plane and data plane status
+  - `namespace` (`string`) - Optional namespace to focus the health check on (default: all namespaces)
+
+- **mesh-topology** - Show the mesh topology including control plane components and cluster connectivity
+
+- **traffic-topology** - Analyze the service mesh traffic topology showing service dependencies, traffic flow, and communication patterns
+  - `namespaces` (`string`) - Comma-separated list of namespaces to include in the graph (default: all mesh namespaces)
+
+- **service-troubleshoot** - Investigate service errors using logs, traces, and Istio configuration to identify root causes
+  - `namespace` (`string`) **(required)** - Namespace where the service is deployed
+  - `service` (`string`) **(required)** - Name of the service to troubleshoot
+
+- **trace-analysis** - Investigate distributed traces for a service to identify latency bottlenecks, error sources, and slow spans
+  - `namespace` (`string`) **(required)** - Namespace where the service is deployed
+  - `service` (`string`) **(required)** - Name of the service to investigate traces for
+
+- **istio-config-review** - Review and validate Istio configuration in a namespace, checking for misconfigurations and best practice violations
+  - `namespace` (`string`) **(required)** - Namespace to review Istio configuration for
+
+</details>
+
+<details>
+
 <summary>kubevirt</summary>
 
 - **vm-troubleshoot** - Generate a step-by-step troubleshooting guide for diagnosing KubeVirt VirtualMachine issues

--- a/pkg/mcp/kiali_test.go
+++ b/pkg/mcp/kiali_test.go
@@ -368,6 +368,48 @@ func (s *KialiSuite) TestMeshHealthCheckPrompt() {
 	})
 }
 
+func (s *KialiSuite) TestMeshTopologyPrompt() {
+	var capturedPaths []string
+	var capturedBodies []string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPaths = append(capturedPaths, r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		capturedBodies = append(capturedBodies, string(body))
+		if r.URL.Path == "/api/chat/mcp/list_or_get_resources" {
+			_, _ = w.Write([]byte(`{"cluster":"default","namespaces":[{"name":"bookinfo","health":"Healthy"},{"name":"istio-system","health":"Healthy"}]}`))
+		} else {
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		}
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("mesh-topology", map[string]string{})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls get_mesh_status endpoint", func() {
+		s.Contains(capturedPaths, "/api/chat/mcp/get_mesh_status")
+	})
+	s.Run("resolves namespaces via list_or_get_resources", func() {
+		s.Contains(capturedPaths, "/api/chat/mcp/list_or_get_resources")
+	})
+	s.Run("calls get_mesh_traffic_graph with resolved namespaces", func() {
+		s.Contains(capturedPaths, "/api/chat/mcp/get_mesh_traffic_graph")
+		for i, path := range capturedPaths {
+			if path == "/api/chat/mcp/get_mesh_traffic_graph" {
+				s.Contains(capturedBodies[i], "bookinfo")
+				s.Contains(capturedBodies[i], "istio-system")
+			}
+		}
+	})
+	s.Run("prompt result contains user message", func() {
+		s.Require().NotEmpty(result.Messages)
+		s.Equal("user", string(result.Messages[0].Role))
+	})
+}
+
 func (s *KialiSuite) TestTrafficTopologyPrompt() {
 	var capturedURL *url.URL
 	var capturedBody string

--- a/pkg/mcp/kiali_test.go
+++ b/pkg/mcp/kiali_test.go
@@ -146,10 +146,10 @@ func (s *KialiSuite) TestKialiPromptsRegistered() {
 	})
 
 	expectedPrompts := []string{
-		"list-applications",
-		"list-namespaces",
-		"list-services",
-		"list-workloads",
+		"mesh-list-applications",
+		"mesh-list-namespaces",
+		"mesh-list-services",
+		"mesh-list-workloads",
 		"list-istio-config",
 		"mesh-topology",
 		"mesh-health-check",
@@ -183,7 +183,7 @@ func (s *KialiSuite) TestListApplicationsPrompt() {
 	}))
 	s.InitMcpClient()
 
-	result, err := s.GetPrompt("list-applications", map[string]string{
+	result, err := s.GetPrompt("mesh-list-applications", map[string]string{
 		"namespace": "bookinfo",
 	})
 
@@ -200,6 +200,109 @@ func (s *KialiSuite) TestListApplicationsPrompt() {
 	})
 	s.Run("request body contains namespace filter", func() {
 		s.Contains(capturedBody, "bookinfo")
+	})
+	s.Run("prompt result contains at least one user message", func() {
+		s.Require().NotEmpty(result.Messages)
+		s.Equal("user", string(result.Messages[0].Role))
+	})
+}
+
+func (s *KialiSuite) TestListNamespacesPrompt() {
+	var capturedURL *url.URL
+	var capturedBody string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := *r.URL
+		capturedURL = &u
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		_, _ = w.Write([]byte(`{"cluster":"default","namespaces":[]}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("mesh-list-namespaces", map[string]string{})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls list_or_get_resources endpoint", func() {
+		s.Require().NotNil(capturedURL)
+		s.Equal("/api/chat/mcp/list_or_get_resources", capturedURL.Path)
+	})
+	s.Run("request body contains resourceType namespace", func() {
+		s.Contains(capturedBody, "namespace")
+	})
+	s.Run("prompt result contains at least one user message", func() {
+		s.Require().NotEmpty(result.Messages)
+		s.Equal("user", string(result.Messages[0].Role))
+	})
+}
+
+func (s *KialiSuite) TestListServicesPrompt() {
+	var capturedURL *url.URL
+	var capturedBody string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := *r.URL
+		capturedURL = &u
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		_, _ = w.Write([]byte(`{"services":[]}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("mesh-list-services", map[string]string{
+		"namespace": "bookinfo",
+	})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls list_or_get_resources endpoint", func() {
+		s.Require().NotNil(capturedURL)
+		s.Equal("/api/chat/mcp/list_or_get_resources", capturedURL.Path)
+	})
+	s.Run("request body contains resourceType service", func() {
+		s.Contains(capturedBody, "service")
+	})
+	s.Run("request body contains namespace filter", func() {
+		s.Contains(capturedBody, "bookinfo")
+	})
+	s.Run("prompt result contains at least one user message", func() {
+		s.Require().NotEmpty(result.Messages)
+		s.Equal("user", string(result.Messages[0].Role))
+	})
+}
+
+func (s *KialiSuite) TestListWorkloadsPrompt() {
+	var capturedURL *url.URL
+	var capturedBody string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := *r.URL
+		capturedURL = &u
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		_, _ = w.Write([]byte(`{"workloads":[]}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("mesh-list-workloads", map[string]string{
+		"namespace": "kube-system",
+	})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls list_or_get_resources endpoint", func() {
+		s.Require().NotNil(capturedURL)
+		s.Equal("/api/chat/mcp/list_or_get_resources", capturedURL.Path)
+	})
+	s.Run("request body contains resourceType workload", func() {
+		s.Contains(capturedBody, "workload")
+	})
+	s.Run("request body contains namespace filter", func() {
+		s.Contains(capturedBody, "kube-system")
 	})
 	s.Run("prompt result contains at least one user message", func() {
 		s.Require().NotEmpty(result.Messages)
@@ -291,6 +394,77 @@ func (s *KialiSuite) TestTrafficTopologyPrompt() {
 	})
 	s.Run("request body contains the namespaces", func() {
 		s.Contains(capturedBody, "bookinfo")
+	})
+}
+
+func (s *KialiSuite) TestTrafficTopologyPromptAllNamespaces() {
+	var mu sync.Mutex
+	var capturedPaths []string
+	var capturedBodies []string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedPaths = append(capturedPaths, r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		capturedBodies = append(capturedBodies, string(body))
+		mu.Unlock()
+		if r.URL.Path == "/api/chat/mcp/list_or_get_resources" {
+			_, _ = w.Write([]byte(`{"namespaces":[{"name":"bookinfo"},{"name":"istio-system"}]}`))
+		} else {
+			_, _ = w.Write([]byte(`{"elements":{}}`))
+		}
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("traffic-topology", map[string]string{
+		"namespaces": "all",
+	})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("resolves namespaces via list_or_get_resources then calls traffic graph", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		s.Require().Len(capturedPaths, 2)
+		s.Equal("/api/chat/mcp/list_or_get_resources", capturedPaths[0])
+		s.Equal("/api/chat/mcp/get_mesh_traffic_graph", capturedPaths[1])
+	})
+	s.Run("traffic graph request contains resolved namespaces", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		s.Contains(capturedBodies[1], "bookinfo")
+		s.Contains(capturedBodies[1], "istio-system")
+	})
+}
+
+func (s *KialiSuite) TestServiceTroubleshootPromptWithWorkload() {
+	var mu sync.Mutex
+	var capturedBodies []string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		body, _ := io.ReadAll(r.Body)
+		capturedBodies = append(capturedBodies, string(body))
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"logs":[]}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("service-troubleshoot", map[string]string{
+		"namespace": "bookinfo",
+		"service":   "productpage",
+		"workload":  "productpage-v1",
+	})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("logs request uses workload name instead of service name", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		s.Require().NotEmpty(capturedBodies)
+		s.Contains(capturedBodies[0], "productpage-v1")
 	})
 }
 

--- a/pkg/mcp/kiali_test.go
+++ b/pkg/mcp/kiali_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
@@ -132,6 +133,278 @@ func (s *KialiSuite) TestGetMeshStatus() {
 		s.Run("response contains status", func() {
 			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "healthy", "Response should contain status")
 		})
+	})
+}
+
+func (s *KialiSuite) TestKialiPromptsRegistered() {
+	s.InitMcpClient()
+	prompts, err := s.ListPrompts()
+
+	s.Run("ListPrompts succeeds", func() {
+		s.NoError(err)
+		s.NotNil(prompts)
+	})
+
+	expectedPrompts := []string{
+		"list-applications",
+		"list-namespaces",
+		"list-services",
+		"list-workloads",
+		"list-istio-config",
+		"mesh-topology",
+		"mesh-health-check",
+		"traffic-topology",
+		"service-troubleshoot",
+		"trace-analysis",
+		"istio-config-review",
+	}
+
+	s.Run("all 11 kiali prompts are registered", func() {
+		s.Require().NotNil(prompts)
+		names := make(map[string]bool, len(prompts.Prompts))
+		for _, p := range prompts.Prompts {
+			names[p.Name] = true
+		}
+		for _, expected := range expectedPrompts {
+			s.Truef(names[expected], "expected prompt %q to be registered", expected)
+		}
+	})
+}
+
+func (s *KialiSuite) TestListApplicationsPrompt() {
+	var capturedURL *url.URL
+	var capturedBody string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := *r.URL
+		capturedURL = &u
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("list-applications", map[string]string{
+		"namespace": "bookinfo",
+	})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls list_or_get_resources endpoint", func() {
+		s.Require().NotNil(capturedURL)
+		s.Equal("/api/chat/mcp/list_or_get_resources", capturedURL.Path)
+	})
+	s.Run("request body contains resourceType app", func() {
+		s.Contains(capturedBody, "app")
+	})
+	s.Run("request body contains namespace filter", func() {
+		s.Contains(capturedBody, "bookinfo")
+	})
+	s.Run("prompt result contains at least one user message", func() {
+		s.Require().NotEmpty(result.Messages)
+		s.Equal("user", string(result.Messages[0].Role))
+	})
+}
+
+func (s *KialiSuite) TestListIstioConfigPrompt() {
+	var capturedURL *url.URL
+	var capturedBody string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := *r.URL
+		capturedURL = &u
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("list-istio-config", map[string]string{
+		"namespace": "bookinfo",
+	})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls manage_istio_config_read endpoint (not list_or_get_resources)", func() {
+		s.Require().NotNil(capturedURL)
+		s.Equal("/api/chat/mcp/manage_istio_config_read", capturedURL.Path)
+	})
+	s.Run("request body contains action list", func() {
+		s.Contains(capturedBody, "list")
+	})
+	s.Run("request body contains namespace filter", func() {
+		s.Contains(capturedBody, "bookinfo")
+	})
+}
+
+func (s *KialiSuite) TestMeshHealthCheckPrompt() {
+	var capturedURL *url.URL
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := *r.URL
+		capturedURL = &u
+		_, _ = w.Write([]byte(`{"status":"healthy","components":[]}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("mesh-health-check", map[string]string{})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls get_mesh_status endpoint", func() {
+		s.Require().NotNil(capturedURL)
+		s.Equal("/api/chat/mcp/get_mesh_status", capturedURL.Path)
+	})
+	s.Run("result has user and assistant messages", func() {
+		s.Require().Len(result.Messages, 2)
+		s.Equal("user", string(result.Messages[0].Role))
+		s.Equal("assistant", string(result.Messages[1].Role))
+	})
+}
+
+func (s *KialiSuite) TestTrafficTopologyPrompt() {
+	var capturedURL *url.URL
+	var capturedBody string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := *r.URL
+		capturedURL = &u
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		_, _ = w.Write([]byte(`{"elements":{}}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("traffic-topology", map[string]string{
+		"namespaces": "bookinfo,default",
+	})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls get_mesh_traffic_graph endpoint", func() {
+		s.Require().NotNil(capturedURL)
+		s.Equal("/api/chat/mcp/get_mesh_traffic_graph", capturedURL.Path)
+	})
+	s.Run("request body contains the namespaces", func() {
+		s.Contains(capturedBody, "bookinfo")
+	})
+}
+
+func (s *KialiSuite) TestServiceTroubleshootPromptRequiredArgs() {
+	s.InitMcpClient()
+
+	s.Run("returns error when namespace is missing", func() {
+		result, err := s.GetPrompt("service-troubleshoot", map[string]string{
+			"service": "productpage",
+		})
+		s.Error(err)
+		s.Nil(result)
+	})
+
+	s.Run("returns error when service is missing", func() {
+		result, err := s.GetPrompt("service-troubleshoot", map[string]string{
+			"namespace": "bookinfo",
+		})
+		s.Error(err)
+		s.Nil(result)
+	})
+}
+
+func (s *KialiSuite) TestServiceTroubleshootPrompt() {
+	var mu sync.Mutex
+	var capturedPaths []string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedPaths = append(capturedPaths, r.URL.Path)
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"logs":[]}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("service-troubleshoot", map[string]string{
+		"namespace": "bookinfo",
+		"service":   "productpage",
+	})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls get_logs and manage_istio_config_read endpoints", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		pathSet := make(map[string]bool)
+		for _, p := range capturedPaths {
+			pathSet[p] = true
+		}
+		s.True(pathSet["/api/chat/mcp/get_logs"], "expected get_logs to be called")
+		s.True(pathSet["/api/chat/mcp/manage_istio_config_read"], "expected manage_istio_config_read to be called")
+	})
+	s.Run("result contains user and assistant messages", func() {
+		s.Require().Len(result.Messages, 2)
+		s.Equal("user", string(result.Messages[0].Role))
+		s.Equal("assistant", string(result.Messages[1].Role))
+	})
+}
+
+func (s *KialiSuite) TestTraceAnalysisPromptRequiredArgs() {
+	s.InitMcpClient()
+
+	s.Run("returns error when namespace is missing", func() {
+		result, err := s.GetPrompt("trace-analysis", map[string]string{
+			"service": "productpage",
+		})
+		s.Error(err)
+		s.Nil(result)
+	})
+
+	s.Run("returns error when service is missing", func() {
+		result, err := s.GetPrompt("trace-analysis", map[string]string{
+			"namespace": "bookinfo",
+		})
+		s.Error(err)
+		s.Nil(result)
+	})
+}
+
+func (s *KialiSuite) TestTraceAnalysisPrompt() {
+	var mu sync.Mutex
+	var capturedPaths []string
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedPaths = append(capturedPaths, r.URL.Path)
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"traces":[]}`))
+	}))
+	s.InitMcpClient()
+
+	result, err := s.GetPrompt("trace-analysis", map[string]string{
+		"namespace": "bookinfo",
+		"service":   "productpage",
+	})
+
+	s.Run("prompt executes without error", func() {
+		s.NoError(err)
+		s.NotNil(result)
+	})
+	s.Run("calls list_traces endpoint twice (recent + error traces)", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		count := 0
+		for _, p := range capturedPaths {
+			if p == "/api/chat/mcp/list_traces" {
+				count++
+			}
+		}
+		s.Equal(2, count, "expected list_traces to be called twice")
+	})
+	s.Run("result contains user and assistant messages", func() {
+		s.Require().Len(result.Messages, 2)
+		s.Equal("user", string(result.Messages[0].Role))
 	})
 }
 

--- a/pkg/toolsets/kiali/prompts/istio_config_review.go
+++ b/pkg/toolsets/kiali/prompts/istio_config_review.go
@@ -1,0 +1,109 @@
+package prompts
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
+)
+
+func InitIstioConfigReview() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "istio-config-review",
+				Title:       "Review Istio Configuration",
+				Description: "Review and validate Istio configuration in a namespace, checking for misconfigurations and best practice violations",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "Namespace to review Istio configuration for",
+						Required:    true,
+					},
+				},
+			},
+			Handler: istioConfigReviewHandler,
+		},
+	}
+}
+
+func istioConfigReviewHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	args := params.GetArguments()
+	namespace := args["namespace"]
+
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace argument is required")
+	}
+
+	klog.Infof("Starting Istio config review for namespace %s...", namespace)
+
+	kiali := kialiclient.NewKiali(params, params.RESTConfig())
+
+	istioContent := fetchKialiData(kiali, params, tools.KialiManageIstioConfigReadEndpoint,
+		map[string]any{"namespace": namespace, "action": "list"})
+
+	resourceContent := fetchKialiData(kiali, params, tools.KialiListOrGetResourcesEndpoint,
+		map[string]any{"namespace": namespace, "resource_type": "services"})
+
+	promptText := buildIstioConfigReviewPrompt(namespace, istioContent, resourceContent)
+
+	return api.NewPromptCallResult(
+		"Istio configuration data gathered successfully",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: promptText,
+				},
+			},
+			{
+				Role: "assistant",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: "I'll review the Istio configuration and check for issues or misconfigurations.",
+				},
+			},
+		},
+		nil,
+	), nil
+}
+
+func buildIstioConfigReviewPrompt(namespace, istioData, resourceData string) string {
+	return fmt.Sprintf(`# Istio Configuration Review
+
+## Namespace: %s
+
+Review the Istio configuration in this namespace for correctness, best practices, and potential issues.
+
+---
+
+## Istio Resources
+
+%s
+
+---
+
+## Services in Namespace
+
+%s
+
+---
+
+## Review Checklist
+
+Analyze the configuration above and check for:
+
+1. **Validation Errors**: Are there any Istio validation warnings or errors reported?
+2. **VirtualService Issues**: Do VirtualServices reference hosts and subsets that actually exist? Are weights valid?
+3. **DestinationRule Consistency**: Do DestinationRules define subsets that match actual workload labels?
+4. **Traffic Policy**: Are there conflicting traffic policies or missing mTLS settings?
+5. **Gateway Configuration**: Are Gateways properly configured with correct hosts and ports?
+6. **Best Practices**: Are there any configuration anti-patterns (e.g., overly broad host matches, missing retries)?
+
+Provide a summary of findings with severity (critical, warning, info) and recommendations.
+`, namespace, istioData, resourceData)
+}

--- a/pkg/toolsets/kiali/prompts/istio_config_review.go
+++ b/pkg/toolsets/kiali/prompts/istio_config_review.go
@@ -46,7 +46,7 @@ func istioConfigReviewHandler(params api.PromptHandlerParams) (*api.PromptCallRe
 		map[string]any{"namespace": namespace, "action": "list"})
 
 	resourceContent := fetchKialiData(kiali, params, tools.KialiListOrGetResourcesEndpoint,
-		map[string]any{"namespace": namespace, "resource_type": "services"})
+		map[string]any{"namespaces": namespace, "resourceType": "service"})
 
 	promptText := buildIstioConfigReviewPrompt(namespace, istioContent, resourceContent)
 

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -98,9 +98,60 @@ func InitListIstioConfig() []api.ServerPrompt {
 					},
 				},
 			},
-			Handler: listResourceHandler("istio"),
+			Handler: listIstioConfigHandler,
 		},
 	}
+}
+
+func listIstioConfigHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	args := params.GetArguments()
+	namespace := args["namespace"]
+
+	klog.Info("Starting list istio config prompt...")
+
+	reqArgs := map[string]any{"action": "list"}
+	if namespace != "" {
+		reqArgs["namespace"] = namespace
+	}
+
+	kiali := kialiclient.NewKiali(params, params.RESTConfig())
+	content, err := kiali.ExecuteRequest(params.Context, tools.KialiManageIstioConfigReadEndpoint, reqArgs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list istio config: %w", err)
+	}
+
+	scope := "all namespaces"
+	if namespace != "" {
+		scope = fmt.Sprintf("namespace '%s'", namespace)
+	}
+
+	promptText := fmt.Sprintf(`# List Istio Configuration
+
+## Scope
+%s
+
+## Data
+
+%s
+
+## Instructions
+
+Summarize the Istio configuration listed above. Highlight any that need attention.
+`, scope, content)
+
+	return api.NewPromptCallResult(
+		"Istio configuration data retrieved successfully",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: promptText,
+				},
+			},
+		},
+		nil,
+	), nil
 }
 
 func InitMeshTopology() []api.ServerPrompt {

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -78,7 +78,7 @@ func InitListWorkloads() []api.ServerPrompt {
 					},
 				},
 			},
-			Handler: listResourceHandler("workloads"),
+			Handler: listResourceHandler("workload"),
 		},
 	}
 }

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -58,7 +58,7 @@ func InitListServices() []api.ServerPrompt {
 					},
 				},
 			},
-			Handler: listResourceHandler("services"),
+			Handler: listResourceHandler("service"),
 		},
 	}
 }

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -38,7 +38,7 @@ func InitListNamespaces() []api.ServerPrompt {
 				Title:       "List Namespaces",
 				Description: "List all namespaces with their sidecar injection status and Istio labels",
 			},
-			Handler: listResourceHandler("namespaces"),
+			Handler: listResourceHandler("namespace"),
 		},
 	}
 }

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -125,7 +125,7 @@ func listResourceHandler(resourceType string) api.PromptHandlerFunc {
 
 		reqArgs := map[string]any{"resourceType": resourceType}
 		if namespace != "" {
-			reqArgs["namespace"] = namespace
+			reqArgs["namespaces"] = namespace
 		}
 
 		kiali := kialiclient.NewKiali(params, params.RESTConfig())

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -123,7 +123,7 @@ func listResourceHandler(resourceType string) api.PromptHandlerFunc {
 
 		klog.Infof("Starting list %s prompt...", resourceType)
 
-		reqArgs := map[string]any{"resource_type": resourceType}
+		reqArgs := map[string]any{"resourceType": resourceType}
 		if namespace != "" {
 			reqArgs["namespace"] = namespace
 		}

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -226,7 +226,13 @@ func meshTopologyHandler(params api.PromptHandlerParams) (*api.PromptCallResult,
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 
 	statusContent := fetchKialiData(kiali, params, tools.KialiGetMeshStatusEndpoint, nil)
-	graphContent := fetchKialiData(kiali, params, tools.KialiGetMeshTrafficGraphEndpoint, nil)
+
+	resolved, err := resolveNamespaces(kiali, params, allNamespacesKeyword)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve mesh namespaces: %w", err)
+	}
+	graphContent := fetchKialiData(kiali, params, tools.KialiGetMeshTrafficGraphEndpoint,
+		map[string]any{"namespaces": resolved})
 
 	promptText := fmt.Sprintf(`# Mesh Topology Overview
 

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -14,8 +14,8 @@ func InitListApplications() []api.ServerPrompt {
 	return []api.ServerPrompt{
 		{
 			Prompt: api.Prompt{
-				Name:        "list-applications",
-				Title:       "List Applications",
+				Name:        "mesh-list-applications",
+				Title:       "List Mesh Applications",
 				Description: "List applications in the mesh namespaces",
 				Arguments: []api.PromptArgument{
 					{
@@ -34,8 +34,8 @@ func InitListNamespaces() []api.ServerPrompt {
 	return []api.ServerPrompt{
 		{
 			Prompt: api.Prompt{
-				Name:        "list-namespaces",
-				Title:       "List Namespaces",
+				Name:        "mesh-list-namespaces",
+				Title:       "List Mesh Namespaces",
 				Description: "List all namespaces with their sidecar injection status and Istio labels",
 			},
 			Handler: listResourceHandler("namespace"),
@@ -47,8 +47,8 @@ func InitListServices() []api.ServerPrompt {
 	return []api.ServerPrompt{
 		{
 			Prompt: api.Prompt{
-				Name:        "list-services",
-				Title:       "List Services",
+				Name:        "mesh-list-services",
+				Title:       "List Mesh Services",
 				Description: "List services in the mesh namespaces",
 				Arguments: []api.PromptArgument{
 					{
@@ -67,8 +67,8 @@ func InitListWorkloads() []api.ServerPrompt {
 	return []api.ServerPrompt{
 		{
 			Prompt: api.Prompt{
-				Name:        "list-workloads",
-				Title:       "List Workloads",
+				Name:        "mesh-list-workloads",
+				Title:       "List Mesh Workloads",
 				Description: "List workloads in the mesh namespaces",
 				Arguments: []api.PromptArgument{
 					{

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -1,0 +1,206 @@
+package prompts
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
+)
+
+func InitListApplications() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "list-applications",
+				Title:       "List Applications",
+				Description: "List applications in the mesh namespaces",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "Optional namespace to filter applications (default: all namespaces)",
+						Required:    false,
+					},
+				},
+			},
+			Handler: listResourceHandler("applications"),
+		},
+	}
+}
+
+func InitListNamespaces() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "list-namespaces",
+				Title:       "List Namespaces",
+				Description: "List all namespaces with their sidecar injection status and Istio labels",
+			},
+			Handler: listResourceHandler("namespaces"),
+		},
+	}
+}
+
+func InitListServices() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "list-services",
+				Title:       "List Services",
+				Description: "List services in the mesh namespaces",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "Optional namespace to filter services (default: all namespaces)",
+						Required:    false,
+					},
+				},
+			},
+			Handler: listResourceHandler("services"),
+		},
+	}
+}
+
+func InitListWorkloads() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "list-workloads",
+				Title:       "List Workloads",
+				Description: "List workloads in the mesh namespaces",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "Optional namespace to filter workloads (default: all namespaces)",
+						Required:    false,
+					},
+				},
+			},
+			Handler: listResourceHandler("workloads"),
+		},
+	}
+}
+
+func InitListIstioConfig() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "list-istio-config",
+				Title:       "List Istio Configuration",
+				Description: "List Istio configuration resources in the mesh namespaces",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "Optional namespace to filter Istio configuration (default: all namespaces)",
+						Required:    false,
+					},
+				},
+			},
+			Handler: listResourceHandler("istio"),
+		},
+	}
+}
+
+func InitMeshTopology() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "mesh-topology",
+				Title:       "Mesh Topology Overview",
+				Description: "Show the mesh topology including control plane components and cluster connectivity",
+			},
+			Handler: meshTopologyHandler,
+		},
+	}
+}
+
+func listResourceHandler(resourceType string) api.PromptHandlerFunc {
+	return func(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+		args := params.GetArguments()
+		namespace := args["namespace"]
+
+		klog.Infof("Starting list %s prompt...", resourceType)
+
+		reqArgs := map[string]any{"resource_type": resourceType}
+		if namespace != "" {
+			reqArgs["namespace"] = namespace
+		}
+
+		kiali := kialiclient.NewKiali(params, params.RESTConfig())
+		content, err := kiali.ExecuteRequest(params.Context, tools.KialiListOrGetResourcesEndpoint, reqArgs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list %s: %w", resourceType, err)
+		}
+
+		scope := "all namespaces"
+		if namespace != "" {
+			scope = fmt.Sprintf("namespace '%s'", namespace)
+		}
+
+		promptText := fmt.Sprintf(`# List %s
+
+## Scope
+%s
+
+## Data
+
+%s
+
+## Instructions
+
+Summarize the %s listed above. Highlight any that need attention.
+`, resourceType, scope, content, resourceType)
+
+		return api.NewPromptCallResult(
+			fmt.Sprintf("%s data retrieved successfully", resourceType),
+			[]api.PromptMessage{
+				{
+					Role: "user",
+					Content: api.PromptContent{
+						Type: "text",
+						Text: promptText,
+					},
+				},
+			},
+			nil,
+		), nil
+	}
+}
+
+func meshTopologyHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	klog.Info("Starting mesh topology prompt...")
+
+	kiali := kialiclient.NewKiali(params, params.RESTConfig())
+
+	statusContent := fetchKialiData(kiali, params, tools.KialiGetMeshStatusEndpoint, nil)
+	graphContent := fetchKialiData(kiali, params, tools.KialiGetMeshTrafficGraphEndpoint, nil)
+
+	promptText := fmt.Sprintf(`# Mesh Topology Overview
+
+## Mesh Status
+%s
+
+## Traffic Graph
+%s
+
+## Instructions
+
+Summarize the mesh topology covering control plane components, cluster connectivity, and data plane overview.
+`, statusContent, graphContent)
+
+	return api.NewPromptCallResult(
+		"Mesh topology data gathered successfully",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: promptText,
+				},
+			},
+		},
+		nil,
+	), nil
+}

--- a/pkg/toolsets/kiali/prompts/list_resources.go
+++ b/pkg/toolsets/kiali/prompts/list_resources.go
@@ -25,7 +25,7 @@ func InitListApplications() []api.ServerPrompt {
 					},
 				},
 			},
-			Handler: listResourceHandler("applications"),
+			Handler: listResourceHandler("app"),
 		},
 	}
 }

--- a/pkg/toolsets/kiali/prompts/mesh_health_check.go
+++ b/pkg/toolsets/kiali/prompts/mesh_health_check.go
@@ -1,0 +1,95 @@
+package prompts
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
+)
+
+func InitMeshHealthCheck() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "mesh-health-check",
+				Title:       "Mesh Health Check",
+				Description: "Perform a comprehensive health assessment of the Istio service mesh including control plane and data plane status",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "Optional namespace to focus the health check on (default: all namespaces)",
+						Required:    false,
+					},
+				},
+			},
+			Handler: meshHealthCheckHandler,
+		},
+	}
+}
+
+func meshHealthCheckHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	args := params.GetArguments()
+	namespace := args["namespace"]
+
+	klog.Info("Starting mesh health check prompt...")
+
+	kiali := kialiclient.NewKiali(params, params.RESTConfig())
+	statusContent, err := kiali.ExecuteRequest(params.Context, tools.KialiGetMeshStatusEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve mesh status: %w", err)
+	}
+
+	promptText := buildMeshHealthPrompt(statusContent, namespace)
+
+	return api.NewPromptCallResult(
+		"Mesh health diagnostic data gathered successfully",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: promptText,
+				},
+			},
+			{
+				Role: "assistant",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: "I'll analyze the mesh health data and provide a comprehensive assessment.",
+				},
+			},
+		},
+		nil,
+	), nil
+}
+
+func buildMeshHealthPrompt(statusData string, namespace string) string {
+	scope := "the entire mesh"
+	if namespace != "" {
+		scope = fmt.Sprintf("the '%s' namespace", namespace)
+	}
+
+	return fmt.Sprintf(`# Mesh Health Check
+
+## Scope
+Analyze the health of %s.
+
+## Collected Data
+
+### Mesh Status
+%s
+
+## Instructions
+
+Based on the data above, provide a comprehensive health report covering:
+
+1. **Control Plane Status**: Is istiod running and healthy? Report any issues with the Istio control plane.
+2. **Data Plane Health**: Which namespaces are healthy, degraded, or unhealthy? Summarize the overall data plane status.
+3. **Observability Stack**: Are Prometheus, Grafana, and tracing backends connected and operational?
+4. **Issues Found**: List any problems discovered, ordered by severity.
+5. **Recommendations**: Suggest actions to resolve any issues found.
+`, scope, statusData)
+}

--- a/pkg/toolsets/kiali/prompts/service_troubleshoot.go
+++ b/pkg/toolsets/kiali/prompts/service_troubleshoot.go
@@ -28,6 +28,11 @@ func InitServiceTroubleshoot() []api.ServerPrompt {
 						Description: "Name of the service to troubleshoot",
 						Required:    true,
 					},
+					{
+						Name:        "workload",
+						Description: "Optional workload or pod name to fetch logs from (if omitted, uses the service name)",
+						Required:    false,
+					},
 				},
 			},
 			Handler: serviceTroubleshootHandler,
@@ -39,6 +44,7 @@ func serviceTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCall
 	args := params.GetArguments()
 	namespace := args["namespace"]
 	service := args["service"]
+	workload := args["workload"]
 
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace argument is required")
@@ -47,12 +53,17 @@ func serviceTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCall
 		return nil, fmt.Errorf("service argument is required")
 	}
 
+	logTarget := service
+	if workload != "" {
+		logTarget = workload
+	}
+
 	klog.Infof("Starting service troubleshoot prompt for %s/%s...", namespace, service)
 
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 
 	logsContent := fetchKialiData(kiali, params, tools.KialiGetLogsEndpoint,
-		map[string]any{"namespace": namespace, "name": service + "-v1"})
+		map[string]any{"namespace": namespace, "name": logTarget})
 
 	istioContent := fetchKialiData(kiali, params, tools.KialiManageIstioConfigReadEndpoint,
 		map[string]any{"namespace": namespace, "action": "list"})

--- a/pkg/toolsets/kiali/prompts/service_troubleshoot.go
+++ b/pkg/toolsets/kiali/prompts/service_troubleshoot.go
@@ -92,6 +92,9 @@ func serviceTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCall
 	), nil
 }
 
+// fetchKialiData calls a Kiali endpoint and returns the response body.
+// On error it returns a placeholder string instead of failing the prompt,
+// allowing other sections to still render useful data.
 func fetchKialiData(kiali *kialiclient.Kiali, params api.PromptHandlerParams, endpoint string, args map[string]any) string {
 	content, err := kiali.ExecuteRequest(params.Context, endpoint, args)
 	if err != nil {

--- a/pkg/toolsets/kiali/prompts/service_troubleshoot.go
+++ b/pkg/toolsets/kiali/prompts/service_troubleshoot.go
@@ -1,0 +1,127 @@
+package prompts
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
+)
+
+func InitServiceTroubleshoot() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "service-troubleshoot",
+				Title:       "Troubleshoot Service Errors",
+				Description: "Investigate service errors using logs, traces, and Istio configuration to identify root causes",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "Namespace where the service is deployed",
+						Required:    true,
+					},
+					{
+						Name:        "service",
+						Description: "Name of the service to troubleshoot",
+						Required:    true,
+					},
+				},
+			},
+			Handler: serviceTroubleshootHandler,
+		},
+	}
+}
+
+func serviceTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	args := params.GetArguments()
+	namespace := args["namespace"]
+	service := args["service"]
+
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace argument is required")
+	}
+	if service == "" {
+		return nil, fmt.Errorf("service argument is required")
+	}
+
+	klog.Infof("Starting service troubleshoot prompt for %s/%s...", namespace, service)
+
+	kiali := kialiclient.NewKiali(params, params.RESTConfig())
+
+	logsContent := fetchKialiData(kiali, params, tools.KialiGetLogsEndpoint,
+		map[string]any{"namespace": namespace, "workload": service + "-v1"})
+
+	istioContent := fetchKialiData(kiali, params, tools.KialiManageIstioConfigReadEndpoint,
+		map[string]any{"namespace": namespace, "action": "list"})
+
+	promptText := buildServiceTroubleshootPrompt(namespace, service, logsContent, istioContent)
+
+	return api.NewPromptCallResult(
+		"Service troubleshooting data gathered successfully",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: promptText,
+				},
+			},
+			{
+				Role: "assistant",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: "I'll analyze the collected data to diagnose the service issues systematically.",
+				},
+			},
+		},
+		nil,
+	), nil
+}
+
+func fetchKialiData(kiali *kialiclient.Kiali, params api.PromptHandlerParams, endpoint string, args map[string]any) string {
+	content, err := kiali.ExecuteRequest(params.Context, endpoint, args)
+	if err != nil {
+		klog.Warningf("Failed to fetch data from %s: %v", endpoint, err)
+		return fmt.Sprintf("(data unavailable: %v)", err)
+	}
+	return content
+}
+
+func buildServiceTroubleshootPrompt(namespace, service, logsData, istioData string) string {
+	return fmt.Sprintf(`# Service Troubleshooting Guide
+
+## Target: %s in namespace %s
+
+Use this guide to diagnose issues with the service. The relevant data has been collected below.
+
+---
+
+## Step 1: Workload Logs
+
+Review the workload logs for error messages, stack traces, or unusual patterns:
+
+%s
+
+---
+
+## Step 2: Istio Configuration
+
+Review the Istio configuration (VirtualServices, DestinationRules, etc.) for routing issues, fault injection, or misconfiguration:
+
+%s
+
+---
+
+## Analysis Instructions
+
+Based on the data above, provide:
+
+1. **Error Summary**: What errors or issues are visible in the logs?
+2. **Istio Impact**: Are there any Istio configurations (fault injection, traffic routing, retries) that could cause or contribute to the errors?
+3. **Root Cause**: What is the most likely root cause?
+4. **Recommendations**: What actions should be taken to resolve the issue?
+`, service, namespace, logsData, istioData)
+}

--- a/pkg/toolsets/kiali/prompts/service_troubleshoot.go
+++ b/pkg/toolsets/kiali/prompts/service_troubleshoot.go
@@ -52,7 +52,7 @@ func serviceTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCall
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 
 	logsContent := fetchKialiData(kiali, params, tools.KialiGetLogsEndpoint,
-		map[string]any{"namespace": namespace, "workload": service + "-v1"})
+		map[string]any{"namespace": namespace, "name": service + "-v1"})
 
 	istioContent := fetchKialiData(kiali, params, tools.KialiManageIstioConfigReadEndpoint,
 		map[string]any{"namespace": namespace, "action": "list"})

--- a/pkg/toolsets/kiali/prompts/trace_analysis.go
+++ b/pkg/toolsets/kiali/prompts/trace_analysis.go
@@ -1,0 +1,117 @@
+package prompts
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
+)
+
+func InitTraceAnalysis() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "trace-analysis",
+				Title:       "Trace and Latency Investigation",
+				Description: "Investigate distributed traces for a service to identify latency bottlenecks, error sources, and slow spans",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "Namespace where the service is deployed",
+						Required:    true,
+					},
+					{
+						Name:        "service",
+						Description: "Name of the service to investigate traces for",
+						Required:    true,
+					},
+				},
+			},
+			Handler: traceAnalysisHandler,
+		},
+	}
+}
+
+func traceAnalysisHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	args := params.GetArguments()
+	namespace := args["namespace"]
+	service := args["service"]
+
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace argument is required")
+	}
+	if service == "" {
+		return nil, fmt.Errorf("service argument is required")
+	}
+
+	klog.Infof("Starting trace analysis prompt for %s/%s...", namespace, service)
+
+	kiali := kialiclient.NewKiali(params, params.RESTConfig())
+
+	tracesContent := fetchKialiData(kiali, params, tools.KialiListTracesEndpoint,
+		map[string]any{"namespace": namespace, "serviceName": service, "limit": 20})
+
+	errorTracesContent := fetchKialiData(kiali, params, tools.KialiListTracesEndpoint,
+		map[string]any{"namespace": namespace, "serviceName": service, "errorOnly": true, "limit": 10})
+
+	promptText := buildTraceAnalysisPrompt(namespace, service, tracesContent, errorTracesContent)
+
+	return api.NewPromptCallResult(
+		"Trace data gathered successfully",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: promptText,
+				},
+			},
+			{
+				Role: "assistant",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: "I'll analyze the trace data to identify latency issues and error patterns.",
+				},
+			},
+		},
+		nil,
+	), nil
+}
+
+func buildTraceAnalysisPrompt(namespace, service, tracesData, errorTracesData string) string {
+	return fmt.Sprintf(`# Trace and Latency Investigation
+
+## Target: %s in namespace %s
+
+Analyze distributed traces to find latency bottlenecks, error patterns, and performance issues.
+
+---
+
+## Recent Traces
+
+%s
+
+---
+
+## Error Traces
+
+%s
+
+---
+
+## Analysis Instructions
+
+Based on the trace data above, provide:
+
+1. **Latency Overview**: What is the typical request duration? Are there outliers with significantly higher latency?
+2. **Slowest Services**: Which downstream services or spans contribute the most latency?
+3. **Error Patterns**: Are there traces with errors? What services or operations are failing?
+4. **Bottlenecks**: Identify any services that appear as common slow points across multiple traces.
+5. **Recommendations**: Suggest optimizations such as caching, connection pooling, retry tuning, or timeout adjustments.
+
+If a specific trace looks problematic, mention its trace ID so the user can drill into details using the get_trace_details tool.
+`, service, namespace, tracesData, errorTracesData)
+}

--- a/pkg/toolsets/kiali/prompts/traffic_topology.go
+++ b/pkg/toolsets/kiali/prompts/traffic_topology.go
@@ -1,7 +1,9 @@
 package prompts
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"k8s.io/klog/v2"
 
@@ -20,8 +22,8 @@ func InitTrafficTopology() []api.ServerPrompt {
 				Arguments: []api.PromptArgument{
 					{
 						Name:        "namespaces",
-						Description: "Comma-separated list of namespaces to include in the graph (default: all mesh namespaces)",
-						Required:    false,
+						Description: "Comma-separated list of namespaces to include in the graph, or 'all' to include all mesh namespaces",
+						Required:    true,
 					},
 				},
 			},
@@ -34,20 +36,26 @@ func trafficTopologyHandler(params api.PromptHandlerParams) (*api.PromptCallResu
 	args := params.GetArguments()
 	namespaces := args["namespaces"]
 
-	klog.Info("Starting traffic topology analysis prompt...")
-
-	reqArgs := map[string]any{}
-	if namespaces != "" {
-		reqArgs["namespaces"] = namespaces
+	if namespaces == "" {
+		return nil, fmt.Errorf("namespaces argument is required: provide a comma-separated list or 'all' for all mesh namespaces")
 	}
 
+	klog.Info("Starting traffic topology analysis prompt...")
+
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
+
+	resolvedNamespaces, err := resolveNamespaces(kiali, params, namespaces)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve namespaces: %w", err)
+	}
+
+	reqArgs := map[string]any{"namespaces": resolvedNamespaces}
 	graphContent, err := kiali.ExecuteRequest(params.Context, tools.KialiGetMeshTrafficGraphEndpoint, reqArgs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve traffic graph: %w", err)
 	}
 
-	promptText := buildTrafficTopologyPrompt(graphContent, namespaces)
+	promptText := buildTrafficTopologyPrompt(graphContent, resolvedNamespaces)
 
 	return api.NewPromptCallResult(
 		"Traffic topology data gathered successfully",
@@ -71,16 +79,57 @@ func trafficTopologyHandler(params api.PromptHandlerParams) (*api.PromptCallResu
 	), nil
 }
 
-func buildTrafficTopologyPrompt(graphData string, namespaces string) string {
-	scope := "all mesh namespaces"
-	if namespaces != "" {
-		scope = fmt.Sprintf("namespaces: %s", namespaces)
+// resolveNamespaces resolves the namespaces argument. If "all" is provided,
+// it discovers all mesh namespaces via the Kiali API. Otherwise it returns
+// the input as-is (comma-separated list).
+func resolveNamespaces(kiali *kialiclient.Kiali, params api.PromptHandlerParams, namespaces string) (string, error) {
+	if !strings.EqualFold(strings.TrimSpace(namespaces), "all") {
+		return namespaces, nil
 	}
 
+	content, err := kiali.ExecuteRequest(params.Context, tools.KialiListOrGetResourcesEndpoint,
+		map[string]any{"resourceType": "namespace"})
+	if err != nil {
+		return "", fmt.Errorf("failed to discover mesh namespaces: %w", err)
+	}
+
+	discovered := parseNamespacesFromResponse(content)
+	if discovered == "" {
+		return "", fmt.Errorf("no mesh namespaces found")
+	}
+	return discovered, nil
+}
+
+// parseNamespacesFromResponse extracts namespace names from the Kiali
+// list_or_get_resources JSON response and returns them as a comma-separated string.
+func parseNamespacesFromResponse(content string) string {
+	type nsItem struct {
+		Name string `json:"name"`
+	}
+	type nsResponse struct {
+		Namespaces []nsItem `json:"namespaces"`
+	}
+
+	var resp nsResponse
+	if err := json.Unmarshal([]byte(content), &resp); err != nil {
+		klog.Warningf("Failed to parse namespace list response: %v", err)
+		return ""
+	}
+
+	names := make([]string, 0, len(resp.Namespaces))
+	for _, ns := range resp.Namespaces {
+		if ns.Name != "" {
+			names = append(names, ns.Name)
+		}
+	}
+	return strings.Join(names, ",")
+}
+
+func buildTrafficTopologyPrompt(graphData string, namespaces string) string {
 	return fmt.Sprintf(`# Traffic Topology Analysis
 
 ## Scope
-Analyze traffic topology for %s.
+Analyze traffic topology for namespaces: %s.
 
 ## Collected Data
 
@@ -95,5 +144,5 @@ Based on the traffic graph data above, provide an analysis covering:
 2. **Traffic Patterns**: Identify high-traffic paths, bottlenecks, or unusual communication patterns.
 3. **Health Overview**: Highlight any services or edges showing errors or degraded health.
 4. **Observations**: Note any unexpected dependencies, circular calls, or services that appear isolated.
-`, scope, graphData)
+`, namespaces, graphData)
 }

--- a/pkg/toolsets/kiali/prompts/traffic_topology.go
+++ b/pkg/toolsets/kiali/prompts/traffic_topology.go
@@ -22,7 +22,7 @@ func InitTrafficTopology() []api.ServerPrompt {
 				Arguments: []api.PromptArgument{
 					{
 						Name:        "namespaces",
-						Description: "Comma-separated list of namespaces to include in the graph, or 'all' to include all mesh namespaces",
+						Description: "Comma-separated list of namespaces to include in the graph, or 'all' to include all accessible mesh namespaces",
 						Required:    true,
 					},
 				},
@@ -37,7 +37,7 @@ func trafficTopologyHandler(params api.PromptHandlerParams) (*api.PromptCallResu
 	namespaces := args["namespaces"]
 
 	if namespaces == "" {
-		return nil, fmt.Errorf("namespaces argument is required: provide a comma-separated list or 'all' for all mesh namespaces")
+		return nil, fmt.Errorf("namespaces argument is required: provide a comma-separated list or 'all' for all accessible mesh namespaces")
 	}
 
 	klog.Info("Starting traffic topology analysis prompt...")
@@ -79,11 +79,15 @@ func trafficTopologyHandler(params api.PromptHandlerParams) (*api.PromptCallResu
 	), nil
 }
 
+// allNamespacesKeyword is the special value users can pass to indicate
+// "all accessible mesh namespaces" instead of listing them explicitly.
+const allNamespacesKeyword = "all"
+
 // resolveNamespaces resolves the namespaces argument. If "all" is provided,
-// it discovers all mesh namespaces via the Kiali API. Otherwise it returns
-// the input as-is (comma-separated list).
+// it discovers all accessible mesh namespaces via the Kiali API. Otherwise
+// it returns the input as-is (comma-separated list).
 func resolveNamespaces(kiali *kialiclient.Kiali, params api.PromptHandlerParams, namespaces string) (string, error) {
-	if !strings.EqualFold(strings.TrimSpace(namespaces), "all") {
+	if !strings.EqualFold(strings.TrimSpace(namespaces), allNamespacesKeyword) {
 		return namespaces, nil
 	}
 

--- a/pkg/toolsets/kiali/prompts/traffic_topology.go
+++ b/pkg/toolsets/kiali/prompts/traffic_topology.go
@@ -1,0 +1,99 @@
+package prompts
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
+)
+
+func InitTrafficTopology() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "traffic-topology",
+				Title:       "Traffic Topology Analysis",
+				Description: "Analyze the service mesh traffic topology showing service dependencies, traffic flow, and communication patterns",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespaces",
+						Description: "Comma-separated list of namespaces to include in the graph (default: all mesh namespaces)",
+						Required:    false,
+					},
+				},
+			},
+			Handler: trafficTopologyHandler,
+		},
+	}
+}
+
+func trafficTopologyHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	args := params.GetArguments()
+	namespaces := args["namespaces"]
+
+	klog.Info("Starting traffic topology analysis prompt...")
+
+	reqArgs := map[string]any{}
+	if namespaces != "" {
+		reqArgs["namespaces"] = namespaces
+	}
+
+	kiali := kialiclient.NewKiali(params, params.RESTConfig())
+	graphContent, err := kiali.ExecuteRequest(params.Context, tools.KialiGetMeshTrafficGraphEndpoint, reqArgs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve traffic graph: %w", err)
+	}
+
+	promptText := buildTrafficTopologyPrompt(graphContent, namespaces)
+
+	return api.NewPromptCallResult(
+		"Traffic topology data gathered successfully",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: promptText,
+				},
+			},
+			{
+				Role: "assistant",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: "I'll analyze the traffic topology and identify service dependencies and communication patterns.",
+				},
+			},
+		},
+		nil,
+	), nil
+}
+
+func buildTrafficTopologyPrompt(graphData string, namespaces string) string {
+	scope := "all mesh namespaces"
+	if namespaces != "" {
+		scope = fmt.Sprintf("namespaces: %s", namespaces)
+	}
+
+	return fmt.Sprintf(`# Traffic Topology Analysis
+
+## Scope
+Analyze traffic topology for %s.
+
+## Collected Data
+
+### Traffic Graph
+%s
+
+## Instructions
+
+Based on the traffic graph data above, provide an analysis covering:
+
+1. **Service Dependencies**: Map out which services communicate with each other and the direction of traffic flow.
+2. **Traffic Patterns**: Identify high-traffic paths, bottlenecks, or unusual communication patterns.
+3. **Health Overview**: Highlight any services or edges showing errors or degraded health.
+4. **Observations**: Note any unexpected dependencies, circular calls, or services that appear isolated.
+`, scope, graphData)
+}

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
+	kialiPrompts "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/prompts"
 	kialiTools "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
 )
 
@@ -37,8 +38,19 @@ func (t *Toolset) GetTools(_ api.Openshift) []api.ServerTool {
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {
-	// Kiali toolset does not provide prompts
-	return nil
+	return slices.Concat(
+		kialiPrompts.InitListApplications(),
+		kialiPrompts.InitListIstioConfig(),
+		kialiPrompts.InitListNamespaces(),
+		kialiPrompts.InitListServices(),
+		kialiPrompts.InitListWorkloads(),
+		kialiPrompts.InitMeshHealthCheck(),
+		kialiPrompts.InitMeshTopology(),
+		kialiPrompts.InitTrafficTopology(),
+		kialiPrompts.InitServiceTroubleshoot(),
+		kialiPrompts.InitTraceAnalysis(),
+		kialiPrompts.InitIstioConfigReview(),
+	)
 }
 
 func (t *Toolset) GetResources() []api.ServerResource {


### PR DESCRIPTION
**Summary**

- Implements GetPrompts() for the Kiali toolset, providing 11 built-in MCP prompts that MCP clients (e.g., Claude Desktop, Cursor) can discover and use for common service mesh tasks
- Adds lightweight resource listing prompts (list_applications, list_namespaces, list_services, list_workloads, list_istio_config) that call list_or_get_resources with structured analysis instructions
- Adds advanced operational prompts (mesh_health_check, mesh_topology, traffic_topology, service_troubleshoot, trace_analysis, istio_config_review) that pre-fetch data from Kiali endpoints and construct detailed analysis guides for the AI model
- Organizes all prompt logic under a new pkg/toolsets/kiali/prompts/ package with reusable handler patterns

Kiali PR: https://github.com/kiali/kiali/pull/9768
