### PR TITLE
fix(mcp): mark context parameter as required in multi-target mode

### DIFF
--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -59,6 +59,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "context"
+      ],
       "type": "object"
     },
     "name": "events_list",
@@ -84,6 +87,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "context"
+      ],
       "type": "object"
     },
     "name": "namespaces_list",
@@ -120,7 +126,8 @@
       },
       "required": [
         "name",
-        "query"
+        "query",
+        "context"
       ],
       "type": "object"
     },
@@ -147,7 +154,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "context"
       ],
       "type": "object"
     },
@@ -179,6 +187,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "context"
+      ],
       "type": "object"
     },
     "name": "nodes_top",
@@ -208,7 +219,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "context"
       ],
       "type": "object"
     },
@@ -250,7 +262,8 @@
       },
       "required": [
         "name",
-        "command"
+        "command",
+        "context"
       ],
       "type": "object"
     },
@@ -281,7 +294,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "context"
       ],
       "type": "object"
     },
@@ -313,6 +327,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "context"
+      ],
       "type": "object"
     },
     "name": "pods_list",
@@ -348,7 +365,8 @@
         }
       },
       "required": [
-        "namespace"
+        "namespace",
+        "context"
       ],
       "type": "object"
     },
@@ -393,7 +411,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "context"
       ],
       "type": "object"
     },
@@ -431,7 +450,8 @@
         }
       },
       "required": [
-        "image"
+        "image",
+        "context"
       ],
       "type": "object"
     },
@@ -472,6 +492,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "context"
+      ],
       "type": "object"
     },
     "name": "pods_top",
@@ -497,7 +520,8 @@
         }
       },
       "required": [
-        "resource"
+        "resource",
+        "context"
       ],
       "type": "object"
     },
@@ -542,7 +566,8 @@
       "required": [
         "apiVersion",
         "kind",
-        "name"
+        "name",
+        "context"
       ],
       "type": "object"
     },
@@ -583,7 +608,8 @@
       "required": [
         "apiVersion",
         "kind",
-        "name"
+        "name",
+        "context"
       ],
       "type": "object"
     },
@@ -629,7 +655,8 @@
       },
       "required": [
         "apiVersion",
-        "kind"
+        "kind",
+        "context"
       ],
       "type": "object"
     },
@@ -674,7 +701,8 @@
       "required": [
         "apiVersion",
         "kind",
-        "name"
+        "name",
+        "context"
       ],
       "type": "object"
     },

--- a/pkg/mcp/tool_mutator.go
+++ b/pkg/mcp/tool_mutator.go
@@ -46,6 +46,10 @@ func WithTargetParameter(defaultCluster, targetParameterName string, isMultiTarg
 				defaultCluster,
 				targetParameterName,
 			)
+			if tool.Tool.InputSchema.Required == nil {
+				tool.Tool.InputSchema.Required = []string{}
+			}
+			tool.Tool.InputSchema.Required = append(tool.Tool.InputSchema.Required, targetParameterName)
 		}
 
 		return tool

--- a/pkg/mcp/tool_mutator_test.go
+++ b/pkg/mcp/tool_mutator_test.go
@@ -163,6 +163,7 @@ func TestWithClusterParameter(t *testing.T) {
 			assert.NotNil(t, clusterProperty)
 			assert.Equal(t, "string", clusterProperty.Type)
 			assert.Contains(t, clusterProperty.Description, tt.defaultCluster)
+			assert.Contains(t, result.Tool.InputSchema.Required, tt.targetParameterName, "cluster parameter should be required in multi-target mode")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

When multi-cluster is enabled and kubeconfig has multiple contexts, the \context\ parameter was added to tool input schemas but **not** marked as required. LLMs correctly read the JSON Schema and treat unrequired parameters as optional, causing tool calls to fall back to the default context instead of the user-specified cluster.

## Fix

In \pkg/mcp/tool_mutator.go\, \WithTargetParameter\ now appends \	argetParameterName\ to \InputSchema.Required\ when \isMultiTarget\ is true. The \Required\ slice is initialized to an empty slice if nil before appending.

\\\go
if isMultiTarget {
    tool.Tool.InputSchema.Properties[targetParameterName] = createTargetProperty(
        defaultCluster,
        targetParameterName,
    )
    if tool.Tool.InputSchema.Required == nil {
        tool.Tool.InputSchema.Required = []string{}
    }
    tool.Tool.InputSchema.Required = append(tool.Tool.InputSchema.Required, targetParameterName)
}
\\\

## Test

\pkg/mcp/tool_mutator_test.go\: added assertion that \Required\ contains the target parameter name in multi-target mode.

## References

- Fixes #1162