### PR TITLE
fix(tokenexchange): enforce require_tls on token exchange HTTP client

### DIFF
--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -49,6 +49,9 @@ func ValidateURLsRequireTLS(urls map[string]string) error {
 // when RequireTLS returns true. This provides Layer 2 (runtime) enforcement as
 // defense-in-depth, catching any URLs that might have been missed during config validation.
 // The RequireTLS function is called per-request, allowing dynamic config changes (e.g., SIGHUP).
+//
+// NOTE: pkg/tokenexchange/config.go duplicates this type and its helpers
+// (tlsEnforcingTransport, isSecureHTTPScheme) to avoid an import cycle.
 type TLSEnforcingTransport struct {
 	Base       http.RoundTripper
 	RequireTLS func() bool

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -117,6 +117,7 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 		FederatedTokenFile: baseConfig.GetStsFederatedTokenFile(),
 		CAFile:             baseConfig.GetCertificateAuthority(),
 	}
+	cfg.SetRequireTLS(baseConfig.IsRequireTLS)
 	if err := cfg.Validate(); err != nil {
 		logger.Error(
 			err,
@@ -147,6 +148,7 @@ type stsConfigCacheKey struct {
 	ClientKeyFile      string
 	FederatedTokenFile string
 	CAFile             string
+	RequireTLS         bool
 }
 
 func newStsConfigCacheKey(tokenURL string, cfg api.BaseConfig) stsConfigCacheKey {
@@ -162,6 +164,7 @@ func newStsConfigCacheKey(tokenURL string, cfg api.BaseConfig) stsConfigCacheKey
 		ClientKeyFile:      cfg.GetStsClientKeyFile(),
 		FederatedTokenFile: cfg.GetStsFederatedTokenFile(),
 		CAFile:             cfg.GetCertificateAuthority(),
+		RequireTLS:         cfg.IsRequireTLS(),
 	}
 }
 

--- a/pkg/kubernetes/provider_token_exchange_test.go
+++ b/pkg/kubernetes/provider_token_exchange_test.go
@@ -232,6 +232,24 @@ func (s *TokenExchangingProviderSuite) TestGetOrBuildStsConfig() {
 			s.NotSame(first, second)
 			s.Equal("/new-token", second.FederatedTokenFile)
 		})
+
+		s.Run("require_tls", func() {
+			snap := s.newSnapshot()
+			cfg := config.Default()
+			cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+			cfg.StsClientId = "client"
+			cfg.StsAudience = "audience"
+			cfg.RequireTLS = false
+			p := newProvider(cfg)
+
+			first := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(first)
+
+			cfg.RequireTLS = true
+			second := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(second)
+			s.NotSame(first, second)
+		})
 	})
 }
 

--- a/pkg/kubernetes/provider_token_exchange_test.go
+++ b/pkg/kubernetes/provider_token_exchange_test.go
@@ -251,6 +251,31 @@ func (s *TokenExchangingProviderSuite) TestGetOrBuildStsConfig() {
 			s.NotSame(first, second)
 		})
 	})
