### PR TITLE
feat(auth): decouple STS endpoint and make RFC 8693 token-type params configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -497,6 +497,7 @@ Configure OAuth/OIDC authentication for HTTP mode deployments.
 | `sts_federated_token_file` | string | `""` | Path to a JWT file from an external identity provider, e.g., SPIRE JWT-SVID (for `federated` auth style). |
 | `sts_subject_token_type` | string | `"urn:ietf:params:oauth:token-type:access_token"` | `subject_token_type` form parameter for RFC 8693 token exchange. Override to `urn:ietf:params:oauth:token-type:jwt` for cross-realm flows. |
 | `sts_requested_token_type` | string | `"urn:ietf:params:oauth:token-type:access_token"` | `requested_token_type` form parameter for RFC 8693 token exchange. Override to `urn:ietf:params:oauth:token-type:jwt` when the STS must mint a fresh JWT rather than echo the subject token shape. |
+| `sts_token_url` | string | `""` | Explicit token endpoint for token exchange. When set, takes precedence over the endpoint discovered from the OIDC provider at `authorization_url`. Use this to point token exchange at a separate STS gateway, or to enable token exchange when no `authorization_url` is configured (e.g., with `skip_jwt_verification=true`). |
 | `cluster_auth_mode` | string | `""` | Cluster auth mode: `passthrough` (forward Authorization header when present, fall back to kubeconfig when absent) or `kubeconfig` (always use kubeconfig credentials). Defaults to `passthrough`. |
 | `certificate_authority` | string | `""` | Path to CA certificate for validating authorization server connections. |
 | `server_url` | string | `""` | Public URL of the MCP server (used for OAuth metadata). |
@@ -525,6 +526,23 @@ sts_auth_style = "assertion"
 sts_client_cert_file = "/path/to/client.crt"
 sts_client_key_file = "/path/to/client.key"
 sts_scopes = ["api://<DOWNSTREAM_API>/.default"]
