### PR TITLE
feat: implement HasGVKs for single cluster provider

### DIFF
--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -122,6 +122,19 @@ func (p *singleClusterProvider) Close() {
 	}
 }
 
-func (p *singleClusterProvider) HasGVKs(_ []schema.GroupVersionKind) bool {
+// HasGVKs uses the cluster's REST mapper to verify that every requested GVK is available.
+func (p *singleClusterProvider) HasGVKs(gvks []schema.GroupVersionKind) bool {
+	if len(gvks) == 0 {
+		return true
+	}
+	if p.manager == nil {
+		return true
+	}
+	mapper := p.manager.kubernetes.RESTMapper()
+	for _, gvk := range gvks {
+		if _, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+			return false
+		}
+	}
 	return true
 }

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes/watcher"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 // singleClusterProvider implements Provider for managing a single
@@ -128,6 +129,7 @@ func (p *singleClusterProvider) HasGVKs(gvks []schema.GroupVersionKind) bool {
 		return true
 	}
 	if p.manager == nil {
+		klog.Warning("HasGVKs called with nil manager, assuming all GVKs are available")
 		return true
 	}
 	mapper := p.manager.kubernetes.RESTMapper()

--- a/pkg/kubernetes/provider_single_test.go
+++ b/pkg/kubernetes/provider_single_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
 
@@ -87,6 +88,50 @@ func (s *ProviderSingleTestSuite) TestGetDefaultTarget() {
 
 func (s *ProviderSingleTestSuite) TestGetTargetParameterName() {
 	s.Empty(s.provider.GetTargetParameterName(), "Expected empty string as target parameter name")
+}
+
+func (s *ProviderSingleTestSuite) TestHasGVKs() {
+	handler := test.NewDiscoveryClientHandler()
+	s.mockServer.Handle(handler)
+
+	s.Run("returns true for nil GVKs list", func() {
+		s.True(s.provider.HasGVKs(nil))
+	})
+
+	s.Run("returns true for empty GVKs list", func() {
+		s.True(s.provider.HasGVKs([]schema.GroupVersionKind{}))
+	})
+
+	s.Run("returns true for a single GVK that exists on the cluster", func() {
+		result := s.provider.HasGVKs([]schema.GroupVersionKind{
+			{Group: "", Version: "v1", Kind: "Pod"},
+		})
+		s.True(result)
+	})
+
+	s.Run("returns true when all GVKs exist on the cluster", func() {
+		result := s.provider.HasGVKs([]schema.GroupVersionKind{
+			{Group: "", Version: "v1", Kind: "Pod"},
+			{Group: "", Version: "v1", Kind: "Node"},
+			{Group: "apps", Version: "v1", Kind: "Deployment"},
+		})
+		s.True(result)
+	})
+
+	s.Run("returns false when a GVK does not exist on the cluster", func() {
+		result := s.provider.HasGVKs([]schema.GroupVersionKind{
+			{Group: "nonexistent.example.com", Version: "v1", Kind: "FakeResource"},
+		})
+		s.False(result)
+	})
+
+	s.Run("returns false when any GVK in the list does not exist", func() {
+		result := s.provider.HasGVKs([]schema.GroupVersionKind{
+			{Group: "", Version: "v1", Kind: "Pod"},
+			{Group: "nonexistent.example.com", Version: "v1", Kind: "FakeResource"},
+		})
+		s.False(result)
+	})
 }
 
 func TestProviderSingle(t *testing.T) {


### PR DESCRIPTION
## Summary
- Implement real `HasGVKs` logic for `singleClusterProvider`, replacing the no-op stub that always returned `true`.
- Uses the cluster's REST mapper to verify that every requested GVK is available on the cluster.
- Includes a nil guard on the manager to safely return `true` (keeping tools visible) if the provider is not yet initialized.

## Test plan
- [x] Unit tests covering nil, empty, single valid, all valid, single invalid, and mixed GVK lists
- [x] All existing tests pass

Implements: OCPMCP-327