+
+	s.Run("wires require_tls enforcement into the built config", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		snap := s.newSnapshot()
+		cfg := config.Default()
+		cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+		cfg.StsClientId = "client"
+		cfg.RequireTLS = true
+		p := newProvider(cfg)
+
+		built := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+		s.Require().NotNil(built)
+
+		// getOrBuildStsConfig must wire the enforcer into the config it returns,
+		// or the http token endpoint slips through when require_tls is on.
+		client, err := built.HTTPClient()
+		s.Require().NoError(err)
+		_, err = client.Get(server.URL)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_tls is enabled")
+	})
 }
 
 func (s *TokenExchangingProviderSuite) newExchangeTestOIDCServer() *exchangeTestOIDCServer {

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -43,6 +43,8 @@ func ExchangeTokenInContext(
 		return stsExchangeTokenInContext(ctx, baseConfig, oidcProvider, httpClient, subjectToken, stsConfig)
 	}
 
+	exCfg.SetRequireTLS(baseConfig.IsRequireTLS)
+
 	exchanger, ok := tokenexchange.GetTokenExchanger(tep.GetTokenExchangeStrategy())
 	if !ok {
 		klogutil.LogWarn(klog.FromContext(ctx), "token exchange strategy not found in registry, falling back to sts exchange",
@@ -183,6 +185,7 @@ func strategyBasedTokenExchange(
 			return ctx, fmt.Errorf("token exchange config validation: %w", err)
 		}
 	}
+	cfg.SetRequireTLS(baseConfig.IsRequireTLS)
 
 	if httpClient != nil {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)

--- a/pkg/kubernetes/token_exchange_test.go
+++ b/pkg/kubernetes/token_exchange_test.go
@@ -2,10 +2,14 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -67,6 +71,54 @@ func (s *TokenExchangeRoutingSuite) TestStsExchangeTokenInContextRouting() {
 
 		auth, _ := result.Value(OAuthAuthorizationHeader).(string)
 		s.Equal("Bearer original-token", auth)
+	})
+}
+
+func (s *TokenExchangeRoutingSuite) TestRequireTLS_BlocksHTTPTokenExchange() {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "exchanged-token",
+			"token_type":   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	s.Run("strategyBasedTokenExchange rejects http token URL when require_tls is true", func() {
+		cfg := config.Default()
+		cfg.RequireTLS = true
+
+		cachedConfig := &tokenexchange.TargetTokenExchangeConfig{
+			TokenURL:     server.URL,
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+		}
+
+		_, err := strategyBasedTokenExchange(
+			context.Background(), cfg, nil, nil, "subject-token",
+			tokenexchange.StrategyRFC8693, cachedConfig,
+		)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_tls is enabled")
+	})
+
+	s.Run("strategyBasedTokenExchange allows http token URL when require_tls is false", func() {
+		cfg := config.Default()
+		cfg.RequireTLS = false
+
+		cachedConfig := &tokenexchange.TargetTokenExchangeConfig{
+			TokenURL:     server.URL,
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+		}
+
+		result, err := strategyBasedTokenExchange(
+			context.Background(), cfg, nil, nil, "subject-token",
+			tokenexchange.StrategyRFC8693, cachedConfig,
+		)
+		s.Require().NoError(err)
+		auth, _ := result.Value(OAuthAuthorizationHeader).(string)
+		s.Equal("Bearer exchanged-token", auth)
 	})
 }
 

--- a/pkg/kubernetes/token_exchange_test.go
+++ b/pkg/kubernetes/token_exchange_test.go
@@ -122,6 +122,61 @@ func (s *TokenExchangeRoutingSuite) TestRequireTLS_BlocksHTTPTokenExchange() {
 	})
 }
 
+// fakeTokenExchangeProvider implements the optional TokenExchangeProvider
+// interface so ExchangeTokenInContext takes the per-target exCfg branch.
+type fakeTokenExchangeProvider struct {
+	fakeDerivedProvider
+	exchangeConfig *tokenexchange.TargetTokenExchangeConfig
+	strategy       string
+}
+
+func (f fakeTokenExchangeProvider) GetTokenExchangeConfig(string) *tokenexchange.TargetTokenExchangeConfig {
+	return f.exchangeConfig
+}
+func (f fakeTokenExchangeProvider) GetTokenExchangeStrategy() string { return f.strategy }
+
+func (s *TokenExchangeRoutingSuite) TestRequireTLS_BlocksExCfgTokenExchange() {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "exchanged-token",
+			"token_type":   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	newProvider := func() fakeTokenExchangeProvider {
+		return fakeTokenExchangeProvider{
+			exchangeConfig: &tokenexchange.TargetTokenExchangeConfig{
+				TokenURL:     server.URL,
+				ClientID:     "test-client",
+				ClientSecret: "test-secret",
+			},
+			strategy: tokenexchange.StrategyRFC8693,
+		}
+	}
+	ctx := context.WithValue(context.Background(), OAuthAuthorizationHeader, "Bearer subject-token")
+
+	s.Run("rejects http token URL via per-target config when require_tls is true", func() {
+		cfg := config.Default()
+		cfg.RequireTLS = true
+
+		_, err := ExchangeTokenInContext(ctx, cfg, nil, nil, newProvider(), "", nil)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_tls is enabled")
+	})
+
+	s.Run("allows http token URL via per-target config when require_tls is false", func() {
+		cfg := config.Default()
+		cfg.RequireTLS = false
+
+		result, err := ExchangeTokenInContext(ctx, cfg, nil, nil, newProvider(), "", nil)
+		s.Require().NoError(err)
+		auth, _ := result.Value(OAuthAuthorizationHeader).(string)
+		s.Equal("Bearer exchanged-token", auth)
+	})
+}
+
 func TestTokenExchangeRouting(t *testing.T) {
 	suite.Run(t, new(TokenExchangeRoutingSuite))
 }

