### PR TITLE
fix(logging): guard log file close against concurrent writes

### DIFF
--- a/pkg/logging/sink.go
+++ b/pkg/logging/sink.go
@@ -6,7 +6,7 @@
 // that "modifying the logger is not thread-safe and should be done while no
 // other goroutines invoke log calls, usually during program initialization."
 // We honor that by configuring klog exactly once in New and routing every
-// subsequent reload through an atomic writer pointer that the textlogger
+// subsequent reload through a mutex-guarded writer that the textlogger
 // writes to.
 package logging
 
@@ -18,7 +18,6 @@ import (
 	"os"
 	"strconv"
 	"sync"
-	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
@@ -35,14 +34,9 @@ const StderrSentinel = "stderr"
 // own -v flag is the real verbosity gate at runtime. See package docs.
 const maxTextloggerVerbosity = 9
 
-// writerHolder lets us put an io.Writer (an interface) inside an
-// atomic.Pointer without the awkward double indirection of
-// atomic.Pointer[io.Writer].
-type writerHolder struct{ io.Writer }
-
 // Sink is the runtime-reloadable log destination. It implements io.Writer
-// so the textlogger can write through it; reloads atomically swap the
-// underlying writer and close the previous file (if any).
+// so the textlogger can write through it; reloads swap the underlying
+// writer and close the previous file (if any).
 //
 // Construct with New. Reload on SIGHUP. Close on shutdown.
 type Sink struct {
@@ -68,14 +62,14 @@ type Sink struct {
 	// stay concurrent); reload and Close take the exclusive lock.
 	mu sync.RWMutex
 
-	// writer is what every Write call routes through. Updated by reload via
-	// Store; never mutated in place.
-	writer atomic.Pointer[writerHolder]
+	// writer is what every Write call routes through, guarded by mu. Replaced
+	// (never mutated in place) by reload and Close under the exclusive lock.
+	writer io.Writer
 
 	// file is the currently-open log file (nil when the destination is
-	// httpOut, errOut, or io.Discard). Owned by the Sink — close happens on
-	// reload (when replaced) and Close.
-	file atomic.Pointer[os.File]
+	// httpOut, errOut, or io.Discard), guarded by mu. Owned by the Sink —
+	// close happens on reload (when replaced) and Close.
+	file *os.File
 
 	// lastLogFile is the last cfg.LogFile value applyDestination acted on,
 	// used to short-circuit reloads that wouldn't change the destination
@@ -145,11 +139,10 @@ func New(cfg *config.StaticConfig, httpOut, errOut io.Writer) (*Sink, error) {
 func (s *Sink) Write(p []byte) (int, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	h := s.writer.Load()
-	if h == nil {
+	if s.writer == nil {
 		return io.Discard.Write(p)
 	}
-	return h.Write(p)
+	return s.writer.Write(p)
 }
 
 // SDKLogger is the slog.Logger to hand to the MCP SDK's ServerOptions. It
@@ -159,14 +152,14 @@ func (s *Sink) SDKLogger() *slog.Logger {
 }
 
 // Reload re-applies cfg to the running sink: it opens the new log file (if
-// any), atomically swaps the writer, closes the previous file, and updates
-// klog's verbosity.
+// any), swaps the writer, closes the previous file, and updates klog's
+// verbosity.
 //
 // Reload is intended to be called by a single goroutine (the SIGHUP
-// handler). Concurrent Reload calls would not corrupt klog state — each
-// step is individually atomic — but they could leave the sink pointing at
-// an already-closed file via a Store/Swap interleaving. The package
-// assumes a single reloader.
+// handler). mu makes each swap+close safe against concurrent Writes, but
+// two concurrent Reloads could still interleave their open-then-swap and
+// leave the sink pointing at an already-closed file. The package assumes
+// a single reloader.
 //
 // The returned error reflects only the destination swap (open-file
 // failure). On error, the previous destination is preserved unchanged.
@@ -197,8 +190,9 @@ func (s *Sink) Close() error {
 	// Exclusive lock so the swap+close can't race an in-flight Write (see mu).
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.writer.Store(&writerHolder{s.errOut})
-	old := s.file.Swap(nil)
+	s.writer = s.errOut
+	old := s.file
+	s.file = nil
 	if old == nil {
 		return nil
 	}
@@ -206,9 +200,8 @@ func (s *Sink) Close() error {
 }
 
 // applyDestination resolves cfg.LogFile to a writer (and optionally an open
-// file), atomically swaps it in, and closes the previously-held file. It is
-// the only path that opens or closes log files — Reload and New both go
-// through it.
+// file), swaps it in, and closes the previously-held file. It is the only
+// path that opens or closes log files — Reload and New both go through it.
 //
 // A reload that wouldn't change the destination is skipped, with one
 // exception: a real file path always reopens, even when the path is
@@ -252,8 +245,9 @@ func (s *Sink) applyDestination(cfg *config.StaticConfig) error {
 	// above, outside the lock, so writers only ever block for the swap+close,
 	// not for open latency.
 	s.mu.Lock()
-	s.writer.Store(&writerHolder{newWriter})
-	oldFile := s.file.Swap(newFile)
+	s.writer = newWriter
+	oldFile := s.file
+	s.file = newFile
 	var closeErr error
 	if oldFile != nil {
 		closeErr = oldFile.Close()

--- a/pkg/logging/sink.go
+++ b/pkg/logging/sink.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"sync"
 	"sync/atomic"
 
 	"github.com/go-logr/logr"
@@ -59,6 +60,13 @@ type Sink struct {
 	// httpOut while still serving stdio would corrupt the MCP protocol
 	// channel.
 	httpMode bool
+
+	// mu makes the writer-swap + file-close (in reload and Close) mutually
+	// exclusive with in-flight Write calls, so a descriptor is never closed
+	// mid-write. That race is a harmless EBADF on POSIX but deadlocks the
+	// runtime poller on Windows. Write holds the shared read lock (writers
+	// stay concurrent); reload and Close take the exclusive lock.
+	mu sync.RWMutex
 
 	// writer is what every Write call routes through. Updated by reload via
 	// Store; never mutated in place.
@@ -132,8 +140,11 @@ func New(cfg *config.StaticConfig, httpOut, errOut io.Writer) (*Sink, error) {
 }
 
 // Write implements io.Writer. It routes to whichever writer Reload most
-// recently installed.
+// recently installed, holding mu's read lock so a reload cannot close the
+// file mid-write (see mu).
 func (s *Sink) Write(p []byte) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	h := s.writer.Load()
 	if h == nil {
 		return io.Discard.Write(p)
@@ -183,6 +194,9 @@ func (s *Sink) Reload(cfg *config.StaticConfig) error {
 // returns an error) lands somewhere visible instead of being swallowed by
 // the file descriptor we are about to close.
 func (s *Sink) Close() error {
+	// Exclusive lock so the swap+close can't race an in-flight Write (see mu).
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.writer.Store(&writerHolder{s.errOut})
 	old := s.file.Swap(nil)
 	if old == nil {
@@ -233,19 +247,24 @@ func (s *Sink) applyDestination(cfg *config.StaticConfig) error {
 
 	s.lastLogFile = cfg.LogFile
 	s.applied = true
-	s.writer.Store(&writerHolder{newWriter})
 
-	// In-flight writes that already loaded the old writer may still hit the
-	// previous fd briefly after Close — same race log rotation already
-	// accepts (logrotate's copytruncate has the identical property).
+	// Swap + close under the exclusive lock (see mu). The new file was opened
+	// above, outside the lock, so writers only ever block for the swap+close,
+	// not for open latency.
+	s.mu.Lock()
+	s.writer.Store(&writerHolder{newWriter})
 	oldFile := s.file.Swap(newFile)
+	var closeErr error
 	if oldFile != nil {
-		if err := oldFile.Close(); err != nil {
-			// Surface this at default verbosity — a Close failure on
-			// rotation is the kind of thing that drops fds on disk-pressure
-			// or flaky network filesystems.
-			klog.Warningf("logging: failed to close previous log file: %v", err)
-		}
+		closeErr = oldFile.Close()
+	}
+	s.mu.Unlock()
+
+	if closeErr != nil {
+		// Logged outside the lock: klog.Warningf re-enters Write's read lock
+		// and sync.RWMutex is not reentrant. A rotation Close failure warrants
+		// default verbosity — it drops fds under disk pressure or flaky netfs.
+		klog.Warningf("logging: failed to close previous log file: %v", closeErr)
 	}
 	return nil
 }

--- a/pkg/logging/sink_test.go
+++ b/pkg/logging/sink_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -304,6 +305,54 @@ func (s *SinkSuite) TestConcurrentWriteAndReloadIsRaceFree() {
 	}
 	close(stop)
 	wg.Wait()
+}
+
+func (s *SinkSuite) TestConcurrentWriteAndReloadNeverWritesToClosedFile() {
+	// Reload closes the previously-open file inline (sink.go applyDestination).
+	// Without mutual exclusion between Write and that close, a Write that has
+	// already loaded the old writer can land on the just-closed descriptor: on
+	// POSIX that surfaces as an os.ErrClosed write error, and on Windows it can
+	// wedge the runtime poller and deadlock the whole package (issue #1199).
+	// Drive direct Sink.Write (bypassing klog's global serialization, so the
+	// writers are genuinely concurrent) against a tight Reload loop and assert
+	// that no write ever observes a closed descriptor.
+	pathA := filepath.Join(s.tempDir, "a.log")
+	pathB := filepath.Join(s.tempDir, "b.log")
+	sink := s.newSink(&config.StaticConfig{LogLevel: 1, LogFile: pathA})
+
+	stop := make(chan struct{})
+	var writeErr atomic.Value // first non-nil error observed by any writer
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if _, err := sink.Write([]byte("hot-loop\n")); err != nil {
+						writeErr.CompareAndSwap(nil, err)
+					}
+					runtime.Gosched()
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 2000; i++ {
+		path := pathA
+		if i%2 == 1 {
+			path = pathB
+		}
+		s.Require().NoError(sink.Reload(&config.StaticConfig{LogLevel: 1, LogFile: path}))
+	}
+	close(stop)
+	wg.Wait()
+
+	err, _ := writeErr.Load().(error)
+	s.NoError(err, "a concurrent Write landed on a descriptor that Reload had already closed")
 }
 
 func (s *SinkSuite) TestReloadIgnoresPortChangeForServeMode() {


### PR DESCRIPTION
## Summary

`pkg/logging`'s `TestSink/TestConcurrentWriteAndReloadIsRaceFree` intermittently deadlocks on `windows-latest`, hanging the package for the full 10‑minute `go test` timeout (#1199). The same close path runs on the production SIGHUP reload (`Sink.Reload → applyDestination → oldFile.Close()`), so this is a latent Windows risk during `log_file` rotation, not just a test artifact.

## Root cause

`Sink.Reload` closed the just-rotated log file inline while concurrent klog writers were still routing through `Sink.Write`. A write that already loaded the old writer can land on the just-closed descriptor:

- on POSIX it returns a harmless `EBADF` / `os.ErrClosed`;
- on Windows the `internal/poll` close path wedges the runtime poller and deadlocks.

## Fix

Add a `sync.RWMutex` to `Sink`:

- `Write` holds the shared read lock across the underlying write.
- `Reload` and `Close` take the exclusive lock around the writer swap + file close, so a descriptor is never closed while a write is in flight.
- The new file is opened *outside* the lock, so the hot logging path only ever blocks for the swap+close (and `Reload` is SIGHUP-rare). The close-failure `klog.Warningf` is emitted outside the lock, since it re-enters `Write`'s read lock and `sync.RWMutex` is not reentrant.

This eliminates both the Windows hang and the deliberately-accepted use-after-close overlap.

## Tests

Adds `TestConcurrentWriteAndReloadNeverWritesToClosedFile`, which drives concurrent direct `Sink.Write` against a tight `Reload` loop and asserts no write lands on a closed descriptor. It fails reliably (5/5) without the fix (`os.ErrClosed`) and passes (10/10) with it. The full `pkg/logging` suite passes under `-race`.

Fixes #1199