### PR TITLE
HTTP: Don't fail for errors during shutdown

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -184,22 +184,15 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 
 	klog.V(0).Infof("Shutting down HTTP server gracefully...")
 
-	// Attempt to shut down both servers, collecting all errors
-	var shutdownErrs []error
-
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		// Don't fail Run() for errors during shutdown
 		klog.Errorf("HTTP server shutdown error: %v", err)
-		shutdownErrs = append(shutdownErrs, err)
 	}
 
 	// Always attempt MCP server shutdown (flushes metrics) even if HTTP shutdown failed
 	if err := mcpServer.Shutdown(shutdownCtx); err != nil {
+		// Don't fail Run() for errors during shutdown
 		klog.Errorf("MCP server shutdown error: %v", err)
-		shutdownErrs = append(shutdownErrs, err)
-	}
-
-	if len(shutdownErrs) > 0 {
-		return errors.Join(shutdownErrs...)
 	}
 
 	klog.V(0).Infof("HTTP server shutdown complete")


### PR DESCRIPTION
Errors during shutdown, like "context deadline exceeded", have been causing `Run()` to fail (and print the usage statement). This is only cosmetically annoying. But philosophically, we only want `Run()` to fail if it encounters an error during startup, or dies unexpectedly while running.

With this change, we still log shutdown errors, but they no longer bubble up the stack. Cosmetically, this means the server doesn't print the usage statement when it shuts down "normally" (errors notwithstanding).