+```
+
+**Example (separate STS gateway from user-token issuer):**
+
+`authorization_url` validates the user's bearer token; `sts_token_url` is the
+distinct gateway that mints the delegated cluster token. The two URLs may
+point at different hosts/realms.
+```toml
+require_oauth     = true
+authorization_url = "https://idp.example.com/realms/users"
+oauth_audience    = "kubernetes-mcp-server"
+
+token_exchange_strategy = "rfc8693"
+sts_token_url           = "https://sts-gateway.internal/oauth/token"
+sts_client_id           = "mcp-backend"
+sts_client_secret       = "your-client-secret"
+sts_audience            = "kubernetes-api"
 ```
 
 **Pure token passthrough (delegate validation to the cluster):**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -495,6 +495,8 @@ Configure OAuth/OIDC authentication for HTTP mode deployments.
 | `sts_client_cert_file` | string | `""` | Path to client certificate PEM file (for `assertion` auth style). |
 | `sts_client_key_file` | string | `""` | Path to client private key PEM file (for `assertion` auth style). |
 | `sts_federated_token_file` | string | `""` | Path to a JWT file from an external identity provider, e.g., SPIRE JWT-SVID (for `federated` auth style). |
+| `sts_subject_token_type` | string | `"urn:ietf:params:oauth:token-type:access_token"` | `subject_token_type` form parameter for RFC 8693 token exchange. Override to `urn:ietf:params:oauth:token-type:jwt` for cross-realm flows. |
+| `sts_requested_token_type` | string | `"urn:ietf:params:oauth:token-type:access_token"` | `requested_token_type` form parameter for RFC 8693 token exchange. Override to `urn:ietf:params:oauth:token-type:jwt` when the STS must mint a fresh JWT rather than echo the subject token shape. |
 | `cluster_auth_mode` | string | `""` | Cluster auth mode: `passthrough` (forward Authorization header when present, fall back to kubeconfig when absent) or `kubeconfig` (always use kubeconfig credentials). Defaults to `passthrough`. |
 | `certificate_authority` | string | `""` | Path to CA certificate for validating authorization server connections. |
 | `server_url` | string | `""` | Public URL of the MCP server (used for OAuth metadata). |

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -73,6 +73,8 @@ type StsConfigProvider interface {
 	GetStsClientCertFile() string
 	GetStsClientKeyFile() string
 	GetStsFederatedTokenFile() string
+	GetStsSubjectTokenType() string
+	GetStsRequestedTokenType() string
 	GetCertificateAuthority() string
 }
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -75,6 +75,7 @@ type StsConfigProvider interface {
 	GetStsFederatedTokenFile() string
 	GetStsSubjectTokenType() string
 	GetStsRequestedTokenType() string
+	GetStsTokenURL() string
 	GetCertificateAuthority() string
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,16 @@ type StaticConfig struct {
 	// StsFederatedTokenFile is the path to a file containing a JWT from an external identity
 	// provider (e.g., SPIRE JWT-SVID). Used with sts_auth_style="federated".
 	StsFederatedTokenFile string `toml:"sts_federated_token_file,omitempty"`
+	// StsSubjectTokenType overrides the subject_token_type form parameter sent during
+	// RFC 8693 token exchange. RFC 8693 section 2.1 mandates this field. Defaults to
+	// "urn:ietf:params:oauth:token-type:access_token" — the canonical value for an
+	// inbound OAuth access token. Override to "...token-type:jwt" for cross-realm flows.
+	StsSubjectTokenType string `toml:"sts_subject_token_type,omitempty"`
+	// StsRequestedTokenType overrides the requested_token_type form parameter sent during
+	// RFC 8693 token exchange. Per RFC 8693 section 2.1 the default is access_token; some
+	// deployments require "urn:ietf:params:oauth:token-type:jwt" to signal the AS should
+	// mint a fresh JWT rather than echo the subject token type.
+	StsRequestedTokenType string `toml:"sts_requested_token_type,omitempty"`
 	// ClusterAuthMode determines how the MCP server authenticates to the cluster.
 	// Valid values: "passthrough" (forward Authorization header, with optional exchange), "kubeconfig" (use kubeconfig credentials).
 	// If empty, defaults to passthrough: forwards the token when present, falls back to kubeconfig when absent.
@@ -433,6 +443,14 @@ func (c *StaticConfig) GetStsFederatedTokenFile() string {
 	return c.StsFederatedTokenFile
 }
 
+func (c *StaticConfig) GetStsSubjectTokenType() string {
+	return c.StsSubjectTokenType
+}
+
+func (c *StaticConfig) GetStsRequestedTokenType() string {
+	return c.StsRequestedTokenType
+}
+
 func (c *StaticConfig) GetCertificateAuthority() string {
 	return c.CertificateAuthority
 }
@@ -488,6 +506,8 @@ func (c *StaticConfig) Validate() error {
 	c.StsClientCertFile = strings.TrimSpace(c.StsClientCertFile)
 	c.StsClientKeyFile = strings.TrimSpace(c.StsClientKeyFile)
 	c.StsFederatedTokenFile = strings.TrimSpace(c.StsFederatedTokenFile)
+	c.StsSubjectTokenType = strings.TrimSpace(c.StsSubjectTokenType)
+	c.StsRequestedTokenType = strings.TrimSpace(c.StsRequestedTokenType)
 	if output.FromString(c.ListOutput) == nil {
 		return fmt.Errorf("invalid output name: %s, valid names are: %s", c.ListOutput, strings.Join(output.Names, ", "))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,6 +112,13 @@ type StaticConfig struct {
 	// deployments require "urn:ietf:params:oauth:token-type:jwt" to signal the AS should
 	// mint a fresh JWT rather than echo the subject token type.
 	StsRequestedTokenType string `toml:"sts_requested_token_type,omitempty"`
+	// StsTokenURL is the explicit token endpoint for RFC 8693 / built-in STS exchange.
+	// When set, it takes precedence over the token endpoint discovered from the OIDC
+	// provider at authorization_url. This decouples the trust boundary for user-token
+	// validation (authorization_url) from the trust boundary for delegated-token issuance
+	// (the STS gateway), which is required for cross-realm deployments and for using
+	// token exchange together with skip_jwt_verification=true.
+	StsTokenURL string `toml:"sts_token_url,omitempty"`
 	// ClusterAuthMode determines how the MCP server authenticates to the cluster.
 	// Valid values: "passthrough" (forward Authorization header, with optional exchange), "kubeconfig" (use kubeconfig credentials).
 	// If empty, defaults to passthrough: forwards the token when present, falls back to kubeconfig when absent.
@@ -451,6 +458,10 @@ func (c *StaticConfig) GetStsRequestedTokenType() string {
 	return c.StsRequestedTokenType
 }
 
+func (c *StaticConfig) GetStsTokenURL() string {
+	return c.StsTokenURL
+}
+
 func (c *StaticConfig) GetCertificateAuthority() string {
 	return c.CertificateAuthority
 }
@@ -508,6 +519,7 @@ func (c *StaticConfig) Validate() error {
 	c.StsFederatedTokenFile = strings.TrimSpace(c.StsFederatedTokenFile)
 	c.StsSubjectTokenType = strings.TrimSpace(c.StsSubjectTokenType)
 	c.StsRequestedTokenType = strings.TrimSpace(c.StsRequestedTokenType)
+	c.StsTokenURL = strings.TrimSpace(c.StsTokenURL)
 	if output.FromString(c.ListOutput) == nil {
 		return fmt.Errorf("invalid output name: %s, valid names are: %s", c.ListOutput, strings.Join(output.Names, ", "))
 	}
@@ -532,6 +544,18 @@ func (c *StaticConfig) Validate() error {
 		}
 		if u.Scheme == "http" {
 			klog.Warningf("authorization-url is using http://, this is not recommended production use")
+		}
+	}
+	if c.StsTokenURL != "" {
+		u, err := url.Parse(c.StsTokenURL)
+		if err != nil {
+			return err
+		}
+		if u.Scheme != "https" && u.Scheme != "http" {
+			return fmt.Errorf("sts_token_url must be a valid URL")
+		}
+		if u.Scheme == "http" {
+			klog.Warningf("sts_token_url is using http://, this is not recommended for production use")
 		}
 	}
 	if err := c.validateSkipJWTVerification(); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1127,6 +1127,31 @@ func (s *ConfigSuite) TestToolOverridesDropInMerge() {
 	})
 }
 
+func (s *ConfigSuite) TestStsTokenTypesParsing() {
+	s.Run("explicit values are parsed and exposed via getters", func() {
+		configPath := s.writeConfig(`
+			sts_subject_token_type = "urn:ietf:params:oauth:token-type:jwt"
+			sts_requested_token_type = "urn:ietf:params:oauth:token-type:jwt"
+		`)
+		config, err := Read(configPath, "")
+		s.Require().NoError(err)
+		s.Require().NotNil(config)
+		s.Equal("urn:ietf:params:oauth:token-type:jwt", config.StsSubjectTokenType)
+		s.Equal("urn:ietf:params:oauth:token-type:jwt", config.StsRequestedTokenType)
+		s.Equal("urn:ietf:params:oauth:token-type:jwt", config.GetStsSubjectTokenType())
+		s.Equal("urn:ietf:params:oauth:token-type:jwt", config.GetStsRequestedTokenType())
+	})
+
+	s.Run("default to empty when omitted", func() {
+		configPath := s.writeConfig(``)
+		config, err := Read(configPath, "")
+		s.Require().NoError(err)
+		s.Require().NotNil(config)
+		s.Empty(config.StsSubjectTokenType, "sts_subject_token_type should default to empty (rfc8693 exchanger applies access_token default)")
+		s.Empty(config.StsRequestedTokenType, "sts_requested_token_type should default to empty (rfc8693 exchanger applies access_token default)")
+	})
+}
+
 func (s *ConfigSuite) TestConfirmationRulesDefaults() {
 	configPath := s.writeConfig(``)
 	config, err := Read(configPath, "")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1152,6 +1152,27 @@ func (s *ConfigSuite) TestStsTokenTypesParsing() {
 	})
 }
 
+func (s *ConfigSuite) TestStsTokenURLParsing() {
+	s.Run("explicit value is parsed and exposed via getter", func() {
+		configPath := s.writeConfig(`
+			sts_token_url = "https://sts-gateway.example.com/oauth/token"
+		`)
+		config, err := Read(configPath, "")
+		s.Require().NoError(err)
+		s.Require().NotNil(config)
+		s.Equal("https://sts-gateway.example.com/oauth/token", config.StsTokenURL)
+		s.Equal("https://sts-gateway.example.com/oauth/token", config.GetStsTokenURL())
+	})
+
+	s.Run("defaults to empty when omitted", func() {
+		configPath := s.writeConfig(``)
+		config, err := Read(configPath, "")
+		s.Require().NoError(err)
+		s.Require().NotNil(config)
+		s.Empty(config.StsTokenURL, "sts_token_url should default to empty (resolution falls back to OIDC discovery)")
+	})
+}
+
 func (s *ConfigSuite) TestConfirmationRulesDefaults() {
 	configPath := s.writeConfig(``)
 	config, err := Read(configPath, "")

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -453,6 +453,47 @@ func (s *ValidateSuite) TestStsFederatedTokenFile() {
 	})
 }
 
+func (s *ValidateSuite) TestStsTokenTypes() {
+	s.Run("empty values are accepted (rfc8693 exchanger applies default)", func() {
+		cfg := s.validConfig()
+		cfg.StsSubjectTokenType = ""
+		cfg.StsRequestedTokenType = ""
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("non-empty values are accepted", func() {
+		cfg := s.validConfig()
+		cfg.StsSubjectTokenType = "urn:ietf:params:oauth:token-type:jwt"
+		cfg.StsRequestedTokenType = "urn:ietf:params:oauth:token-type:jwt"
+		s.NoError(cfg.Validate())
+		s.Equal("urn:ietf:params:oauth:token-type:jwt", cfg.StsSubjectTokenType)
+		s.Equal("urn:ietf:params:oauth:token-type:jwt", cfg.StsRequestedTokenType)
+	})
+
+	s.Run("whitespace-only sts_subject_token_type is trimmed to empty", func() {
+		cfg := s.validConfig()
+		cfg.StsSubjectTokenType = "   "
+		s.NoError(cfg.Validate())
+		s.Equal("", cfg.StsSubjectTokenType, "whitespace should be trimmed from sts_subject_token_type")
+	})
+
+	s.Run("whitespace-only sts_requested_token_type is trimmed to empty", func() {
+		cfg := s.validConfig()
+		cfg.StsRequestedTokenType = "   "
+		s.NoError(cfg.Validate())
+		s.Equal("", cfg.StsRequestedTokenType, "whitespace should be trimmed from sts_requested_token_type")
+	})
+
+	s.Run("padded values are trimmed but preserved", func() {
+		cfg := s.validConfig()
+		cfg.StsSubjectTokenType = "  urn:ietf:params:oauth:token-type:jwt  "
+		cfg.StsRequestedTokenType = "  urn:ietf:params:oauth:token-type:jwt  "
+		s.NoError(cfg.Validate())
+		s.Equal("urn:ietf:params:oauth:token-type:jwt", cfg.StsSubjectTokenType)
+		s.Equal("urn:ietf:params:oauth:token-type:jwt", cfg.StsRequestedTokenType)
+	})
+}
+
 func (s *ValidateSuite) TestConfirmationFallback() {
 	s.Run("empty fallback is accepted", func() {
 		cfg := s.validConfig()

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -453,6 +453,48 @@ func (s *ValidateSuite) TestStsFederatedTokenFile() {
 	})
 }
 
+func (s *ValidateSuite) TestStsTokenURL() {
+	s.Run("empty is accepted (resolution falls back to OIDC discovery)", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = ""
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("https URL is accepted", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "https://sts-gateway.example.com/oauth/token"
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("http URL is accepted with warning", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "http://sts-gateway.example.com/oauth/token"
+		s.NoError(cfg.Validate())
+	})
+
+	s.Run("invalid scheme is rejected", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "ftp://sts-gateway.example.com/oauth/token"
+		err := cfg.Validate()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "sts_token_url must be a valid URL")
+	})
+
+	s.Run("whitespace-only is trimmed to empty", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "   "
+		s.NoError(cfg.Validate())
+		s.Equal("", cfg.StsTokenURL, "whitespace should be trimmed from sts_token_url")
+	})
+
+	s.Run("padded value is trimmed but preserved", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "  https://sts-gateway.example.com/oauth/token  "
+		s.NoError(cfg.Validate())
+		s.Equal("https://sts-gateway.example.com/oauth/token", cfg.StsTokenURL)
+	})
+}
+
 func (s *ValidateSuite) TestStsTokenTypes() {
 	s.Run("empty values are accepted (rfc8693 exchanger applies default)", func() {
 		cfg := s.validConfig()

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -508,6 +508,112 @@ func (s *AuthorizationSuite) TestAuthorizationOidcTokenExchange() {
 	}
 }
 
+// TestAuthorizationStsTokenURLDecouplesIssuerFromGateway is the integration
+// test that proves the trust boundary actually splits on the wire when
+// sts_token_url points at a different host than authorization_url. The user's
+// JWT must be validated against the issuer (JWKS fetched from
+// authorization_url), but the exchange POST must hit the explicitly-configured
+// STS gateway — not the issuer's discovered token endpoint.
+//
+// Without sts_token_url support this configuration is impossible: the runtime
+// only knows about the issuer's discovered token endpoint, so validation and
+// exchange both end up at the same host.
+func (s *AuthorizationSuite) TestAuthorizationStsTokenURLDecouplesIssuerFromGateway() {
+	// Two independent OIDC test servers: one is the IDP that signs and validates
+	// the user's bearer token, the other is the standalone STS gateway that
+	// mints the exchanged backend token.
+	idp := NewOidcTestServer(s.T())
+	s.T().Cleanup(idp.Close)
+	stsGateway := NewOidcTestServer(s.T())
+	s.T().Cleanup(stsGateway.Close)
+
+	rawClaims := `{
+		"iss": "` + idp.URL + `",
+		"exp": ` + strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10) + `,
+		"aud": "%s"
+	}`
+	validUserToken := oidctest.SignIDToken(idp.PrivateKey, "test-oidc-key-id", oidc.RS256,
+		fmt.Sprintf(rawClaims, "mcp-server"))
+	validBackendToken := oidctest.SignIDToken(stsGateway.PrivateKey, "test-oidc-key-id", oidc.RS256,
+		fmt.Sprintf(rawClaims, "backend-audience"))
+
+	// Each server tracks whether its /token endpoint was hit. Only the gateway
+	// should see exchange traffic; if the IDP receives an exchange request, the
+	// decoupling failed.
+	var idpTokenHits atomic.Int32
+	idp.TokenEndpointHandler = func(w http.ResponseWriter, r *http.Request) {
+		idpTokenHits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"idp /token must not be hit when sts_token_url is set"}`))
+	}
+	var gatewayTokenHits atomic.Int32
+	stsGateway.TokenEndpointHandler = func(w http.ResponseWriter, r *http.Request) {
+		gatewayTokenHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"access_token":"%s","token_type":"Bearer","expires_in":253402297199}`, validBackendToken)
+	}
+
+	// Wire validation against the IDP, exchange against the gateway.
+	s.OidcProvider = idp.Provider
+	s.StaticConfig.AuthorizationURL = idp.URL
+	s.StaticConfig.OAuthAudience = "mcp-server"
+	s.StaticConfig.StsTokenURL = stsGateway.URL + "/token"
+	s.StaticConfig.TokenExchangeStrategy = "rfc8693"
+	s.StaticConfig.StsClientId = "test-sts-client-id"
+	s.StaticConfig.StsClientSecret = "test-sts-client-secret"
+	s.StaticConfig.StsAudience = "backend-audience"
+	s.StaticConfig.StsScopes = []string{"backend-scope"}
+
+	// Capture the Authorization header the MCP server sends to the cluster.
+	s.MockServer.ResetHandlers()
+	var backendAuth atomic.Value
+	s.MockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			backendAuth.Store(auth)
+		}
+	}))
+
+	s.StartServer()
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + validUserToken,
+	})
+
+	s.Run("Initialize succeeds — IDP validates user token via JWKS", func() {
+		s.Require().NotNil(s.mcpClient.Session, "Expected session for successful authentication")
+		s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initialize result to not be nil")
+	})
+
+	s.Run("Tool call triggers exchange against sts_token_url, not authorization_url", func() {
+		toolResult, err := s.mcpClient.Session.CallTool(s.T().Context(), &mcp.CallToolParams{
+			Name:      "events_list",
+			Arguments: map[string]any{},
+		})
+		s.Require().NoError(err, "Expected no error calling tool")
+		s.Require().NotNil(toolResult, "Expected tool result to not be nil")
+	})
+
+	s.Run("STS gateway received the exchange request", func() {
+		s.Greater(gatewayTokenHits.Load(), int32(0),
+			"sts_token_url gateway should have received at least one exchange POST")
+	})
+
+	s.Run("IDP /token endpoint was NOT used for exchange", func() {
+		s.Equal(int32(0), idpTokenHits.Load(),
+			"IDP /token must not be hit when sts_token_url is configured — that would mean the trust boundary did not split")
+	})
+
+	s.Run("Backend receives exchanged token, not original user token", func() {
+		got, _ := backendAuth.Load().(string)
+		s.Require().NotEmpty(got, "Expected backend to receive an Authorization header")
+		s.Equal("Bearer "+validBackendToken, got,
+			"Backend must receive the gateway-minted token; receiving the original user token would mean exchange silently no-op'd")
+	})
+
+	s.mcpClient.Close()
+	s.mcpClient = nil
+	s.stopRunningServer()
+}
+
 func (s *AuthorizationSuite) TestAuthorizationPassthroughWarning() {
 	// When require_oauth=true, skip_jwt_verification=true, and no OIDC provider
 	// is configured (passthrough mode), a warning log should be emitted once.

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -57,14 +57,9 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(snap *oauth.Snapshot) *tok
 		return nil
 	}
 
-	var tokenURL string
-	if snap.OIDCProvider != nil {
-		if endpoint := snap.OIDCProvider.Endpoint(); endpoint.TokenURL != "" {
-			tokenURL = endpoint.TokenURL
-		}
-	}
+	tokenURL := resolveStsTokenURL(p.baseConfig, snap.OIDCProvider)
 	if tokenURL == "" {
-		klog.Warningf("token exchange strategy %q configured but OIDC provider returned empty token URL", strategy)
+		klog.Warningf("token exchange strategy %q configured but no token URL available (set sts_token_url or configure authorization_url for OIDC discovery)", strategy)
 		return nil
 	}
 

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -91,6 +91,8 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(snap *oauth.Snapshot) *tok
 		ClientCertFile:     p.baseConfig.GetStsClientCertFile(),
 		ClientKeyFile:      p.baseConfig.GetStsClientKeyFile(),
 		FederatedTokenFile: p.baseConfig.GetStsFederatedTokenFile(),
+		SubjectTokenType:   p.baseConfig.GetStsSubjectTokenType(),
+		RequestedTokenType: p.baseConfig.GetStsRequestedTokenType(),
 		CAFile:             p.baseConfig.GetCertificateAuthority(),
 	}
 	if err := cfg.Validate(); err != nil {

--- a/pkg/kubernetes/sts.go
+++ b/pkg/kubernetes/sts.go
@@ -26,6 +26,9 @@ type SecurityTokenService struct {
 	ClientSecret            string
 	ExternalAccountAudience string
 	ExternalAccountScopes   []string
+	// TokenURL is the resolved STS endpoint: the explicit sts_token_url when
+	// configured, otherwise the discovered token endpoint of the OIDC provider.
+	TokenURL string
 }
 
 func NewFromConfig(stsConfigProvider api.StsConfigProvider, provider *oidc.Provider) *SecurityTokenService {
@@ -35,16 +38,17 @@ func NewFromConfig(stsConfigProvider api.StsConfigProvider, provider *oidc.Provi
 		ClientSecret:            stsConfigProvider.GetStsClientSecret(),
 		ExternalAccountAudience: stsConfigProvider.GetStsAudience(),
 		ExternalAccountScopes:   stsConfigProvider.GetStsScopes(),
+		TokenURL:                resolveStsTokenURL(stsConfigProvider, provider),
 	}
 }
 
 func (sts *SecurityTokenService) IsEnabled() bool {
-	return sts.Provider != nil && sts.ClientId != "" && sts.ExternalAccountAudience != ""
+	return sts.TokenURL != "" && sts.ClientId != "" && sts.ExternalAccountAudience != ""
 }
 
 func (sts *SecurityTokenService) ExternalAccountTokenExchange(ctx context.Context, originalToken *oauth2.Token) (*oauth2.Token, error) {
 	ts, err := externalaccount.NewTokenSource(ctx, externalaccount.Config{
-		TokenURL:             sts.Endpoint().TokenURL,
+		TokenURL:             sts.TokenURL,
 		ClientID:             sts.ClientId,
 		ClientSecret:         sts.ClientSecret,
 		Audience:             sts.ExternalAccountAudience,

--- a/pkg/kubernetes/sts_test.go
+++ b/pkg/kubernetes/sts_test.go
@@ -13,13 +13,14 @@ import (
 )
 
 func TestIsEnabled(t *testing.T) {
+	const tokenURL = "https://sts.example.com/token"
 	disabledCases := []SecurityTokenService{
 		{},
-		{Provider: nil},
-		{Provider: &oidc.Provider{}},
-		{Provider: &oidc.Provider{}, ClientId: "test-client-id", ClientSecret: "test-client-secret"},
+		{TokenURL: ""},
+		{TokenURL: tokenURL},
+		{TokenURL: tokenURL, ClientId: "test-client-id", ClientSecret: "test-client-secret"},
 		{ClientId: "test-client-id", ClientSecret: "test-client-secret", ExternalAccountAudience: "test-audience"},
-		{Provider: &oidc.Provider{}, ClientSecret: "test-client-secret", ExternalAccountAudience: "test-audience"},
+		{TokenURL: tokenURL, ClientSecret: "test-client-secret", ExternalAccountAudience: "test-audience"},
 	}
 	for _, sts := range disabledCases {
 		t.Run(fmt.Sprintf("SecurityTokenService{%+v}.IsEnabled() = false", sts), func(t *testing.T) {
@@ -29,9 +30,9 @@ func TestIsEnabled(t *testing.T) {
 		})
 	}
 	enabledCases := []SecurityTokenService{
-		{Provider: &oidc.Provider{}, ClientId: "test-client-id", ExternalAccountAudience: "test-audience"},
-		{Provider: &oidc.Provider{}, ClientId: "test-client-id", ExternalAccountAudience: "test-audience", ClientSecret: "test-client-secret"},
-		{Provider: &oidc.Provider{}, ClientId: "test-client-id", ExternalAccountAudience: "test-audience", ClientSecret: "test-client-secret", ExternalAccountScopes: []string{"test-scope"}},
+		{TokenURL: tokenURL, ClientId: "test-client-id", ExternalAccountAudience: "test-audience"},
+		{TokenURL: tokenURL, ClientId: "test-client-id", ExternalAccountAudience: "test-audience", ClientSecret: "test-client-secret"},
+		{TokenURL: tokenURL, ClientId: "test-client-id", ExternalAccountAudience: "test-audience", ClientSecret: "test-client-secret", ExternalAccountScopes: []string{"test-scope"}},
 	}
 	for _, sts := range enabledCases {
 		t.Run(fmt.Sprintf("SecurityTokenService{%+v}.IsEnabled() = true", sts), func(t *testing.T) {
@@ -74,7 +75,7 @@ func TestExternalAccountTokenExchange(t *testing.T) {
 		t.Fatalf("oidc.NewProvider() error = %v; want nil", err)
 	}
 	// With missing Token Source information
-	_, err = (&SecurityTokenService{Provider: provider}).ExternalAccountTokenExchange(t.Context(), &oauth2.Token{})
+	_, err = (&SecurityTokenService{Provider: provider, TokenURL: provider.Endpoint().TokenURL}).ExternalAccountTokenExchange(t.Context(), &oauth2.Token{})
 	t.Run("ExternalAccountTokenExchange with missing token source returns error", func(t *testing.T) {
 		if err == nil {
 			t.Fatalf("ExternalAccountTokenExchange() error = nil; want error")
@@ -86,6 +87,7 @@ func TestExternalAccountTokenExchange(t *testing.T) {
 	// With valid Token Source information
 	sts := SecurityTokenService{
 		Provider:                provider,
+		TokenURL:                provider.Endpoint().TokenURL,
 		ClientId:                "test-client-id",
 		ClientSecret:            "test-client-secret",
 		ExternalAccountAudience: "test-audience",

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -174,6 +174,8 @@ func strategyBasedTokenExchange(
 			ClientCertFile:     baseConfig.GetStsClientCertFile(),
 			ClientKeyFile:      baseConfig.GetStsClientKeyFile(),
 			FederatedTokenFile: baseConfig.GetStsFederatedTokenFile(),
+			SubjectTokenType:   baseConfig.GetStsSubjectTokenType(),
+			RequestedTokenType: baseConfig.GetStsRequestedTokenType(),
 			CAFile:             baseConfig.GetCertificateAuthority(),
 		}
 		if err := cfg.Validate(); err != nil {

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -13,6 +13,21 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// resolveStsTokenURL returns the explicit sts_token_url if configured;
+// otherwise falls back to the OIDC provider's discovered token endpoint.
+// The explicit URL decouples the STS gateway from the user-token issuer
+// (authorization_url), which is required for cross-realm RFC 8693 deployments
+// and enables token exchange when skip_jwt_verification=true (no OIDC provider).
+func resolveStsTokenURL(stsConfig api.StsConfigProvider, oidcProvider *oidc.Provider) string {
+	if explicit := stsConfig.GetStsTokenURL(); explicit != "" {
+		return explicit
+	}
+	if oidcProvider != nil {
+		return oidcProvider.Endpoint().TokenURL
+	}
+	return ""
+}
+
 // ExchangeTokenInContext exchanges the OAuth token in the context for a token
 // that can access the target cluster. The optional stsConfig parameter allows
 // callers to reuse a TargetTokenExchangeConfig across calls to benefit from
@@ -148,15 +163,9 @@ func strategyBasedTokenExchange(
 
 	cfg := cachedConfig
 	if cfg == nil {
-		// Build token URL from OIDC provider
-		var tokenURL string
-		if oidcProvider != nil {
-			if endpoint := oidcProvider.Endpoint(); endpoint.TokenURL != "" {
-				tokenURL = endpoint.TokenURL
-			}
-		}
+		tokenURL := resolveStsTokenURL(baseConfig, oidcProvider)
 		if tokenURL == "" {
-			return ctx, fmt.Errorf("token exchange failed: no token URL available from OIDC provider")
+			return ctx, fmt.Errorf("token exchange failed: no token URL available (set sts_token_url or configure authorization_url for OIDC discovery)")
 		}
 
 		authStyle := baseConfig.GetStsAuthStyle()

--- a/pkg/kubernetes/token_exchange_test.go
+++ b/pkg/kubernetes/token_exchange_test.go
@@ -2,10 +2,14 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -67,6 +71,47 @@ func (s *TokenExchangeRoutingSuite) TestStsExchangeTokenInContextRouting() {
 
 		auth, _ := result.Value(OAuthAuthorizationHeader).(string)
 		s.Equal("Bearer original-token", auth)
+	})
+}
+
+func (s *TokenExchangeRoutingSuite) TestResolveStsTokenURL() {
+	mockServer := test.NewMockServer()
+	authServer := mockServer.Config().Host
+	mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/.well-known/openid-configuration" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+				"issuer": "%s",
+				"authorization_endpoint": "%s/authorize",
+				"token_endpoint": "%s/token"
+			}`, authServer, authServer, authServer)
+		}
+	}))
+	s.T().Cleanup(mockServer.Close)
+	provider, err := oidc.NewProvider(s.T().Context(), authServer)
+	s.Require().NoError(err)
+	discoveredURL := provider.Endpoint().TokenURL
+	s.Require().NotEmpty(discoveredURL, "test prerequisite: OIDC discovery should yield a token endpoint")
+
+	s.Run("explicit sts_token_url wins over discovered endpoint", func() {
+		cfg := config.Default()
+		cfg.StsTokenURL = "https://explicit-sts.example.com/token"
+		got := resolveStsTokenURL(cfg, provider)
+		s.Equal("https://explicit-sts.example.com/token", got, "explicit URL must take precedence over OIDC discovery")
+	})
+
+	s.Run("falls back to OIDC provider endpoint when sts_token_url is empty", func() {
+		cfg := config.Default()
+		cfg.StsTokenURL = ""
+		got := resolveStsTokenURL(cfg, provider)
+		s.Equal(discoveredURL, got, "empty explicit URL should fall back to OIDC-discovered endpoint")
+	})
+
+	s.Run("returns empty when neither source is available", func() {
+		cfg := config.Default()
+		cfg.StsTokenURL = ""
+		got := resolveStsTokenURL(cfg, nil)
+		s.Equal("", got, "no explicit URL and no provider should yield empty string")
 	})
 }
 