--- a/pkg/tokenexchange/config.go
+++ b/pkg/tokenexchange/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -77,6 +79,45 @@ type TargetTokenExchangeConfig struct {
 	assertionMutex sync.Mutex `toml:"-"`
 	// clientMutex protects HTTP client creation from race conditions
 	clientMutex sync.Mutex `toml:"-"`
+
+	// requireTLS is nil or a function that returns true when TLS is required.
+	// When non-nil, HTTPClient() wraps the transport to reject non-HTTPS URLs at runtime.
+	requireTLS func() bool `toml:"-"`
+}
+
+// SetRequireTLS configures TLS enforcement for the HTTP client.
+// When enforcer is non-nil and returns true, HTTPClient() will reject
+// requests to non-HTTPS URLs. The enforcer is captured when the client
+// is built, so callers must set it before the first HTTPClient() call.
+func (c *TargetTokenExchangeConfig) SetRequireTLS(enforcer func() bool) {
+	c.clientMutex.Lock()
+	defer c.clientMutex.Unlock()
+	c.requireTLS = enforcer
+}
+
+// tlsEnforcingTransport wraps an http.RoundTripper and rejects non-HTTPS requests
+// when RequireTLS returns true. Inlined here to avoid an import cycle with pkg/config.
+type tlsEnforcingTransport struct {
+	Base       http.RoundTripper
+	RequireTLS func() bool
+}
+
+func (t *tlsEnforcingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.RequireTLS != nil && t.RequireTLS() && !isSecureHTTPScheme(req.URL.Scheme) {
+		klog.FromContext(req.Context()).V(1).Info("require_tls: blocked request to host", "host", req.URL.Host)
+		return nil, fmt.Errorf("require_tls is enabled but request to %s uses %q scheme (secure scheme required)",
+			req.URL.Host, req.URL.Scheme)
+	}
+	return t.Base.RoundTrip(req)
+}
+
+func isSecureHTTPScheme(scheme string) bool {
+	switch scheme {
+	case "https", "wss":
+		return true
+	default:
+		return false
+	}
 }
 
 // Validate checks that the configuration values are valid
@@ -117,7 +158,7 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 		return c.client, nil
 	}
 
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	// Always set MinVersion for security, regardless of CAFile
 	tlsConfig := &tls.Config{
@@ -138,7 +179,12 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 		tlsConfig.RootCAs = caCertPool
 	}
 
