### PR TITLE
Kiali And Istio versions bump.

### DIFF
--- a/build/kiali.mk
+++ b/build/kiali.mk
@@ -2,8 +2,8 @@
 
 ISTIOCTL = $(shell pwd)/_output/tools/bin/istioctl
 ISTIO_ADDONS_DIR = $(shell pwd)/_output/istio-addons
-ISTIO_VERSION = 1.28.0
-KIALI_VERSION = v2.25.0
+ISTIO_VERSION = 1.30.1
+KIALI_VERSION = v2.27.0
 # Release version without patch (e.g. 1.28.0 -> 1.28)
 
 # Download and install istioctl (also copies samples/addons for install-istio)


### PR DESCRIPTION
Updated Istio and Kiali versions to latest released versions.

**Before**
ISTIO_VERSION = 1.28.0
KIALI_VERSION = v2.25.0

**After**
ISTIO_VERSION = 1.30.1
KIALI_VERSION = v2.27.0