--- a/pkg/tokenexchange/config.go
+++ b/pkg/tokenexchange/config.go
@@ -38,6 +38,11 @@ type TargetTokenExchangeConfig struct {
 	// For same-realm: "urn:ietf:params:oauth:token-type:access_token"
 	// For cross-realm: "urn:ietf:params:oauth:token-type:jwt"
 	SubjectTokenType string `toml:"subject_token_type"`
+	// RequestedTokenType specifies the requested_token_type form parameter.
+	// Per RFC 8693 section 2.1 the default is access_token when omitted. Override to
+	// "urn:ietf:params:oauth:token-type:jwt" when the STS expects to mint a
+	// fresh JWT.
+	RequestedTokenType string `toml:"requested_token_type,omitempty"`
 	// SubjectIssuer is the IDP alias for cross-realm token exchange
 	// Only required when exchanging tokens across Keycloak realms
 	SubjectIssuer string `toml:"subject_issuer,omitempty"`

--- a/pkg/tokenexchange/rfc8693_exchanger.go
+++ b/pkg/tokenexchange/rfc8693_exchanger.go
@@ -20,12 +20,27 @@ func (e *rfc8693Exchanger) Exchange(ctx context.Context, cfg *TargetTokenExchang
 		return nil, fmt.Errorf("failed to acquire http client to talk to IdP for target: %w", err)
 	}
 
+	// RFC 8693 section 2.1 mandates subject_token_type. Default to access_token
+	// — the canonical value for an inbound OAuth access token. Cross-realm
+	// flows can override to token-type:jwt.
+	subjectTokenType := cfg.SubjectTokenType
+	if subjectTokenType == "" {
+		subjectTokenType = TokenTypeAccessToken
+	}
+	// Per RFC 8693 section 2.1 requested_token_type defaults to access_token
+	// when omitted. Some STS deployments require token-type:jwt to signal the
+	// AS should mint a fresh signed JWT rather than echo the subject token shape.
+	requestedTokenType := cfg.RequestedTokenType
+	if requestedTokenType == "" {
+		requestedTokenType = TokenTypeAccessToken
+	}
+
 	data := url.Values{}
 	data.Set(FormKeyGrantType, GrantTypeTokenExchange)
 	data.Set(FormKeySubjectToken, subjectToken)
-	data.Set(FormKeySubjectTokenType, cfg.SubjectTokenType)
+	data.Set(FormKeySubjectTokenType, subjectTokenType)
 	data.Set(FormKeyAudience, cfg.Audience)
-	data.Set(FormKeyRequestedTokenType, TokenTypeAccessToken)
+	data.Set(FormKeyRequestedTokenType, requestedTokenType)
 
 	if len(cfg.Scopes) > 0 {
 		data.Set(FormKeyScope, strings.Join(cfg.Scopes, " "))

--- a/pkg/tokenexchange/rfc8693_exchanger_test.go
+++ b/pkg/tokenexchange/rfc8693_exchanger_test.go
@@ -1,0 +1,176 @@
+package tokenexchange
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type RFC8693ExchangerTestSuite struct {
+	suite.Suite
+}
+
+// newRecordingServer returns an httptest.Server that decodes the form body of the
+// inbound request into the supplied url.Values pointer and replies with a valid
+// token exchange response.
+func (s *RFC8693ExchangerTestSuite) newRecordingServer(captured *map[string]string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.Equal(http.MethodPost, r.Method)
+		s.Equal(ContentTypeXWWWFormUrlEncoded, r.Header.Get(HeaderContentType))
+
+		s.Require().NoError(r.ParseForm())
+		out := make(map[string]string, len(r.Form))
+		for k := range r.Form {
+			out[k] = r.Form.Get(k)
+		}
+		*captured = out
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "exchanged-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+}
+
+func (s *RFC8693ExchangerTestSuite) TestExchange() {
+	s.Run("defaults subject_token_type to access_token when empty", func() {
+		var form map[string]string
+		server := s.newRecordingServer(&form)
+		defer server.Close()
+
+		exchanger := &rfc8693Exchanger{}
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL: server.URL,
+			Audience: "kubernetes-api",
+			// SubjectTokenType intentionally empty
+		}
+
+		token, err := exchanger.Exchange(context.Background(), cfg, "incoming-token")
+		s.Require().NoError(err)
+		s.Equal("exchanged-token", token.AccessToken)
+		s.Equal(TokenTypeAccessToken, form[FormKeySubjectTokenType],
+			"empty SubjectTokenType should default to access_token (RFC 8693 section 2.1)")
+	})
+
+	s.Run("defaults requested_token_type to access_token when empty", func() {
+		var form map[string]string
+		server := s.newRecordingServer(&form)
+		defer server.Close()
+
+		exchanger := &rfc8693Exchanger{}
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL: server.URL,
+			Audience: "kubernetes-api",
+			// RequestedTokenType intentionally empty
+		}
+
+		_, err := exchanger.Exchange(context.Background(), cfg, "incoming-token")
+		s.Require().NoError(err)
+		s.Equal(TokenTypeAccessToken, form[FormKeyRequestedTokenType],
+			"empty RequestedTokenType should default to access_token (RFC 8693 section 2.1)")
+	})
+
+	s.Run("overrides subject_token_type with configured value", func() {
+		var form map[string]string
+		server := s.newRecordingServer(&form)
+		defer server.Close()
+
+		exchanger := &rfc8693Exchanger{}
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL:         server.URL,
+			Audience:         "kubernetes-api",
+			SubjectTokenType: TokenTypeJWT,
+		}
+
+		_, err := exchanger.Exchange(context.Background(), cfg, "incoming-token")
+		s.Require().NoError(err)
+		s.Equal(TokenTypeJWT, form[FormKeySubjectTokenType],
+			"configured SubjectTokenType should be sent verbatim")
+	})
+
+	s.Run("overrides requested_token_type with configured value", func() {
+		var form map[string]string
+		server := s.newRecordingServer(&form)
+		defer server.Close()
+
+		exchanger := &rfc8693Exchanger{}
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL:           server.URL,
+			Audience:           "kubernetes-api",
+			RequestedTokenType: TokenTypeJWT,
+		}
+
+		_, err := exchanger.Exchange(context.Background(), cfg, "incoming-token")
+		s.Require().NoError(err)
+		s.Equal(TokenTypeJWT, form[FormKeyRequestedTokenType],
+			"configured RequestedTokenType should be sent verbatim")
+	})
+
+	s.Run("sends both overrides independently", func() {
+		var form map[string]string
+		server := s.newRecordingServer(&form)
+		defer server.Close()
+
+		exchanger := &rfc8693Exchanger{}
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL:           server.URL,
+			Audience:           "kubernetes-api",
+			SubjectTokenType:   TokenTypeJWT,
+			RequestedTokenType: TokenTypeJWT,
+		}
+
+		_, err := exchanger.Exchange(context.Background(), cfg, "incoming-token")
+		s.Require().NoError(err)
+		s.Equal(TokenTypeJWT, form[FormKeySubjectTokenType])
+		s.Equal(TokenTypeJWT, form[FormKeyRequestedTokenType])
+	})
+
+	s.Run("sends mandatory form fields", func() {
+		var form map[string]string
+		server := s.newRecordingServer(&form)
+		defer server.Close()
+
+		exchanger := &rfc8693Exchanger{}
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL: server.URL,
+			Audience: "kubernetes-api",
+			Scopes:   []string{"openid", "profile"},
+		}
+
+		_, err := exchanger.Exchange(context.Background(), cfg, "incoming-token")
+		s.Require().NoError(err)
+		s.Equal(GrantTypeTokenExchange, form[FormKeyGrantType])
+		s.Equal("incoming-token", form[FormKeySubjectToken])
+		s.Equal("kubernetes-api", form[FormKeyAudience])
+		s.Equal("openid profile", form[FormKeyScope])
+	})
+
+	s.Run("returns error on failed exchange", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_token"}`))
+		}))
+		defer server.Close()
+
+		exchanger := &rfc8693Exchanger{}
+		cfg := &TargetTokenExchangeConfig{
+			TokenURL: server.URL,
+			Audience: "kubernetes-api",
+		}
+
+		token, err := exchanger.Exchange(context.Background(), cfg, "bad-token")
+		s.Require().Error(err)
+		s.Nil(token)
+		s.Contains(err.Error(), "401")
+	})
+}
+
+func TestRFC8693Exchanger(t *testing.T) {
+	suite.Run(t, new(RFC8693ExchangerTestSuite))
+}