-	transport.TLSClientConfig = tlsConfig
+	baseTransport.TLSClientConfig = tlsConfig
+
+	var transport http.RoundTripper = baseTransport
+	if c.requireTLS != nil {
+		transport = &tlsEnforcingTransport{Base: baseTransport, RequireTLS: c.requireTLS}
+	}
 
 	if c.client != nil {
 		c.client.CloseIdleConnections()

--- a/pkg/tokenexchange/config.go
+++ b/pkg/tokenexchange/config.go
@@ -80,23 +80,31 @@ type TargetTokenExchangeConfig struct {
 	// clientMutex protects HTTP client creation from race conditions
 	clientMutex sync.Mutex `toml:"-"`
 
-	// requireTLS is nil or a function that returns true when TLS is required.
-	// When non-nil, HTTPClient() wraps the transport to reject non-HTTPS URLs at runtime.
+	// requireTLS, when set, returns true while TLS is required. The wrapped
+	// transport reads it live per request via currentRequireTLS.
 	requireTLS func() bool `toml:"-"`
 }
 
-// SetRequireTLS configures TLS enforcement for the HTTP client.
-// When enforcer is non-nil and returns true, HTTPClient() will reject
-// requests to non-HTTPS URLs. The enforcer is captured when the client
-// is built, so callers must set it before the first HTTPClient() call.
+// SetRequireTLS installs the TLS enforcer, which HTTPClient() wraps the
+// transport with. It is read live per request, so re-setting it — e.g. a SIGHUP
+// that toggles require_tls — is honored on an already-memoized client.
 func (c *TargetTokenExchangeConfig) SetRequireTLS(enforcer func() bool) {
 	c.clientMutex.Lock()
 	defer c.clientMutex.Unlock()
 	c.requireTLS = enforcer
 }
 
-// tlsEnforcingTransport wraps an http.RoundTripper and rejects non-HTTPS requests
-// when RequireTLS returns true. Inlined here to avoid an import cycle with pkg/config.
+// currentRequireTLS reports whether TLS is required now, reading the latest
+// enforcer under clientMutex.
+func (c *TargetTokenExchangeConfig) currentRequireTLS() bool {
+	c.clientMutex.Lock()
+	defer c.clientMutex.Unlock()
+	return c.requireTLS != nil && c.requireTLS()
+}
+
+// tlsEnforcingTransport rejects non-HTTPS requests when RequireTLS returns true.
+// Mirrors pkg/config.TLSEnforcingTransport (duplicated to avoid an import cycle),
+// but RequireTLS is wired to currentRequireTLS for live, per-request evaluation.
 type tlsEnforcingTransport struct {
 	Base       http.RoundTripper
 	RequireTLS func() bool
@@ -181,9 +189,12 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 
 	baseTransport.TLSClientConfig = tlsConfig
 
+	// Wrap when an enforcer is configured. RequireTLS reads currentRequireTLS,
+	// so a later SetRequireTLS (e.g. a SIGHUP that toggles require_tls) is
+	// honored on this memoized client without a rebuild.
 	var transport http.RoundTripper = baseTransport
 	if c.requireTLS != nil {
-		transport = &tlsEnforcingTransport{Base: baseTransport, RequireTLS: c.requireTLS}
+		transport = &tlsEnforcingTransport{Base: baseTransport, RequireTLS: c.currentRequireTLS}
 	}
 
 	if c.client != nil {

--- a/pkg/tokenexchange/config.go
+++ b/pkg/tokenexchange/config.go
@@ -80,14 +80,14 @@ type TargetTokenExchangeConfig struct {
 	// clientMutex protects HTTP client creation from race conditions
 	clientMutex sync.Mutex `toml:"-"`
 
-	// requireTLS, when set, returns true while TLS is required. The wrapped
-	// transport reads it live per request via currentRequireTLS.
+	// requireTLS, when set, returns true while TLS is required. The transport
+	// consults it live per request via currentRequireTLS.
 	requireTLS func() bool `toml:"-"`
 }
 
-// SetRequireTLS installs the TLS enforcer, which HTTPClient() wraps the
-// transport with. It is read live per request, so re-setting it — e.g. a SIGHUP
-// that toggles require_tls — is honored on an already-memoized client.
+// SetRequireTLS installs the TLS enforcer. HTTPClient() always wraps its
+// transport to read it live per request, so this may be (re)set at any time —
+// before or after the client is memoized, e.g. on a SIGHUP toggle.
 func (c *TargetTokenExchangeConfig) SetRequireTLS(enforcer func() bool) {
 	c.clientMutex.Lock()
 	defer c.clientMutex.Unlock()
@@ -189,13 +189,11 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 
 	baseTransport.TLSClientConfig = tlsConfig
 
-	// Wrap when an enforcer is configured. RequireTLS reads currentRequireTLS,
-	// so a later SetRequireTLS (e.g. a SIGHUP that toggles require_tls) is
-	// honored on this memoized client without a rebuild.
-	var transport http.RoundTripper = baseTransport
-	if c.requireTLS != nil {
-		transport = &tlsEnforcingTransport{Base: baseTransport, RequireTLS: c.currentRequireTLS}
-	}
+	// Always wrap so require_tls is enforced live per request via
+	// currentRequireTLS, regardless of whether an enforcer was set before this
+	// client was memoized. currentRequireTLS is a no-op until SetRequireTLS
+	// installs one, at the cost of a clientMutex lock per request.
+	transport := &tlsEnforcingTransport{Base: baseTransport, RequireTLS: c.currentRequireTLS}
 
 	if c.client != nil {
 		c.client.CloseIdleConnections()

--- a/pkg/tokenexchange/config_test.go
+++ b/pkg/tokenexchange/config_test.go
@@ -1,11 +1,13 @@
 package tokenexchange
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"math/big"
 	"net"
@@ -106,6 +108,181 @@ func (s *TargetTokenExchangeConfigSuite) TestHTTPClientCAFile() {
 		_, err := (&TargetTokenExchangeConfig{CAFile: filepath.Join(s.T().TempDir(), "missing.pem")}).HTTPClient()
 		s.Require().Error(err)
 		s.Contains(err.Error(), "failed to read CA file")
+	})
+}
+
+func (s *TargetTokenExchangeConfigSuite) TestSetRequireTLS() {
+	s.Run("no enforcement when requireTLS is nil", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "test-token",
+				"token_type":   "Bearer",
+			})
+		}))
+		defer server.Close()
+
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL: server.URL,
+		}
+		client, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+
+		resp, err := client.Get(server.URL)
+		s.Require().NoError(err)
+		_ = resp.Body.Close()
+		s.Equal(http.StatusOK, resp.StatusCode)
+	})
+
+	s.Run("blocks HTTP when requireTLS returns true", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := &TargetTokenExchangeConfig{}
+		cfg.SetRequireTLS(func() bool { return true })
+
+		client, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+
+		_, err = client.Get(server.URL)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_tls is enabled")
+	})
+
+	s.Run("allows HTTPS when requireTLS returns true", func() {
+		server := s.newTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := &TargetTokenExchangeConfig{
+			CAFile: s.writeCAFile(server.Certificate()),
+		}
+		cfg.SetRequireTLS(func() bool { return true })
+
+		client, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+
+		resp, err := client.Get(server.URL)
+		s.Require().NoError(err)
+		_ = resp.Body.Close()
+		s.Equal(http.StatusOK, resp.StatusCode)
+	})
+
+	s.Run("allows HTTP when requireTLS returns false", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := &TargetTokenExchangeConfig{}
+		cfg.SetRequireTLS(func() bool { return false })
+
+		client, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+
+		resp, err := client.Get(server.URL)
+		s.Require().NoError(err)
+		_ = resp.Body.Close()
+		s.Equal(http.StatusOK, resp.StatusCode)
+	})
+
+	s.Run("evaluates requireTLS per request not at build time", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		enforce := true
+		cfg := &TargetTokenExchangeConfig{}
+		cfg.SetRequireTLS(func() bool { return enforce })
+
+		client, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+
+		_, err = client.Get(server.URL)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_tls is enabled")
+
+		enforce = false
+		resp, err := client.Get(server.URL)
+		s.Require().NoError(err)
+		_ = resp.Body.Close()
+		s.Equal(http.StatusOK, resp.StatusCode)
+	})
+}
+
+func (s *TargetTokenExchangeConfigSuite) TestExchangeEnforcement() {
+	s.Run("rfc8693 exchanger is blocked with http URL and requireTLS", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "exchanged-token",
+				"token_type":   "Bearer",
+			})
+		}))
+		defer server.Close()
+
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL:     server.URL,
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+		}
+		cfg.SetRequireTLS(func() bool { return true })
+
+		exchanger := &rfc8693Exchanger{}
+		_, err := exchanger.Exchange(context.Background(), cfg, "incoming-token")
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_tls is enabled")
+	})
+
+	s.Run("keycloak-v1 exchanger is blocked with http URL and requireTLS", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "exchanged-token",
+				"token_type":   "Bearer",
+			})
+		}))
+		defer server.Close()
+
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL:     server.URL,
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+		}
+		cfg.SetRequireTLS(func() bool { return true })
+
+		exchanger := &keycloakV1Exchanger{}
+		_, err := exchanger.Exchange(context.Background(), cfg, "incoming-token")
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_tls is enabled")
+	})
+
+	s.Run("entra-obo exchanger is blocked with http URL and requireTLS", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "exchanged-token",
+				"token_type":   "Bearer",
+			})
+		}))
+		defer server.Close()
+
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL:     server.URL,
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			Scopes:       []string{"api://target/.default"},
+		}
+		cfg.SetRequireTLS(func() bool { return true })
+
+		exchanger := &entraOBOExchanger{}
+		_, err := exchanger.Exchange(context.Background(), cfg, "incoming-token")
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_tls is enabled")
 	})
 }
 

