### PR TITLE
test(watcher): de-flake TestClusterState on slow runners

### DIFF
--- a/pkg/kubernetes/watcher/cluster_test.go
+++ b/pkg/kubernetes/watcher/cluster_test.go
@@ -18,9 +18,14 @@ import (
 const (
 	// eventuallyTick is the polling interval for Eventually assertions
 	eventuallyTick = time.Millisecond
-	// watcherStateTimeout is the maximum time to wait for the watcher to capture initial state
-	watcherStateTimeout = 100 * time.Millisecond
-	watcherPollTimeout  = 250 * time.Millisecond
+	// Eventually ceilings: generous so slow CI runners (macos-15-intel under -race)
+	// don't flake. Eventually short-circuits on success, so the ceiling costs nothing
+	// on the happy path.
+	watcherStateTimeout = 5 * time.Second // waiting for initial state capture
+	watcherPollTimeout  = 5 * time.Second // waiting for poll onChange / debounce timer
+	// watcherNeverWindow bounds Never assertions; kept small as Never always waits the
+	// full duration.
+	watcherNeverWindow = 250 * time.Millisecond
 )
 
 type ClusterStateTestSuite struct {
@@ -325,7 +330,7 @@ func (s *ClusterStateTestSuite) TestClose() {
 			// We expect this to never happen because no callbacks should be triggered after close
 			s.Never(func() bool {
 				return callCount.Load() > beforeCount
-			}, watcherPollTimeout, eventuallyTick, "should not poll after close")
+			}, watcherNeverWindow, eventuallyTick, "should not poll after close")
 			afterCount := callCount.Load()
 			s.Equal(beforeCount, afterCount, "should not poll after close")
 		})


### PR DESCRIPTION
## Summary

`TestClusterState` in `pkg/kubernetes/watcher` flakes on slow CI runners
(consistently `macos-15-intel`, also `windows-latest`) under `go test -race`.
The hard-coded sub-second `Eventually` budgets are too tight for those runners,
and because the timeouts live in the shared test file the flake can fail **any**
branch/PR build — not just the one it lands on.

This is a pure test-timing fix — no production code changes.

## Changes

- `watcherStateTimeout`: `100ms` → `5s`
- `watcherPollTimeout`: `250ms` → `5s`
- New `watcherNeverWindow = 250ms`, applied only to the `Never(...)` "stops polling" assertion.

`Eventually` short-circuits the moment its condition is met, so raising the
ceilings adds **zero** happy-path latency while tolerating tail latency on slow
runners. The single `Never` assertion keeps its small 250ms window because a
negative assertion always consumes its full duration.

## Verification

- `go test -race -run TestClusterState ./pkg/kubernetes/watcher/` passes; 15× sequential `-race` runs all green.
- Happy-path runtime unchanged: whole suite ~0.46s; the `stops_polling` subtest stays at its 250ms `Never` window.
- `gofmt -l` and `go vet` clean.

Closes #1198