### PR TITLE
feat: add HasGVKs method to Provider interface

### DIFF
--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes/watcher"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -288,4 +289,8 @@ func (p *kcpClusterProvider) Close() {
 			w.Close()
 		}
 	}
+}
+
+func (p *kcpClusterProvider) HasGVKs(_ []schema.GroupVersionKind) bool {
+	return true
 }

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // McpReload is a function type that defines a callback for reloading MCP toolsets (including tools, prompts, or other configurations)
@@ -31,6 +32,10 @@ type Provider interface {
 	// WatchTargets sets up a watcher for changes in the cluster targets and calls the provided McpReload function when changes are detected
 	WatchTargets(reload McpReload)
 	Close()
+	// HasGVKs reports whether every GVK in gvks is available on at least one target
+	// exposed by this provider. Providers that have not opted in to GVK discovery
+	// should return true so existing tools remain visible.
+	HasGVKs(gvks []schema.GroupVersionKind) bool
 }
 
 // TokenExchangeProvider is an optional interface that providers can implement to suport per-target token exchange.

--- a/pkg/kubernetes/provider_kubeconfig.go
+++ b/pkg/kubernetes/provider_kubeconfig.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes/watcher"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // KubeConfigTargetParameterName is the parameter name used to specify
@@ -194,4 +195,8 @@ func (p *kubeConfigClusterProvider) Close() {
 			w.Close()
 		}
 	}
+}
+
+func (p *kubeConfigClusterProvider) HasGVKs(_ []schema.GroupVersionKind) bool {
+	return true
 }

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes/watcher"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // singleClusterProvider implements Provider for managing a single
@@ -119,4 +120,8 @@ func (p *singleClusterProvider) Close() {
 			w.Close()
 		}
 	}
+}
+
+func (p *singleClusterProvider) HasGVKs(_ []schema.GroupVersionKind) bool {
+	return true
 }

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 )
 
@@ -129,4 +130,8 @@ func (p *tokenExchangingProvider) WatchTargets(reload McpReload) {
 
 func (p *tokenExchangingProvider) Close() {
 	p.provider.Close()
+}
+
+func (p *tokenExchangingProvider) HasGVKs(gvks []schema.GroupVersionKind) bool {
+	return p.provider.HasGVKs(gvks)
 }


### PR DESCRIPTION
## Summary
- Add `HasGVKs(gvks []schema.GroupVersionKind) bool` to the `Provider` interface.
  Reports whether every GVK in `gvks` is available on at least one target exposed by the provider.
- All existing provider implementations are no-ops that return `true`, preserving current tool visibility.
- Providers can opt in to GVK discovery by implementing real logic later.

## Test plan
- [x] All existing tests pass
- [x] Build and lint pass

Implements: OCPMCP-328

Co-Authored-By: claude