--- a/pkg/tokenexchange/config_test.go
+++ b/pkg/tokenexchange/config_test.go
@@ -212,6 +212,29 @@ func (s *TargetTokenExchangeConfigSuite) TestSetRequireTLS() {
 		_ = resp.Body.Close()
 		s.Equal(http.StatusOK, resp.StatusCode)
 	})
+
+	s.Run("re-setting the enforcer is honored on the memoized client", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := &TargetTokenExchangeConfig{}
+		cfg.SetRequireTLS(func() bool { return false })
+		client, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+
+		resp, err := client.Get(server.URL)
+		s.Require().NoError(err)
+		_ = resp.Body.Close()
+
+		// A later SetRequireTLS (e.g. SIGHUP toggle) must take effect on the same
+		// memoized client, with no rebuild (guards the cached exCfg path).
+		cfg.SetRequireTLS(func() bool { return true })
+		_, err = client.Get(server.URL)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "require_tls is enabled")
+	})
 }
 
 func (s *TargetTokenExchangeConfigSuite) TestExchangeEnforcement() {

--- a/pkg/tokenexchange/config_test.go
+++ b/pkg/tokenexchange/config_test.go
@@ -30,7 +30,9 @@ func (s *TargetTokenExchangeConfigSuite) TestHTTPClientCAFile() {
 		client, err := (&TargetTokenExchangeConfig{}).HTTPClient()
 		s.Require().NoError(err)
 
-		transport, ok := client.Transport.(*http.Transport)
+		wrapper, ok := client.Transport.(*tlsEnforcingTransport)
+		s.Require().True(ok)
+		transport, ok := wrapper.Base.(*http.Transport)
 		s.Require().True(ok)
 		s.Require().NotNil(transport.TLSClientConfig)
 		s.Equal(uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
@@ -213,14 +215,14 @@ func (s *TargetTokenExchangeConfigSuite) TestSetRequireTLS() {
 		s.Equal(http.StatusOK, resp.StatusCode)
 	})
 
-	s.Run("re-setting the enforcer is honored on the memoized client", func() {
+	s.Run("enforces when the enforcer is set after the client is built", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer server.Close()
 
+		// Build (and memoize) the client with no enforcer installed.
 		cfg := &TargetTokenExchangeConfig{}
-		cfg.SetRequireTLS(func() bool { return false })
 		client, err := cfg.HTTPClient()
 		s.Require().NoError(err)
 
@@ -228,8 +230,9 @@ func (s *TargetTokenExchangeConfigSuite) TestSetRequireTLS() {
 		s.Require().NoError(err)
 		_ = resp.Body.Close()
 
-		// A later SetRequireTLS (e.g. SIGHUP toggle) must take effect on the same
-		// memoized client, with no rebuild (guards the cached exCfg path).
+		// Always-wrapping means a later SetRequireTLS still takes effect on the
+		// same memoized client, with no rebuild (guards against an unwrapped
+		// client being cached before the enforcer is wired).
 		cfg.SetRequireTLS(func() bool { return true })
 		_, err = client.Get(server.URL)
 		s.Require().Error(err)


### PR DESCRIPTION
### Summary

Wraps the `TargetTokenExchangeConfig.HTTPClient()` transport with TLS enforcement when `require_tls` is enabled, fixing a gap where `rfc8693`, `keycloak-v1`, and `entra-obo` strategy exchangers would bypass the security check.

When `require_tls=true`, the token exchange HTTP client now rejects non-HTTPS URLs at the transport level, matching the enforcement already in place for OAuth and Kiali clients.

### Motivation

Fixes https://github.com/containers/kubernetes-mcp-server/issues/1111