### PR DESCRIPTION
## Summary

Two related changes to `pkg/tokenexchange` / `pkg/kubernetes`, fully backwards-compatible:

- RFC 8693 `subject_token_type` was sent empty when unset (violates [RFC 8693 section 2.1](https://datatracker.ietf.org/doc/html/rfc8693#section-2.1)) and `requested_token_type` was hardcoded. Both are now configurable via `sts_subject_token_type` / `sts_requested_token_type`, defaulting to `access_token`.
- Add `sts_token_url` to point token exchange at a separate STS gateway, decoupled from the IDP at `authorization_url`. Unblocks cross-realm RFC 8693 and `skip_jwt_verification=true` + token exchange (which had no provider to discover an endpoint from).

## New TOML keys

| Key | Default | Purpose |
|---|---|---|
| `sts_subject_token_type` | `urn:ietf:params:oauth:token-type:access_token` | RFC 8693 `subject_token_type` form param |
| `sts_requested_token_type` | `urn:ietf:params:oauth:token-type:access_token` | RFC 8693 `requested_token_type` form param |
| `sts_token_url` | *(falls back to OIDC discovery)* | Explicit STS endpoint |

## Notable behavior changes

- `SecurityTokenService.IsEnabled()` now keys off `TokenURL != ""` instead of `Provider != nil` — "is exchange usable?" is correctly "do I have an endpoint to POST to?". Required for the passthrough + gateway combo.
- New `resolveStsTokenURL` helper: explicit `sts_token_url` wins, else OIDC-discovered endpoint.
- `sts_token_url` validated as `http`/`https`, warns on `http`.

## Example: separate gateway from issuer

```toml
authorization_url       = "https://idp.example.com/realms/users"     # validates user JWT
sts_token_url           = "https://sts-gateway.internal/oauth/token" # mints cluster token
token_exchange_strategy = "rfc8693"
sts_client_id           = "mcp-backend"
sts_client_secret       = "..."
sts_audience            = "kubernetes-api"
```
