### PR TITLE
chore(logs)!: switch to contextual logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,11 @@ Implement new functionality in the Go sources under `cmd/` and `pkg/`.
 The JavaScript (`npm/`) and Python (`python/`) directories only wrap the compiled binary for distribution (npm and PyPI).
 Most changes will not require touching them unless the version or packaging needs to be updated.
 
+### Logging
+
+When adding log lines, always use a contextual logger (`klog.FromContext(ctx)`). If necessary, add a `ctx` parameter to the function, and wire
+the context through to where you need a logger.
+
 ### Adding new MCP tools
 
 The project uses a toolset-based architecture for organizing MCP tools:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -187,13 +187,15 @@ func WithDirPath(path string) ReadConfigOpt {
 // Read reads the toml file, applies drop-in configs from configDir (if provided),
 // and returns the StaticConfig with any opts applied.
 // Loading order: defaults → main config file → drop-in files (lexically sorted)
-func Read(configPath, dropInConfigDir string) (*StaticConfig, error) {
+func Read(ctx context.Context, configPath, dropInConfigDir string) (*StaticConfig, error) {
 	var configFiles []string
 	var configDir string
 
+	logger := klog.FromContext(ctx)
+
 	// Main config file
 	if configPath != "" {
-		klog.V(2).Infof("Loading main config from: %s", configPath)
+		logger.V(2).Info("Loading main config", "path", configPath)
 		configFiles = append(configFiles, configPath)
 
 		// get and save the absolute dir path to the config file, so that other config parsers can use it
@@ -218,19 +220,19 @@ func Read(configPath, dropInConfigDir string) (*StaticConfig, error) {
 		configDir = dropInConfigDir
 	}
 
-	dropInFiles, err := loadDropInConfigs(dropInConfigDir)
+	dropInFiles, err := loadDropInConfigs(ctx, dropInConfigDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load drop-in configs from %s: %w", dropInConfigDir, err)
 	}
 	if len(dropInFiles) == 0 {
-		klog.V(2).Infof("No drop-in config files found in: %s", dropInConfigDir)
+		logger.V(2).Info("No drop-in config files found", "config_dir", dropInConfigDir)
 	} else {
-		klog.V(2).Infof("Loading %d drop-in config file(s) from: %s", len(dropInFiles), dropInConfigDir)
+		logger.V(2).Info("Loading drop-in config file(s)", "num_config_files", len(dropInFiles), "config_dir", dropInConfigDir)
 	}
 	configFiles = append(configFiles, dropInFiles...)
 
 	// Read and merge all config files
-	configData, err := readAndMergeFiles(configFiles)
+	configData, err := readAndMergeFiles(ctx, configFiles)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read and merge config files: %w", err)
 	}
@@ -241,12 +243,13 @@ func Read(configPath, dropInConfigDir string) (*StaticConfig, error) {
 // loadDropInConfigs loads and merges config files from a drop-in directory.
 // Files are processed in lexical (alphabetical) order.
 // Only files with .toml extension are processed; dotfiles are ignored.
-func loadDropInConfigs(dropInConfigDir string) ([]string, error) {
+func loadDropInConfigs(ctx context.Context, dropInConfigDir string) ([]string, error) {
+	logger := klog.FromContext(ctx)
 	// Check if directory exists
 	info, err := os.Stat(dropInConfigDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			klog.V(2).Infof("Drop-in config directory does not exist, skipping: %s", dropInConfigDir)
+			logger.V(2).Info("Drop-in config directory does not exist, skipping", "config_dir", dropInConfigDir)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to stat drop-in directory: %w", err)
@@ -257,13 +260,15 @@ func loadDropInConfigs(dropInConfigDir string) ([]string, error) {
 	}
 
 	// Get all .toml files in the directory
-	return getSortedConfigFiles(dropInConfigDir)
+	return getSortedConfigFiles(ctx, dropInConfigDir)
 }
 
 // getSortedConfigFiles returns a sorted list of .toml files in the specified directory.
 // Dotfiles (starting with '.') and non-.toml files are ignored.
 // Files are sorted lexically (alphabetically) by filename.
-func getSortedConfigFiles(dir string) ([]string, error) {
+func getSortedConfigFiles(ctx context.Context, dir string) ([]string, error) {
+	logger := klog.FromContext(ctx)
+
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read directory: %w", err)
@@ -280,13 +285,13 @@ func getSortedConfigFiles(dir string) ([]string, error) {
 
 		// Skip dotfiles
 		if strings.HasPrefix(name, ".") {
-			klog.V(4).Infof("Skipping dotfile: %s", name)
+			logger.V(4).Info("Skipping dotfile", "file_name", name)
 			continue
 		}
 
 		// Only process .toml files
 		if !strings.HasSuffix(name, ".toml") {
-			klog.V(4).Infof("Skipping non-.toml file: %s", name)
+			logger.V(4).Info("Skipping non-.toml file", "file_name", name)
 			continue
 		}
 
@@ -301,11 +306,11 @@ func getSortedConfigFiles(dir string) ([]string, error) {
 
 // readAndMergeFiles reads and merges multiple TOML config files into a single byte slice.
 // Files are merged in the order provided, with later files overriding earlier ones.
-func readAndMergeFiles(files []string) ([]byte, error) {
+func readAndMergeFiles(ctx context.Context, files []string) ([]byte, error) {
 	rawConfig := map[string]interface{}{}
 	// Merge each file in order using deep merge
 	for _, file := range files {
-		klog.V(3).Infof("  - Merging config: %s", filepath.Base(file))
+		klog.FromContext(ctx).V(3).Info("Merging config", "file_name", filepath.Base(file))
 		configData, err := os.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read config %s: %w", file, err)
@@ -479,7 +484,7 @@ func (c *StaticConfig) WithTokenExchangeStrategies(strategies []string) *StaticC
 
 // Validate validates config-level invariants that must hold at both startup and
 // on SIGHUP reload.
-func (c *StaticConfig) Validate() error {
+func (c *StaticConfig) Validate(ctx context.Context) error {
 	// Normalize whitespace-padded fields before any checks use them.
 	c.CertificateAuthority = strings.TrimSpace(c.CertificateAuthority)
 	c.TLSCert = strings.TrimSpace(c.TLSCert)
@@ -511,10 +516,13 @@ func (c *StaticConfig) Validate() error {
 			return fmt.Errorf("--authorization-url must be a valid URL")
 		}
 		if u.Scheme == "http" {
-			klog.Warningf("authorization-url is using http://, this is not recommended production use")
+			klog.FromContext(ctx).Info(
+				"authorization-url is using insecure scheme, this is not recommended production use",
+				"url.scheme", "http",
+			)
 		}
 	}
-	if err := c.validateSkipJWTVerification(); err != nil {
+	if err := c.validateSkipJWTVerification(ctx); err != nil {
 		return err
 	}
 	if c.CertificateAuthority != "" {
@@ -576,12 +584,12 @@ func (c *StaticConfig) validateConfirmation() error {
 // validateSkipJWTVerification checks that the user has explicitly opted in to
 // skipping JWT signature verification when require_oauth is enabled but no
 // authorization_url is configured.
-func (c *StaticConfig) validateSkipJWTVerification() error {
+func (c *StaticConfig) validateSkipJWTVerification(ctx context.Context) error {
 	if !c.RequireOAuth || c.AuthorizationURL != "" {
 		return nil
 	}
 	if c.SkipJWTVerification {
-		klog.Warningf("skip_jwt_verification is enabled with no authorization_url: bearer tokens will be forwarded without any local validation. " +
+		klog.FromContext(ctx).Info("skip_jwt_verification is enabled with no authorization_url: bearer tokens will be forwarded without any local validation. " +
 			"The cluster (or a trusted upstream) is the sole authority. Only use this when cluster_auth_mode=passthrough and the cluster validates tokens directly.")
 		return nil
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
@@ -516,7 +517,8 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 			return fmt.Errorf("--authorization-url must be a valid URL")
 		}
 		if u.Scheme == "http" {
-			klog.FromContext(ctx).Info(
+			klogutil.Warn(
+				ctx,
 				"authorization-url is using insecure scheme, this is not recommended production use",
 				"url.scheme", "http",
 			)
@@ -589,8 +591,9 @@ func (c *StaticConfig) validateSkipJWTVerification(ctx context.Context) error {
 		return nil
 	}
 	if c.SkipJWTVerification {
-		klog.FromContext(ctx).Info("skip_jwt_verification is enabled with no authorization_url: bearer tokens will be forwarded without any local validation. " +
-			"The cluster (or a trusted upstream) is the sole authority. Only use this when cluster_auth_mode=passthrough and the cluster validates tokens directly.")
+		klogutil.Warn(ctx,
+			"skip_jwt_verification is enabled with no authorization_url: bearer tokens will be forwarded without any local validation. "+
+				"The cluster (or a trusted upstream) is the sole authority. Only use this when cluster_auth_mode=passthrough and the cluster validates tokens directly.")
 		return nil
 	}
 	return fmt.Errorf("require_oauth is enabled but authorization_url is not configured: " +

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -59,7 +59,7 @@ func (s *ConfigSuite) TestBaseDefaultValues() {
 }
 
 func (s *ConfigSuite) TestReadConfigMissingFile() {
-	config, err := Read("non-existent-config.toml", "")
+	config, err := Read(s.T().Context(), "non-existent-config.toml", "")
 	s.Run("returns error for missing file", func() {
 		s.Require().NotNil(err, "Expected error for missing file, got nil")
 		s.True(errors.Is(err, fs.ErrNotExist), "Expected ErrNotExist, got %v", err)
@@ -81,7 +81,7 @@ func (s *ConfigSuite) TestReadConfigInvalid() {
 		kind = "Role
 	`)
 
-	config, err := Read(invalidConfigPath, "")
+	config, err := Read(s.T().Context(), invalidConfigPath, "")
 	s.Run("returns error for invalid file", func() {
 		s.Require().NotNil(err, "Expected error for invalid file, got nil")
 	})
@@ -133,7 +133,7 @@ func (s *ConfigSuite) TestReadConfigValid() {
 
 	`)
 
-	config, err := Read(validConfigPath, "")
+	config, err := Read(s.T().Context(), validConfigPath, "")
 	s.Require().NotNil(config)
 	s.Run("reads and unmarshalls file", func() {
 		s.Nil(err, "Expected nil error for valid file")
@@ -234,7 +234,7 @@ func (s *ConfigSuite) TestReadConfigStatelessDefaults() {
 		port = "8080"
 	`)
 
-	config, err := Read(configPath, "")
+	config, err := Read(s.T().Context(), configPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -251,7 +251,7 @@ func (s *ConfigSuite) TestReadConfigStatelessExplicitFalse() {
 		stateless = false
 	`)
 
-	config, err := Read(configPath, "")
+	config, err := Read(s.T().Context(), configPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -265,7 +265,7 @@ func (s *ConfigSuite) TestReadConfigValidPreservesDefaultsForMissingFields() {
 		port = "1337"
 	`)
 
-	config, err := Read(validConfigPath, "")
+	config, err := Read(s.T().Context(), validConfigPath, "")
 	s.Require().NotNil(config)
 	s.Run("reads and unmarshalls file", func() {
 		s.Nil(err, "Expected nil error for valid file")
@@ -310,7 +310,7 @@ func (s *ConfigSuite) TestGetSortedConfigFiles() {
 	err := os.Mkdir(subDir, 0755)
 	s.Require().NoError(err)
 
-	sorted, err := getSortedConfigFiles(tempDir)
+	sorted, err := getSortedConfigFiles(s.T().Context(), tempDir)
 	s.Require().NoError(err)
 
 	s.Run("returns only .toml files", func() {
@@ -372,7 +372,7 @@ func (s *ConfigSuite) TestDropInConfigPrecedence() {
 	`), 0644)
 	s.Require().NoError(err)
 
-	config, err := Read(mainConfigPath, dropInDir)
+	config, err := Read(s.T().Context(), mainConfigPath, dropInDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -399,7 +399,7 @@ func (s *ConfigSuite) TestDropInConfigMissingDirectory() {
 		port = "8080"
 	`)
 
-	config, err := Read(mainConfigPath, "/non/existent/directory")
+	config, err := Read(s.T().Context(), mainConfigPath, "/non/existent/directory")
 	s.Require().NoError(err, "Should not error for missing drop-in directory")
 	s.Require().NotNil(config)
 
@@ -416,7 +416,7 @@ func (s *ConfigSuite) TestDropInConfigEmptyDirectory() {
 
 	dropInDir := s.T().TempDir()
 
-	config, err := Read(mainConfigPath, dropInDir)
+	config, err := Read(s.T().Context(), mainConfigPath, dropInDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -448,7 +448,7 @@ func (s *ConfigSuite) TestDropInConfigPartialOverride() {
 	`), 0644)
 	s.Require().NoError(err)
 
-	config, err := Read(mainConfigPath, dropInDir)
+	config, err := Read(s.T().Context(), mainConfigPath, dropInDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -483,7 +483,7 @@ func (s *ConfigSuite) TestDropInConfigWithArrays() {
 	`), 0644)
 	s.Require().NoError(err)
 
-	config, err := Read(mainConfigPath, dropInDir)
+	config, err := Read(s.T().Context(), mainConfigPath, dropInDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -520,7 +520,7 @@ func (s *ConfigSuite) TestDefaultConfDResolution() {
 	`), 0644))
 
 	// Read config WITHOUT specifying drop-in directory - should auto-discover conf.d
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -537,7 +537,7 @@ func (s *ConfigSuite) TestDefaultConfDNotExist() {
 		port = "8080"
 	`)
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err, "Should not error when default conf.d doesn't exist")
 	s.Require().NotNil(config)
 
@@ -567,7 +567,7 @@ func (s *ConfigSuite) TestStandaloneConfigDir() {
 	`), 0644))
 
 	// Read with empty config path (standalone --config-dir)
-	config, err := Read("", tempDir)
+	config, err := Read(s.T().Context(), "", tempDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -589,7 +589,7 @@ func (s *ConfigSuite) TestStandaloneConfigDirPreservesDefaults() {
 		port = "9999"
 	`), 0644))
 
-	config, err := Read("", tempDir)
+	config, err := Read(s.T().Context(), "", tempDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -604,7 +604,7 @@ func (s *ConfigSuite) TestStandaloneConfigDirEmpty() {
 	// Test standalone --config-dir with empty directory
 	tempDir := s.T().TempDir()
 
-	config, err := Read("", tempDir)
+	config, err := Read(s.T().Context(), "", tempDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -616,7 +616,7 @@ func (s *ConfigSuite) TestStandaloneConfigDirEmpty() {
 
 func (s *ConfigSuite) TestStandaloneConfigDirNonExistent() {
 	// Test standalone --config-dir with non-existent directory
-	config, err := Read("", "/non/existent/directory")
+	config, err := Read(s.T().Context(), "", "/non/existent/directory")
 	s.Require().NoError(err, "Should not error for non-existent directory")
 	s.Require().NotNil(config)
 
@@ -653,7 +653,7 @@ func (s *ConfigSuite) TestConfigDirOverridesDefaultConfD() {
 	`), 0644))
 
 	// Read with explicit config-dir (should override default conf.d)
-	config, err := Read(mainConfigPath, customDir)
+	config, err := Read(s.T().Context(), mainConfigPath, customDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -684,7 +684,7 @@ func (s *ConfigSuite) TestInvalidTomlInDropIn() {
 		port = "unclosed string
 	`), 0644))
 
-	config, err := Read(mainConfigPath, dropInDir)
+	config, err := Read(s.T().Context(), mainConfigPath, dropInDir)
 
 	s.Run("returns error for invalid TOML in drop-in", func() {
 		s.Require().Error(err, "Expected error for invalid TOML")
@@ -720,7 +720,7 @@ func (s *ConfigSuite) TestAbsoluteDropInConfigDir() {
 	absDropInDir, err := filepath.Abs(dropInDir)
 	s.Require().NoError(err)
 
-	config, err := Read(mainConfigPath, absDropInDir)
+	config, err := Read(s.T().Context(), mainConfigPath, absDropInDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -741,7 +741,7 @@ func (s *ConfigSuite) TestDropInNotADirectory() {
 	notADir := filepath.Join(tempDir, "not-a-dir")
 	s.Require().NoError(os.WriteFile(notADir, []byte("i am a file"), 0644))
 
-	config, err := Read(mainConfigPath, notADir)
+	config, err := Read(s.T().Context(), mainConfigPath, notADir)
 
 	s.Run("returns error when drop-in path is not a directory", func() {
 		s.Require().Error(err)
@@ -872,7 +872,7 @@ func (s *ConfigSuite) TestDropInWithDeniedResources() {
 		]
 	`), 0644))
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -914,7 +914,7 @@ func (s *ConfigSuite) TestRelativeConfigDirPath() {
 	`), 0644))
 
 	// Use relative path for config-dir
-	config, err := Read(mainConfigPath, "overrides.d")
+	config, err := Read(s.T().Context(), mainConfigPath, "overrides.d")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -926,7 +926,7 @@ func (s *ConfigSuite) TestRelativeConfigDirPath() {
 
 func (s *ConfigSuite) TestBothConfigAndConfigDirEmpty() {
 	// Edge case: Read("", "") should return defaults
-	config, err := Read("", "")
+	config, err := Read(s.T().Context(), "", "")
 	s.Require().NoError(err, "Should not error when both config and config-dir are empty")
 	s.Require().NotNil(config)
 
@@ -966,7 +966,7 @@ func (s *ConfigSuite) TestMultipleDropInFilesInOrder() {
 		s.Require().NoError(os.WriteFile(filepath.Join(confDDir, name), []byte(content), 0644))
 	}
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -1013,7 +1013,7 @@ func (s *ConfigSuite) TestDropInWithNestedConfig() {
 		setting3 = "new-in-drop-in-2"
 	`), 0644))
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -1039,7 +1039,7 @@ func (s *ConfigSuite) TestEmptyConfigFile() {
 		port = "9999"
 	`), 0644))
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -1061,7 +1061,7 @@ func (s *ConfigSuite) TestToolOverridesParsed() {
 		description = "Custom resources get description"
 	`)
 
-	config, err := Read(configPath, "")
+	config, err := Read(s.T().Context(), configPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -1078,7 +1078,7 @@ func (s *ConfigSuite) TestToolOverridesMatchDefaultsWhenNotSpecified() {
 		log_level = 1
 	`)
 
-	config, err := Read(configPath, "")
+	config, err := Read(s.T().Context(), configPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -1110,7 +1110,7 @@ func (s *ConfigSuite) TestToolOverridesDropInMerge() {
 		description = "New events description"
 	`), 0644))
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -1129,7 +1129,7 @@ func (s *ConfigSuite) TestToolOverridesDropInMerge() {
 
 func (s *ConfigSuite) TestConfirmationRulesDefaults() {
 	configPath := s.writeConfig(``)
-	config, err := Read(configPath, "")
+	config, err := Read(s.T().Context(), configPath, "")
 	s.Require().NoError(err)
 	s.Run("default fallback is allow", func() {
 		s.Equal("allow", config.GetConfirmationFallback())
@@ -1161,7 +1161,7 @@ func (s *ConfigSuite) TestConfirmationRulesParsing() {
 		kind = "Secret"
 		message = "Accessing a Secret."
 	`)
-	config, err := Read(configPath, "")
+	config, err := Read(s.T().Context(), configPath, "")
 	s.Require().NoError(err)
 	s.Run("confirmation_fallback parsed correctly", func() {
 		s.Equal("deny", config.GetConfirmationFallback())

--- a/pkg/config/provider_config_test.go
+++ b/pkg/config/provider_config_test.go
@@ -68,7 +68,7 @@ func (s *ProviderConfigSuite) TestReadConfigValid() {
 		int_prop = 42
 	`)
 
-	config, err := Read(validConfigPath, "")
+	config, err := Read(s.T().Context(), validConfigPath, "")
 	s.Run("returns no error for valid file with registered provider config", func() {
 		s.Require().NoError(err, "Expected no error for valid file, got %v", err)
 	})
@@ -97,7 +97,7 @@ func (s *ProviderConfigSuite) TestReadConfigInvalidProviderConfig() {
 		int_prop = 42
 	`)
 
-	config, err := Read(invalidConfigPath, "")
+	config, err := Read(s.T().Context(), invalidConfigPath, "")
 	s.Run("returns error for invalid provider config", func() {
 		s.Require().NotNil(err, "Expected error for invalid provider config, got nil")
 		s.ErrorContains(err, "validation error forced by test", "Expected validation error from provider config")
@@ -116,7 +116,7 @@ func (s *ProviderConfigSuite) TestReadConfigUnregisteredProviderConfig() {
 		int_prop = 42
 	`)
 
-	config, err := Read(invalidConfigPath, "")
+	config, err := Read(s.T().Context(), invalidConfigPath, "")
 	s.Run("returns no error for unregistered provider config", func() {
 		s.Require().NoError(err, "Expected no error for unregistered provider config, got %v", err)
 	})
@@ -141,7 +141,7 @@ func (s *ProviderConfigSuite) TestReadConfigParserError() {
 		int_prop = 42
 	`)
 
-	config, err := Read(invalidConfigPath, "")
+	config, err := Read(s.T().Context(), invalidConfigPath, "")
 	s.Run("returns error for provider config parser error", func() {
 		s.Require().NotNil(err, "Expected error for provider config parser error, got nil")
 		s.ErrorContains(err, "parser error forced by test", "Expected parser error from provider config")
@@ -172,7 +172,7 @@ func (s *ProviderConfigSuite) TestConfigDirPathInContext() {
 	absConfigPath, err := filepath.Abs(configPath)
 	s.Require().NoError(err, "test error: getting the absConfigPath should not fail")
 
-	_, err = Read(configPath, "")
+	_, err = Read(s.T().Context(), configPath, "")
 	s.Run("provides config directory path in context to parser", func() {
 		s.Require().NoError(err, "Expected no error reading config")
 		s.NotEmpty(capturedDirPath, "Expected non-empty directory path in context")
@@ -218,7 +218,7 @@ func (s *ProviderConfigSuite) TestExtendedConfigMergingAcrossDropIns() {
 	`), 0644)
 	s.Require().NoError(err)
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -268,7 +268,7 @@ func (s *ProviderConfigSuite) TestExtendedConfigFromDropInOnly() {
 	`), 0644)
 	s.Require().NoError(err)
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -309,7 +309,7 @@ func (s *ProviderConfigSuite) TestStandaloneConfigDirWithExtendedConfig() {
 	s.Require().NoError(err)
 
 	// Read with standalone config-dir (empty config path)
-	config, err := Read("", tempDir)
+	config, err := Read(s.T().Context(), "", tempDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -352,7 +352,7 @@ func (s *ProviderConfigSuite) TestConfigDirPathInContextStandalone() {
 	absTempDir, err := filepath.Abs(tempDir)
 	s.Require().NoError(err)
 
-	_, err = Read("", tempDir)
+	_, err = Read(s.T().Context(), "", tempDir)
 	s.Run("provides config directory path in context for standalone mode", func() {
 		s.Require().NoError(err)
 		s.NotEmpty(capturedDirPath, "Expected non-empty directory path in context")

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -56,7 +56,7 @@ type TLSEnforcingTransport struct {
 
 func (t *TLSEnforcingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.RequireTLS != nil && t.RequireTLS() && !isSecureHTTPScheme(req.URL.Scheme) {
-		klog.V(1).Infof("require_tls: blocked request to %s", req.URL.Host)
+		klog.FromContext(req.Context()).V(1).Info("require_tls: blocked request to host", "host", req.URL.Host)
 		return nil, fmt.Errorf("require_tls is enabled but request to %s uses %q scheme (secure scheme required)",
 			req.URL.Host, req.URL.Scheme)
 	}

--- a/pkg/config/toolset_config_test.go
+++ b/pkg/config/toolset_config_test.go
@@ -67,7 +67,7 @@ func (s *ToolsetConfigSuite) TestReadConfigValid() {
 		timeout = 30
 	`)
 
-	config, err := Read(validConfigPath, "")
+	config, err := Read(s.T().Context(), validConfigPath, "")
 	s.Run("returns no error for valid file with registered toolset config", func() {
 		s.Require().NoError(err, "Expected no error for valid file, got %v", err)
 	})
@@ -95,7 +95,7 @@ func (s *ToolsetConfigSuite) TestReadConfigInvalidToolsetConfig() {
 		timeout = 30
 	`)
 
-	config, err := Read(invalidConfigPath, "")
+	config, err := Read(s.T().Context(), invalidConfigPath, "")
 	s.Run("returns error for invalid toolset config", func() {
 		s.Require().NotNil(err, "Expected error for invalid toolset config, got nil")
 		s.ErrorContains(err, "validation error forced by test", "Expected validation error from toolset config")
@@ -113,7 +113,7 @@ func (s *ToolsetConfigSuite) TestReadConfigUnregisteredToolsetConfig() {
 		timeout = 30
 	`)
 
-	config, err := Read(unregisteredConfigPath, "")
+	config, err := Read(s.T().Context(), unregisteredConfigPath, "")
 	s.Run("returns no error for unregistered toolset config", func() {
 		s.Require().NoError(err, "Expected no error for unregistered toolset config, got %v", err)
 	})
@@ -146,7 +146,7 @@ func (s *ToolsetConfigSuite) TestConfigDirPathInContext() {
 	absConfigPath, err := filepath.Abs(configPath)
 	s.Require().NoError(err, "test error: getting the absConfigPath should not fail")
 
-	_, err = Read(configPath, "")
+	_, err = Read(s.T().Context(), configPath, "")
 	s.Run("provides config directory path in context to parser", func() {
 		s.Require().NoError(err, "Expected no error reading config")
 		s.NotEmpty(capturedDirPath, "Expected non-empty directory path in context")
@@ -191,7 +191,7 @@ func (s *ToolsetConfigSuite) TestExtendedConfigMergingAcrossDropIns() {
 	`), 0644)
 	s.Require().NoError(err)
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -240,7 +240,7 @@ func (s *ToolsetConfigSuite) TestExtendedConfigFromDropInOnly() {
 	`), 0644)
 	s.Require().NoError(err)
 
-	config, err := Read(mainConfigPath, "")
+	config, err := Read(s.T().Context(), mainConfigPath, "")
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -280,7 +280,7 @@ func (s *ToolsetConfigSuite) TestStandaloneConfigDirWithExtendedConfig() {
 	s.Require().NoError(err)
 
 	// Read with standalone config-dir (empty config path)
-	config, err := Read("", tempDir)
+	config, err := Read(s.T().Context(), "", tempDir)
 	s.Require().NoError(err)
 	s.Require().NotNil(config)
 
@@ -322,7 +322,7 @@ func (s *ToolsetConfigSuite) TestConfigDirPathInContextStandalone() {
 	absTempDir, err := filepath.Abs(tempDir)
 	s.Require().NoError(err)
 
-	_, err = Read("", tempDir)
+	_, err = Read(s.T().Context(), "", tempDir)
 	s.Run("provides config directory path in context for standalone mode", func() {
 		s.Require().NoError(err)
 		s.NotEmpty(capturedDirPath, "Expected non-empty directory path in context")

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -27,7 +27,7 @@ func (s *ValidateSuite) validConfig() *config.StaticConfig {
 func (s *ValidateSuite) TestValidDefaultConfig() {
 	s.Run("default config passes validation", func() {
 		cfg := s.validConfig()
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 }
 
@@ -35,7 +35,7 @@ func (s *ValidateSuite) TestListOutput() {
 	s.Run("invalid list_output is rejected", func() {
 		cfg := s.validConfig()
 		cfg.ListOutput = "invalid-format"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid output name")
 		s.Contains(err.Error(), "invalid-format")
@@ -44,7 +44,7 @@ func (s *ValidateSuite) TestListOutput() {
 	s.Run("empty list_output is rejected", func() {
 		cfg := s.validConfig()
 		cfg.ListOutput = ""
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid output name")
 	})
@@ -52,13 +52,13 @@ func (s *ValidateSuite) TestListOutput() {
 	s.Run("yaml list_output is accepted", func() {
 		cfg := s.validConfig()
 		cfg.ListOutput = "yaml"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("table list_output is accepted", func() {
 		cfg := s.validConfig()
 		cfg.ListOutput = "table"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 }
 
@@ -66,7 +66,7 @@ func (s *ValidateSuite) TestToolsets() {
 	s.Run("invalid toolset name is rejected", func() {
 		cfg := s.validConfig()
 		cfg.Toolsets = []string{"nonexistent-toolset"}
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid toolset name")
 		s.Contains(err.Error(), "nonexistent-toolset")
@@ -75,7 +75,7 @@ func (s *ValidateSuite) TestToolsets() {
 	s.Run("valid toolset names are accepted", func() {
 		cfg := s.validConfig()
 		cfg.Toolsets = []string{"core", "config"}
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 }
 
@@ -83,13 +83,13 @@ func (s *ValidateSuite) TestClusterProviderStrategy() {
 	s.Run("unknown strategy is skipped without WithProviderStrategies", func() {
 		cfg := s.validConfig()
 		cfg.ClusterProviderStrategy = "nonexistent-strategy"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("unknown strategy is rejected with WithProviderStrategies", func() {
 		cfg := s.validConfig()
 		cfg.ClusterProviderStrategy = "nonexistent-strategy"
-		err := cfg.WithProviderStrategies([]string{"kubeconfig", "in-cluster"}).Validate()
+		err := cfg.WithProviderStrategies([]string{"kubeconfig", "in-cluster"}).Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid cluster-provider")
 		s.Contains(err.Error(), "nonexistent-strategy")
@@ -98,7 +98,7 @@ func (s *ValidateSuite) TestClusterProviderStrategy() {
 	s.Run("valid strategy is accepted with WithProviderStrategies", func() {
 		cfg := s.validConfig()
 		cfg.ClusterProviderStrategy = "kubeconfig"
-		s.NoError(cfg.WithProviderStrategies([]string{"kubeconfig", "in-cluster"}).Validate())
+		s.NoError(cfg.WithProviderStrategies([]string{"kubeconfig", "in-cluster"}).Validate(s.T().Context()))
 	})
 }
 
@@ -107,7 +107,7 @@ func (s *ValidateSuite) TestAuthorizationURL() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = "ftp://example.com/auth"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "--authorization-url must be a valid URL")
 	})
@@ -116,21 +116,21 @@ func (s *ValidateSuite) TestAuthorizationURL() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = "https://example.com/auth"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("http scheme is accepted with warning", func() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = "http://example.com/auth"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("authorization_url without require_oauth is rejected", func() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = false
 		cfg.AuthorizationURL = "https://example.com/auth"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "require-oauth is enabled")
 	})
@@ -142,7 +142,7 @@ func (s *ValidateSuite) TestCertificateAuthority() {
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.CertificateAuthority = "/nonexistent/path/ca.crt"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "certificate-authority must be a valid file path")
 	})
@@ -156,13 +156,13 @@ func (s *ValidateSuite) TestCertificateAuthority() {
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.CertificateAuthority = caPath
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("whitespace-only is treated as empty", func() {
 		cfg := s.validConfig()
 		cfg.CertificateAuthority = "   "
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 		s.Equal("", cfg.CertificateAuthority, "whitespace should be trimmed from certificate-authority")
 	})
 }
@@ -176,7 +176,7 @@ func (s *ValidateSuite) TestTLSCertKey() {
 		cfg := s.validConfig()
 		cfg.TLSCert = certPath
 		cfg.TLSKey = ""
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "both --tls-cert and --tls-key must be provided together")
 	})
@@ -189,7 +189,7 @@ func (s *ValidateSuite) TestTLSCertKey() {
 		cfg := s.validConfig()
 		cfg.TLSCert = ""
 		cfg.TLSKey = keyPath
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "both --tls-cert and --tls-key must be provided together")
 	})
@@ -202,7 +202,7 @@ func (s *ValidateSuite) TestTLSCertKey() {
 		cfg := s.validConfig()
 		cfg.TLSCert = "/nonexistent/cert.pem"
 		cfg.TLSKey = keyPath
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "tls-cert must be a valid file path")
 	})
@@ -215,7 +215,7 @@ func (s *ValidateSuite) TestTLSCertKey() {
 		cfg := s.validConfig()
 		cfg.TLSCert = certPath
 		cfg.TLSKey = "/nonexistent/key.pem"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "tls-key must be a valid file path")
 	})
@@ -230,14 +230,14 @@ func (s *ValidateSuite) TestTLSCertKey() {
 		cfg := s.validConfig()
 		cfg.TLSCert = certPath
 		cfg.TLSKey = keyPath
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("whitespace-only tls_cert and tls_key are treated as empty", func() {
 		cfg := s.validConfig()
 		cfg.TLSCert = "   "
 		cfg.TLSKey = "   "
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 		s.Equal("", cfg.TLSCert, "whitespace should be trimmed from tls-cert")
 		s.Equal("", cfg.TLSKey, "whitespace should be trimmed from tls-key")
 	})
@@ -249,7 +249,7 @@ func (s *ValidateSuite) TestTokenExchangeStrategy() {
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.TokenExchangeStrategy = "nonexistent-strategy"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("unknown strategy is rejected with WithTokenExchangeStrategies", func() {
@@ -257,7 +257,7 @@ func (s *ValidateSuite) TestTokenExchangeStrategy() {
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.TokenExchangeStrategy = "nonexistent-strategy"
-		err := cfg.WithTokenExchangeStrategies([]string{"rfc8693", "keycloak-v1", "entra-obo"}).Validate()
+		err := cfg.WithTokenExchangeStrategies([]string{"rfc8693", "keycloak-v1", "entra-obo"}).Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid token_exchange_strategy")
 		s.Contains(err.Error(), "nonexistent-strategy")
@@ -268,7 +268,7 @@ func (s *ValidateSuite) TestTokenExchangeStrategy() {
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = "https://example.com/auth"
 		cfg.TokenExchangeStrategy = "rfc8693"
-		s.NoError(cfg.WithTokenExchangeStrategies([]string{"rfc8693", "keycloak-v1", "entra-obo"}).Validate())
+		s.NoError(cfg.WithTokenExchangeStrategies([]string{"rfc8693", "keycloak-v1", "entra-obo"}).Validate(s.T().Context()))
 	})
 }
 
@@ -276,7 +276,7 @@ func (s *ValidateSuite) TestStsAuthStyle() {
 	s.Run("invalid sts_auth_style is rejected", func() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "invalid-style"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid sts_auth_style")
 		s.Contains(err.Error(), "invalid-style")
@@ -285,25 +285,25 @@ func (s *ValidateSuite) TestStsAuthStyle() {
 	s.Run("empty sts_auth_style is accepted", func() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = ""
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("params sts_auth_style is accepted", func() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "params"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("header sts_auth_style is accepted", func() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "header"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("whitespace-only sts_auth_style is treated as empty", func() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "   "
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 		s.Equal("", cfg.StsAuthStyle, "whitespace should be trimmed from sts_auth_style")
 	})
 }
@@ -312,7 +312,7 @@ func (s *ValidateSuite) TestStsClientCertKey() {
 	s.Run("assertion auth_style without cert file is rejected", func() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "assertion"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "sts_client_cert_file is required")
 	})
@@ -325,7 +325,7 @@ func (s *ValidateSuite) TestStsClientCertKey() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "assertion"
 		cfg.StsClientCertFile = certPath
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "sts_client_key_file is required")
 	})
@@ -339,7 +339,7 @@ func (s *ValidateSuite) TestStsClientCertKey() {
 		cfg.StsAuthStyle = "assertion"
 		cfg.StsClientCertFile = "/nonexistent/cert.pem"
 		cfg.StsClientKeyFile = keyPath
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "sts_client_cert_file must be a valid file path")
 	})
@@ -353,7 +353,7 @@ func (s *ValidateSuite) TestStsClientCertKey() {
 		cfg.StsAuthStyle = "assertion"
 		cfg.StsClientCertFile = certPath
 		cfg.StsClientKeyFile = "/nonexistent/key.pem"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "sts_client_key_file must be a valid file path")
 	})
@@ -369,7 +369,7 @@ func (s *ValidateSuite) TestStsClientCertKey() {
 		cfg.StsAuthStyle = "assertion"
 		cfg.StsClientCertFile = certPath
 		cfg.StsClientKeyFile = keyPath
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("whitespace-only sts_client_cert_file is treated as empty", func() {
@@ -381,7 +381,7 @@ func (s *ValidateSuite) TestStsClientCertKey() {
 		cfg.StsAuthStyle = "assertion"
 		cfg.StsClientCertFile = "   "
 		cfg.StsClientKeyFile = keyPath
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "sts_client_cert_file is required")
 		s.Equal("", cfg.StsClientCertFile, "whitespace should be trimmed from sts_client_cert_file")
@@ -396,7 +396,7 @@ func (s *ValidateSuite) TestStsClientCertKey() {
 		cfg.StsAuthStyle = "assertion"
 		cfg.StsClientCertFile = certPath
 		cfg.StsClientKeyFile = "   "
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "sts_client_key_file is required")
 		s.Equal("", cfg.StsClientKeyFile, "whitespace should be trimmed from sts_client_key_file")
@@ -407,7 +407,7 @@ func (s *ValidateSuite) TestStsFederatedTokenFile() {
 	s.Run("federated auth_style without token file is rejected", func() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "federated"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "sts_federated_token_file is required")
 	})
@@ -416,7 +416,7 @@ func (s *ValidateSuite) TestStsFederatedTokenFile() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "federated"
 		cfg.StsFederatedTokenFile = "/nonexistent/token"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "sts_federated_token_file must be a valid file path")
 	})
@@ -429,14 +429,14 @@ func (s *ValidateSuite) TestStsFederatedTokenFile() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "federated"
 		cfg.StsFederatedTokenFile = tokenPath
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("whitespace-only sts_federated_token_file is treated as empty", func() {
 		cfg := s.validConfig()
 		cfg.StsAuthStyle = "federated"
 		cfg.StsFederatedTokenFile = "   "
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "sts_federated_token_file is required")
 		s.Equal("", cfg.StsFederatedTokenFile, "whitespace should be trimmed")
@@ -449,7 +449,7 @@ func (s *ValidateSuite) TestStsFederatedTokenFile() {
 		tokenPath := filepath.Join(tmpDir, "token")
 		s.Require().NoError(os.WriteFile(tokenPath, []byte("jwt-token"), 0600))
 		cfg.StsFederatedTokenFile = tokenPath
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 }
 
@@ -457,25 +457,25 @@ func (s *ValidateSuite) TestConfirmationFallback() {
 	s.Run("empty fallback is accepted", func() {
 		cfg := s.validConfig()
 		cfg.ConfirmationFallback = ""
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("allow fallback is accepted", func() {
 		cfg := s.validConfig()
 		cfg.ConfirmationFallback = "allow"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("deny fallback is accepted", func() {
 		cfg := s.validConfig()
 		cfg.ConfirmationFallback = "deny"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("invalid fallback value is rejected", func() {
 		cfg := s.validConfig()
 		cfg.ConfirmationFallback = "block"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid confirmation_fallback")
 		s.Contains(err.Error(), "block")
@@ -486,7 +486,7 @@ func (s *ValidateSuite) TestConfirmationRules() {
 	s.Run("empty rules are accepted", func() {
 		cfg := s.validConfig()
 		cfg.ConfirmationRules = nil
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("valid tool-level rule is accepted", func() {
@@ -494,7 +494,7 @@ func (s *ValidateSuite) TestConfirmationRules() {
 		cfg.ConfirmationRules = []api.ConfirmationRule{
 			{Tool: "helm_uninstall", Message: "Uninstall a release."},
 		}
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("valid kube-level rule is accepted", func() {
@@ -502,7 +502,7 @@ func (s *ValidateSuite) TestConfirmationRules() {
 		cfg.ConfirmationRules = []api.ConfirmationRule{
 			{Verb: "delete", Kind: "Secret", Message: "Delete a Secret."},
 		}
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("rule mixing tool and kube fields is rejected", func() {
@@ -510,7 +510,7 @@ func (s *ValidateSuite) TestConfirmationRules() {
 		cfg.ConfirmationRules = []api.ConfirmationRule{
 			{Tool: "helm_uninstall", Verb: "delete", Message: "Mixed rule."},
 		}
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid confirmation rules")
 	})
@@ -520,7 +520,7 @@ func (s *ValidateSuite) TestConfirmationRules() {
 		cfg.ConfirmationRules = []api.ConfirmationRule{
 			{Message: "No level fields."},
 		}
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "must set at least one")
 	})
@@ -531,7 +531,7 @@ func (s *ValidateSuite) TestConfirmationRules() {
 			{Tool: "a", Verb: "delete", Message: "Mixed 1."},
 			{Kind: "Pod", Tool: "b", Message: "Mixed 2."},
 		}
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "confirmation_rules[0]")
 		s.Contains(err.Error(), "confirmation_rules[1]")
@@ -543,7 +543,7 @@ func (s *ValidateSuite) TestSkipJWTVerification() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = "https://example.com/auth"
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("require_oauth without authorization_url and skip_jwt_verification=false is rejected", func() {
@@ -551,7 +551,7 @@ func (s *ValidateSuite) TestSkipJWTVerification() {
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = ""
 		cfg.SkipJWTVerification = false
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "require_oauth is enabled but authorization_url is not configured")
 		s.Contains(err.Error(), "skip_jwt_verification=true")
@@ -562,20 +562,20 @@ func (s *ValidateSuite) TestSkipJWTVerification() {
 		cfg.RequireOAuth = true
 		cfg.AuthorizationURL = ""
 		cfg.SkipJWTVerification = true
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("require_oauth=false with skip_jwt_verification=true is accepted", func() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = false
 		cfg.SkipJWTVerification = true
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("require_oauth=false is accepted", func() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = false
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 }
 
@@ -584,7 +584,7 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = false
 		cfg.ClusterAuthMode = api.ClusterAuthPassthrough
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("passthrough with require_oauth is accepted", func() {
@@ -592,7 +592,7 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 		cfg.RequireOAuth = true
 		cfg.SkipJWTVerification = true
 		cfg.ClusterAuthMode = api.ClusterAuthPassthrough
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("kubeconfig with require_oauth is rejected", func() {
@@ -600,7 +600,7 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 		cfg.RequireOAuth = true
 		cfg.SkipJWTVerification = true
 		cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "is not compatible with require_oauth=true")
 	})
@@ -609,13 +609,13 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = false
 		cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
-		s.NoError(cfg.Validate())
+		s.NoError(cfg.Validate(s.T().Context()))
 	})
 
 	s.Run("invalid cluster_auth_mode is rejected", func() {
 		cfg := s.validConfig()
 		cfg.ClusterAuthMode = "bogus"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid cluster_auth_mode")
 	})
@@ -624,7 +624,7 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = false
 		cfg.TokenExchangeStrategy = "rfc8693"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "token exchange requires require_oauth=true")
 	})
@@ -633,7 +633,7 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 		cfg := s.validConfig()
 		cfg.RequireOAuth = false
 		cfg.StsAudience = "backend-audience"
-		err := cfg.Validate()
+		err := cfg.Validate(s.T().Context())
 		s.Require().Error(err)
 		s.Contains(err.Error(), "token exchange requires require_oauth=true")
 	})

--- a/pkg/confirmation/confirmation.go
+++ b/pkg/confirmation/confirmation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/google/jsonschema-go/jsonschema"
 	"k8s.io/klog/v2"
 )
@@ -56,7 +57,7 @@ func CheckConfirmation(ctx context.Context, elicitor api.Elicitor, message, fall
 			if fallback == "deny" {
 				return ErrConfirmationDenied
 			}
-			klog.FromContext(ctx).Info("Confirmation rules matched but client does not support elicitation, proceeding with fallback \"allow\"", "message", message)
+			klogutil.Warn(ctx, "Confirmation rules matched but client does not support elicitation, proceeding with fallback \"allow\"", "message", message)
 			return nil
 		}
 		return err

--- a/pkg/confirmation/confirmation.go
+++ b/pkg/confirmation/confirmation.go
@@ -7,7 +7,6 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/google/jsonschema-go/jsonschema"
-	"k8s.io/klog/v2"
 )
 
 // ErrConfirmationDenied is returned when the user declines a confirmation prompt

--- a/pkg/confirmation/confirmation.go
+++ b/pkg/confirmation/confirmation.go
@@ -56,7 +56,7 @@ func CheckConfirmation(ctx context.Context, elicitor api.Elicitor, message, fall
 			if fallback == "deny" {
 				return ErrConfirmationDenied
 			}
-			klog.Warningf("Confirmation rules matched but client does not support elicitation, proceeding with fallback \"allow\": %s", message)
+			klog.FromContext(ctx).Info("Confirmation rules matched but client does not support elicitation, proceeding with fallback \"allow\"", "message", message)
 			return nil
 		}
 		return err

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -127,8 +127,11 @@ func (h *Helm) newAction(ctx context.Context, namespace string, allNamespaces bo
 		return nil, err
 	}
 	cfg.RegistryClient = registryClient
+	logger := klog.FromContext(ctx)
 	return cfg, cfg.Init(h.kubernetes, applicableNamespace, storageDriver, func(format string, v ...any) {
-		klog.FromContext(ctx).Info(fmt.Sprintf(format, v...)) // TODO: revisit if this really needs to be info log, this is the helm "debug logger"
+		if logger.V(5).Enabled() {
+			logger.V(5).Info(fmt.Sprintf(format, v...))
+		}
 	})
 }
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -37,7 +37,7 @@ func (h *Helm) Install(ctx context.Context, chart string, values map[string]inte
 	if err := validateChartReference(chart, h.config); err != nil {
 		return "", err
 	}
-	cfg, err := h.newAction(h.kubernetes.NamespaceOrDefault(namespace), false)
+	cfg, err := h.newAction(ctx, h.kubernetes.NamespaceOrDefault(namespace), false)
 	if err != nil {
 		return "", err
 	}
@@ -74,8 +74,8 @@ func (h *Helm) Install(ctx context.Context, chart string, values map[string]inte
 }
 
 // List lists all the releases for the specified namespace (or current namespace if). Or allNamespaces is true, it lists all releases across all namespaces.
-func (h *Helm) List(namespace string, allNamespaces bool) (string, error) {
-	cfg, err := h.newAction(namespace, allNamespaces)
+func (h *Helm) List(ctx context.Context, namespace string, allNamespaces bool) (string, error) {
+	cfg, err := h.newAction(ctx, namespace, allNamespaces)
 	if err != nil {
 		return "", err
 	}
@@ -94,8 +94,8 @@ func (h *Helm) List(namespace string, allNamespaces bool) (string, error) {
 	return string(ret), nil
 }
 
-func (h *Helm) Uninstall(name string, namespace string) (string, error) {
-	cfg, err := h.newAction(h.kubernetes.NamespaceOrDefault(namespace), false)
+func (h *Helm) Uninstall(ctx context.Context, name string, namespace string) (string, error) {
+	cfg, err := h.newAction(ctx, h.kubernetes.NamespaceOrDefault(namespace), false)
 	if err != nil {
 		return "", err
 	}
@@ -112,7 +112,7 @@ func (h *Helm) Uninstall(name string, namespace string) (string, error) {
 	return fmt.Sprintf("Uninstalled release %s %s", uninstalledRelease.Release.Name, uninstalledRelease.Info), nil
 }
 
-func (h *Helm) newAction(namespace string, allNamespaces bool) (*action.Configuration, error) {
+func (h *Helm) newAction(ctx context.Context, namespace string, allNamespaces bool) (*action.Configuration, error) {
 	storageDriver := ""
 	if h.config != nil {
 		storageDriver = h.config.StorageDriver
@@ -127,7 +127,9 @@ func (h *Helm) newAction(namespace string, allNamespaces bool) (*action.Configur
 		return nil, err
 	}
 	cfg.RegistryClient = registryClient
-	return cfg, cfg.Init(h.kubernetes, applicableNamespace, storageDriver, klog.V(5).Infof)
+	return cfg, cfg.Init(h.kubernetes, applicableNamespace, storageDriver, func(format string, v ...any) {
+		klog.FromContext(ctx).Info(fmt.Sprintf(format, v...)) // TODO: revisit if this really needs to be info log, this is the helm "debug logger"
+	})
 }
 
 // validateChartReference blocks chart references using dangerous URL schemes.

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 )
@@ -116,7 +117,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 			// Cluster is the sole authority for validating token (ex. sha256 token with OpenShift)
 			if staticConfig.SkipJWTVerification && staticConfig.AuthorizationURL == "" {
 				skipJWTWarningOnce.Do(func() {
-					logger.Info("Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
+					klogutil.Warn(r.Context(), "Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
 				})
 				ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
 				next.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -117,7 +117,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 			// Cluster is the sole authority for validating token (ex. sha256 token with OpenShift)
 			if staticConfig.SkipJWTVerification && staticConfig.AuthorizationURL == "" {
 				skipJWTWarningOnce.Do(func() {
-					klogutil.Warn(r.Context(), "Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
+					klogutil.WarnLogger(logger, "Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
 				})
 				ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
 				next.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -57,6 +57,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 	var skipJWTWarningOnce sync.Once
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			logger := klog.FromContext(r.Context())
 			// Skip auth for infrastructure endpoints (health, metrics) and well-known endpoints
 			// Use prefix matching per endpoint to handle sub-paths like /.well-known/oauth-protected-resource/sse
 			requestPath := r.URL.EscapedPath()
@@ -89,7 +90,11 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
-				klog.V(1).Infof("Authentication failed - missing or invalid bearer token: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+				logger.V(1).Info("Authentication failed - missing or invalid bearer token",
+					"http.request.method", r.Method,
+					"url.path", r.URL.Path,
+					"client.address", r.RemoteAddr,
+				)
 				write401(w, wwwAuthenticateHeader, "missing_token", "Unauthorized: Bearer token required")
 				return
 			}
@@ -98,7 +103,11 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 
 			// Empty token check post-trimming
 			if token == "" {
-				klog.V(1).Infof("Authentication failed - empty bearer token: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+				logger.V(1).Info("Authentication failed - empty bearer token",
+					"http.request.method", r.Method,
+					"url.path", r.URL.Path,
+					"client.address", r.RemoteAddr,
+				)
 				write401(w, wwwAuthenticateHeader, "invalid_token", "Unauthorized: Bearer token is empty")
 				return
 			}
@@ -107,7 +116,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 			// Cluster is the sole authority for validating token (ex. sha256 token with OpenShift)
 			if staticConfig.SkipJWTVerification && staticConfig.AuthorizationURL == "" {
 				skipJWTWarningOnce.Do(func() {
-					klog.Warningf("Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
+					logger.Info("Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
 				})
 				ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
 				next.ServeHTTP(w, r.WithContext(ctx))
@@ -129,14 +138,22 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 				if snapshot == nil || snapshot.OIDCProvider == nil {
 					// Provider was configured (authorization_url set) but is unavailable — reject
 					if staticConfig.AuthorizationURL != "" {
-						klog.V(1).Infof("Authentication rejected - OIDC provider unavailable: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+						logger.V(1).Info("Authentication rejected - OIDC provider unavailable",
+							"http.request.method", r.Method,
+							"url.path", r.URL.Path,
+							"client.address", r.RemoteAddr,
+						)
 						write401(w, wwwAuthenticateHeader, "temporarily_unavailable", "OIDC provider is not available")
 						return
 					}
 
 					// No provider configured - require explicit opt-in via skip_jwt_verification
 					// We can only reach this if skip_jwt_verification is false
-					klog.V(1).Infof("Authentication rejected - JWT verification not configured: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+					logger.V(1).Info("Authentication rejected - JWT verification not configured",
+						"http.request.method", r.Method,
+						"url.path", r.URL.Path,
+						"client.address", r.RemoteAddr,
+					)
 					http.Error(w, "JWT verification not configured - set authorization_url or skip_jwt_verification", http.StatusInternalServerError)
 					return
 				} else {
@@ -144,7 +161,12 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 				}
 			}
 			if err != nil {
-				klog.V(1).Infof("Authentication failed - JWT validation error: %s %s from %s, error: %v", r.Method, r.URL.Path, r.RemoteAddr, err)
+				logger.V(1).Info("Authentication failed - JWT validation error",
+					"http.request.method", r.Method,
+					"url.path", r.URL.Path,
+					"client.address", r.RemoteAddr,
+					"exception.message", err.Error(),
+				)
 				write401(w, wwwAuthenticateHeader, "invalid_token", "Unauthorized: Invalid token")
 				return
 			}

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -53,7 +53,7 @@ func (s *AuthorizationSuite) SetupTest() {
 	flags := flag.NewFlagSet("test", flag.ContinueOnError)
 	klog.InitFlags(flags)
 	_ = flags.Set("v", "5")
-	klog.SetLogger(textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(5), textlogger.Output(&s.logBuffer))))
+	s.Logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(5), textlogger.Output(&s.logBuffer)))
 
 	// Default Auth settings (overridden in tests as needed)
 	s.OidcProvider = nil
@@ -179,7 +179,7 @@ func (s *AuthorizationSuite) TestAuthorizationUnauthorizedHeaderInvalid() {
 		})
 		s.Run("logs error", func() {
 			s.Contains(s.logBuffer.String(), "Authentication failed - JWT validation error", "Expected log entry for JWT validation error")
-			s.Contains(s.logBuffer.String(), "error: failed to parse JWT token: illegal base64 data", "Expected log entry for JWT validation error details")
+			s.Contains(s.logBuffer.String(), "failed to parse JWT token: illegal base64 data", "Expected log entry for JWT validation error details")
 		})
 	})
 }

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -92,11 +93,11 @@ func statsHandler(mcpServer *mcp.Server) http.HandlerFunc {
 			return
 		}
 
-		stats := mcpServer.GetMetrics().GetStats()
+		stats := mcpServer.GetMetrics().GetStats(r.Context())
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(stats); err != nil {
-			klog.V(1).Infof("Failed to encode stats response: %v", err)
+			klog.FromContext(r.Context()).V(1).Info("Failed to encode stats response", "exception.message", err.Error())
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
@@ -104,6 +105,7 @@ func statsHandler(mcpServer *mcp.Server) http.HandlerFunc {
 }
 
 func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticConfigState, oauthState *oauth.State) error {
+	logger := klog.FromContext(ctx)
 	// Only fields read below are startup-only; middleware reloads via cfgState.
 	staticConfig := cfgState.Load()
 	mux := http.NewServeMux()
@@ -127,6 +129,10 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},
+		// BaseContext propagates the server context (including the klog logger)
+		// to all incoming request contexts, so klog.FromContext(r.Context())
+		// returns the contextual logger rather than the global fallback.
+		BaseContext: func(_ net.Listener) context.Context { return ctx },
 	}
 
 	// Only set up custom error logger for TLS mode to filter noisy TLS handshake errors
@@ -157,10 +163,16 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 	go func() {
 		var err error
 		if staticConfig.TLSCert != "" && staticConfig.TLSKey != "" {
-			klog.V(0).Infof("HTTPS server starting on port %s (endpoints: /mcp, /sse, /message, /healthz, /stats, /metrics)", staticConfig.Port)
+			logger.Info("HTTPS server starting",
+				"server.port", staticConfig.Port,
+				"endpoints", "/mcp, /sse, /message, /healthz, /stats, /metrics",
+			)
 			err = httpServer.ListenAndServeTLS(staticConfig.TLSCert, staticConfig.TLSKey)
 		} else {
-			klog.V(0).Infof("HTTP server starting on port %s (endpoints: /mcp, /sse, /message, /healthz, /stats, /metrics)", staticConfig.Port)
+			logger.Info("HTTP server starting",
+				"server.port", staticConfig.Port,
+				"endpoints", "/mcp, /sse, /message, /healthz, /stats, /metrics",
+			)
 			err = httpServer.ListenAndServe()
 		}
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -170,31 +182,31 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 
 	select {
 	case sig := <-sigChan:
-		klog.V(0).Infof("Received signal %v, initiating graceful shutdown", sig)
+		logger.Info("Received signal, initiating graceful shutdown", "signal", sig.String())
 		cancel()
 	case <-ctx.Done():
-		klog.V(0).Infof("Context cancelled, initiating graceful shutdown")
+		logger.Info("Context cancelled, initiating graceful shutdown")
 	case err := <-serverErr:
-		klog.Errorf("HTTP server error: %v", err)
+		logger.Error(err, "HTTP server error")
 		return err
 	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 
-	klog.V(0).Infof("Shutting down HTTP server gracefully...")
+	logger.Info("Shutting down HTTP server gracefully...")
 
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		// Don't fail Run() for errors during shutdown
-		klog.Errorf("HTTP server shutdown error: %v", err)
+		logger.Error(err, "HTTP server shutdown error")
 	}
 
 	// Always attempt MCP server shutdown (flushes metrics) even if HTTP shutdown failed
 	if err := mcpServer.Shutdown(shutdownCtx); err != nil {
 		// Don't fail Run() for errors during shutdown
-		klog.Errorf("MCP server shutdown error: %v", err)
+		logger.Error(err, "MCP server shutdown error")
 	}
 
-	klog.V(0).Infof("HTTP server shutdown complete")
+	logger.Info("HTTP server shutdown complete")
 	return nil
 }

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
@@ -34,6 +36,7 @@ type BaseHttpSuite struct {
 	suite.Suite
 	MockServer      *test.MockServer
 	StaticConfig    *config.StaticConfig
+	Logger          logr.Logger
 	mcpServer       *mcp.Server
 	OidcProvider    *oidc.Provider
 	OAuthState      *oauth.State
@@ -59,15 +62,18 @@ func (s *BaseHttpSuite) StartServer() {
 	s.StaticConfig.Port = strconv.Itoa(tcpAddr.Port)
 
 	s.OAuthState = oauth.NewState(oauth.SnapshotFromConfig(s.StaticConfig, s.OidcProvider, nil))
-	provider, err := kubernetes.NewProvider(s.StaticConfig, kubernetes.WithTokenExchange(s.OAuthState))
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.StaticConfig, kubernetes.WithTokenExchange(s.OAuthState))
 	s.Require().NoError(err, "Expected no error creating kubernetes target provider")
-	s.mcpServer, err = mcp.NewServer(mcp.Configuration{StaticConfig: s.StaticConfig}, provider)
+	s.mcpServer, err = mcp.NewServer(s.T().Context(), mcp.Configuration{StaticConfig: s.StaticConfig}, provider)
 	s.Require().NoError(err, "Expected no error creating MCP server")
 	s.Require().NotNil(s.mcpServer, "MCP server should not be nil")
 	var timeoutCtx, cancelCtx context.Context
 	timeoutCtx, s.timeoutCancel = context.WithTimeout(s.T().Context(), 10*time.Second)
 	group, gc := errgroup.WithContext(timeoutCtx)
 	cancelCtx, s.StopServer = context.WithCancel(gc)
+	if s.Logger.GetSink() != nil {
+		cancelCtx = klog.NewContext(cancelCtx, s.Logger)
+	}
 	group.Go(func() error {
 		return Serve(cancelCtx, s.mcpServer, config.NewStaticConfigState(s.StaticConfig), s.OAuthState)
 	})
@@ -101,6 +107,7 @@ func (s *BaseHttpSuite) stopRunningServer() {
 
 type httpContext struct {
 	klogState       klog.State
+	logger          logr.Logger
 	mockServer      *test.MockServer
 	LogBuffer       test.SyncBuffer
 	HttpAddress     string             // HTTP server address
@@ -126,7 +133,7 @@ func (c *httpContext) beforeEach(t *testing.T) {
 	flags := flag.NewFlagSet("test", flag.ContinueOnError)
 	klog.InitFlags(flags)
 	_ = flags.Set("v", "5")
-	klog.SetLogger(textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(5), textlogger.Output(&c.LogBuffer))))
+	c.logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(5), textlogger.Output(&c.LogBuffer)))
 	// Start server in random port
 	ln, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {
@@ -138,11 +145,11 @@ func (c *httpContext) beforeEach(t *testing.T) {
 	}
 	c.StaticConfig.Port = fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port)
 	c.OAuthState = oauth.NewState(oauth.SnapshotFromConfig(c.StaticConfig, c.OidcProvider, nil))
-	provider, err := kubernetes.NewProvider(c.StaticConfig, kubernetes.WithTokenExchange(c.OAuthState))
+	provider, err := kubernetes.NewProvider(t.Context(), c.StaticConfig, kubernetes.WithTokenExchange(c.OAuthState))
 	if err != nil {
 		t.Fatalf("Failed to create kubernetes target provider: %v", err)
 	}
-	mcpServer, err := mcp.NewServer(mcp.Configuration{StaticConfig: c.StaticConfig}, provider)
+	mcpServer, err := mcp.NewServer(t.Context(), mcp.Configuration{StaticConfig: c.StaticConfig}, provider)
 	if err != nil {
 		t.Fatalf("Failed to create MCP server: %v", err)
 	}
@@ -151,7 +158,7 @@ func (c *httpContext) beforeEach(t *testing.T) {
 	group, gc := errgroup.WithContext(timeoutCtx)
 	cancelCtx, c.StopServer = context.WithCancel(gc)
 	group.Go(func() error {
-		return Serve(cancelCtx, mcpServer, config.NewStaticConfigState(c.StaticConfig), c.OAuthState)
+		return Serve(klog.NewContext(cancelCtx, c.logger), mcpServer, config.NewStaticConfigState(c.StaticConfig), c.OAuthState)
 	})
 	c.WaitForShutdown = group.Wait
 	// Wait for HTTP server to start (using net)
@@ -287,12 +294,19 @@ func TestMiddlewareLogging(t *testing.T) {
 	testCase(t, func(ctx *httpContext) {
 		_, _ = http.Get(fmt.Sprintf("http://%s/.well-known/oauth-protected-resource", ctx.HttpAddress))
 		t.Run("Logs HTTP requests and responses", func(t *testing.T) {
-			if !strings.Contains(ctx.LogBuffer.String(), "GET /.well-known/oauth-protected-resource 404") {
-				t.Errorf("Expected log entry for GET /.well-known/oauth-protected-resource, got: %s", ctx.LogBuffer.String())
+			logStr := ctx.LogBuffer.String()
+			if !strings.Contains(logStr, "HTTP request completed") {
+				t.Errorf("Expected log entry for HTTP request completed, got: %s", logStr)
+			}
+			if !strings.Contains(logStr, `url.path="/.well-known/oauth-protected-resource"`) {
+				t.Errorf("Expected log to contain url.path, got: %s", logStr)
+			}
+			if !strings.Contains(logStr, "http.response.status_code=404") {
+				t.Errorf("Expected log to contain status code 404, got: %s", logStr)
 			}
 		})
 		t.Run("Logs HTTP request duration", func(t *testing.T) {
-			expected := `"GET /.well-known/oauth-protected-resource 404 (.+)"`
+			expected := `duration="(.+?)"`
 			m := regexp.MustCompile(expected).FindStringSubmatch(ctx.LogBuffer.String())
 			if len(m) != 2 {
 				t.Fatalf("Expected log entry to contain duration, got %s", ctx.LogBuffer.String())

--- a/pkg/http/middleware.go
+++ b/pkg/http/middleware.go
@@ -102,7 +102,12 @@ func RequestMiddleware(cfgState *config.StaticConfigState) func(http.Handler) ht
 				}
 				start := time.Now()
 				next.ServeHTTP(lrw, r)
-				klog.V(5).Infof("%s %s %d %v", r.Method, r.URL.Path, lrw.statusCode, time.Since(start))
+				klog.FromContext(r.Context()).V(5).Info("HTTP request completed",
+					"http.request.method", r.Method,
+					"url.path", r.URL.Path,
+					"http.response.status_code", lrw.statusCode,
+					"duration", time.Since(start),
+				)
 				return
 			}
 
@@ -175,7 +180,12 @@ func RequestMiddleware(cfgState *config.StaticConfigState) func(http.Handler) ht
 				span.SetStatus(codes.Ok, "")
 			}
 
-			klog.V(5).Infof("%s %s %d %v", r.Method, r.URL.Path, lrw.statusCode, duration)
+			klog.FromContext(r.Context()).V(5).Info("HTTP request completed",
+				"http.request.method", r.Method,
+				"url.path", r.URL.Path,
+				"http.response.status_code", lrw.statusCode,
+				"duration", duration,
+			)
 		})
 	}
 }

--- a/pkg/http/middleware_test.go
+++ b/pkg/http/middleware_test.go
@@ -41,7 +41,7 @@ func (s *HTTPTraceContextPropagationSuite) SetupTest() {
 	s.T().Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 
 	// Initialize telemetry (exporter may fail but tracingEnabled will be set)
-	cleanup, _ := telemetry.InitTracer("test", "1.0.0")
+	cleanup, _ := telemetry.InitTracer(s.T().Context(), "test", "1.0.0")
 	s.cleanupTelemetry = cleanup
 
 	// Set up a global text map propagator for tests
@@ -356,7 +356,7 @@ func (s *TrustProxyHeadersSuite) SetupTest() {
 	// RequestMiddleware skips span creation when telemetry.Enabled() is false,
 	// so flip the flag on by initializing the tracer with an OTLP endpoint.
 	s.T().Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
-	cleanup, err := telemetry.InitTracer("test", "1.0.0")
+	cleanup, err := telemetry.InitTracer(s.T().Context(), "test", "1.0.0")
 	s.Require().NoError(err, "Expected telemetry.InitTracer to succeed")
 	s.cleanupTelemetry = cleanup
 }

--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -148,10 +148,15 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 		return
 	}
 
+	logger := klog.FromContext(request.Context())
+
 	// Try direct proxy first (works for Keycloak and other providers that support all endpoints)
 	resourceMetadata, respHeaders, err := w.fetchWellKnownEndpoint(request, upstreamURL)
 	if err != nil {
-		klog.V(1).Infof("Well-known proxy failed to fetch %s: %v", requestPath, err)
+		logger.V(1).Info("Well-known proxy failed to fetch endpoint",
+			"url.path", requestPath,
+			"exception.message", err.Error(),
+		)
 		http.Error(writer, "Failed to fetch well-known metadata", http.StatusInternalServerError)
 		return
 	}
@@ -164,7 +169,9 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 		case strings.HasPrefix(requestPath, oauthAuthorizationServerEndpoint):
 			resourceMetadata, err = w.generateAuthorizationServerMetadata(request)
 			if err != nil {
-				klog.V(1).Infof("Well-known proxy failed to generate authorization server metadata: %v", err)
+				logger.V(1).Info("Well-known proxy failed to generate authorization server metadata",
+					"exception.message", err.Error(),
+				)
 				http.Error(writer, "Failed to generate well-known metadata", http.StatusInternalServerError)
 				return
 			}
@@ -172,7 +179,9 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 		case strings.HasPrefix(requestPath, oauthProtectedResourceEndpoint):
 			resourceMetadata, err = w.generateProtectedResourceMetadata(request)
 			if err != nil {
-				klog.V(1).Infof("Well-known proxy failed to generate protected resource metadata: %v", err)
+				logger.V(1).Info("Well-known proxy failed to generate protected resource metadata",
+					"exception.message", err.Error(),
+				)
 				http.Error(writer, "Failed to generate well-known metadata", http.StatusInternalServerError)
 				return
 			}
@@ -188,7 +197,10 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 
 	body, err := json.Marshal(resourceMetadata)
 	if err != nil {
-		klog.V(1).Infof("Well-known proxy failed to marshal response for %s: %v", request.URL.Path, err)
+		logger.V(1).Info("Well-known proxy failed to marshal response",
+			"url.path", request.URL.Path,
+			"exception.message", err.Error(),
+		)
 		http.Error(writer, "Internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes/watcher"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -100,7 +101,7 @@ func (p *kcpClusterProvider) reset(ctx context.Context) error {
 	// Discover workspaces
 	workspaceList, err := p.discoverWorkspaces(baseManager)
 	if err != nil {
-		klog.FromContext(ctx).Info("Failed to discover workspaces via API, falling back to kubeconfig", "exception.message", err)
+		klogutil.Warn(ctx, "Failed to discover workspaces via API, falling back to kubeconfig", "exception.message", err)
 		workspaceList, err = p.workspacesFromKubeconfig(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to discover workspaces: %w", err)

--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -101,7 +101,7 @@ func (p *kcpClusterProvider) reset(ctx context.Context) error {
 	// Discover workspaces
 	workspaceList, err := p.discoverWorkspaces(baseManager)
 	if err != nil {
-		klogutil.Warn(ctx, "Failed to discover workspaces via API, falling back to kubeconfig", "exception.message", err)
+		klogutil.Warn(ctx, "Failed to discover workspaces via API, falling back to kubeconfig", "exception.message", err.Error())
 		workspaceList, err = p.workspacesFromKubeconfig(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to discover workspaces: %w", err)

--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -44,15 +44,15 @@ func init() {
 
 // newKcpClusterProvider creates a provider that manages multiple kcp workspaces.
 // Each workspace is treated as a separate cluster target.
-func newKcpClusterProvider(cfg api.BaseConfig) (kubernetes.Provider, error) {
+func newKcpClusterProvider(ctx context.Context, cfg api.BaseConfig) (kubernetes.Provider, error) {
 	ret := &kcpClusterProvider{config: cfg}
-	if err := ret.reset(); err != nil {
+	if err := ret.reset(ctx); err != nil {
 		return nil, err
 	}
 	return ret, nil
 }
 
-func (p *kcpClusterProvider) reset() error {
+func (p *kcpClusterProvider) reset(ctx context.Context) error {
 	// Load kubeconfig
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	if p.config.GetKubeConfigPath() != "" {
@@ -92,7 +92,7 @@ func (p *kcpClusterProvider) reset() error {
 	}
 
 	// Create base manager for workspace discovery
-	baseManager, err := kubernetes.NewKubeconfigManager(p.config, rawConfig.CurrentContext)
+	baseManager, err := kubernetes.NewKubeconfigManager(ctx, p.config, rawConfig.CurrentContext)
 	if err != nil {
 		return fmt.Errorf("failed to create base manager: %w", err)
 	}
@@ -100,8 +100,8 @@ func (p *kcpClusterProvider) reset() error {
 	// Discover workspaces
 	workspaceList, err := p.discoverWorkspaces(baseManager)
 	if err != nil {
-		klog.Warningf("Failed to discover workspaces via API, falling back to kubeconfig: %v", err)
-		workspaceList, err = p.workspacesFromKubeconfig()
+		klog.FromContext(ctx).Info("Failed to discover workspaces via API, falling back to kubeconfig", "exception.message", err)
+		workspaceList, err = p.workspacesFromKubeconfig(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to discover workspaces: %w", err)
 		}
@@ -117,12 +117,12 @@ func (p *kcpClusterProvider) reset() error {
 
 	// Setup watchers
 	p.Close()
-	k8s, err := baseManager.Derived(context.Background())
+	k8s, err := baseManager.Derived(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get kubernetes client: %w", err)
 	}
-	p.workspaceWatcher = NewWorkspaceWatcher(k8s.DynamicClient(), p.defaultWorkspace)
-	p.clusterStateWatcher = watcher.NewClusterState(k8s.DiscoveryClient())
+	p.workspaceWatcher = NewWorkspaceWatcher(ctx, k8s.DynamicClient(), p.defaultWorkspace)
+	p.clusterStateWatcher = watcher.NewClusterState(ctx, k8s.DiscoveryClient())
 
 	return nil
 }
@@ -134,7 +134,7 @@ func (p *kcpClusterProvider) discoverWorkspaces(_ *kubernetes.Manager) ([]string
 }
 
 // workspacesFromKubeconfig extracts workspace names from kubeconfig cluster URLs as a fallback.
-func (p *kcpClusterProvider) workspacesFromKubeconfig() ([]string, error) {
+func (p *kcpClusterProvider) workspacesFromKubeconfig(ctx context.Context) ([]string, error) {
 	rawConfig, err := p.clientCmdConfig.RawConfig()
 	if err != nil {
 		return nil, err
@@ -152,12 +152,12 @@ func (p *kcpClusterProvider) workspacesFromKubeconfig() ([]string, error) {
 		result = append(result, ws)
 	}
 
-	klog.V(2).Infof("Discovered %d workspaces from kubeconfig", len(result))
+	klog.FromContext(ctx).V(2).Info("Discovered workspaces from kubeconfig", "num_workspaces", len(result))
 	return result, nil
 }
 
 // managerForWorkspace returns or creates a Manager for the specified workspace.
-func (p *kcpClusterProvider) managerForWorkspace(workspace string) (*kubernetes.Manager, error) {
+func (p *kcpClusterProvider) managerForWorkspace(ctx context.Context, workspace string) (*kubernetes.Manager, error) {
 	m, ok := p.managers[workspace]
 	if ok && m != nil {
 		return m, nil
@@ -183,7 +183,7 @@ func (p *kcpClusterProvider) managerForWorkspace(workspace string) (*kubernetes.
 	clientCmdConfig := clientcmd.NewDefaultClientConfig(rawConfig,
 		&clientcmd.ConfigOverrides{CurrentContext: contextName})
 
-	m, err = kubernetes.NewManager(p.config, workspaceRestConfig, clientCmdConfig)
+	m, err = kubernetes.NewManager(ctx, p.config, workspaceRestConfig, clientCmdConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager for workspace %s: %w", workspace, err)
 	}
@@ -258,7 +258,7 @@ func (p *kcpClusterProvider) GetDerivedKubernetes(ctx context.Context, workspace
 		workspace = p.defaultWorkspace
 	}
 
-	m, err := p.managerForWorkspace(workspace)
+	m, err := p.managerForWorkspace(ctx, workspace)
 	if err != nil {
 		return nil, err
 	}
@@ -270,17 +270,17 @@ func (p *kcpClusterProvider) GetDefaultTarget() string {
 	return p.defaultWorkspace
 }
 
-func (p *kcpClusterProvider) WatchTargets(reload kubernetes.McpReload) {
+func (p *kcpClusterProvider) WatchTargets(ctx context.Context, reload kubernetes.McpReload) {
 	reloadWithReset := func() error {
-		if err := p.reset(); err != nil {
+		if err := p.reset(ctx); err != nil {
 			return err
 		}
-		p.WatchTargets(reload)
+		p.WatchTargets(ctx, reload)
 		return reload()
 	}
 
-	p.workspaceWatcher.Watch(reloadWithReset)
-	p.clusterStateWatcher.Watch(reload)
+	p.workspaceWatcher.Watch(ctx, reloadWithReset)
+	p.clusterStateWatcher.Watch(ctx, reload)
 }
 
 func (p *kcpClusterProvider) Close() {
@@ -291,6 +291,6 @@ func (p *kcpClusterProvider) Close() {
 	}
 }
 
-func (p *kcpClusterProvider) HasGVKs(_ []schema.GroupVersionKind) bool {
+func (p *kcpClusterProvider) HasGVKs(_ context.Context, _ []schema.GroupVersionKind) bool {
 	return true
 }

--- a/pkg/kcp/workspace.go
+++ b/pkg/kcp/workspace.go
@@ -64,7 +64,7 @@ func DiscoverWorkspacesRecursive(
 
 	dynamicClient, err := dynamic.NewForConfig(workspaceRestConfig)
 	if err != nil {
-		logger.V(3).Info("Failed to create client for workspace", "workspace", parentWorkspace, "exception.message", err)
+		logger.V(3).Info("Failed to create client for workspace", "workspace", parentWorkspace, "exception.message", err.Error())
 		return nil // Don't fail entirely, just skip this workspace
 	}
 
@@ -72,7 +72,7 @@ func DiscoverWorkspacesRecursive(
 	workspaceList, err := dynamicClient.Resource(WorkspaceGVR).
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		logger.V(3).Info("Failed to list workspaces in parent workspace", "parent_workspace", parentWorkspace, "exception.message", err)
+		logger.V(3).Info("Failed to list workspaces in parent workspace", "parent_workspace", parentWorkspace, "exception.message", err.Error())
 		return nil // Don't fail entirely, just skip
 	}
 
@@ -98,7 +98,7 @@ func DiscoverWorkspacesRecursive(
 		// Recursively discover children of this workspace
 		err = DiscoverWorkspacesRecursive(ctx, baseRestConfig, fullPath, discovered)
 		if err != nil {
-			logger.V(3).Info("Failed to recurse into workspace", "workspace_path", fullPath, "exception.message", err)
+			logger.V(3).Info("Failed to recurse into workspace", "workspace_path", fullPath, "exception.message", err.Error())
 			// Continue with other workspaces
 		}
 	}

--- a/pkg/kcp/workspace.go
+++ b/pkg/kcp/workspace.go
@@ -54,6 +54,7 @@ func DiscoverWorkspacesRecursive(
 	parentWorkspace string,
 	discovered map[string]bool,
 ) error {
+	logger := klog.FromContext(ctx)
 	// Parse base URL from the config
 	baseURL, _ := ParseServerURL(baseRestConfig.Host)
 
@@ -63,7 +64,7 @@ func DiscoverWorkspacesRecursive(
 
 	dynamicClient, err := dynamic.NewForConfig(workspaceRestConfig)
 	if err != nil {
-		klog.V(3).Infof("Failed to create client for workspace %s: %v", parentWorkspace, err)
+		logger.V(3).Info("Failed to create client for workspace", "workspace", parentWorkspace, "exception.message", err)
 		return nil // Don't fail entirely, just skip this workspace
 	}
 
@@ -71,7 +72,7 @@ func DiscoverWorkspacesRecursive(
 	workspaceList, err := dynamicClient.Resource(WorkspaceGVR).
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		klog.V(3).Infof("Failed to list workspaces in %s: %v", parentWorkspace, err)
+		logger.V(3).Info("Failed to list workspaces in parent workspace", "parent_workspace", parentWorkspace, "exception.message", err)
 		return nil // Don't fail entirely, just skip
 	}
 
@@ -92,12 +93,12 @@ func DiscoverWorkspacesRecursive(
 		}
 
 		discovered[fullPath] = true
-		klog.V(3).Infof("Discovered workspace: %s", fullPath)
+		logger.V(3).Info("Discovered workspace", "workspace_path", fullPath)
 
 		// Recursively discover children of this workspace
 		err = DiscoverWorkspacesRecursive(ctx, baseRestConfig, fullPath, discovered)
 		if err != nil {
-			klog.V(3).Infof("Failed to recurse into workspace %s: %v", fullPath, err)
+			logger.V(3).Info("Failed to recurse into workspace", "workspace_path", fullPath, "exception.message", err)
 			// Continue with other workspaces
 		}
 	}
@@ -129,6 +130,6 @@ func DiscoverAllWorkspaces(
 		workspaces = append(workspaces, ws)
 	}
 
-	klog.V(2).Infof("Discovered %d workspaces via kcp API (including nested)", len(workspaces))
+	klog.FromContext(ctx).V(2).Info("Discovered workspaces via kcp API (including nested)", "num_workspaces", len(workspaces))
 	return workspaces, nil
 }

--- a/pkg/kcp/workspace_watcher.go
+++ b/pkg/kcp/workspace_watcher.go
@@ -43,21 +43,23 @@ var _ watcher.Watcher = (*WorkspaceWatcher)(nil)
 
 // NewWorkspaceWatcher creates a new workspace watcher that polls the kcp tenancy API
 // for workspace changes.
-func NewWorkspaceWatcher(dynamicClient dynamic.Interface, rootWorkspace string) *WorkspaceWatcher {
+func NewWorkspaceWatcher(ctx context.Context, dynamicClient dynamic.Interface, rootWorkspace string) *WorkspaceWatcher {
 	pollInterval := DefaultWorkspacePollInterval
 	debounceWindow := DefaultWorkspaceDebounceWindow
+
+	logger := klog.FromContext(ctx)
 
 	// Allow override via environment variable for testing
 	if envInterval := os.Getenv("WORKSPACE_POLL_INTERVAL_MS"); envInterval != "" {
 		if ms, err := strconv.Atoi(envInterval); err == nil && ms > 0 {
 			pollInterval = time.Duration(ms) * time.Millisecond
-			klog.V(2).Infof("Using custom workspace poll interval: %v", pollInterval)
+			logger.V(2).Info("Using custom workspace poll interval", "poll_interval", pollInterval)
 		}
 	}
 	if envDebounce := os.Getenv("WORKSPACE_DEBOUNCE_WINDOW_MS"); envDebounce != "" {
 		if ms, err := strconv.Atoi(envDebounce); err == nil && ms > 0 {
 			debounceWindow = time.Duration(ms) * time.Millisecond
-			klog.V(2).Infof("Using custom workspace debounce window: %v", debounceWindow)
+			logger.V(2).Info("Using custom workspace debounce window", "debounce_window", debounceWindow)
 		}
 	}
 
@@ -74,33 +76,37 @@ func NewWorkspaceWatcher(dynamicClient dynamic.Interface, rootWorkspace string) 
 // Watch starts watching for workspace changes. The onChange callback is called
 // when workspace changes are detected after debouncing.
 // This can only be called once per WorkspaceWatcher instance.
-func (w *WorkspaceWatcher) Watch(onChange func() error) {
+func (w *WorkspaceWatcher) Watch(ctx context.Context, onChange func() error) {
 	w.mu.Lock()
 	if w.started {
 		w.mu.Unlock()
 		return
 	}
 	w.started = true
-	w.lastKnownState = w.captureState()
+	w.lastKnownState = w.captureState(ctx)
 	w.mu.Unlock()
+
+	logger := klog.FromContext(ctx)
 
 	go func() {
 		defer close(w.stoppedCh)
 		ticker := time.NewTicker(w.pollInterval)
 		defer ticker.Stop()
 
-		klog.V(2).Infof("Started workspace watcher (poll interval: %v, debounce: %v)",
-			w.pollInterval, w.debounceWindow)
+		logger.V(2).Info("Started workspace watcher",
+			"poll_interval", w.pollInterval,
+			"debounce_window", w.debounceWindow,
+		)
 
 		for {
 			select {
 			case <-w.stopCh:
-				klog.V(2).Info("Stopping workspace watcher")
+				logger.V(2).Info("Stopping workspace watcher")
 				return
 			case <-ticker.C:
 				w.mu.Lock()
-				current := w.captureState()
-				klog.V(3).Infof("Polled workspaces: %d total", len(current.workspaces))
+				current := w.captureState(ctx)
+				logger.V(3).Info("Polled workspaces", "cluster.workspaces.count", len(current.workspaces))
 
 				changed := len(current.workspaces) != len(w.lastKnownState.workspaces)
 				if !changed {
@@ -113,19 +119,19 @@ func (w *WorkspaceWatcher) Watch(onChange func() error) {
 				}
 
 				if changed {
-					klog.V(2).Info("Workspace state changed, scheduling debounced reload")
+					logger.V(2).Info("Workspace state changed, scheduling debounced reload")
 					if w.debounceTimer != nil {
 						w.debounceTimer.Stop()
 					}
 					w.debounceTimer = time.AfterFunc(w.debounceWindow, func() {
-						klog.V(2).Info("Workspace debounce window expired, triggering reload")
+						logger.V(2).Info("Workspace debounce window expired, triggering reload")
 						if err := onChange(); err != nil {
-							klog.Errorf("Failed to reload: %v", err)
+							logger.Info("Failed to reload", "exception.message", err)
 						} else {
 							w.mu.Lock()
-							w.lastKnownState = w.captureState()
+							w.lastKnownState = w.captureState(ctx)
 							w.mu.Unlock()
-							klog.V(2).Info("Reload completed")
+							logger.V(2).Info("Reload completed")
 						}
 					})
 				}
@@ -167,13 +173,14 @@ func (w *WorkspaceWatcher) Close() {
 }
 
 // captureState queries the current workspace list from the kcp tenancy API.
-func (w *WorkspaceWatcher) captureState() workspaceState {
+func (w *WorkspaceWatcher) captureState(ctx context.Context) workspaceState {
+	logger := klog.FromContext(ctx)
 	state := workspaceState{workspaces: []string{}}
 
 	list, err := w.dynamicClient.Resource(WorkspaceGVR).
-		List(context.TODO(), metav1.ListOptions{})
+		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		klog.V(2).Infof("Unable to list workspaces from kcp API (this is expected if tenancy API is not available): %v", err)
+		logger.V(2).Info("Unable to list workspaces from kcp API (this is expected if tenancy API is not available)", "exception.message", err)
 		// Return empty state - this means workspace watching won't work,
 		// but the provider will still function using kubeconfig-based discovery
 		return state

--- a/pkg/kcp/workspace_watcher.go
+++ b/pkg/kcp/workspace_watcher.go
@@ -126,7 +126,7 @@ func (w *WorkspaceWatcher) Watch(ctx context.Context, onChange func() error) {
 					w.debounceTimer = time.AfterFunc(w.debounceWindow, func() {
 						logger.V(2).Info("Workspace debounce window expired, triggering reload")
 						if err := onChange(); err != nil {
-							logger.Info("Failed to reload", "exception.message", err)
+							logger.Error(err, "Failed to reload")
 						} else {
 							w.mu.Lock()
 							w.lastKnownState = w.captureState(ctx)

--- a/pkg/kcp/workspace_watcher.go
+++ b/pkg/kcp/workspace_watcher.go
@@ -180,7 +180,7 @@ func (w *WorkspaceWatcher) captureState(ctx context.Context) workspaceState {
 	list, err := w.dynamicClient.Resource(WorkspaceGVR).
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		logger.V(2).Info("Unable to list workspaces from kcp API (this is expected if tenancy API is not available)", "exception.message", err)
+		logger.V(2).Info("Unable to list workspaces from kcp API (this is expected if tenancy API is not available)", "exception.message", err.Error())
 		// Return empty state - this means workspace watching won't work,
 		// but the provider will still function using kubeconfig-based discovery
 		return state

--- a/pkg/kiali/kiali.go
+++ b/pkg/kiali/kiali.go
@@ -86,7 +86,8 @@ func (k *Kiali) validateAndGetURL(endpoint string) (string, error) {
 	return u.String(), nil
 }
 
-func (k *Kiali) createHTTPClient() *http.Client {
+func (k *Kiali) createHTTPClient(ctx context.Context) *http.Client {
+	logger := klog.FromContext(ctx)
 	// Base TLS configuration with minimum version for security
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
@@ -98,7 +99,7 @@ func (k *Kiali) createHTTPClient() *http.Client {
 		// Read the certificate from file
 		caPEM, err := os.ReadFile(caValue)
 		if err != nil {
-			klog.Errorf("failed to read CA certificate from file %s: %v; proceeding without custom CA", caValue, err)
+			logger.Error(err, "failed to read CA certificate from file, proceeding without custom CA", "ca_file", caValue)
 			return k.wrapWithTLSEnforcement(&http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig: tlsConfig,
@@ -116,7 +117,7 @@ func (k *Kiali) createHTTPClient() *http.Client {
 		if ok := certPool.AppendCertsFromPEM(caPEM); ok {
 			tlsConfig.RootCAs = certPool
 		} else {
-			klog.V(0).Infof("failed to append provided certificate authority; proceeding without custom CA")
+			logger.V(0).Info("failed to append provided certificate authority; proceeding without custom CA")
 		}
 	}
 
@@ -173,7 +174,7 @@ func (k *Kiali) ExecuteRequest(ctx context.Context, endpoint string, arguments m
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal arguments: %w", err)
 	}
-	klog.V(0).Infof("kiali API call: %s", ApiCallURL)
+	klog.FromContext(ctx).V(0).Info("kiali API call", "url.full", ApiCallURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ApiCallURL, strings.NewReader(string(jsonData)))
 	if err != nil {
 		return "", err
@@ -184,7 +185,7 @@ func (k *Kiali) ExecuteRequest(ctx context.Context, endpoint string, arguments m
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Kubernetes-MCP-Server", "true")
-	client := k.createHTTPClient()
+	client := k.createHTTPClient(ctx)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err

--- a/pkg/klogutil/util.go
+++ b/pkg/klogutil/util.go
@@ -1,0 +1,11 @@
+package klogutil
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+)
+
+func Warn(ctx context.Context, msg string, kv ...any) {
+	klog.FromContext(ctx).Info(msg, append([]any{"log.severity", "WARN"}, kv...)...)
+}

--- a/pkg/klogutil/util.go
+++ b/pkg/klogutil/util.go
@@ -6,6 +6,16 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// Warn obtains a klog logger from context and logs the provided message + kvs
+// with a log.severity=WARN. This is done as klog.Logger interface does not have
+// a native Warn method
 func Warn(ctx context.Context, msg string, kv ...any) {
 	klog.FromContext(ctx).Info(msg, append([]any{"log.severity", "WARN"}, kv...)...)
+}
+
+// WarnLogger logs the provided message + kvs with a log.severity=WARN on the
+// provided logger. This is done as klog.Logger interface does not have a native
+// Warn method
+func WarnLogger(logger klog.Logger, msg string, kv ...any) {
+	logger.Info(msg, append([]any{"log.severity", "WARN"}, kv...)...)
 }

--- a/pkg/klogutil/util_test.go
+++ b/pkg/klogutil/util_test.go
@@ -1,0 +1,90 @@
+package klogutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/klog/v2"
+)
+
+type KlogUtilSuite struct {
+	suite.Suite
+}
+
+func TestKlogUtil(t *testing.T) {
+	suite.Run(t, new(KlogUtilSuite))
+}
+
+// newCapturingLogger returns a logr.Logger that appends each log line to the
+// provided slice, making it easy to assert on log output.
+func newCapturingLogger(lines *[]string) logr.Logger {
+	return funcr.New(func(prefix, args string) {
+		*lines = append(*lines, prefix+args)
+	}, funcr.Options{})
+}
+
+func (s *KlogUtilSuite) TestWarn() {
+	s.Run("logs message with WARN severity", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines)
+		ctx := klog.NewContext(context.Background(), logger)
+
+		Warn(ctx, "something happened")
+
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], "something happened")
+		s.Contains(lines[0], "log.severity")
+		s.Contains(lines[0], "WARN")
+	})
+
+	s.Run("includes extra key-value pairs", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines)
+		ctx := klog.NewContext(context.Background(), logger)
+
+		Warn(ctx, "disk full", "path", "/var/log")
+
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], "path")
+		s.Contains(lines[0], "/var/log")
+	})
+
+	s.Run("works with no extra key-value pairs", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines)
+		ctx := klog.NewContext(context.Background(), logger)
+
+		Warn(ctx, "bare warning")
+
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], "bare warning")
+	})
+}
+
+func (s *KlogUtilSuite) TestWarnLogger() {
+	s.Run("logs message with WARN severity", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines)
+
+		WarnLogger(logger, "timeout exceeded")
+
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], "timeout exceeded")
+		s.Contains(lines[0], "log.severity")
+		s.Contains(lines[0], "WARN")
+	})
+
+	s.Run("includes extra key-value pairs", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines)
+
+		WarnLogger(logger, "retry", "attempt", 3)
+
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], "attempt")
+		s.Contains(lines[0], "3")
+	})
+}

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -128,13 +128,14 @@ func NewMCPServerOptions(streams genericiooptions.IOStreams) *MCPServerOptions {
 
 func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewMCPServerOptions(streams)
+	ctx := context.Background()
 	cmd := &cobra.Command{
 		Use:     "kubernetes-mcp-server [command] [options]",
 		Short:   "Kubernetes Model Context Protocol (MCP) server",
 		Long:    long,
 		Example: examples,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(c); err != nil {
+			if err := o.Complete(ctx, c); err != nil {
 				return err
 			}
 			// Close the log sink whatever happens next: Validate may fail, Run
@@ -143,14 +144,14 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 			defer func() {
 				if o.logSink != nil {
 					if err := o.logSink.Close(); err != nil {
-						klog.Errorf("failed to close log sink: %v", err)
+						klog.FromContext(ctx).Error(err, "failed to close log sink")
 					}
 				}
 			}()
-			if err := o.Validate(); err != nil {
+			if err := o.Validate(ctx); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
+			if err := o.Run(ctx); err != nil {
 				return err
 			}
 
@@ -192,9 +193,9 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func (m *MCPServerOptions) Complete(cmd *cobra.Command) error {
+func (m *MCPServerOptions) Complete(ctx context.Context, cmd *cobra.Command) error {
 	if m.ConfigPath != "" || m.ConfigDir != "" {
-		cnf, err := config.Read(m.ConfigPath, m.ConfigDir)
+		cnf, err := config.Read(ctx, m.ConfigPath, m.ConfigDir)
 		if err != nil {
 			return err
 		}
@@ -283,12 +284,12 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 }
 
-func (m *MCPServerOptions) Validate() error {
+func (m *MCPServerOptions) Validate(ctx context.Context) error {
 	// Config-level validations (shared with SIGHUP reload)
 	if err := m.StaticConfig.
 		WithProviderStrategies(kubernetes.GetRegisteredStrategies()).
 		WithTokenExchangeStrategies(tokenexchange.GetRegisteredStrategies()).
-		Validate(); err != nil {
+		Validate(ctx); err != nil {
 		return err
 	}
 	// CLI-level validations (flag interactions that can't change on reload)
@@ -303,26 +304,26 @@ func (m *MCPServerOptions) Validate() error {
 	return nil
 }
 
-func (m *MCPServerOptions) Run() error {
+func (m *MCPServerOptions) Run(ctx context.Context) error {
 	// Initialize OpenTelemetry tracing with config (env vars take precedence)
-	cleanup, _ := telemetry.InitTracerWithConfig(&m.StaticConfig.Telemetry, version.BinaryName, version.Version)
+	cleanup, _ := telemetry.InitTracerWithConfig(ctx, &m.StaticConfig.Telemetry, version.BinaryName, version.Version)
 	defer cleanup()
-
-	klog.V(1).Info("Starting kubernetes-mcp-server")
-	klog.V(1).Infof(" - Config: %s", m.ConfigPath)
-	klog.V(1).Infof(" - Toolsets: %s", strings.Join(m.StaticConfig.Toolsets, ", "))
-	klog.V(1).Infof(" - ListOutput: %s", m.StaticConfig.ListOutput)
-	klog.V(1).Infof(" - Read-only mode: %t", m.StaticConfig.ReadOnly)
-	klog.V(1).Infof(" - Disable destructive tools: %t", m.StaticConfig.DisableDestructive)
-	klog.V(1).Infof(" - Stateless mode: %t", m.StaticConfig.Stateless)
-	klog.V(1).Infof(" - Telemetry enabled: %t", m.StaticConfig.Telemetry.IsEnabled())
 
 	strategy := m.StaticConfig.ClusterProviderStrategy
 	if strategy == "" {
 		strategy = "auto-detect (it is recommended to set this explicitly in your Config)"
 	}
 
-	klog.V(1).Infof(" - ClusterProviderStrategy: %s", strategy)
+	klog.FromContext(ctx).V(1).Info("Starting kubernetes-mcp-server",
+		"config.path", m.ConfigPath,
+		"config.toolsets", m.StaticConfig.Toolsets,
+		"config.list_output", m.StaticConfig.ListOutput,
+		"config.read_only", m.StaticConfig.ReadOnly,
+		"config.disable_destructive", m.StaticConfig.DisableDestructive,
+		"config.stateless", m.StaticConfig.Stateless,
+		"config.telemetry.enabled", m.StaticConfig.Telemetry.Enabled,
+		"config.cluster_provider_strategy", strategy,
+	)
 
 	if m.Version {
 		_, _ = fmt.Fprintf(m.Out, "%s\n", version.Version)
@@ -335,12 +336,12 @@ func (m *MCPServerOptions) Run() error {
 	}
 	oauthState := internaloauth.NewState(internaloauth.SnapshotFromConfig(m.StaticConfig, oidcProvider, httpClient))
 
-	provider, err := kubernetes.NewProvider(m.StaticConfig, kubernetes.WithTokenExchange(oauthState))
+	provider, err := kubernetes.NewProvider(ctx, m.StaticConfig, kubernetes.WithTokenExchange(oauthState))
 	if err != nil {
 		return fmt.Errorf("unable to create kubernetes target provider: %w", err)
 	}
 
-	mcpServer, err := mcp.NewServer(mcp.Configuration{
+	mcpServer, err := mcp.NewServer(ctx, mcp.Configuration{
 		StaticConfig: m.StaticConfig,
 		SDKLogger:    m.logSink.SDKLogger(),
 	}, provider)
@@ -362,7 +363,7 @@ func (m *MCPServerOptions) Run() error {
 	// to drain — important because the goroutine accesses m.logSink, which
 	// the deferred Close in NewMCPServer's RunE would otherwise race with.
 	if m.ConfigPath != "" || m.ConfigDir != "" {
-		stopSIGHUP := m.setupSIGHUPHandler(mcpServer, oauthState, cfgState)
+		stopSIGHUP := m.setupSIGHUPHandler(ctx, mcpServer, oauthState, cfgState)
 		defer stopSIGHUP()
 	}
 
@@ -371,7 +372,6 @@ func (m *MCPServerOptions) Run() error {
 		return internalhttp.Serve(ctx, mcpServer, cfgState, oauthState)
 	}
 
-	ctx := context.Background()
 	if err := mcpServer.ServeStdio(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return err
 	}
@@ -382,27 +382,34 @@ func (m *MCPServerOptions) Run() error {
 // setupSIGHUPHandler sets up a signal handler to reload configuration on SIGHUP.
 // Returns a stop function that should be called to clean up the handler.
 // The stop function waits for the handler goroutine to finish.
-func (m *MCPServerOptions) setupSIGHUPHandler(mcpServer *mcp.Server, oauthState *internaloauth.State, cfgState *config.StaticConfigState) (stop func()) {
+func (m *MCPServerOptions) setupSIGHUPHandler(
+	ctx context.Context,
+	mcpServer *mcp.Server,
+	oauthState *internaloauth.State,
+	cfgState *config.StaticConfigState,
+) (stop func()) {
 	sigHupCh := make(chan os.Signal, 1)
 	done := make(chan struct{})
 	signal.Notify(sigHupCh, syscall.SIGHUP)
 
+	logger := klog.FromContext(ctx)
+
 	go func() {
 		defer close(done)
 		for range sigHupCh {
-			klog.V(1).Info("Received SIGHUP signal, reloading configuration...")
+			logger.V(1).Info("Received SIGHUP signal, reloading configuration...")
 
 			// Reload config from files
-			newConfig, err := config.Read(m.ConfigPath, m.ConfigDir)
+			newConfig, err := config.Read(ctx, m.ConfigPath, m.ConfigDir)
 			if err != nil {
-				klog.Errorf("Failed to reload configuration from disk: %v", err)
+				logger.Error(err, "Failed to reload configuration from disk")
 				continue
 			}
 
 			// Apply the new configuration to the MCP server first — if this fails,
 			// we skip the OAuth state and config state updates to avoid inconsistent state.
-			if err := mcpServer.ReloadConfiguration(newConfig); err != nil {
-				klog.Errorf("Failed to apply reloaded configuration: %v", err)
+			if err := mcpServer.ReloadConfiguration(ctx, newConfig); err != nil {
+				logger.Error(err, "Failed to apply reloaded configuration")
 				continue
 			}
 
@@ -412,7 +419,7 @@ func (m *MCPServerOptions) setupSIGHUPHandler(mcpServer *mcp.Server, oauthState 
 			// nil in tests that exercise the SIGHUP handler in isolation.
 			if m.logSink != nil {
 				if err := m.logSink.Reload(newConfig); err != nil {
-					klog.Errorf("Failed to reload log destination, keeping previous one: %v", err)
+					logger.Error(err, "Failed to reload log destination, keeping previous one")
 				}
 			}
 			// Publish the new config so the HTTP auth middleware picks it up.
@@ -425,26 +432,26 @@ func (m *MCPServerOptions) setupSIGHUPHandler(mcpServer *mcp.Server, oauthState 
 			}
 			newSnapshot := internaloauth.SnapshotFromConfig(newConfig, currentSnapshot.OIDCProvider, currentSnapshot.HTTPClient)
 			if currentSnapshot.HasProviderConfigChanged(newSnapshot) {
-				klog.V(1).Info("OAuth configuration changed, recreating OIDC provider...")
+				logger.V(1).Info("OAuth configuration changed, recreating OIDC provider...")
 				newProvider, newClient, err := internaloauth.CreateOIDCProviderAndClient(newConfig)
 				if err != nil {
-					klog.Errorf("Failed to recreate OIDC provider during reload: %v", err)
+					logger.Error(err, "Failed to recreate OIDC provider during reload")
 					continue
 				}
 				newSnapshot.OIDCProvider = newProvider
 				newSnapshot.HTTPClient = newClient
 				oauthState.Store(newSnapshot)
-				klog.V(1).Info("OIDC provider and HTTP client updated successfully")
+				logger.V(1).Info("OIDC provider and HTTP client updated successfully")
 			} else if currentSnapshot.HasWellKnownConfigChanged(newSnapshot) {
 				oauthState.Store(newSnapshot)
-				klog.V(1).Info("OAuth well-known configuration updated")
+				logger.V(1).Info("OAuth well-known configuration updated")
 			}
 
-			klog.V(1).Info("Configuration reloaded successfully via SIGHUP")
+			logger.V(1).Info("Configuration reloaded successfully via SIGHUP")
 		}
 	}()
 
-	klog.V(2).Info("SIGHUP handler registered for configuration reload")
+	logger.V(2).Info("SIGHUP handler registered for configuration reload")
 
 	return func() {
 		signal.Stop(sigHupCh)

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -128,13 +128,13 @@ func NewMCPServerOptions(streams genericiooptions.IOStreams) *MCPServerOptions {
 
 func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewMCPServerOptions(streams)
-	ctx := context.Background()
 	cmd := &cobra.Command{
 		Use:     "kubernetes-mcp-server [command] [options]",
 		Short:   "Kubernetes Model Context Protocol (MCP) server",
 		Long:    long,
 		Example: examples,
 		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
 			if err := o.Complete(ctx, c); err != nil {
 				return err
 			}
@@ -321,7 +321,7 @@ func (m *MCPServerOptions) Run(ctx context.Context) error {
 		"config.read_only", m.StaticConfig.ReadOnly,
 		"config.disable_destructive", m.StaticConfig.DisableDestructive,
 		"config.stateless", m.StaticConfig.Stateless,
-		"config.telemetry.enabled", m.StaticConfig.Telemetry.Enabled,
+		"config.telemetry.enabled", m.StaticConfig.Telemetry.IsEnabled(),
 		"config.cluster_provider_strategy", strategy,
 	)
 
@@ -349,7 +349,7 @@ func (m *MCPServerOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize MCP server: %w", err)
 	}
 	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		if err := mcpServer.Shutdown(shutdownCtx); err != nil {
 			klog.Errorf("MCP server shutdown error: %v", err)
@@ -368,7 +368,6 @@ func (m *MCPServerOptions) Run(ctx context.Context) error {
 	}
 
 	if m.StaticConfig.Port != "" {
-		ctx := context.Background()
 		return internalhttp.Serve(ctx, mcpServer, cfgState, oauthState)
 	}
 

--- a/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -67,12 +66,11 @@ func (s *SIGHUPSuite) TearDownTest() {
 }
 
 func (s *SIGHUPSuite) InitServer(configPath, configDir string) *MCPServerOptions {
-	ctx := context.Background()
-	cfg, err := config.Read(ctx, configPath, configDir)
+	cfg, err := config.Read(s.T().Context(), configPath, configDir)
 	s.Require().NoError(err)
 	cfg.KubeConfig = s.mockServer.KubeconfigFile(s.T())
 
-	provider, err := kubernetes.NewProvider(ctx, cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), cfg)
 	s.Require().NoError(err)
 	s.server, err = mcp.NewServer(s.T().Context(), mcp.Configuration{
 		StaticConfig: cfg,
@@ -90,7 +88,7 @@ func (s *SIGHUPSuite) InitServer(configPath, configDir string) *MCPServerOptions
 	oauthState := oauth.NewState(&oauth.Snapshot{})
 
 	cfgState := config.NewStaticConfigState(cfg)
-	s.stopSIGHUP = opts.setupSIGHUPHandler(ctx, s.server, oauthState, cfgState)
+	s.stopSIGHUP = opts.setupSIGHUPHandler(s.T().Context(), s.server, oauthState, cfgState)
 	return opts
 }
 
@@ -297,7 +295,7 @@ func TestSIGHUPInvokesLogSinkReload(t *testing.T) {
 	mockServer.Handle(test.NewDiscoveryClientHandler())
 	t.Cleanup(mockServer.Close)
 
-	cfg, err := config.Read(context.Background(), configPath, "")
+	cfg, err := config.Read(t.Context(), configPath, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +312,7 @@ func TestSIGHUPInvokesLogSinkReload(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = sink.Close() })
 
-	provider, err := kubernetes.NewProvider(context.Background(), cfg)
+	provider, err := kubernetes.NewProvider(t.Context(), cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -333,7 +331,7 @@ func TestSIGHUPInvokesLogSinkReload(t *testing.T) {
 		logSink: sink,
 	}
 	cfgState := config.NewStaticConfigState(cfg)
-	stop := opts.setupSIGHUPHandler(context.Background(), mcpServer, oauth.NewState(&oauth.Snapshot{}), cfgState)
+	stop := opts.setupSIGHUPHandler(t.Context(), mcpServer, oauth.NewState(&oauth.Snapshot{}), cfgState)
 	t.Cleanup(stop)
 
 	if err := os.WriteFile(configPath, []byte(

--- a/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -66,13 +67,14 @@ func (s *SIGHUPSuite) TearDownTest() {
 }
 
 func (s *SIGHUPSuite) InitServer(configPath, configDir string) *MCPServerOptions {
-	cfg, err := config.Read(configPath, configDir)
+	ctx := context.Background()
+	cfg, err := config.Read(ctx, configPath, configDir)
 	s.Require().NoError(err)
 	cfg.KubeConfig = s.mockServer.KubeconfigFile(s.T())
 
-	provider, err := kubernetes.NewProvider(cfg)
+	provider, err := kubernetes.NewProvider(ctx, cfg)
 	s.Require().NoError(err)
-	s.server, err = mcp.NewServer(mcp.Configuration{
+	s.server, err = mcp.NewServer(s.T().Context(), mcp.Configuration{
 		StaticConfig: cfg,
 	}, provider)
 	s.Require().NoError(err)
@@ -88,7 +90,7 @@ func (s *SIGHUPSuite) InitServer(configPath, configDir string) *MCPServerOptions
 	oauthState := oauth.NewState(&oauth.Snapshot{})
 
 	cfgState := config.NewStaticConfigState(cfg)
-	s.stopSIGHUP = opts.setupSIGHUPHandler(s.server, oauthState, cfgState)
+	s.stopSIGHUP = opts.setupSIGHUPHandler(ctx, s.server, oauthState, cfgState)
 	return opts
 }
 
@@ -295,7 +297,7 @@ func TestSIGHUPInvokesLogSinkReload(t *testing.T) {
 	mockServer.Handle(test.NewDiscoveryClientHandler())
 	t.Cleanup(mockServer.Close)
 
-	cfg, err := config.Read(configPath, "")
+	cfg, err := config.Read(context.Background(), configPath, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,11 +314,11 @@ func TestSIGHUPInvokesLogSinkReload(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = sink.Close() })
 
-	provider, err := kubernetes.NewProvider(cfg)
+	provider, err := kubernetes.NewProvider(context.Background(), cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mcpServer, err := mcp.NewServer(mcp.Configuration{StaticConfig: cfg, SDKLogger: sink.SDKLogger()}, provider)
+	mcpServer, err := mcp.NewServer(t.Context(), mcp.Configuration{StaticConfig: cfg, SDKLogger: sink.SDKLogger()}, provider)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +333,7 @@ func TestSIGHUPInvokesLogSinkReload(t *testing.T) {
 		logSink: sink,
 	}
 	cfgState := config.NewStaticConfigState(cfg)
-	stop := opts.setupSIGHUPHandler(mcpServer, oauth.NewState(&oauth.Snapshot{}), cfgState)
+	stop := opts.setupSIGHUPHandler(context.Background(), mcpServer, oauth.NewState(&oauth.Snapshot{}), cfgState)
 	t.Cleanup(stop)
 
 	if err := os.WriteFile(configPath, []byte(

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -56,7 +56,7 @@ func TestConfig(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
-		expectedConfig := `" - Config: "`
+		expectedConfig := `config.path=""`
 		if err := rootCmd.Execute(); !strings.Contains(out.String(), expectedConfig) {
 			t.Fatalf("Expected config to be %s, got %s %v", expectedConfig, out.String(), err)
 		}
@@ -68,7 +68,7 @@ func TestConfig(t *testing.T) {
 		emptyConfigPath := filepath.Join(filepath.Dir(file), "testdata", "empty-config.toml")
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--config", emptyConfigPath})
 		_ = rootCmd.Execute()
-		expected := `(?m)\" - Config\:[^\"]+empty-config\.toml\"`
+		expected := `config\.path="[^"]*empty-config\.toml"`
 		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expected, out.String(), err)
 		}
@@ -93,23 +93,23 @@ func TestConfig(t *testing.T) {
 		validConfigPath := filepath.Join(filepath.Dir(file), "testdata", "valid-config.toml")
 		rootCmd.SetArgs([]string{"--version", "--config", validConfigPath})
 		_ = rootCmd.Execute()
-		expectedConfig := `(?m)\" - Config\:[^\"]+valid-config\.toml\"`
+		expectedConfig := `config\.path="[^"]*valid-config\.toml"`
 		if m, err := regexp.MatchString(expectedConfig, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expectedConfig, out.String(), err)
 		}
-		expectedListOutput := `(?m)\" - ListOutput\: yaml"`
+		expectedListOutput := `config\.list_output="yaml"`
 		if m, err := regexp.MatchString(expectedListOutput, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expectedListOutput, out.String(), err)
 		}
-		expectedReadOnly := `(?m)\" - Read-only mode: true"`
+		expectedReadOnly := `config\.read_only=true`
 		if m, err := regexp.MatchString(expectedReadOnly, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expectedReadOnly, out.String(), err)
 		}
-		expectedDisableDestruction := `(?m)\" - Disable destructive tools: true"`
+		expectedDisableDestruction := `config\.disable_destructive=true`
 		if m, err := regexp.MatchString(expectedDisableDestruction, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expectedDisableDestruction, out.String(), err)
 		}
-		expectedStateless := `(?m)\" - Stateless mode: true"`
+		expectedStateless := `config\.stateless=true`
 		if m, err := regexp.MatchString(expectedStateless, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expectedStateless, out.String(), err)
 		}
@@ -121,23 +121,23 @@ func TestConfig(t *testing.T) {
 		validConfigPath := filepath.Join(filepath.Dir(file), "testdata", "valid-config.toml")
 		rootCmd.SetArgs([]string{"--version", "--list-output=table", "--disable-destructive=false", "--read-only=false", "--stateless=false", "--config", validConfigPath})
 		_ = rootCmd.Execute()
-		expected := `(?m)\" - Config\:[^\"]+valid-config\.toml\"`
+		expected := `config\.path="[^"]*valid-config\.toml"`
 		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expected, out.String(), err)
 		}
-		expectedListOutput := `(?m)\" - ListOutput\: table"`
+		expectedListOutput := `config\.list_output="table"`
 		if m, err := regexp.MatchString(expectedListOutput, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expectedListOutput, out.String(), err)
 		}
-		expectedReadOnly := `(?m)\" - Read-only mode: false"`
+		expectedReadOnly := `config\.read_only=false`
 		if m, err := regexp.MatchString(expectedReadOnly, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expectedReadOnly, out.String(), err)
 		}
-		expectedDisableDestruction := `(?m)\" - Disable destructive tools: false"`
+		expectedDisableDestruction := `config\.disable_destructive=false`
 		if m, err := regexp.MatchString(expectedDisableDestruction, out.String()); !m || err != nil {
 			t.Fatalf("Expected config to be %s, got %s %v", expectedDisableDestruction, out.String(), err)
 		}
-		expectedStateless := `(?m)\" - Stateless mode: false"`
+		expectedStateless := `config\.stateless=false`
 		if m, err := regexp.MatchString(expectedStateless, out.String()); !m || err != nil {
 			t.Fatalf("Expected stateless mode to be false (flag overrides config), got %s %v", out.String(), err)
 		}
@@ -147,7 +147,7 @@ func TestConfig(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
 		_ = rootCmd.Execute()
-		expectedStateless := `(?m)\" - Stateless mode: false"`
+		expectedStateless := `config\.stateless=false`
 		if m, err := regexp.MatchString(expectedStateless, out.String()); !m || err != nil {
 			t.Fatalf("Expected stateless mode to be false by default, got %s %v", out.String(), err)
 		}
@@ -157,7 +157,7 @@ func TestConfig(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--stateless=true"})
 		_ = rootCmd.Execute()
-		expectedStateless := `(?m)\" - Stateless mode: true"`
+		expectedStateless := `config\.stateless=true`
 		if m, err := regexp.MatchString(expectedStateless, out.String()); !m || err != nil {
 			t.Fatalf("Expected stateless mode to be true, got %s %v", out.String(), err)
 		}
@@ -167,7 +167,7 @@ func TestConfig(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--stateless=false"})
 		_ = rootCmd.Execute()
-		expectedStateless := `(?m)\" - Stateless mode: false"`
+		expectedStateless := `config\.stateless=false`
 		if m, err := regexp.MatchString(expectedStateless, out.String()); !m || err != nil {
 			t.Fatalf("Expected stateless mode to be false, got %s %v", out.String(), err)
 		}
@@ -210,9 +210,9 @@ func (s *CmdSuite) TestConfigDir() {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--config-dir", dropInDir})
 		s.Require().NoError(rootCmd.Execute())
-		s.Contains(out.String(), "ListOutput: yaml")
-		s.Contains(out.String(), "Read-only mode: true")
-		s.Contains(out.String(), "Disable destructive tools: true")
+		s.Contains(out.String(), `config.list_output="yaml"`)
+		s.Contains(out.String(), "config.read_only=true")
+		s.Contains(out.String(), "config.disable_destructive=true")
 	})
 	s.Run("--config-dir path is a file throws error", func() {
 		tempDir := s.T().TempDir()
@@ -232,7 +232,7 @@ func (s *CmdSuite) TestConfigDir() {
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--config-dir", "/nonexistent/path/to/config-dir"})
 		err := rootCmd.Execute()
 		s.Require().NoError(err, "Nonexistent directories should be gracefully skipped")
-		s.Contains(out.String(), fmt.Sprintf("ListOutput: %s", config.Default().ListOutput), "Default values should be used")
+		s.Contains(out.String(), fmt.Sprintf(`config.list_output="%s"`, config.Default().ListOutput), "Default values should be used")
 	})
 	s.Run("--config with --config-dir merges configs", func() {
 		tempDir := s.T().TempDir()
@@ -254,10 +254,10 @@ func (s *CmdSuite) TestConfigDir() {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--config", mainConfigPath, "--config-dir", dropInDir})
 		s.Require().NoError(rootCmd.Execute())
-		s.Contains(out.String(), "ListOutput: table", "list_output from main config")
-		s.Contains(out.String(), "Read-only mode: true", "read_only overridden by drop-in")
-		s.Contains(out.String(), "Disable destructive tools: true", "disable_destructive from drop-in")
-		s.Contains(out.String(), "Stateless mode: true", "stateless from drop-in")
+		s.Contains(out.String(), `config.list_output="table"`, "list_output from main config")
+		s.Contains(out.String(), "config.read_only=true", "read_only overridden by drop-in")
+		s.Contains(out.String(), "config.disable_destructive=true", "disable_destructive from drop-in")
+		s.Contains(out.String(), "config.stateless=true", "stateless from drop-in")
 	})
 	s.Run("multiple drop-in files are merged in order", func() {
 		dropInDir := s.T().TempDir()
@@ -274,9 +274,9 @@ func (s *CmdSuite) TestConfigDir() {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--config-dir", dropInDir})
 		s.Require().NoError(rootCmd.Execute())
-		s.Contains(out.String(), "ListOutput: table", "list_output from 20-second.toml (last wins)")
-		s.Contains(out.String(), "Read-only mode: true", "read_only from 10-first.toml")
-		s.Contains(out.String(), "Disable destructive tools: true", "disable_destructive from 20-second.toml")
+		s.Contains(out.String(), `config.list_output="table"`, "list_output from 20-second.toml (last wins)")
+		s.Contains(out.String(), "config.read_only=true", "read_only from 10-first.toml")
+		s.Contains(out.String(), "config.disable_destructive=true", "disable_destructive from 20-second.toml")
 	})
 	s.Run("flags take precedence over --config-dir", func() {
 		dropInDir := s.T().TempDir()
@@ -291,10 +291,10 @@ func (s *CmdSuite) TestConfigDir() {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--list-output=table", "--read-only=false", "--disable-destructive=false", "--stateless=false", "--config-dir", dropInDir})
 		s.Require().NoError(rootCmd.Execute())
-		s.Contains(out.String(), "ListOutput: table", "flag takes precedence")
-		s.Contains(out.String(), "Read-only mode: false", "flag takes precedence")
-		s.Contains(out.String(), "Disable destructive tools: false", "flag takes precedence")
-		s.Contains(out.String(), "Stateless mode: false", "flag takes precedence")
+		s.Contains(out.String(), `config.list_output="table"`, "flag takes precedence")
+		s.Contains(out.String(), "config.read_only=false", "flag takes precedence")
+		s.Contains(out.String(), "config.disable_destructive=false", "flag takes precedence")
+		s.Contains(out.String(), "config.stateless=false", "flag takes precedence")
 	})
 }
 
@@ -317,7 +317,7 @@ func TestToolsets(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
-		expected := "- Toolsets: " + strings.Join(config.Default().Toolsets, ", ")
+		expected := `config.toolsets=["` + strings.Join(config.Default().Toolsets, `","`) + `"]`
 		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
 			t.Fatalf("Expected toolsets '%s', got %s %v", expected, out, err)
 		}
@@ -327,7 +327,7 @@ func TestToolsets(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--toolsets", "helm,config"})
 		_ = rootCmd.Execute()
-		expected := `(?m)\" - Toolsets\: helm, config\"`
+		expected := `config\.toolsets=\["helm","config"\]`
 		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
 			t.Fatalf("Expected toolset to be %s, got %s %v", expected, out.String(), err)
 		}
@@ -349,7 +349,7 @@ func TestListOutput(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
 		defaults := config.Default()
-		expected := fmt.Sprintf("- ListOutput: %s", defaults.ListOutput)
+		expected := fmt.Sprintf(`config.list_output="%s"`, defaults.ListOutput)
 		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
 			t.Fatalf("Expected list-output '%s', got %s %v", defaults.ListOutput, out, err)
 		}
@@ -359,7 +359,7 @@ func TestListOutput(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--list-output", "yaml"})
 		_ = rootCmd.Execute()
-		expected := `(?m)\" - ListOutput\: yaml\"`
+		expected := `config\.list_output="yaml"`
 		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
 			t.Fatalf("Expected list-output to be %s, got %s %v", expected, out.String(), err)
 		}
@@ -371,7 +371,7 @@ func TestReadOnly(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
-		expected := fmt.Sprintf(" - Read-only mode: %v", config.Default().ReadOnly)
+		expected := fmt.Sprintf("config.read_only=%v", config.Default().ReadOnly)
 		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
 			t.Fatalf("Expected read-only mode %v, got %s %v", config.Default().ReadOnly, out, err)
 		}
@@ -381,7 +381,7 @@ func TestReadOnly(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--read-only"})
 		_ = rootCmd.Execute()
-		expected := `(?m)\" - Read-only mode\: true\"`
+		expected := `config\.read_only=true`
 		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
 			t.Fatalf("Expected read-only mode to be %s, got %s %v", expected, out.String(), err)
 		}
@@ -394,7 +394,7 @@ func TestDisableDestructive(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
 		defaults := config.Default()
-		expected := fmt.Sprintf(" - Disable destructive tools: %t", defaults.DisableDestructive)
+		expected := fmt.Sprintf("config.disable_destructive=%t", defaults.DisableDestructive)
 		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
 			t.Fatalf("Expected disable destructive %t, got %s %v", defaults.DisableDestructive, out, err)
 		}
@@ -404,7 +404,7 @@ func TestDisableDestructive(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--disable-destructive"})
 		_ = rootCmd.Execute()
-		expected := `(?m)\" - Disable destructive tools\: true\"`
+		expected := `config\.disable_destructive=true`
 		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
 			t.Fatalf("Expected disable-destructive mode to be %s, got %s %v", expected, out.String(), err)
 		}
@@ -460,7 +460,7 @@ func TestDisableMultiCluster(t *testing.T) {
 		ioStreams, out := testStream()
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
-		if err := rootCmd.Execute(); !strings.Contains(out.String(), " - ClusterProviderStrategy: auto-detect (it is recommended to set this explicitly in your Config)") {
+		if err := rootCmd.Execute(); !strings.Contains(out.String(), `config.cluster_provider_strategy="auto-detect (it is recommended to set this explicitly in your Config)"`) {
 			t.Fatalf("Expected ClusterProviderStrategy kubeconfig, got %s %v", out, err)
 		}
 	})
@@ -469,7 +469,7 @@ func TestDisableMultiCluster(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--disable-multi-cluster"})
 		_ = rootCmd.Execute()
-		expected := `(?m)\" - ClusterProviderStrategy\: disabled\"`
+		expected := `config\.cluster_provider_strategy="disabled"`
 		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
 			t.Fatalf("Expected ClusterProviderStrategy %s, got %s %v", expected, out.String(), err)
 		}
@@ -522,7 +522,7 @@ func TestStateless(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1"})
 		defaults := config.Default()
-		expected := fmt.Sprintf(" - Stateless mode: %t", defaults.Stateless)
+		expected := fmt.Sprintf("config.stateless=%t", defaults.Stateless)
 		if err := rootCmd.Execute(); !strings.Contains(out.String(), expected) {
 			t.Fatalf("Expected stateless mode %t, got %s %v", defaults.Stateless, out, err)
 		}
@@ -532,7 +532,7 @@ func TestStateless(t *testing.T) {
 		rootCmd := NewMCPServer(ioStreams)
 		rootCmd.SetArgs([]string{"--version", "--port=1337", "--log-level=1", "--stateless"})
 		_ = rootCmd.Execute()
-		expected := `(?m)\" - Stateless mode\: true\"`
+		expected := `config\.stateless=true`
 		if m, err := regexp.MatchString(expected, out.String()); !m || err != nil {
 			t.Fatalf("Expected stateless mode to be %s, got %s %v", expected, out.String(), err)
 		}

--- a/pkg/kubernetes/accesscontrol_round_tripper.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -44,7 +45,7 @@ func NewAccessControlRoundTripper(ctx context.Context, cfg AccessControlRoundTri
 	var apiPathPrefix string
 	if cfg.HostURL != "" {
 		if hostURL, err := url.Parse(cfg.HostURL); err != nil {
-			klog.FromContext(ctx).Info(
+			klogutil.Warn(ctx,
 				"failed to parse Kubernetes API server host to determine API path prefix",
 				"url.full", cfg.HostURL,
 				"exception.message", err.Error(),

--- a/pkg/kubernetes/accesscontrol_round_tripper.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,11 +40,15 @@ type AccessControlRoundTripperConfig struct {
 }
 
 // NewAccessControlRoundTripper creates a new AccessControlRoundTripper.
-func NewAccessControlRoundTripper(cfg AccessControlRoundTripperConfig) *AccessControlRoundTripper {
+func NewAccessControlRoundTripper(ctx context.Context, cfg AccessControlRoundTripperConfig) *AccessControlRoundTripper {
 	var apiPathPrefix string
 	if cfg.HostURL != "" {
 		if hostURL, err := url.Parse(cfg.HostURL); err != nil {
-			klog.Warningf("failed to parse Kubernetes API server host %q to determine API path prefix: %v", cfg.HostURL, err)
+			klog.FromContext(ctx).Info(
+				"failed to parse Kubernetes API server host to determine API path prefix",
+				"url.full", cfg.HostURL,
+				"exception.message", err.Error(),
+			)
 		} else {
 			apiPathPrefix = hostURL.Path
 		}
@@ -133,10 +138,11 @@ func (rt *AccessControlRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 		validationReq.Body = body
 	}
 
+	logger := klog.FromContext(req.Context())
 	for _, v := range rt.validators {
 		if validationErr := v.Validate(req.Context(), validationReq); validationErr != nil {
 			if ve, ok := validationErr.(*api.ValidationError); ok {
-				klog.V(4).Infof("Validation failed [%s]: %v", v.Name(), ve)
+				logger.V(4).Info("Validation failed", "validator_name", v.Name(), "exception.message", ve.Error())
 			}
 			return nil, validationErr
 		}

--- a/pkg/kubernetes/accesscontrol_round_tripper_test.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper_test.go
@@ -295,7 +295,7 @@ func (s *AccessControlRoundTripperTestSuite) TestValidationDisabledBypassesValid
 
 	s.Run("validation disabled allows request with unknown fields", func() {
 		delegateCalled = false
-		rt := NewAccessControlRoundTripper(AccessControlRoundTripperConfig{
+		rt := NewAccessControlRoundTripper(s.T().Context(), AccessControlRoundTripperConfig{
 			Delegate:           mockDelegate,
 			RestMapperProvider: func() meta.RESTMapper { return s.restMapper },
 			ValidationEnabled:  false,
@@ -311,7 +311,7 @@ func (s *AccessControlRoundTripperTestSuite) TestValidationDisabledBypassesValid
 
 	s.Run("validation enabled rejects request with unknown fields", func() {
 		delegateCalled = false
-		rt := NewAccessControlRoundTripper(AccessControlRoundTripperConfig{
+		rt := NewAccessControlRoundTripper(s.T().Context(), AccessControlRoundTripperConfig{
 			Delegate:           mockDelegate,
 			RestMapperProvider: func() meta.RESTMapper { return s.restMapper },
 			ValidationEnabled:  true,

--- a/pkg/kubernetes/auth.go
+++ b/pkg/kubernetes/auth.go
@@ -40,13 +40,23 @@ func CanI(
 		return false, err
 	}
 
-	if klog.V(5).Enabled() {
+	logger := klog.FromContext(ctx)
+	if logger.V(5).Enabled() {
 		if response.Status.Allowed {
-			klog.V(5).Infof("RBAC check: allowed %s on %s/%s in %s",
-				verb, gvr.Group, gvr.Resource, namespace)
+			logger.V(5).Info("RBAC check allowed",
+				"kubernetes.rbac.verb", verb,
+				"kubernetes.api.group", gvr.Group,
+				"kubernetes.api.resource", gvr.Resource,
+				"kubernetes.namespace.name", namespace,
+			)
 		} else {
-			klog.V(5).Infof("RBAC check: denied %s on %s/%s in %s: %s",
-				verb, gvr.Group, gvr.Resource, namespace, response.Status.Reason)
+			logger.V(5).Info("RBAC check denied",
+				"kubernetes.rbac.verb", verb,
+				"kubernetes.api.group", gvr.Group,
+				"kubernetes.api.resource", gvr.Resource,
+				"kubernetes.namespace.name", namespace,
+				"kubernetes.rbac.reason", response.Status.Reason,
+			)
 		}
 	}
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -53,7 +54,12 @@ type Kubernetes struct {
 
 var _ api.KubernetesClient = (*Kubernetes)(nil)
 
-func NewKubernetes(baseConfig api.BaseConfig, clientCmdConfig clientcmd.ClientConfig, restConfig *rest.Config) (*Kubernetes, error) {
+func NewKubernetes(
+	ctx context.Context,
+	baseConfig api.BaseConfig,
+	clientCmdConfig clientcmd.ClientConfig,
+	restConfig *rest.Config,
+) (*Kubernetes, error) {
 	k := &Kubernetes{
 		config:          baseConfig,
 		clientCmdConfig: clientCmdConfig,
@@ -64,7 +70,7 @@ func NewKubernetes(baseConfig api.BaseConfig, clientCmdConfig clientcmd.ClientCo
 	}
 
 	k.restConfig.Wrap(func(original http.RoundTripper) http.RoundTripper {
-		return NewAccessControlRoundTripper(AccessControlRoundTripperConfig{
+		return NewAccessControlRoundTripper(ctx, AccessControlRoundTripperConfig{
 			Delegate:                  original,
 			DeniedResourcesProvider:   baseConfig,
 			RestMapperProvider:        func() meta.RESTMapper { return k.restMapper },

--- a/pkg/kubernetes/kubernetes_close_test.go
+++ b/pkg/kubernetes/kubernetes_close_test.go
@@ -47,7 +47,7 @@ func (s *DerivedClientCleanupSuite) SetupTest() {
 	cfg := test.Must(config.ReadToml([]byte(`kubeconfig = "` + strings.ReplaceAll(kubeconfigFile, `\`, `\\`) + `"`)))
 
 	var err error
-	s.manager, err = NewKubeconfigManager(cfg, "")
+	s.manager, err = NewKubeconfigManager(s.T().Context(), cfg, "")
 	s.Require().NoError(err)
 }
 

--- a/pkg/kubernetes/kubernetes_derived_test.go
+++ b/pkg/kubernetes/kubernetes_derived_test.go
@@ -49,7 +49,7 @@ users:
 			kubeconfig = "` + strings.ReplaceAll(kubeconfigPath, `\`, `\\`) + `"
 		`)))
 		s.Run("without authorization header returns original clientset", func() {
-			testManager, err := NewKubeconfigManager(testStaticConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			derived, err := testManager.Derived(s.T().Context())
@@ -59,7 +59,7 @@ users:
 		})
 
 		s.Run("with invalid authorization header returns original client", func() {
-			testManager, err := NewKubeconfigManager(testStaticConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			ctx := context.WithValue(s.T().Context(), HeaderKey("Authorization"), "invalid-token")
@@ -70,7 +70,7 @@ users:
 		})
 
 		s.Run("with valid bearer token creates derived kubernetes with correct configuration", func() {
-			testManager, err := NewKubeconfigManager(testStaticConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			ctx := context.WithValue(s.T().Context(), HeaderKey("Authorization"), "Bearer aiTana-julIA")
@@ -162,7 +162,7 @@ users:
 		`)))
 
 		s.Run("with bearer token but RawConfig fails returns error", func() {
-			testManager, err := NewKubeconfigManager(testStaticConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			// Corrupt the clientCmdConfig by setting it to a config that will fail on RawConfig()
@@ -170,7 +170,7 @@ users:
 			badConfig := test.Must(config.ReadToml([]byte(`
 				kubeconfig = "` + strings.ReplaceAll(badKubeconfigPath, `\`, `\\`) + `"
 			`)))
-			badManager, _ := NewManager(badConfig, testManager.kubernetes.RESTConfig(), testManager.kubernetes.ToRawKubeConfigLoader())
+			badManager, _ := NewManager(s.T().Context(), badConfig, testManager.kubernetes.RESTConfig(), testManager.kubernetes.ToRawKubeConfigLoader())
 			// Replace the clientCmdConfig with one that will fail
 			pathOptions := clientcmd.NewDefaultPathOptions()
 			pathOptions.LoadingRules.ExplicitPath = badKubeconfigPath
@@ -201,11 +201,11 @@ users:
 			workingConfig := test.Must(config.ReadToml([]byte(`
 				kubeconfig = "` + strings.ReplaceAll(workingKubeconfigPath, `\`, `\\`) + `"
 			`)))
-			testManager, err := NewKubeconfigManager(workingConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), workingConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			// Now create a bad manager with RequireOAuth=true
-			badManager, _ := NewManager(testStaticConfig, testManager.kubernetes.RESTConfig(), testManager.kubernetes.ToRawKubeConfigLoader())
+			badManager, _ := NewManager(s.T().Context(), testStaticConfig, testManager.kubernetes.RESTConfig(), testManager.kubernetes.ToRawKubeConfigLoader())
 			// Replace the clientCmdConfig with one that will fail
 			pathOptions := clientcmd.NewDefaultPathOptions()
 			pathOptions.LoadingRules.ExplicitPath = badKubeconfigPath
@@ -228,7 +228,7 @@ users:
 		`)))
 
 		s.Run("with bearer token but invalid rest config returns error", func() {
-			testManager, err := NewKubeconfigManager(testStaticConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			// Corrupt the rest config to make NewKubernetes fail
@@ -248,7 +248,7 @@ users:
 		`)))
 
 		s.Run("with bearer token but invalid rest config returns error", func() {
-			testManager, err := NewKubeconfigManager(testStaticConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			// Corrupt the rest config to make NewKubernetes fail
@@ -269,7 +269,7 @@ users:
 		`)))
 
 		s.Run("with no authorization header returns error", func() {
-			testManager, err := NewKubeconfigManager(testStaticConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			derived, err := testManager.Derived(s.T().Context())
@@ -279,7 +279,7 @@ users:
 		})
 
 		s.Run("with invalid authorization header returns error", func() {
-			testManager, err := NewKubeconfigManager(testStaticConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			ctx := context.WithValue(s.T().Context(), HeaderKey("Authorization"), "invalid-token")
@@ -290,7 +290,7 @@ users:
 		})
 
 		s.Run("with valid bearer token creates derived kubernetes", func() {
-			testManager, err := NewKubeconfigManager(testStaticConfig, "")
+			testManager, err := NewKubeconfigManager(s.T().Context(), testStaticConfig, "")
 			s.Require().NoErrorf(err, "failed to create test manager: %v", err)
 
 			ctx := context.WithValue(s.T().Context(), HeaderKey("Authorization"), "Bearer aiTana-julIA")

--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -29,7 +29,7 @@ var (
 	ErrorInClusterNotInCluster         = errors.New("in-cluster manager cannot be used outside of a cluster")
 )
 
-func NewKubeconfigManager(config api.BaseConfig, kubeconfigContext string) (*Manager, error) {
+func NewKubeconfigManager(ctx context.Context, config api.BaseConfig, kubeconfigContext string) (*Manager, error) {
 	if IsInCluster(config) {
 		return nil, ErrorKubeconfigInClusterNotAllowed
 	}
@@ -39,7 +39,7 @@ func NewKubeconfigManager(config api.BaseConfig, kubeconfigContext string) (*Man
 		pathOptions.LoadingRules.ExplicitPath = config.GetKubeConfigPath()
 	}
 
-	resolvedContext, err := resolveKubeconfigContext(pathOptions.LoadingRules, kubeconfigContext)
+	resolvedContext, err := resolveKubeconfigContext(ctx, pathOptions.LoadingRules, kubeconfigContext)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func NewKubeconfigManager(config api.BaseConfig, kubeconfigContext string) (*Man
 		return nil, fmt.Errorf("failed to create kubernetes rest config from kubeconfig: %w", err)
 	}
 
-	return NewManager(config, restConfig, clientCmdConfig)
+	return NewManager(ctx, config, restConfig, clientCmdConfig)
 }
 
 // resolveKubeconfigContext determines which kubeconfig context to use.
@@ -65,7 +65,7 @@ func NewKubeconfigManager(config api.BaseConfig, kubeconfigContext string) (*Man
 //   - returns the current-context if set
 //   - auto-selects the only available context if there is exactly one
 //   - returns a descriptive error if there are zero or multiple contexts
-func resolveKubeconfigContext(loadingRules *clientcmd.ClientConfigLoadingRules, kubeconfigContext string) (string, error) {
+func resolveKubeconfigContext(ctx context.Context, loadingRules *clientcmd.ClientConfigLoadingRules, kubeconfigContext string) (string, error) {
 	if kubeconfigContext != "" {
 		return kubeconfigContext, nil
 	}
@@ -86,7 +86,10 @@ func resolveKubeconfigContext(loadingRules *clientcmd.ClientConfigLoadingRules, 
 				"Configure a context with 'kubectl config set-context <name>' and 'kubectl config use-context <name>'")
 	case 1:
 		for name := range rawConfig.Contexts {
-			klog.Infof("current-context is not set in kubeconfig, auto-selecting the only available context %q", name)
+			klog.FromContext(ctx).Info(
+				"current-context is not set in kubeconfig, auto-selecting the only available context",
+				"context_name", name,
+			)
 			return name, nil
 		}
 	}
@@ -102,7 +105,7 @@ func resolveKubeconfigContext(loadingRules *clientcmd.ClientConfigLoadingRules, 
 		strings.Join(names, ", "))
 }
 
-func NewInClusterManager(config api.BaseConfig) (*Manager, error) {
+func NewInClusterManager(ctx context.Context, config api.BaseConfig) (*Manager, error) {
 	if config.GetKubeConfigPath() != "" {
 		return nil, fmt.Errorf("kubeconfig file %s cannot be used with the in-cluster deployments: %w", config.GetKubeConfigPath(), ErrorKubeconfigInClusterNotAllowed)
 	}
@@ -131,10 +134,10 @@ func NewInClusterManager(config api.BaseConfig) (*Manager, error) {
 	}
 	clientCmdConfig.CurrentContext = inClusterKubeConfigDefaultContext
 
-	return NewManager(config, restConfig, clientcmd.NewDefaultClientConfig(*clientCmdConfig, nil))
+	return NewManager(ctx, config, restConfig, clientcmd.NewDefaultClientConfig(*clientCmdConfig, nil))
 }
 
-func NewManager(config api.BaseConfig, restConfig *rest.Config, clientCmdConfig clientcmd.ClientConfig) (*Manager, error) {
+func NewManager(ctx context.Context, config api.BaseConfig, restConfig *rest.Config, clientCmdConfig clientcmd.ClientConfig) (*Manager, error) {
 	if config == nil {
 		return nil, errors.New("config cannot be nil")
 	}
@@ -156,7 +159,7 @@ func NewManager(config api.BaseConfig, restConfig *rest.Config, clientCmdConfig 
 	//k8s.restConfig.Wrap(func(original http.RoundTripper) http.RoundTripper {
 	//	return &impersonateRoundTripper{original}
 	//})
-	k8s.kubernetes, err = NewKubernetes(k8s.config, clientCmdConfig, restConfig)
+	k8s.kubernetes, err = NewKubernetes(ctx, k8s.config, clientCmdConfig, restConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -166,6 +169,7 @@ func NewManager(config api.BaseConfig, restConfig *rest.Config, clientCmdConfig 
 func (m *Manager) Derived(ctx context.Context) (*Kubernetes, error) {
 	authorization, ok := ctx.Value(OAuthAuthorizationHeader).(string)
 	hasToken := ok && strings.HasPrefix(authorization, "Bearer ")
+	logger := klog.FromContext(ctx)
 
 	// No token: fall back to kubeconfig credentials, unless require_oauth=true.
 	// In kubeconfig mode, the token exchange layer clears the auth header before we get here,
@@ -177,11 +181,11 @@ func (m *Manager) Derived(ctx context.Context) (*Kubernetes, error) {
 		if m.config.IsRequireOAuth() {
 			return nil, errors.New("oauth token required")
 		}
-		klog.V(5).Infof("No bearer token in context, falling back to kubeconfig credentials")
+		logger.V(5).Info("No bearer token in context, falling back to kubeconfig credentials")
 		return m.kubernetes, nil
 	}
 
-	klog.V(5).Infof("%s header found (Bearer), using provided bearer token", OAuthAuthorizationHeader)
+	logger.V(5).Info("Authorization header found (Bearer), using provided bearer token")
 	userAgent := CustomUserAgent
 	if ua, ok := ctx.Value(UserAgentHeader).(string); ok && ua != "" {
 		userAgent = ua
@@ -209,7 +213,7 @@ func (m *Manager) Derived(ctx context.Context) (*Kubernetes, error) {
 		return nil, fmt.Errorf("failed to get kubeconfig: %w", err)
 	}
 	clientCmdApiConfig.AuthInfos = make(map[string]*clientcmdapi.AuthInfo)
-	derived, err := NewKubernetes(m.config, clientcmd.NewDefaultClientConfig(clientCmdApiConfig, nil), derivedCfg)
+	derived, err := NewKubernetes(ctx, m.config, clientcmd.NewDefaultClientConfig(clientCmdApiConfig, nil), derivedCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create derived client: %w", err)
 	}

--- a/pkg/kubernetes/manager_test.go
+++ b/pkg/kubernetes/manager_test.go
@@ -41,7 +41,7 @@ func (s *ManagerTestSuite) TestNewInClusterManager() {
 			return &rest.Config{}, nil
 		}
 		s.Run("with default StaticConfig (empty kubeconfig)", func() {
-			manager, err := NewInClusterManager(&config.StaticConfig{})
+			manager, err := NewInClusterManager(s.T().Context(), &config.StaticConfig{})
 			s.Require().NoError(err)
 			s.Require().NotNil(manager)
 			s.Run("behaves as in cluster", func() {
@@ -54,7 +54,7 @@ func (s *ManagerTestSuite) TestNewInClusterManager() {
 			})
 		})
 		s.Run("with explicit kubeconfig", func() {
-			manager, err := NewInClusterManager(&config.StaticConfig{
+			manager, err := NewInClusterManager(s.T().Context(), &config.StaticConfig{
 				KubeConfig: s.mockServer.KubeconfigFile(s.T()),
 			})
 			s.Run("returns error", func() {
@@ -68,7 +68,7 @@ func (s *ManagerTestSuite) TestNewInClusterManager() {
 		InClusterConfig = func() (*rest.Config, error) {
 			return nil, rest.ErrNotInCluster
 		}
-		manager, err := NewInClusterManager(&config.StaticConfig{})
+		manager, err := NewInClusterManager(s.T().Context(), &config.StaticConfig{})
 		s.Run("returns error", func() {
 			s.Error(err)
 			s.Nil(manager)
@@ -86,7 +86,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 		s.Run("with valid kubeconfig in env", func() {
 			kubeconfig := s.mockServer.KubeconfigFile(s.T())
 			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfig))
-			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+			manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{}, "")
 			s.Require().NoError(err)
 			s.Require().NotNil(manager)
 			s.Run("behaves as NOT in cluster", func() {
@@ -109,7 +109,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 			kubeconfigInEnv := s.mockServer.KubeconfigFile(s.T())
 			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigInEnv))
 			kubeconfigExplicit := s.mockServer.KubeconfigFile(s.T())
-			manager, err := NewKubeconfigManager(&config.StaticConfig{
+			manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{
 				KubeConfig: kubeconfigExplicit,
 			}, "")
 			s.Require().NoError(err)
@@ -137,7 +137,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 			kubeconfig.CurrentContext = "not-the-mock-server"
 			kubeconfigFile := test.KubeconfigFile(s.T(), kubeconfig)
 			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigFile))
-			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "fake-context") // fake-context is the one mock-server serves
+			manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{}, "fake-context") // fake-context is the one mock-server serves
 			s.Require().NoError(err)
 			s.Require().NotNil(manager)
 			s.Run("behaves as NOT in cluster", func() {
@@ -156,7 +156,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 		s.Run("with valid kubeconfig in env and explicit kubeconfig context (invalid)", func() {
 			kubeconfigInEnv := s.mockServer.KubeconfigFile(s.T())
 			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigInEnv))
-			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "i-do-not-exist")
+			manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{}, "i-do-not-exist")
 			s.Run("returns error", func() {
 				s.Error(err)
 				s.Nil(manager)
@@ -165,7 +165,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 		})
 		s.Run("with invalid path kubeconfig in env", func() {
 			s.Require().NoError(os.Setenv("KUBECONFIG", "i-dont-exist"))
-			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+			manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{}, "")
 			s.Run("returns error", func() {
 				s.Error(err)
 				s.Nil(manager)
@@ -176,7 +176,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 			kubeconfigPath := filepath.Join(s.T().TempDir(), "config")
 			s.Require().NoError(os.WriteFile(kubeconfigPath, []byte(""), 0644))
 			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigPath))
-			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+			manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{}, "")
 			s.Run("returns error", func() {
 				s.Error(err)
 				s.Nil(manager)
@@ -188,7 +188,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 			kubeconfig.CurrentContext = ""
 			kubeconfigFile := test.KubeconfigFile(s.T(), kubeconfig)
 			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigFile))
-			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+			manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{}, "")
 			s.Require().NoError(err)
 			s.Require().NotNil(manager)
 			s.Run("rest config host points to mock server", func() {
@@ -201,7 +201,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 			kubeconfig.Contexts["another-context"] = clientcmdapi.NewContext()
 			kubeconfigFile := test.KubeconfigFile(s.T(), kubeconfig)
 			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigFile))
-			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+			manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{}, "")
 			s.Run("returns error listing available contexts", func() {
 				s.Error(err)
 				s.Nil(manager)
@@ -213,7 +213,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 			kubeconfig := clientcmdapi.NewConfig()
 			kubeconfigFile := test.KubeconfigFile(s.T(), kubeconfig)
 			s.Require().NoError(os.Setenv("KUBECONFIG", kubeconfigFile))
-			manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+			manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{}, "")
 			s.Run("returns error", func() {
 				s.Error(err)
 				s.Nil(manager)
@@ -225,7 +225,7 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 		InClusterConfig = func() (*rest.Config, error) {
 			return &rest.Config{}, nil
 		}
-		manager, err := NewKubeconfigManager(&config.StaticConfig{}, "")
+		manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{}, "")
 		s.Run("returns error", func() {
 			s.Error(err)
 			s.Nil(manager)
@@ -237,28 +237,28 @@ func (s *ManagerTestSuite) TestNewKubeconfigManager() {
 
 func (s *ManagerTestSuite) TestNewManager() {
 	s.Run("with nil config returns error", func() {
-		manager, err := NewManager(nil, &rest.Config{}, clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, nil))
+		manager, err := NewManager(s.T().Context(), nil, &rest.Config{}, clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, nil))
 		s.Require().Error(err)
 		s.EqualError(err, "config cannot be nil", "expected 'config cannot be nil' error")
 		s.Nil(manager, "expected nil manager when config is nil")
 	})
 
 	s.Run("with nil restConfig returns error", func() {
-		manager, err := NewManager(&config.StaticConfig{}, nil, clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, nil))
+		manager, err := NewManager(s.T().Context(), &config.StaticConfig{}, nil, clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, nil))
 		s.Require().Error(err)
 		s.EqualError(err, "restConfig cannot be nil", "expected 'restConfig cannot be nil' error")
 		s.Nil(manager, "expected nil manager when restConfig is nil")
 	})
 
 	s.Run("with nil clientCmdConfig returns error", func() {
-		manager, err := NewManager(&config.StaticConfig{}, &rest.Config{}, nil)
+		manager, err := NewManager(s.T().Context(), &config.StaticConfig{}, &rest.Config{}, nil)
 		s.Require().Error(err)
 		s.EqualError(err, "clientCmdConfig cannot be nil", "expected 'clientCmdConfig cannot be nil' error")
 		s.Nil(manager, "expected nil manager when clientCmdConfig is nil")
 	})
 
 	s.Run("with all nil parameters returns config error first", func() {
-		manager, err := NewManager(nil, nil, nil)
+		manager, err := NewManager(s.T().Context(), nil, nil, nil)
 		s.Require().Error(err)
 		s.EqualError(err, "config cannot be nil", "expected 'config cannot be nil' error as first check")
 		s.Nil(manager, "expected nil manager when all parameters are nil")

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -30,12 +30,12 @@ type Provider interface {
 	GetDefaultTarget() string
 	GetTargetParameterName() string
 	// WatchTargets sets up a watcher for changes in the cluster targets and calls the provided McpReload function when changes are detected
-	WatchTargets(reload McpReload)
+	WatchTargets(ctx context.Context, reload McpReload)
 	Close()
 	// HasGVKs reports whether every GVK in gvks is available on at least one target
 	// exposed by this provider. Providers that have not opted in to GVK discovery
 	// should return true so existing tools remain visible.
-	HasGVKs(gvks []schema.GroupVersionKind) bool
+	HasGVKs(ctx context.Context, gvks []schema.GroupVersionKind) bool
 }
 
 // TokenExchangeProvider is an optional interface that providers can implement to suport per-target token exchange.
@@ -67,7 +67,7 @@ func WithTokenExchange(oauthState *oauth.State) ProviderOption {
 	}
 }
 
-func NewProvider(cfg api.BaseConfig, opts ...ProviderOption) (Provider, error) {
+func NewProvider(ctx context.Context, cfg api.BaseConfig, opts ...ProviderOption) (Provider, error) {
 	var providerOpts providerOptions
 	for _, opt := range opts {
 		opt(&providerOpts)
@@ -80,7 +80,7 @@ func NewProvider(cfg api.BaseConfig, opts ...ProviderOption) (Provider, error) {
 		return nil, err
 	}
 
-	provider, err := factory(cfg)
+	provider, err := factory(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes/provider_close_test.go
+++ b/pkg/kubernetes/provider_close_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,7 +20,7 @@ import (
 
 // resettable is satisfied by both singleClusterProvider and kubeConfigClusterProvider.
 type resettable interface {
-	reset() error
+	reset(ctx context.Context) error
 }
 
 // ProviderCloseTestSuite verifies that provider reset() calls close HTTP
@@ -61,9 +62,9 @@ func (s *ProviderCloseTestSuite) SetupTest() {
 	}
 	cfg := &config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)}
 
-	singleProvider, err := newSingleClusterProvider(api.ClusterProviderDisabled)(cfg)
+	singleProvider, err := newSingleClusterProvider(api.ClusterProviderDisabled)(s.T().Context(), cfg)
 	s.Require().NoError(err)
-	kubeconfigProvider, err := newKubeConfigClusterProvider(cfg)
+	kubeconfigProvider, err := newKubeConfigClusterProvider(s.T().Context(), cfg)
 	s.Require().NoError(err)
 
 	s.providers = []Provider{singleProvider, kubeconfigProvider}
@@ -131,7 +132,7 @@ func (s *ProviderCloseTestSuite) TestClosesOldConnectionsOnReset() {
 
 			providerConns := s.connsSince(beforeConns)
 
-			err = provider.(resettable).reset()
+			err = provider.(resettable).reset(s.T().Context())
 			s.Require().NoError(err)
 
 			s.Eventually(func() bool {
@@ -175,7 +176,7 @@ func (s *ProviderCloseTestSuite) TestClosesLazyContextConnectionsOnReset() {
 
 			providerConns := s.connsSince(beforeConns)
 
-			err = provider.(resettable).reset()
+			err = provider.(resettable).reset(s.T().Context())
 			s.Require().NoError(err)
 
 			s.Eventually(func() bool {

--- a/pkg/kubernetes/provider_kubeconfig.go
+++ b/pkg/kubernetes/provider_kubeconfig.go
@@ -38,19 +38,19 @@ func init() {
 // via kubeconfig contexts.
 // Internally, it leverages a KubeconfigManager for each context, initializing them
 // lazily when requested.
-func newKubeConfigClusterProvider(cfg api.BaseConfig) (Provider, error) {
+func newKubeConfigClusterProvider(ctx context.Context, cfg api.BaseConfig) (Provider, error) {
 	ret := &kubeConfigClusterProvider{config: cfg}
-	if err := ret.reset(); err != nil {
+	if err := ret.reset(ctx); err != nil {
 		return nil, err
 	}
 	return ret, nil
 }
 
-func (p *kubeConfigClusterProvider) reset() error {
+func (p *kubeConfigClusterProvider) reset(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	m, err := NewKubeconfigManager(p.config, "")
+	m, err := NewKubeconfigManager(ctx, p.config, "")
 	if err != nil {
 		if errors.Is(err, ErrorKubeconfigInClusterNotAllowed) {
 			return fmt.Errorf( //nolint:ST1005 // user-facing error with actionable multi-line guidance
@@ -98,16 +98,16 @@ func (p *kubeConfigClusterProvider) reset() error {
 	}
 
 	p.Close()
-	p.kubeconfigWatcher = watcher.NewKubeconfig(m.kubernetes.clientCmdConfig)
-	p.clusterStateWatcher = watcher.NewClusterState(m.kubernetes.DiscoveryClient())
+	p.kubeconfigWatcher = watcher.NewKubeconfig(ctx, m.kubernetes.clientCmdConfig)
+	p.clusterStateWatcher = watcher.NewClusterState(ctx, m.kubernetes.DiscoveryClient())
 	p.defaultContext = defaultContext
 
 	return nil
 }
 
-func (p *kubeConfigClusterProvider) managerForContext(context string) (*Manager, error) {
+func (p *kubeConfigClusterProvider) managerForContext(ctx context.Context, kubeContext string) (*Manager, error) {
 	p.mu.RLock()
-	m, ok := p.managers[context]
+	m, ok := p.managers[kubeContext]
 	p.mu.RUnlock()
 	if ok && m != nil {
 		return m, nil
@@ -116,18 +116,18 @@ func (p *kubeConfigClusterProvider) managerForContext(context string) (*Manager,
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	m, ok = p.managers[context]
+	m, ok = p.managers[kubeContext]
 	if ok && m != nil {
 		return m, nil
 	}
 	baseManager := p.managers[p.defaultContext]
 
-	m, err := NewKubeconfigManager(baseManager.config, context)
+	m, err := NewKubeconfigManager(ctx, baseManager.config, kubeContext)
 	if err != nil {
 		return nil, err
 	}
 
-	p.managers[context] = m
+	p.managers[kubeContext] = m
 
 	return m, nil
 }
@@ -164,7 +164,7 @@ func (p *kubeConfigClusterProvider) GetTargetParameterName() string {
 }
 
 func (p *kubeConfigClusterProvider) GetDerivedKubernetes(ctx context.Context, context string) (*Kubernetes, error) {
-	m, err := p.managerForContext(context)
+	m, err := p.managerForContext(ctx, context)
 	if err != nil {
 		return nil, err
 	}
@@ -177,16 +177,16 @@ func (p *kubeConfigClusterProvider) GetDefaultTarget() string {
 	return p.defaultContext
 }
 
-func (p *kubeConfigClusterProvider) WatchTargets(reload McpReload) {
+func (p *kubeConfigClusterProvider) WatchTargets(ctx context.Context, reload McpReload) {
 	reloadWithReset := func() error {
-		if err := p.reset(); err != nil {
+		if err := p.reset(ctx); err != nil {
 			return err
 		}
-		p.WatchTargets(reload)
+		p.WatchTargets(ctx, reload)
 		return reload()
 	}
-	p.kubeconfigWatcher.Watch(reloadWithReset)
-	p.clusterStateWatcher.Watch(reload)
+	p.kubeconfigWatcher.Watch(ctx, reloadWithReset)
+	p.clusterStateWatcher.Watch(ctx, reload)
 }
 
 func (p *kubeConfigClusterProvider) Close() {
@@ -197,6 +197,6 @@ func (p *kubeConfigClusterProvider) Close() {
 	}
 }
 
-func (p *kubeConfigClusterProvider) HasGVKs(_ []schema.GroupVersionKind) bool {
+func (p *kubeConfigClusterProvider) HasGVKs(_ context.Context, _ []schema.GroupVersionKind) bool {
 	return true
 }

--- a/pkg/kubernetes/provider_kubeconfig_test.go
+++ b/pkg/kubernetes/provider_kubeconfig_test.go
@@ -29,7 +29,7 @@ func (s *ProviderKubeconfigTestSuite) SetupTest() {
 		// Add multiple fake contexts to force multi-cluster behavior
 		kubeconfig.Contexts[fmt.Sprintf("context-%d", i)] = clientcmdapi.NewContext()
 	}
-	provider, err := NewProvider(&config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
+	provider, err := NewProvider(s.T().Context(), &config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
 	s.Require().NoError(err, "Expected no error creating provider with kubeconfig")
 	s.provider = provider
 }
@@ -100,7 +100,7 @@ func (s *ProviderKubeconfigTestSuite) TestEmptyCurrentContext() {
 	s.Run("with single context auto-selects it as default target", func() {
 		kubeconfig := s.mockServer.Kubeconfig()
 		kubeconfig.CurrentContext = ""
-		provider, err := NewProvider(&config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
+		provider, err := NewProvider(s.T().Context(), &config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
 		s.Require().NoError(err, "Expected no error creating provider with empty current-context and single context")
 		s.Equal("fake-context", provider.GetDefaultTarget(), "Expected auto-selected fake-context as default target")
 	})
@@ -108,7 +108,7 @@ func (s *ProviderKubeconfigTestSuite) TestEmptyCurrentContext() {
 		kubeconfig := s.mockServer.Kubeconfig()
 		kubeconfig.CurrentContext = ""
 		kubeconfig.Contexts["another-context"] = clientcmdapi.NewContext()
-		_, err := NewProvider(&config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
+		_, err := NewProvider(s.T().Context(), &config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
 		s.Require().Error(err, "Expected error creating provider with empty current-context and multiple contexts")
 		s.ErrorContains(err, "current-context is not set")
 		s.ErrorContains(err, "kubectl config use-context")
@@ -162,7 +162,7 @@ func (s *ProviderKubeconfigTestSuite) TestConcurrentLazyManagerInit() {
 			kubeconfig.Contexts[fmt.Sprintf("lazy-context-%d", i)] = ctx
 		}
 
-		provider, err := NewProvider(&config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
+		provider, err := NewProvider(s.T().Context(), &config.StaticConfig{KubeConfig: test.KubeconfigFile(s.T(), kubeconfig)})
 		s.Require().NoError(err, "Expected no error creating provider")
 
 		const goroutines = 20
@@ -198,12 +198,12 @@ func (s *ProviderKubeconfigTestSuite) TestWatchTargetsWithConcurrentReaders() {
 		}
 
 		kubeconfigPath := test.KubeconfigFile(s.T(), kubeconfig)
-		provider, err := NewProvider(&config.StaticConfig{KubeConfig: kubeconfigPath})
+		provider, err := NewProvider(s.T().Context(), &config.StaticConfig{KubeConfig: kubeconfigPath})
 		s.Require().NoError(err, "Expected no error creating provider")
 		s.T().Cleanup(provider.Close)
 
 		callback, waitForCallback := CallbackWaiter()
-		provider.WatchTargets(callback)
+		provider.WatchTargets(s.T().Context(), callback)
 
 		const readers = 10
 		stop := make(chan struct{})

--- a/pkg/kubernetes/provider_registry.go
+++ b/pkg/kubernetes/provider_registry.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
@@ -10,7 +11,7 @@ import (
 // ProviderFactory creates a new Provider instance for a given strategy.
 // Implementations should validate that the Manager is compatible with their strategy
 // (e.g., kubeconfig provider should reject in-cluster managers).
-type ProviderFactory func(cfg api.BaseConfig) (Provider, error)
+type ProviderFactory func(ctx context.Context, cfg api.BaseConfig) (Provider, error)
 
 var providerReg = &providerRegistry{factories: make(map[string]ProviderFactory)}
 

--- a/pkg/kubernetes/provider_registry_test.go
+++ b/pkg/kubernetes/provider_registry_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -13,18 +14,18 @@ type ProviderRegistryTestSuite struct {
 
 func (s *ProviderRegistryTestSuite) TestRegisterProvider() {
 	s.Run("With no pre-existing provider, registers the provider", func() {
-		RegisterProvider("test-strategy", func(cfg api.BaseConfig) (Provider, error) {
+		RegisterProvider("test-strategy", func(_ context.Context, cfg api.BaseConfig) (Provider, error) {
 			return nil, nil
 		})
 		_, exists := providerReg.factories["test-strategy"]
 		s.True(exists, "Provider should be registered")
 	})
 	s.Run("With pre-existing provider, panics", func() {
-		RegisterProvider("test-pre-existent", func(cfg api.BaseConfig) (Provider, error) {
+		RegisterProvider("test-pre-existent", func(_ context.Context, cfg api.BaseConfig) (Provider, error) {
 			return nil, nil
 		})
 		s.Panics(func() {
-			RegisterProvider("test-pre-existent", func(cfg api.BaseConfig) (Provider, error) {
+			RegisterProvider("test-pre-existent", func(_ context.Context, cfg api.BaseConfig) (Provider, error) {
 				return nil, nil
 			})
 		}, "Registering a provider with an existing strategy should panic")
@@ -39,10 +40,10 @@ func (s *ProviderRegistryTestSuite) TestGetRegisteredStrategies() {
 	})
 	s.Run("With multiple registered providers, returns sorted list", func() {
 		providerReg.clear()
-		RegisterProvider("foo-strategy", func(cfg api.BaseConfig) (Provider, error) {
+		RegisterProvider("foo-strategy", func(_ context.Context, cfg api.BaseConfig) (Provider, error) {
 			return nil, nil
 		})
-		RegisterProvider("bar-strategy", func(cfg api.BaseConfig) (Provider, error) {
+		RegisterProvider("bar-strategy", func(_ context.Context, cfg api.BaseConfig) (Provider, error) {
 			return nil, nil
 		})
 		strategies := GetRegisteredStrategies()

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -34,19 +34,19 @@ func init() {
 // When used within a cluster or with an 'in-cluster' strategy, it uses an InClusterManager.
 // Otherwise, it uses a KubeconfigManager.
 func newSingleClusterProvider(strategy string) ProviderFactory {
-	return func(cfg api.BaseConfig) (Provider, error) {
+	return func(ctx context.Context, cfg api.BaseConfig) (Provider, error) {
 		ret := &singleClusterProvider{
 			config:   cfg,
 			strategy: strategy,
 		}
-		if err := ret.reset(); err != nil {
+		if err := ret.reset(ctx); err != nil {
 			return nil, err
 		}
 		return ret, nil
 	}
 }
 
-func (p *singleClusterProvider) reset() error {
+func (p *singleClusterProvider) reset(ctx context.Context) error {
 	if p.config != nil && p.config.GetKubeConfigPath() != "" && p.strategy == api.ClusterProviderInCluster {
 		return fmt.Errorf("kubeconfig file %s cannot be used with the in-cluster ClusterProviderStrategy",
 			p.config.GetKubeConfigPath())
@@ -57,9 +57,9 @@ func (p *singleClusterProvider) reset() error {
 	}
 	var err error
 	if p.strategy == api.ClusterProviderInCluster || IsInCluster(p.config) {
-		p.manager, err = NewInClusterManager(p.config)
+		p.manager, err = NewInClusterManager(ctx, p.config)
 	} else {
-		p.manager, err = NewKubeconfigManager(p.config, "")
+		p.manager, err = NewKubeconfigManager(ctx, p.config, "")
 	}
 	if err != nil {
 		if errors.Is(err, ErrorInClusterNotInCluster) {
@@ -70,8 +70,8 @@ func (p *singleClusterProvider) reset() error {
 	}
 
 	p.Close()
-	p.kubeconfigWatcher = watcher.NewKubeconfig(p.manager.kubernetes.clientCmdConfig)
-	p.clusterStateWatcher = watcher.NewClusterState(p.manager.kubernetes.DiscoveryClient())
+	p.kubeconfigWatcher = watcher.NewKubeconfig(ctx, p.manager.kubernetes.clientCmdConfig)
+	p.clusterStateWatcher = watcher.NewClusterState(ctx, p.manager.kubernetes.DiscoveryClient())
 	return nil
 }
 
@@ -103,16 +103,16 @@ func (p *singleClusterProvider) GetTargetParameterName() string {
 	return ""
 }
 
-func (p *singleClusterProvider) WatchTargets(reload McpReload) {
+func (p *singleClusterProvider) WatchTargets(ctx context.Context, reload McpReload) {
 	reloadWithReset := func() error {
-		if err := p.reset(); err != nil {
+		if err := p.reset(ctx); err != nil {
 			return err
 		}
-		p.WatchTargets(reload)
+		p.WatchTargets(ctx, reload)
 		return reload()
 	}
-	p.kubeconfigWatcher.Watch(reloadWithReset)
-	p.clusterStateWatcher.Watch(reload)
+	p.kubeconfigWatcher.Watch(ctx, reloadWithReset)
+	p.clusterStateWatcher.Watch(ctx, reload)
 }
 
 func (p *singleClusterProvider) Close() {
@@ -124,12 +124,12 @@ func (p *singleClusterProvider) Close() {
 }
 
 // HasGVKs uses the cluster's REST mapper to verify that every requested GVK is available.
-func (p *singleClusterProvider) HasGVKs(gvks []schema.GroupVersionKind) bool {
+func (p *singleClusterProvider) HasGVKs(ctx context.Context, gvks []schema.GroupVersionKind) bool {
 	if len(gvks) == 0 {
 		return true
 	}
 	if p.manager == nil {
-		klog.Warning("HasGVKs called with nil manager, assuming all GVKs are available")
+		klog.FromContext(ctx).Info("HasGVKs called with nil manager, assuming all GVKs are available")
 		return true
 	}
 	mapper := p.manager.kubernetes.RESTMapper()

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes/watcher"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2"
 )
 
 // singleClusterProvider implements Provider for managing a single
@@ -129,7 +129,7 @@ func (p *singleClusterProvider) HasGVKs(ctx context.Context, gvks []schema.Group
 		return true
 	}
 	if p.manager == nil {
-		klog.FromContext(ctx).Info("HasGVKs called with nil manager, assuming all GVKs are available")
+		klogutil.Warn(ctx, "HasGVKs called with nil manager, assuming all GVKs are available")
 		return true
 	}
 	mapper := p.manager.kubernetes.RESTMapper()

--- a/pkg/kubernetes/provider_single_test.go
+++ b/pkg/kubernetes/provider_single_test.go
@@ -25,7 +25,7 @@ func (s *ProviderSingleTestSuite) SetupTest() {
 	InClusterConfig = func() (*rest.Config, error) {
 		return s.mockServer.Config(), nil
 	}
-	provider, err := NewProvider(&config.StaticConfig{})
+	provider, err := NewProvider(s.T().Context(), &config.StaticConfig{})
 	s.Require().NoError(err, "Expected no error creating provider with kubeconfig")
 	s.provider = provider
 }
@@ -95,22 +95,22 @@ func (s *ProviderSingleTestSuite) TestHasGVKs() {
 	s.mockServer.Handle(handler)
 
 	s.Run("returns true for nil GVKs list", func() {
-		s.True(s.provider.HasGVKs(nil))
+		s.True(s.provider.HasGVKs(s.T().Context(), nil))
 	})
 
 	s.Run("returns true for empty GVKs list", func() {
-		s.True(s.provider.HasGVKs([]schema.GroupVersionKind{}))
+		s.True(s.provider.HasGVKs(s.T().Context(), []schema.GroupVersionKind{}))
 	})
 
 	s.Run("returns true for a single GVK that exists on the cluster", func() {
-		result := s.provider.HasGVKs([]schema.GroupVersionKind{
+		result := s.provider.HasGVKs(s.T().Context(), []schema.GroupVersionKind{
 			{Group: "", Version: "v1", Kind: "Pod"},
 		})
 		s.True(result)
 	})
 
 	s.Run("returns true when all GVKs exist on the cluster", func() {
-		result := s.provider.HasGVKs([]schema.GroupVersionKind{
+		result := s.provider.HasGVKs(s.T().Context(), []schema.GroupVersionKind{
 			{Group: "", Version: "v1", Kind: "Pod"},
 			{Group: "", Version: "v1", Kind: "Node"},
 			{Group: "apps", Version: "v1", Kind: "Deployment"},
@@ -119,14 +119,14 @@ func (s *ProviderSingleTestSuite) TestHasGVKs() {
 	})
 
 	s.Run("returns false when a GVK does not exist on the cluster", func() {
-		result := s.provider.HasGVKs([]schema.GroupVersionKind{
+		result := s.provider.HasGVKs(s.T().Context(), []schema.GroupVersionKind{
 			{Group: "nonexistent.example.com", Version: "v1", Kind: "FakeResource"},
 		})
 		s.False(result)
 	})
 
 	s.Run("returns false when any GVK in the list does not exist", func() {
-		result := s.provider.HasGVKs([]schema.GroupVersionKind{
+		result := s.provider.HasGVKs(s.T().Context(), []schema.GroupVersionKind{
 			{Group: "", Version: "v1", Kind: "Pod"},
 			{Group: "nonexistent.example.com", Version: "v1", Kind: "FakeResource"},
 		})

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -61,7 +61,7 @@ func (s *ProviderTestSuite) TestNewProviderInCluster() {
 	}
 	s.Run("With no cluster_provider_strategy, returns single-cluster provider", func() {
 		cfg := test.Must(config.ReadToml([]byte{}))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().NoError(err, "Expected no error for in-cluster provider")
 		s.NotNil(provider, "Expected provider instance")
 		s.IsType(&singleClusterProvider{}, provider, "Expected singleClusterProvider type")
@@ -70,7 +70,7 @@ func (s *ProviderTestSuite) TestNewProviderInCluster() {
 		cfg := test.Must(config.ReadToml([]byte(`
 			cluster_provider_strategy = "in-cluster"
 		`)))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().NoError(err, "Expected no error for single-cluster strategy")
 		s.NotNil(provider, "Expected provider instance")
 		s.IsType(&singleClusterProvider{}, provider, "Expected singleClusterProvider type")
@@ -79,7 +79,7 @@ func (s *ProviderTestSuite) TestNewProviderInCluster() {
 		cfg := test.Must(config.ReadToml([]byte(`
 			cluster_provider_strategy = "kubeconfig"
 		`)))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().Error(err, "Expected error for kubeconfig strategy")
 		s.ErrorContains(err, "kubeconfig ClusterProviderStrategy is invalid for in-cluster deployments")
 		s.ErrorContains(err, "--kubeconfig /path/to/kubeconfig --cluster-provider kubeconfig")
@@ -91,7 +91,7 @@ func (s *ProviderTestSuite) TestNewProviderInCluster() {
 			cluster_provider_strategy = "kubeconfig"
 			kubeconfig = "` + s.kubeconfigPath + `"
 		`)))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().NoError(err, "Expected no error for kubeconfig strategy")
 		s.NotNil(provider, "Expected provider instance")
 		s.IsType(&kubeConfigClusterProvider{}, provider, "Expected kubeConfigClusterProvider type")
@@ -100,7 +100,7 @@ func (s *ProviderTestSuite) TestNewProviderInCluster() {
 		cfg := test.Must(config.ReadToml([]byte(`
 			cluster_provider_strategy = "i-do-not-exist"
 		`)))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().Error(err, "Expected error for non-existent strategy")
 		s.ErrorContains(err, "no provider registered for strategy 'i-do-not-exist'")
 		s.Nilf(provider, "Expected no provider instance, got %v", provider)
@@ -114,7 +114,7 @@ func (s *ProviderTestSuite) TestNewProviderLocal() {
 	s.Require().NoError(os.Setenv("KUBECONFIG", s.kubeconfigPath))
 	s.Run("With no cluster_provider_strategy, returns kubeconfig provider", func() {
 		cfg := test.Must(config.ReadToml([]byte{}))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().NoError(err, "Expected no error for kubeconfig provider")
 		s.NotNil(provider, "Expected provider instance")
 		s.IsType(&kubeConfigClusterProvider{}, provider, "Expected kubeConfigClusterProvider type")
@@ -123,7 +123,7 @@ func (s *ProviderTestSuite) TestNewProviderLocal() {
 		cfg := test.Must(config.ReadToml([]byte(`
 			cluster_provider_strategy = "kubeconfig"
 		`)))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().NoError(err, "Expected no error for kubeconfig provider")
 		s.NotNil(provider, "Expected provider instance")
 		s.IsType(&kubeConfigClusterProvider{}, provider, "Expected kubeConfigClusterProvider type")
@@ -132,7 +132,7 @@ func (s *ProviderTestSuite) TestNewProviderLocal() {
 		cfg := test.Must(config.ReadToml([]byte(`
 			cluster_provider_strategy = "disabled"
 		`)))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().NoError(err, "Expected no error for disabled strategy")
 		s.NotNil(provider, "Expected provider instance")
 		s.IsType(&singleClusterProvider{}, provider, "Expected singleClusterProvider type")
@@ -141,7 +141,7 @@ func (s *ProviderTestSuite) TestNewProviderLocal() {
 		cfg := test.Must(config.ReadToml([]byte(`
 			cluster_provider_strategy = "in-cluster"
 		`)))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().Error(err, "Expected error for in-cluster strategy")
 		s.ErrorContains(err, "server must be deployed in cluster for the in-cluster ClusterProviderStrategy")
 		s.Nilf(provider, "Expected no provider instance, got %v", provider)
@@ -151,7 +151,7 @@ func (s *ProviderTestSuite) TestNewProviderLocal() {
 			kubeconfig = "` + s.kubeconfigPath + `"
 			cluster_provider_strategy = "in-cluster"
 		`)))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().Error(err, "Expected error for in-cluster strategy")
 		s.Regexp("kubeconfig file .+ cannot be used with the in-cluster ClusterProviderStrategy", err.Error())
 		s.Nilf(provider, "Expected no provider instance, got %v", provider)
@@ -160,7 +160,7 @@ func (s *ProviderTestSuite) TestNewProviderLocal() {
 		cfg := test.Must(config.ReadToml([]byte(`
 			cluster_provider_strategy = "i-do-not-exist"
 		`)))
-		provider, err := NewProvider(cfg)
+		provider, err := NewProvider(s.T().Context(), cfg)
 		s.Require().Error(err, "Expected error for non-existent strategy")
 		s.ErrorContains(err, "no provider registered for strategy 'i-do-not-exist'")
 		s.Nilf(provider, "Expected no provider instance, got %v", provider)

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -67,7 +68,7 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 		}
 	}
 	if tokenURL == "" {
-		logger.Info("token exchange strategy configured but OIDC provider returned empty token URL",
+		klogutil.Warn(ctx, "token exchange strategy configured but OIDC provider returned empty token URL",
 			"token_exchange.strategy", strategy,
 		)
 		return nil

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -68,7 +68,7 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 		}
 	}
 	if tokenURL == "" {
-		klogutil.Warn(ctx, "token exchange strategy configured but OIDC provider returned empty token URL",
+		klogutil.WarnLogger(logger, "token exchange strategy configured but OIDC provider returned empty token URL",
 			"token_exchange.strategy", strategy,
 		)
 		return nil

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -42,7 +42,7 @@ func (p *tokenExchangingProvider) GetDerivedKubernetes(ctx context.Context, targ
 	if snap == nil {
 		return p.provider.GetDerivedKubernetes(ctx, target)
 	}
-	stsConfig := p.getOrBuildStsConfig(snap)
+	stsConfig := p.getOrBuildStsConfig(ctx, snap)
 	ctx, err := ExchangeTokenInContext(ctx, p.baseConfig, snap.OIDCProvider, snap.HTTPClient, p.provider, target, stsConfig)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,9 @@ func (p *tokenExchangingProvider) GetDerivedKubernetes(ctx context.Context, targ
 
 // getOrBuildStsConfig returns a cached STS config, rebuilding it when the
 // OIDC provider's token URL changes (e.g., after SIGHUP).
-func (p *tokenExchangingProvider) getOrBuildStsConfig(snap *oauth.Snapshot) *tokenexchange.TargetTokenExchangeConfig {
+func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap *oauth.Snapshot) *tokenexchange.TargetTokenExchangeConfig {
+	logger := klog.FromContext(ctx)
+
 	strategy := p.baseConfig.GetStsStrategy()
 	if strategy == "" {
 		return nil
@@ -65,7 +67,9 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(snap *oauth.Snapshot) *tok
 		}
 	}
 	if tokenURL == "" {
-		klog.Warningf("token exchange strategy %q configured but OIDC provider returned empty token URL", strategy)
+		logger.Info("token exchange strategy configured but OIDC provider returned empty token URL",
+			"token_exchange.strategy", strategy,
+		)
 		return nil
 	}
 
@@ -95,7 +99,10 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(snap *oauth.Snapshot) *tok
 		CAFile:             p.baseConfig.GetCertificateAuthority(),
 	}
 	if err := cfg.Validate(); err != nil {
-		klog.Warningf("STS config validation failed, token exchange will be attempted per-request but will likely fail with the same error: %v", err)
+		logger.Error(
+			err,
+			"STS config validation failed, token exchange will be attempted per-request but will likely fail with the same error",
+		)
 		return nil
 	}
 
@@ -124,14 +131,14 @@ func (p *tokenExchangingProvider) GetTargetParameterName() string {
 	return p.provider.GetTargetParameterName()
 }
 
-func (p *tokenExchangingProvider) WatchTargets(reload McpReload) {
-	p.provider.WatchTargets(reload)
+func (p *tokenExchangingProvider) WatchTargets(ctx context.Context, reload McpReload) {
+	p.provider.WatchTargets(ctx, reload)
 }
 
 func (p *tokenExchangingProvider) Close() {
 	p.provider.Close()
 }
 
-func (p *tokenExchangingProvider) HasGVKs(gvks []schema.GroupVersionKind) bool {
-	return p.provider.HasGVKs(gvks)
+func (p *tokenExchangingProvider) HasGVKs(ctx context.Context, gvks []schema.GroupVersionKind) bool {
+	return p.provider.HasGVKs(ctx, gvks)
 }

--- a/pkg/kubernetes/provider_watch_test.go
+++ b/pkg/kubernetes/provider_watch_test.go
@@ -51,9 +51,9 @@ func (s *ProviderWatchTargetsTestSuite) TearDownTest() {
 
 func (s *ProviderWatchTargetsTestSuite) TestClusterStateChanges() {
 	testCases := []func() (Provider, error){
-		func() (Provider, error) { return newKubeConfigClusterProvider(s.staticConfig) },
+		func() (Provider, error) { return newKubeConfigClusterProvider(s.T().Context(), s.staticConfig) },
 		func() (Provider, error) {
-			return newSingleClusterProvider(api.ClusterProviderDisabled)(s.staticConfig)
+			return newSingleClusterProvider(api.ClusterProviderDisabled)(s.T().Context(), s.staticConfig)
 		},
 	}
 	for _, tc := range testCases {
@@ -62,7 +62,7 @@ func (s *ProviderWatchTargetsTestSuite) TestClusterStateChanges() {
 
 		s.Run("With provider "+reflect.TypeOf(provider).String(), func() {
 			callback, waitForCallback := CallbackWaiter()
-			provider.WatchTargets(callback)
+			provider.WatchTargets(s.T().Context(), callback)
 			s.Run("Reloads provider on cluster changes", func() {
 				s.discoveryClientHandler.AddAPIResourceList(metav1.APIResourceList{GroupVersion: "alex.example.com/v1"})
 
@@ -75,11 +75,11 @@ func (s *ProviderWatchTargetsTestSuite) TestClusterStateChanges() {
 }
 
 func (s *ProviderWatchTargetsTestSuite) TestKubeConfigClusterProvider() {
-	provider, err := newKubeConfigClusterProvider(s.staticConfig)
+	provider, err := newKubeConfigClusterProvider(s.T().Context(), s.staticConfig)
 	s.Require().NoError(err, "Expected no error from provider creation")
 
 	callback, waitForCallback := CallbackWaiter()
-	provider.WatchTargets(callback)
+	provider.WatchTargets(s.T().Context(), callback)
 
 	s.Run("KubeConfigClusterProvider updates targets (reset) on kubeconfig change", func() {
 		s.kubeconfig.CurrentContext = "context-1"
@@ -118,11 +118,11 @@ func (s *ProviderWatchTargetsTestSuite) TestKubeConfigClusterProvider() {
 }
 
 func (s *ProviderWatchTargetsTestSuite) TestSingleClusterProvider() {
-	provider, err := newSingleClusterProvider(api.ClusterProviderDisabled)(s.staticConfig)
+	provider, err := newSingleClusterProvider(api.ClusterProviderDisabled)(s.T().Context(), s.staticConfig)
 	s.Require().NoError(err, "Expected no error from provider creation")
 
 	callback, waitForCallback := CallbackWaiter()
-	provider.WatchTargets(callback)
+	provider.WatchTargets(s.T().Context(), callback)
 
 	s.Run("SingleClusterProvider reloads/resets on kubeconfig change", func() {
 		s.kubeconfig.CurrentContext = "context-1"

--- a/pkg/kubernetes/rbac_validator.go
+++ b/pkg/kubernetes/rbac_validator.go
@@ -36,7 +36,7 @@ func (v *RBACValidator) Validate(ctx context.Context, req *api.HTTPValidationReq
 
 	allowed, err := CanI(ctx, authClient, req.GVR, req.Namespace, req.ResourceName, req.Verb)
 	if err != nil {
-		klog.V(4).Infof("RBAC pre-validation failed with error: %v", err)
+		klog.FromContext(ctx).V(4).Info("RBAC pre-validation failed", "exception.message", err.Error())
 		return nil
 	}
 

--- a/pkg/kubernetes/schema_validator.go
+++ b/pkg/kubernetes/schema_validator.go
@@ -42,14 +42,16 @@ func (v *SchemaValidator) Validate(ctx context.Context, req *api.HTTPValidationR
 		return nil
 	}
 
+	logger := klog.FromContext(ctx)
+
 	// Only validate for create/update operations (exclude patch as partial bodies cause false positives)
 	if req.Verb != "create" && req.Verb != "update" {
 		return nil
 	}
 
-	validator, err := v.getValidator()
+	validator, err := v.getValidator(ctx)
 	if err != nil {
-		klog.V(4).Infof("Failed to get schema validator: %v", err)
+		logger.V(4).Info("Failed to get schema validator", "exception.message", err.Error())
 		return nil
 	}
 
@@ -63,7 +65,7 @@ func (v *SchemaValidator) Validate(ctx context.Context, req *api.HTTPValidationR
 		// In that case, skip validation rather than blocking the request
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "yaml:") || strings.Contains(errMsg, "json:") {
-			klog.V(4).Infof("Schema validation skipped due to parsing error: %v", err)
+			logger.V(4).Info("Schema validation skipped due to parsing error", "exception.message", err.Error())
 			return nil
 		}
 		return convertKubectlValidationError(err)
@@ -81,7 +83,7 @@ func (a *openAPIResourcesAdapter) OpenAPISchema() (kubectlopenapi.Resources, err
 	return a.parser.Parse()
 }
 
-func (v *SchemaValidator) getValidator() (kubectlvalidation.Schema, error) {
+func (v *SchemaValidator) getValidator(ctx context.Context) (kubectlvalidation.Schema, error) {
 	v.validatorMu.Lock()
 	defer v.validatorMu.Unlock()
 
@@ -96,7 +98,7 @@ func (v *SchemaValidator) getValidator() (kubectlvalidation.Schema, error) {
 
 	openAPIClient, ok := discoveryClient.(discovery.OpenAPISchemaInterface)
 	if !ok {
-		klog.V(4).Infof("Discovery client does not support OpenAPI schema")
+		klog.FromContext(ctx).V(4).Info("Discovery client does not support OpenAPI schema")
 		return nil, nil
 	}
 

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -44,7 +44,9 @@ func ExchangeTokenInContext(
 
 	exchanger, ok := tokenexchange.GetTokenExchanger(tep.GetTokenExchangeStrategy())
 	if !ok {
-		klog.Warningf("token exchange strategy %q not found in registry", tep.GetTokenExchangeStrategy())
+		klog.FromContext(ctx).Info("token exchange strategy not found in registry, falling back to sts exchange",
+			"token_exchange.strategy", tep.GetTokenExchangeStrategy(),
+		)
 		return stsExchangeTokenInContext(ctx, baseConfig, oidcProvider, httpClient, subjectToken, stsConfig)
 	}
 

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
-	"k8s.io/klog/v2"
 )
 
 // ExchangeTokenInContext exchanges the OAuth token in the context for a token
@@ -44,7 +44,7 @@ func ExchangeTokenInContext(
 
 	exchanger, ok := tokenexchange.GetTokenExchanger(tep.GetTokenExchangeStrategy())
 	if !ok {
-		klog.FromContext(ctx).Info("token exchange strategy not found in registry, falling back to sts exchange",
+		klogutil.Warn(ctx, "token exchange strategy not found in registry, falling back to sts exchange",
 			"token_exchange.strategy", tep.GetTokenExchangeStrategy(),
 		)
 		return stsExchangeTokenInContext(ctx, baseConfig, oidcProvider, httpClient, subjectToken, stsConfig)

--- a/pkg/kubernetes/watcher/cluster.go
+++ b/pkg/kubernetes/watcher/cluster.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"context"
 	"os"
 	"sort"
 	"strconv"
@@ -40,21 +41,22 @@ type ClusterState struct {
 
 var _ Watcher = (*ClusterState)(nil)
 
-func NewClusterState(discoveryClient discovery.CachedDiscoveryInterface) *ClusterState {
+func NewClusterState(ctx context.Context, discoveryClient discovery.CachedDiscoveryInterface) *ClusterState {
 	pollInterval := DefaultClusterStatePollInterval
 	debounceWindow := DefaultClusterStateDebounceWindow
+	logger := klog.FromContext(ctx)
 
 	// Allow override via environment variable for testing
 	if envInterval := os.Getenv("CLUSTER_STATE_POLL_INTERVAL_MS"); envInterval != "" {
 		if ms, err := strconv.Atoi(envInterval); err == nil && ms > 0 {
 			pollInterval = time.Duration(ms) * time.Millisecond
-			klog.V(2).Infof("Using custom cluster state poll interval: %v", pollInterval)
+			logger.V(2).Info("Using custom cluster state poll interval", "poll_interval", pollInterval)
 		}
 	}
 	if envDebounce := os.Getenv("CLUSTER_STATE_DEBOUNCE_WINDOW_MS"); envDebounce != "" {
 		if ms, err := strconv.Atoi(envDebounce); err == nil && ms > 0 {
 			debounceWindow = time.Duration(ms) * time.Millisecond
-			klog.V(2).Infof("Using custom cluster state debounce window: %v", debounceWindow)
+			logger.V(2).Info("Using custom cluster state debounce window", "debounce_window", debounceWindow)
 		}
 	}
 
@@ -70,7 +72,9 @@ func NewClusterState(discoveryClient discovery.CachedDiscoveryInterface) *Cluste
 // Watch starts a background watcher that periodically polls for cluster state changes
 // and triggers a debounced reload when changes are detected.
 // It can only be called once per ClusterState instance.
-func (w *ClusterState) Watch(onChange func() error) {
+func (w *ClusterState) Watch(ctx context.Context, onChange func() error) {
+	logger := klog.FromContext(ctx)
+
 	w.mu.Lock()
 	if w.started {
 		w.mu.Unlock()
@@ -86,12 +90,15 @@ func (w *ClusterState) Watch(onChange func() error) {
 		ticker := time.NewTicker(w.pollInterval)
 		defer ticker.Stop()
 
-		klog.V(2).Infof("Started cluster state watcher (poll interval: %v, debounce: %v)", w.pollInterval, w.debounceWindow)
+		logger.V(2).Info("Started cluster state watcher",
+			"poll_interval", w.pollInterval,
+			"debounce_window", w.debounceWindow,
+		)
 
 		for {
 			select {
 			case <-w.stopCh:
-				klog.V(2).Info("Stopping cluster state watcher")
+				logger.V(2).Info("Stopping cluster state watcher")
 				return
 			case <-ticker.C:
 				// Invalidate discovery cache to get fresh API groups
@@ -99,7 +106,10 @@ func (w *ClusterState) Watch(onChange func() error) {
 
 				w.mu.Lock()
 				current := w.captureState()
-				klog.V(3).Infof("Polled cluster state: %d API groups, OpenShift=%v", len(current.apiGroups), current.isOpenShift)
+				logger.V(3).Info("Polled cluster state",
+					"cluster.api_groups.count", len(current.apiGroups),
+					"cluster.is_openshift", current.isOpenShift,
+				)
 
 				changed := current.isOpenShift != w.lastKnownState.isOpenShift ||
 					len(current.apiGroups) != len(w.lastKnownState.apiGroups)
@@ -114,19 +124,19 @@ func (w *ClusterState) Watch(onChange func() error) {
 				}
 
 				if changed {
-					klog.V(2).Info("Cluster state changed, scheduling debounced reload")
+					logger.V(2).Info("Cluster state changed, scheduling debounced reload")
 					if w.debounceTimer != nil {
 						w.debounceTimer.Stop()
 					}
 					w.debounceTimer = time.AfterFunc(w.debounceWindow, func() {
-						klog.V(2).Info("Debounce window expired, triggering reload")
+						logger.V(2).Info("Debounce window expired, triggering reload")
 						if err := onChange(); err != nil {
-							klog.Errorf("Failed to reload: %v", err)
+							logger.Error(err, "Failed to reload")
 						} else {
 							w.mu.Lock()
 							w.lastKnownState = w.captureState()
 							w.mu.Unlock()
-							klog.V(2).Info("Reload completed")
+							logger.V(2).Info("Reload completed")
 						}
 					})
 				}

--- a/pkg/kubernetes/watcher/cluster_test.go
+++ b/pkg/kubernetes/watcher/cluster_test.go
@@ -52,7 +52,7 @@ func (s *ClusterStateTestSuite) TestNewClusterState() {
 		s.mockServer.Handle(test.NewDiscoveryClientHandler())
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 
 		s.Run("initializes with default poll interval at 30s", func() {
 			s.Equal(30*time.Second, watcher.pollInterval)
@@ -75,7 +75,7 @@ func (s *ClusterStateTestSuite) TestNewClusterState() {
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
 		s.T().Setenv("CLUSTER_STATE_POLL_INTERVAL_MS", "500")
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 
 		s.Run("uses custom poll interval", func() {
 			s.Equal(500*time.Millisecond, watcher.pollInterval)
@@ -90,7 +90,7 @@ func (s *ClusterStateTestSuite) TestNewClusterState() {
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
 		s.T().Setenv("CLUSTER_STATE_DEBOUNCE_WINDOW_MS", "250")
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 
 		s.Run("uses default poll interval", func() {
 			s.Equal(30*time.Second, watcher.pollInterval)
@@ -106,7 +106,7 @@ func (s *ClusterStateTestSuite) TestNewClusterState() {
 
 		s.T().Setenv("CLUSTER_STATE_POLL_INTERVAL_MS", "100")
 		s.T().Setenv("CLUSTER_STATE_DEBOUNCE_WINDOW_MS", "50")
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 
 		s.Run("uses custom poll interval", func() {
 			s.Equal(100*time.Millisecond, watcher.pollInterval)
@@ -122,19 +122,19 @@ func (s *ClusterStateTestSuite) TestNewClusterState() {
 
 		s.Run("ignores non-numeric value", func() {
 			s.T().Setenv("CLUSTER_STATE_POLL_INTERVAL_MS", "invalid")
-			watcher := NewClusterState(discoveryClient)
+			watcher := NewClusterState(s.T().Context(), discoveryClient)
 			s.Equal(30*time.Second, watcher.pollInterval)
 		})
 
 		s.Run("ignores negative value", func() {
 			s.T().Setenv("CLUSTER_STATE_POLL_INTERVAL_MS", "-100")
-			watcher := NewClusterState(discoveryClient)
+			watcher := NewClusterState(s.T().Context(), discoveryClient)
 			s.Equal(30*time.Second, watcher.pollInterval)
 		})
 
 		s.Run("ignores zero value", func() {
 			s.T().Setenv("CLUSTER_STATE_POLL_INTERVAL_MS", "0")
-			watcher := NewClusterState(discoveryClient)
+			watcher := NewClusterState(s.T().Context(), discoveryClient)
 			s.Equal(30*time.Second, watcher.pollInterval)
 		})
 	})
@@ -145,19 +145,19 @@ func (s *ClusterStateTestSuite) TestNewClusterState() {
 
 		s.Run("ignores non-numeric value", func() {
 			s.T().Setenv("CLUSTER_STATE_DEBOUNCE_WINDOW_MS", "invalid")
-			watcher := NewClusterState(discoveryClient)
+			watcher := NewClusterState(s.T().Context(), discoveryClient)
 			s.Equal(5*time.Second, watcher.debounceWindow)
 		})
 
 		s.Run("ignores negative value", func() {
 			s.T().Setenv("CLUSTER_STATE_DEBOUNCE_WINDOW_MS", "-50")
-			watcher := NewClusterState(discoveryClient)
+			watcher := NewClusterState(s.T().Context(), discoveryClient)
 			s.Equal(5*time.Second, watcher.debounceWindow)
 		})
 
 		s.Run("ignores zero value", func() {
 			s.T().Setenv("CLUSTER_STATE_DEBOUNCE_WINDOW_MS", "0")
-			watcher := NewClusterState(discoveryClient)
+			watcher := NewClusterState(s.T().Context(), discoveryClient)
 			s.Equal(5*time.Second, watcher.debounceWindow)
 		})
 	})
@@ -167,7 +167,7 @@ func (s *ClusterStateTestSuite) TestWatch() {
 	s.Run("captures initial cluster state", func() {
 		s.mockServer.Handle(test.NewDiscoveryClientHandler())
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 
 		var callCount atomic.Int32
 		onChange := func() error {
@@ -176,7 +176,7 @@ func (s *ClusterStateTestSuite) TestWatch() {
 		}
 
 		go func() {
-			watcher.Watch(onChange)
+			watcher.Watch(s.T().Context(), onChange)
 		}()
 		s.T().Cleanup(watcher.Close)
 
@@ -201,7 +201,7 @@ func (s *ClusterStateTestSuite) TestWatch() {
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
 		// Create watcher with very short intervals for testing
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 		watcher.pollInterval = 50 * time.Millisecond
 		watcher.debounceWindow = 20 * time.Millisecond
 
@@ -212,7 +212,7 @@ func (s *ClusterStateTestSuite) TestWatch() {
 		}
 
 		go func() {
-			watcher.Watch(onChange)
+			watcher.Watch(s.T().Context(), onChange)
 		}()
 		s.T().Cleanup(watcher.Close)
 
@@ -234,7 +234,7 @@ func (s *ClusterStateTestSuite) TestWatch() {
 		s.mockServer.Handle(test.NewInOpenShiftHandler())
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 
 		var callCount atomic.Int32
 		onChange := func() error {
@@ -243,7 +243,7 @@ func (s *ClusterStateTestSuite) TestWatch() {
 		}
 
 		go func() {
-			watcher.Watch(onChange)
+			watcher.Watch(s.T().Context(), onChange)
 		}()
 		s.T().Cleanup(watcher.Close)
 
@@ -264,7 +264,7 @@ func (s *ClusterStateTestSuite) TestWatch() {
 		s.mockServer.Handle(handler)
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 		watcher.pollInterval = 50 * time.Millisecond
 		watcher.debounceWindow = 20 * time.Millisecond
 
@@ -276,7 +276,7 @@ func (s *ClusterStateTestSuite) TestWatch() {
 		}
 
 		go func() {
-			watcher.Watch(onChange)
+			watcher.Watch(s.T().Context(), onChange)
 		}()
 		s.T().Cleanup(watcher.Close)
 
@@ -300,7 +300,7 @@ func (s *ClusterStateTestSuite) TestClose() {
 		s.mockServer.Handle(test.NewDiscoveryClientHandler())
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 		watcher.pollInterval = 50 * time.Millisecond
 		watcher.debounceWindow = 10 * time.Millisecond
 
@@ -311,7 +311,7 @@ func (s *ClusterStateTestSuite) TestClose() {
 		}
 
 		go func() {
-			watcher.Watch(onChange)
+			watcher.Watch(s.T().Context(), onChange)
 		}()
 
 		// Wait for the watcher to start
@@ -335,9 +335,9 @@ func (s *ClusterStateTestSuite) TestClose() {
 		s.mockServer.Handle(test.NewDiscoveryClientHandler())
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 		onChange := func() error { return nil }
-		watcher.Watch(onChange)
+		watcher.Watch(s.T().Context(), onChange)
 
 		s.NotPanics(func() {
 			watcher.Close()
@@ -351,7 +351,7 @@ func (s *ClusterStateTestSuite) TestClose() {
 		s.mockServer.Handle(handler)
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 		watcher.pollInterval = 30 * time.Millisecond
 		watcher.debounceWindow = 500 * time.Millisecond // Long debounce window
 
@@ -362,7 +362,7 @@ func (s *ClusterStateTestSuite) TestClose() {
 		}
 
 		go func() {
-			watcher.Watch(onChange)
+			watcher.Watch(s.T().Context(), onChange)
 		}()
 
 		// Wait for the watcher to start
@@ -400,7 +400,7 @@ func (s *ClusterStateTestSuite) TestClose() {
 		s.mockServer.Handle(test.NewDiscoveryClientHandler())
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 		// Don't call Watch() - the watcher goroutine is never started
 
 		// Close the stoppedCh channel since the goroutine never started
@@ -419,7 +419,7 @@ func (s *ClusterStateTestSuite) TestCaptureState() {
 		s.mockServer.Handle(handler)
 		discoveryClient := memory.NewMemCacheClient(discovery.NewDiscoveryClientForConfigOrDie(s.mockServer.Config()))
 
-		watcher := NewClusterState(discoveryClient)
+		watcher := NewClusterState(s.T().Context(), discoveryClient)
 		state := watcher.captureState()
 
 		s.Run("sorts groups alphabetically", func() {

--- a/pkg/kubernetes/watcher/kubeconfig.go
+++ b/pkg/kubernetes/watcher/kubeconfig.go
@@ -97,7 +97,7 @@ func (w *Kubeconfig) Watch(ctx context.Context, onChange func() error) {
 				w.debounceTimer = time.AfterFunc(w.debounceWindow, func() {
 					logger.V(2).Info("Kubeconfig debounce window expired, triggering reload")
 					if err := onChange(); err != nil {
-						logger.Error(err, "Failed to reload after kubeconfig change: %v")
+						logger.Error(err, "Failed to reload after kubeconfig change")
 					}
 				})
 				w.mu.Unlock()

--- a/pkg/kubernetes/watcher/kubeconfig.go
+++ b/pkg/kubernetes/watcher/kubeconfig.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"context"
 	"os"
 	"strconv"
 	"sync"
@@ -28,14 +29,14 @@ type Kubeconfig struct {
 
 var _ Watcher = (*Kubeconfig)(nil)
 
-func NewKubeconfig(clientConfig clientcmd.ClientConfig) *Kubeconfig {
+func NewKubeconfig(ctx context.Context, clientConfig clientcmd.ClientConfig) *Kubeconfig {
 	debounceWindow := DefaultKubeconfigDebounceWindow
 
 	// Allow override via environment variable for testing
 	if envDebounce := os.Getenv("KUBECONFIG_DEBOUNCE_WINDOW_MS"); envDebounce != "" {
 		if ms, err := strconv.Atoi(envDebounce); err == nil && ms > 0 {
 			debounceWindow = time.Duration(ms) * time.Millisecond
-			klog.V(2).Infof("Using custom kubeconfig debounce window: %v", debounceWindow)
+			klog.FromContext(ctx).V(2).Info("Using custom kubeconfig debounce window", "debounce_window", debounceWindow)
 		}
 	}
 
@@ -50,7 +51,9 @@ func NewKubeconfig(clientConfig clientcmd.ClientConfig) *Kubeconfig {
 // Watch starts a background watcher that monitors kubeconfig file changes
 // and triggers a debounced reload when changes are detected.
 // It can only be called once per Kubeconfig instance.
-func (w *Kubeconfig) Watch(onChange func() error) {
+func (w *Kubeconfig) Watch(ctx context.Context, onChange func() error) {
+	logger := klog.FromContext(ctx)
+
 	w.mu.Lock()
 	if w.started {
 		w.mu.Unlock()
@@ -75,26 +78,26 @@ func (w *Kubeconfig) Watch(onChange func() error) {
 		defer close(w.stoppedCh)
 		defer func() { _ = watcher.Close() }()
 
-		klog.V(2).Infof("Started kubeconfig watcher (debounce: %v)", w.debounceWindow)
+		logger.V(2).Info("Started kubeconfig watcher", "debounce_window", w.debounceWindow)
 
 		for {
 			select {
 			case <-w.stopCh:
-				klog.V(2).Info("Stopping kubeconfig watcher")
+				logger.V(2).Info("Stopping kubeconfig watcher")
 				return
 			case _, ok := <-watcher.Events:
 				if !ok {
 					return
 				}
 				w.mu.Lock()
-				klog.V(3).Info("Kubeconfig file change detected, scheduling debounced reload")
+				logger.V(3).Info("Kubeconfig file change detected, scheduling debounced reload")
 				if w.debounceTimer != nil {
 					w.debounceTimer.Stop()
 				}
 				w.debounceTimer = time.AfterFunc(w.debounceWindow, func() {
-					klog.V(2).Info("Kubeconfig debounce window expired, triggering reload")
+					logger.V(2).Info("Kubeconfig debounce window expired, triggering reload")
 					if err := onChange(); err != nil {
-						klog.Errorf("Failed to reload after kubeconfig change: %v", err)
+						logger.Error(err, "Failed to reload after kubeconfig change: %v")
 					}
 				})
 				w.mu.Unlock()

--- a/pkg/kubernetes/watcher/kubeconfig_test.go
+++ b/pkg/kubernetes/watcher/kubeconfig_test.go
@@ -37,7 +37,7 @@ func (s *KubeconfigTestSuite) SetupTest() {
 
 func (s *KubeconfigTestSuite) TestNewKubeconfig() {
 	s.Run("creates watcher with client config", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 
 		s.Run("stores client config", func() {
 			s.NotNil(watcher.ClientConfig)
@@ -51,7 +51,7 @@ func (s *KubeconfigTestSuite) TestNewKubeconfig() {
 
 func (s *KubeconfigTestSuite) TestWatch() {
 	s.Run("triggers onChange callback on file modification", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 		s.T().Cleanup(watcher.Close)
 
 		var changeDetected atomic.Bool
@@ -60,7 +60,7 @@ func (s *KubeconfigTestSuite) TestWatch() {
 			return nil
 		}
 
-		watcher.Watch(onChange)
+		watcher.Watch(s.T().Context(), onChange)
 
 		// Wait for the watcher to be ready
 		s.Eventually(func() bool {
@@ -81,11 +81,11 @@ func (s *KubeconfigTestSuite) TestWatch() {
 			&clientcmd.ClientConfigLoadingRules{ExplicitPath: ""},
 			&clientcmd.ConfigOverrides{},
 		)
-		watcher := NewKubeconfig(clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), clientConfig)
 
 		var completed atomic.Bool
 		go func() {
-			watcher.Watch(func() error { return nil })
+			watcher.Watch(s.T().Context(), func() error { return nil })
 			completed.Store(true)
 		}()
 
@@ -95,7 +95,7 @@ func (s *KubeconfigTestSuite) TestWatch() {
 	})
 
 	s.Run("handles multiple file changes with debouncing", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 		s.T().Cleanup(watcher.Close)
 
 		var callCount atomic.Int32
@@ -104,7 +104,7 @@ func (s *KubeconfigTestSuite) TestWatch() {
 			return nil
 		}
 
-		watcher.Watch(onChange)
+		watcher.Watch(s.T().Context(), onChange)
 
 		// Wait for the watcher to be ready
 		s.Eventually(func() bool {
@@ -125,7 +125,7 @@ func (s *KubeconfigTestSuite) TestWatch() {
 	})
 
 	s.Run("handles onChange callback errors gracefully", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 		s.T().Cleanup(watcher.Close)
 
 		var errorReturned atomic.Bool
@@ -134,7 +134,7 @@ func (s *KubeconfigTestSuite) TestWatch() {
 			return os.ErrInvalid // Return an error
 		}
 
-		watcher.Watch(onChange)
+		watcher.Watch(s.T().Context(), onChange)
 
 		// Wait for the watcher to be ready
 		s.Eventually(func() bool {
@@ -151,14 +151,14 @@ func (s *KubeconfigTestSuite) TestWatch() {
 	})
 
 	s.Run("ignores subsequent Watch calls when already started", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 		s.T().Cleanup(watcher.Close)
 
 		var firstWatcherActive atomic.Bool
 		var secondWatcherActive atomic.Bool
 
 		// Start first watcher
-		watcher.Watch(func() error {
+		watcher.Watch(s.T().Context(), func() error {
 			firstWatcherActive.Store(true)
 			return nil
 		})
@@ -169,7 +169,7 @@ func (s *KubeconfigTestSuite) TestWatch() {
 		}, kubeconfigTestTimeout, kubeconfigEventuallyTick, "timeout waiting for first watcher to be ready")
 
 		// Try to start second watcher (should be ignored since already started)
-		watcher.Watch(func() error {
+		watcher.Watch(s.T().Context(), func() error {
 			secondWatcherActive.Store(true)
 			return nil
 		})
@@ -189,7 +189,7 @@ func (s *KubeconfigTestSuite) TestWatch() {
 
 func (s *KubeconfigTestSuite) TestClose() {
 	s.Run("does not panic when watcher not started", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 
 		s.NotPanics(func() {
 			watcher.Close()
@@ -197,9 +197,9 @@ func (s *KubeconfigTestSuite) TestClose() {
 	})
 
 	s.Run("closes watcher successfully", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 
-		watcher.Watch(func() error { return nil })
+		watcher.Watch(s.T().Context(), func() error { return nil })
 
 		// Wait for the watcher to be ready
 		s.Eventually(func() bool {
@@ -212,10 +212,10 @@ func (s *KubeconfigTestSuite) TestClose() {
 	})
 
 	s.Run("stops triggering onChange after close", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 
 		var callCount atomic.Int32
-		watcher.Watch(func() error {
+		watcher.Watch(s.T().Context(), func() error {
 			callCount.Add(1)
 			return nil
 		})
@@ -241,9 +241,9 @@ func (s *KubeconfigTestSuite) TestClose() {
 	})
 
 	s.Run("handles multiple close calls", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 
-		watcher.Watch(func() error { return nil })
+		watcher.Watch(s.T().Context(), func() error { return nil })
 
 		// Wait for the watcher to be ready
 		s.Eventually(func() bool {
@@ -257,9 +257,9 @@ func (s *KubeconfigTestSuite) TestClose() {
 	})
 
 	s.Run("handles close when stopCh is already closed", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 
-		watcher.Watch(func() error { return nil })
+		watcher.Watch(s.T().Context(), func() error { return nil })
 
 		// Wait for the watcher to be ready
 		s.Eventually(func() bool {
@@ -291,10 +291,10 @@ func (s *KubeconfigTestSuite) TestClose() {
 	})
 
 	s.Run("stops debounce timer on close", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 
 		var callCount atomic.Int32
-		watcher.Watch(func() error {
+		watcher.Watch(s.T().Context(), func() error {
 			callCount.Add(1)
 			return nil
 		})
@@ -323,10 +323,10 @@ func (s *KubeconfigTestSuite) TestClose() {
 	})
 
 	s.Run("can restart watcher after close", func() {
-		watcher := NewKubeconfig(s.clientConfig)
+		watcher := NewKubeconfig(s.T().Context(), s.clientConfig)
 
 		var firstCallbackTriggered atomic.Bool
-		watcher.Watch(func() error {
+		watcher.Watch(s.T().Context(), func() error {
 			firstCallbackTriggered.Store(true)
 			return nil
 		})
@@ -345,7 +345,7 @@ func (s *KubeconfigTestSuite) TestClose() {
 
 		// Start a new watcher
 		var secondCallbackTriggered atomic.Bool
-		watcher.Watch(func() error {
+		watcher.Watch(s.T().Context(), func() error {
 			secondCallbackTriggered.Store(true)
 			return nil
 		})

--- a/pkg/kubernetes/watcher/watcher.go
+++ b/pkg/kubernetes/watcher/watcher.go
@@ -1,6 +1,8 @@
 package watcher
 
+import "context"
+
 type Watcher interface {
-	Watch(onChange func() error)
+	Watch(ctx context.Context, onChange func() error)
 	Close()
 }

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -208,9 +208,9 @@ func (s *BaseMcpSuite) TearDownTest() {
 }
 
 func (s *BaseMcpSuite) InitMcpClient(options ...test.McpClientOption) {
-	provider, err := internalk8s.NewProvider(s.Cfg)
+	provider, err := internalk8s.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err, "Expected no error creating k8s provider")
-	s.mcpServer, err = NewServer(Configuration{StaticConfig: s.Cfg}, provider)
+	s.mcpServer, err = NewServer(s.T().Context(), Configuration{StaticConfig: s.Cfg}, provider)
 	s.Require().NoError(err, "Expected no error creating MCP server")
 	s.McpClient = test.NewMcpClient(s.T(), s.mcpServer.ServeHTTP(), options...)
 }

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -111,7 +111,7 @@ type Server struct {
 	closeOnce                sync.Once
 }
 
-func NewServer(configuration Configuration, targetProvider internalk8s.Provider) (*Server, error) {
+func NewServer(ctx context.Context, configuration Configuration, targetProvider internalk8s.Provider) (*Server, error) {
 	sdkLogger := configuration.SDKLogger
 	if sdkLogger == nil {
 		sdkLogger = slog.New(logr.ToSlogHandler(klog.Background()))
@@ -139,7 +139,7 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 	s.configuration.Store(&configuration)
 
 	// Initialize metrics system
-	metricsInstance, err := metrics.New(metrics.Config{
+	metricsInstance, err := metrics.New(ctx, metrics.Config{
 		TracerName:     version.BinaryName + "/mcp",
 		ServiceName:    version.BinaryName,
 		ServiceVersion: version.Version,
@@ -174,11 +174,11 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 	// path entirely; protocolSendingMiddleware makes them visible at V(6).
 	s.server.AddSendingMiddleware(protocolSendingMiddleware)
 
-	err = s.applyToolsets(s.configuration.Load())
+	err = s.applyToolsets(ctx, s.configuration.Load())
 	if err != nil {
 		return nil, err
 	}
-	s.p.WatchTargets(s.reapplyToolsets)
+	s.p.WatchTargets(ctx, s.reapplyToolsets)
 
 	return s, nil
 }
@@ -191,7 +191,9 @@ func NewServer(configuration Configuration, targetProvider internalk8s.Provider)
 // a new cfg while we're blocked on reloadMu — we'd then silently roll it
 // back by re-installing the stale snapshot.
 func (s *Server) reapplyToolsets() error {
-	return s.applyToolsets(nil)
+	// TODO: context.Background is likely correct here, but let's verify when we add otel traces on SIGHUP path
+	// We want to make sure all the logs get correlated correctly through handling a SIGHUP signal
+	return s.applyToolsets(context.Background(), nil)
 }
 
 // applyToolsets recomputes the SDK's tool/prompt/resource/template surface
@@ -207,7 +209,7 @@ func (s *Server) reapplyToolsets() error {
 //
 // On error s.configuration, the SDK, and the enabled-X bookkeeping all stay
 // at their prior consistent values.
-func (s *Server) applyToolsets(cfg *Configuration) error {
+func (s *Server) applyToolsets(ctx context.Context, cfg *Configuration) error {
 	// TODO: No option to perform a full replacement of tools.
 	// s.server.SetTools(tools...)
 
@@ -314,7 +316,7 @@ func (s *Server) applyToolsets(cfg *Configuration) error {
 	s.mu.Unlock()
 
 	// Start new watch
-	s.p.WatchTargets(s.reapplyToolsets)
+	s.p.WatchTargets(ctx, s.reapplyToolsets)
 	return nil
 }
 
@@ -546,14 +548,15 @@ func (s *Server) GetEnabledResourceTemplates() []string {
 // SDK, and the enabled-X bookkeeping at their previous consistent values, so
 // concurrent readers (rate-limit closure, confirmation rules, list output...)
 // can never observe a new-but-rejected configuration.
-func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
-	klog.V(1).Info("Reloading MCP server configuration...")
+func (s *Server) ReloadConfiguration(ctx context.Context, newConfig *config.StaticConfig) error {
+	logger := klog.FromContext(ctx)
+	logger.V(1).Info("Reloading MCP server configuration...")
 
 	// Validate config-level invariants (same checks as startup)
 	if err := newConfig.
 		WithProviderStrategies(internalk8s.GetRegisteredStrategies()).
 		WithTokenExchangeStrategies(tokenexchange.GetRegisteredStrategies()).
-		Validate(); err != nil {
+		Validate(ctx); err != nil {
 		return fmt.Errorf("configuration reload rejected: %w", err)
 	}
 
@@ -561,11 +564,11 @@ func (s *Server) ReloadConfiguration(newConfig *config.StaticConfig) error {
 	// atomically only if the convert phase succeeds.
 	candidate := &Configuration{StaticConfig: newConfig}
 
-	if err := s.applyToolsets(candidate); err != nil {
+	if err := s.applyToolsets(ctx, candidate); err != nil {
 		return fmt.Errorf("failed to reload toolsets: %w", err)
 	}
 
-	klog.V(1).Info("MCP server configuration reloaded successfully")
+	logger.V(1).Info("MCP server configuration reloaded successfully")
 	return nil
 }
 

--- a/pkg/mcp/mcp_config_provider_test.go
+++ b/pkg/mcp/mcp_config_provider_test.go
@@ -159,7 +159,7 @@ func (s *McpConfigProviderSuite) TestStrategyReflectsConfigReload() {
 		toolsets = ["config-provider-test"]
 		cluster_provider_strategy = "in-cluster"
 	`), newConfig), "Expected to parse reload config")
-	err := s.mcpServer.ReloadConfiguration(newConfig)
+	err := s.mcpServer.ReloadConfiguration(s.T().Context(), newConfig)
 	s.Require().NoError(err)
 
 	s.Run("strategy reflects config reload", func() {

--- a/pkg/mcp/mcp_metrics_test.go
+++ b/pkg/mcp/mcp_metrics_test.go
@@ -25,7 +25,7 @@ func (s *McpMetricsSuite) TestToolCallMetricsRecorded() {
 	s.Require().Nilf(err, "call tool failed %v", err)
 	s.Require().Falsef(toolResult.IsError, "call tool failed")
 
-	stats := s.mcpServer.GetMetrics().GetStats()
+	stats := s.mcpServer.GetMetrics().GetStats(s.T().Context())
 
 	s.Run("increments total tool call count", func() {
 		s.GreaterOrEqual(stats.TotalToolCalls, int64(1))
@@ -48,7 +48,7 @@ func (s *McpMetricsSuite) TestToolCallErrorMetricsRecorded() {
 	s.Require().Nilf(err, "call tool should not return transport error %v", err)
 	s.Require().True(toolResult.IsError, "call tool should return error result for missing params")
 
-	stats := s.mcpServer.GetMetrics().GetStats()
+	stats := s.mcpServer.GetMetrics().GetStats(s.T().Context())
 
 	s.Run("increments total tool call count", func() {
 		s.GreaterOrEqual(stats.TotalToolCalls, int64(1))
@@ -71,7 +71,7 @@ func (s *McpMetricsSuite) TestMultipleToolCallsAggregate() {
 	_, err = s.CallTool("pods_list", map[string]interface{}{})
 	s.Require().Nilf(err, "third call failed %v", err)
 
-	stats := s.mcpServer.GetMetrics().GetStats()
+	stats := s.mcpServer.GetMetrics().GetStats(s.T().Context())
 
 	s.Run("total count matches sum of calls", func() {
 		s.GreaterOrEqual(stats.TotalToolCalls, int64(3))
@@ -114,7 +114,7 @@ func (s *McpMetricsSuite) TestPrometheusHandlerReflectsToolCalls() {
 
 func (s *McpMetricsSuite) TestStatsInitializedBeforeCalls() {
 	s.InitMcpClient()
-	stats := s.mcpServer.GetMetrics().GetStats()
+	stats := s.mcpServer.GetMetrics().GetStats(s.T().Context())
 
 	s.Run("maps are initialized", func() {
 		s.NotNil(stats.ToolCallsByName)

--- a/pkg/mcp/mcp_middleware_test.go
+++ b/pkg/mcp/mcp_middleware_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"regexp"
 	"strconv"
 	"testing"
 
@@ -52,13 +51,10 @@ func (s *McpLoggingSuite) TestLogsToolCall() {
 	s.Require().NoError(err, "call to tool configuration_view failed")
 
 	s.Run("Logs tool name", func() {
-		s.Contains(s.logBuffer.String(), "mcp tool call: configuration_view(")
+		s.Contains(s.logBuffer.String(), `mcp.tool_call.tool_name="configuration_view"`)
 	})
 	s.Run("Logs tool call arguments", func() {
-		expected := `"mcp tool call: configuration_view\((.+)\)"`
-		m := regexp.MustCompile(expected).FindStringSubmatch(s.logBuffer.String())
-		s.Len(m, 2, "Expected log entry to contain arguments")
-		s.Equal("map[minified:false]", m[1], "Expected log arguments to be 'map[minified:false]'")
+		s.Contains(s.logBuffer.String(), `mcp.tool_call.arguments="map[minified:false]"`)
 	})
 }
 
@@ -74,8 +70,7 @@ func (s *McpLoggingSuite) TestLogsToolCallHeaders() {
 	s.Require().NoError(err, "call to tool configuration_view failed")
 
 	s.Run("Logs tool call headers", func() {
-		expectedLog := "mcp tool call headers: A-Loggable-Header: should-be-logged"
-		s.Contains(s.logBuffer.String(), expectedLog, "Expected log to contain loggable header")
+		s.Contains(s.logBuffer.String(), "A-Loggable-Header: should-be-logged", "Expected log to contain loggable header")
 	})
 	sensitiveHeaders := []string{
 		"Authorization:",

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -61,9 +61,9 @@ func (s *ConfigReloadSuite) TearDownTest() {
 
 func (s *ConfigReloadSuite) TestConfigurationReload() {
 	// Initialize server with initial config
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
+	server, err := NewServer(s.T().Context(), Configuration{
 		StaticConfig: s.Cfg,
 	}, provider)
 	s.Require().NoError(err)
@@ -83,7 +83,7 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 		newConfig.Toolsets = []string{"core", "config"}
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 
-		err = server.ReloadConfiguration(newConfig)
+		err = server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().NoError(err)
 
 		s.Equal(5, server.configuration.Load().LogLevel)
@@ -98,7 +98,7 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 		newConfig.Toolsets = []string{"core", "config", "helm"}
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 
-		err = server.ReloadConfiguration(newConfig)
+		err = server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().NoError(err)
 
 		s.Equal(5, server.configuration.Load().LogLevel)
@@ -113,7 +113,7 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 		newConfig.Toolsets = []string{"core", "config", "helm"}
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 
-		err = server.ReloadConfiguration(newConfig)
+		err = server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().NoError(err)
 
 		s.Equal(7, server.configuration.Load().LogLevel)
@@ -128,7 +128,7 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 		newConfig.Toolsets = []string{"core", "config"}
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 
-		err = server.ReloadConfiguration(newConfig)
+		err = server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().NoError(err)
 
 		s.Equal(0, server.configuration.Load().LogLevel)
@@ -138,9 +138,9 @@ func (s *ConfigReloadSuite) TestConfigurationReload() {
 }
 
 func (s *ConfigReloadSuite) TestConfigurationValues() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
+	server, err := NewServer(s.T().Context(), Configuration{
 		StaticConfig: s.Cfg,
 	}, provider)
 	s.Require().NoError(err)
@@ -156,7 +156,7 @@ func (s *ConfigReloadSuite) TestConfigurationValues() {
 		newConfig.Toolsets = []string{"core", "config", "helm"}
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 
-		err = server.ReloadConfiguration(newConfig)
+		err = server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().NoError(err)
 
 		// Verify configuration was updated
@@ -168,9 +168,9 @@ func (s *ConfigReloadSuite) TestConfigurationValues() {
 }
 
 func (s *ConfigReloadSuite) TestMultipleReloads() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
+	server, err := NewServer(s.T().Context(), Configuration{
 		StaticConfig: s.Cfg,
 	}, provider)
 	s.Require().NoError(err)
@@ -182,7 +182,7 @@ func (s *ConfigReloadSuite) TestMultipleReloads() {
 		cfg1.LogLevel = 3
 		cfg1.KubeConfig = s.Cfg.KubeConfig
 		cfg1.Toolsets = []string{"core"}
-		err = server.ReloadConfiguration(cfg1)
+		err = server.ReloadConfiguration(s.T().Context(), cfg1)
 		s.Require().NoError(err)
 		s.Equal(3, server.configuration.Load().LogLevel)
 
@@ -191,7 +191,7 @@ func (s *ConfigReloadSuite) TestMultipleReloads() {
 		cfg2.LogLevel = 6
 		cfg2.KubeConfig = s.Cfg.KubeConfig
 		cfg2.Toolsets = []string{"core", "config"}
-		err = server.ReloadConfiguration(cfg2)
+		err = server.ReloadConfiguration(s.T().Context(), cfg2)
 		s.Require().NoError(err)
 		s.Equal(6, server.configuration.Load().LogLevel)
 
@@ -200,7 +200,7 @@ func (s *ConfigReloadSuite) TestMultipleReloads() {
 		cfg3.LogLevel = 9
 		cfg3.KubeConfig = s.Cfg.KubeConfig
 		cfg3.Toolsets = []string{"core", "config", "helm"}
-		err = server.ReloadConfiguration(cfg3)
+		err = server.ReloadConfiguration(s.T().Context(), cfg3)
 		s.Require().NoError(err)
 		s.Equal(9, server.configuration.Load().LogLevel)
 	})
@@ -219,7 +219,7 @@ func (s *ConfigReloadSuite) TestReloadUpdatesToolsets() {
 	newConfig.KubeConfig = s.Cfg.KubeConfig
 
 	// Reload configuration on the server the MCP client is connected to
-	err = s.mcpServer.ReloadConfiguration(newConfig)
+	err = s.mcpServer.ReloadConfiguration(s.T().Context(), newConfig)
 	s.Require().NoError(err)
 
 	// Verify helm tools are available
@@ -237,9 +237,9 @@ func (s *ConfigReloadSuite) TestReloadUpdatesToolsets() {
 }
 
 func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
+	server, err := NewServer(s.T().Context(), Configuration{
 		StaticConfig: s.Cfg,
 	}, provider)
 	s.Require().NoError(err)
@@ -251,7 +251,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
 		newConfig.RequireTLS = true
 		newConfig.AuthorizationURL = "http://example.com/auth"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "authorization_url")
 		s.Contains(err.Error(), "secure scheme required")
@@ -264,7 +264,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
 		newConfig.AuthorizationURL = "https://example.com/auth"
 		newConfig.ServerURL = "http://example.com:8080"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "server_url")
 		s.Contains(err.Error(), "secure scheme required")
@@ -277,7 +277,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
 		newConfig.AuthorizationURL = "https://example.com/auth"
 		newConfig.ServerURL = "https://example.com:8080"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.NoError(err)
 	})
 
@@ -287,15 +287,15 @@ func (s *ConfigReloadSuite) TestReloadRejectsHTTPURLsWhenRequireTLS() {
 		newConfig.RequireTLS = false
 		newConfig.AuthorizationURL = "http://example.com/auth"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.NoError(err)
 	})
 }
 
 func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
+	server, err := NewServer(s.T().Context(), Configuration{
 		StaticConfig: s.Cfg,
 	}, provider)
 	s.Require().NoError(err)
@@ -305,7 +305,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		newConfig := config.Default()
 		newConfig.ListOutput = "invalid-format"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid output name")
 	})
@@ -314,7 +314,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		newConfig := config.Default()
 		newConfig.Toolsets = []string{"nonexistent-toolset"}
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid toolset name")
 	})
@@ -323,7 +323,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		newConfig := config.Default()
 		newConfig.ClusterProviderStrategy = "nonexistent-strategy"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "invalid cluster-provider")
 	})
@@ -333,7 +333,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		newConfig.RequireOAuth = true
 		newConfig.AuthorizationURL = "ftp://example.com/auth"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "--authorization-url must be a valid URL")
 	})
@@ -344,7 +344,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		newConfig.AuthorizationURL = "https://example.com/auth"
 		newConfig.CertificateAuthority = "/nonexistent/path/ca.crt"
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "certificate-authority must be a valid file path")
 	})
@@ -354,7 +354,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		newConfig.TLSCert = "/some/cert.pem"
 		newConfig.TLSKey = ""
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "both --tls-cert and --tls-key must be provided together")
 	})
@@ -365,7 +365,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		newConfig.AuthorizationURL = ""
 		newConfig.SkipJWTVerification = false
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().Error(err)
 		s.Contains(err.Error(), "require_oauth is enabled but authorization_url is not configured")
 	})
@@ -376,7 +376,7 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 		newConfig.AuthorizationURL = ""
 		newConfig.SkipJWTVerification = true
 		newConfig.KubeConfig = s.Cfg.KubeConfig
-		err := server.ReloadConfiguration(newConfig)
+		err := server.ReloadConfiguration(s.T().Context(), newConfig)
 		s.NoError(err)
 	})
 }
@@ -389,9 +389,9 @@ func (s *ConfigReloadSuite) TestReloadRejectsInvalidConfig() {
 // directly so we exercise the transactional swap rather than the Validate
 // fast-path.
 func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
+	server, err := NewServer(s.T().Context(), Configuration{
 		StaticConfig: s.Cfg,
 	}, provider)
 	s.Require().NoError(err)
@@ -416,7 +416,7 @@ func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
 	}
 
 	s.Run("convert-phase failure does not mutate s.configuration", func() {
-		err := server.applyToolsets(candidate)
+		err := server.applyToolsets(s.T().Context(), candidate)
 		s.Require().Error(err, "reload must fail when a tool has a non-object input schema")
 
 		s.Same(prevConfig, server.configuration.Load(),
@@ -446,9 +446,9 @@ func (s *ConfigReloadSuite) TestReloadFailureLeavesConfigurationIntact() {
 // guarded only by the now-unused-by-handlers s.mu, `go test -race` would
 // report a data race on the field. With atomic.Pointer it is race-free.
 func (s *ConfigReloadSuite) TestConcurrentReadsDuringReload() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
+	server, err := NewServer(s.T().Context(), Configuration{
 		StaticConfig: s.Cfg,
 	}, provider)
 	s.Require().NoError(err)
@@ -495,7 +495,7 @@ func (s *ConfigReloadSuite) TestConcurrentReadsDuringReload() {
 			newCfg.LogLevel = 1
 		}
 		toggle = !toggle
-		s.Require().NoError(server.ReloadConfiguration(newCfg))
+		s.Require().NoError(server.ReloadConfiguration(s.T().Context(), newCfg))
 	}
 }
 
@@ -506,9 +506,9 @@ func (s *ConfigReloadSuite) TestConcurrentReadsDuringReload() {
 // applyToolsets before publish, the first-read writes are gone and
 // `-race` stays clean.
 func (s *ConfigReloadSuite) TestConcurrentListOutputAfterReload() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
+	server, err := NewServer(s.T().Context(), Configuration{
 		StaticConfig: s.Cfg,
 	}, provider)
 	s.Require().NoError(err)
@@ -522,7 +522,7 @@ func (s *ConfigReloadSuite) TestConcurrentListOutputAfterReload() {
 		} else {
 			newCfg.ListOutput = "table"
 		}
-		s.Require().NoError(server.ReloadConfiguration(newCfg))
+		s.Require().NoError(server.ReloadConfiguration(s.T().Context(), newCfg))
 
 		var wg sync.WaitGroup
 		for r := 0; r < 16; r++ {
@@ -539,9 +539,9 @@ func (s *ConfigReloadSuite) TestConcurrentListOutputAfterReload() {
 }
 
 func (s *ConfigReloadSuite) TestServerLifecycle() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	server, err := NewServer(Configuration{
+	server, err := NewServer(s.T().Context(), Configuration{
 		StaticConfig: s.Cfg,
 	}, provider)
 	s.Require().NoError(err)

--- a/pkg/mcp/mcp_test.go
+++ b/pkg/mcp/mcp_test.go
@@ -207,9 +207,9 @@ func (s *UserAgentPropagationSuite) TestPropagatesExplicitUserAgentWithOAuthToKu
 func (s *UserAgentPropagationSuite) TestFallsBackToMCPClientInfoForUserAgent() {
 	// Create MCP client through a handler that strips the User-Agent header,
 	// simulating a transport without HTTP User-Agent (like stdio).
-	provider, err := internalk8s.NewProvider(s.Cfg)
+	provider, err := internalk8s.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	s.mcpServer, err = NewServer(Configuration{StaticConfig: s.Cfg}, provider)
+	s.mcpServer, err = NewServer(s.T().Context(), Configuration{StaticConfig: s.Cfg}, provider)
 	s.Require().NoError(err)
 	handler := s.mcpServer.ServeHTTP()
 	strippedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -237,9 +237,9 @@ func (s *UserAgentPropagationSuite) TestFallsBackToMCPClientInfoForUserAgent() {
 func (s *UserAgentPropagationSuite) TestFallsBackToServerPrefixWhenNoClientInfo() {
 	// Create MCP client through a handler that strips the User-Agent header
 	// and initialize with empty client info.
-	provider, err := internalk8s.NewProvider(s.Cfg)
+	provider, err := internalk8s.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	s.mcpServer, err = NewServer(Configuration{StaticConfig: s.Cfg}, provider)
+	s.mcpServer, err = NewServer(s.T().Context(), Configuration{StaticConfig: s.Cfg}, provider)
 	s.Require().NoError(err)
 	handler := s.mcpServer.ServeHTTP()
 	strippedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -273,9 +273,9 @@ func (s *UserAgentPropagationSuite) TestDoesNotPanicWhenClientInfoIsNil() {
 	// However, some non-compliant clients omit it, which caused a nil pointer panic
 	// in the user-agent middleware. This test verifies that the server handles
 	// non-compliant clients gracefully by sending a raw initialize request without clientInfo.
-	provider, err := internalk8s.NewProvider(s.Cfg)
+	provider, err := internalk8s.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err)
-	s.mcpServer, err = NewServer(Configuration{StaticConfig: s.Cfg}, provider)
+	s.mcpServer, err = NewServer(s.T().Context(), Configuration{StaticConfig: s.Cfg}, provider)
 	s.Require().NoError(err)
 	handler := s.mcpServer.ServeHTTP()
 	strippedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -58,33 +58,42 @@ var redactedHeaders = map[string]bool{
 func protocolReceivingMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 		rawParams := req.GetParams()
-		// Gate the JSON marshal explicitly: Infof's args are evaluated
+		logger := klog.FromContext(ctx)
+		// Gate the JSON marshal explicitly: Info's args are evaluated
 		// before the V(6) check, so an unguarded jsonCompact(rawParams)
 		// would marshal every request even at the default log_level=0.
-		if klog.V(6).Enabled() {
-			klog.V(6).Infof("mcp protocol: client→server %s params=%s", method, mcplog.Sanitize(jsonCompact(rawParams)))
+		if logger.V(6).Enabled() {
+			logger.V(6).Info("mcp protocol", "mcp.client.method", method, "mcp.params", mcplog.Sanitize(jsonCompact(rawParams)))
 		}
-		if params, ok := rawParams.(*mcp.CallToolParamsRaw); ok {
+		if params, ok := rawParams.(*mcp.CallToolParamsRaw); ok && logger.V(5).Enabled() {
 			// Same gating rationale as the V(6) block above: the per-tool
 			// conversion and the per-header buffer build run before the
 			// V() check unless we short-circuit explicitly.
-			if klog.V(5).Enabled() {
-				if toolCallRequest, err := GoSdkToolCallParamsToToolCallRequest(params); err == nil {
-					klog.V(5).Infof("mcp tool call: %s(%v)", toolCallRequest.Name, mcplog.Sanitize(fmt.Sprintf("%v", toolCallRequest.GetArguments())))
-				}
+			var attributes []any
+
+			if toolCallRequest, err := GoSdkToolCallParamsToToolCallRequest(params); err == nil {
+				attributes = append(attributes,
+					"mcp.tool_call.tool_name", toolCallRequest.Name,
+					"mcp.tool_call.arguments", mcplog.Sanitize(fmt.Sprintf("%v", toolCallRequest.GetArguments())),
+				)
 			}
-			if klog.V(7).Enabled() && req.GetExtra() != nil && req.GetExtra().Header != nil {
+
+			if logger.V(7).Enabled() && req.GetExtra() != nil && req.GetExtra().Header != nil {
 				buffer := bytes.NewBuffer(make([]byte, 0))
 				if err := req.GetExtra().Header.WriteSubset(buffer, redactedHeaders); err == nil {
-					klog.V(7).Infof("mcp tool call headers: %s", mcplog.Sanitize(buffer.String()))
+					attributes = append(attributes,
+						"mcp.tool_call.headers", mcplog.Sanitize(buffer.String()),
+					)
 				}
 			}
+
+			logger.V(5).Info("mcp tool call", attributes...)
 		}
 		result, err := next(ctx, method, req)
 		if err != nil {
-			klog.V(6).Infof("mcp protocol: server→client %s error=%s", method, mcplog.Sanitize(fmt.Sprintf("%v", err)))
-		} else if klog.V(6).Enabled() {
-			klog.V(6).Infof("mcp protocol: server→client %s result=%s", method, mcplog.Sanitize(jsonCompact(result)))
+			logger.V(6).Info("mcp protocol", "mcp.client.method", method, "exception.message", mcplog.Sanitize(fmt.Sprintf("%v", err)))
+		} else if logger.V(6).Enabled() {
+			logger.V(6).Info("mcp protocol", "mcp.client.method", method, "mcp.call.result", mcplog.Sanitize(jsonCompact(result)))
 		}
 		return result, err
 	}
@@ -100,15 +109,16 @@ func protocolReceivingMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 // Sanitization is applied identically to the receiving path.
 func protocolSendingMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
-		if klog.V(6).Enabled() {
-			klog.V(6).Infof("mcp protocol: server→client %s params=%s", method, mcplog.Sanitize(jsonCompact(req.GetParams())))
+		logger := klog.FromContext(ctx)
+		if logger.V(6).Enabled() {
+			logger.V(6).Info("mcp protocol", "mcp.server.method", method, "mcp.params", mcplog.Sanitize(jsonCompact(req.GetParams())))
 		}
 		result, err := next(ctx, method, req)
 		if err != nil {
-			klog.V(6).Infof("mcp protocol: client→server %s error=%s", method, mcplog.Sanitize(fmt.Sprintf("%v", err)))
-		} else if result != nil && klog.V(6).Enabled() {
+			logger.V(6).Info("mcp protocol", "mcp.server.method", method, "exception.message", mcplog.Sanitize(fmt.Sprintf("%v", err)))
+		} else if result != nil && logger.V(6).Enabled() {
 			// Notifications return nil result; only requests have one.
-			klog.V(6).Infof("mcp protocol: client→server %s result=%s", method, mcplog.Sanitize(jsonCompact(result)))
+			logger.V(6).Info("mcp protocol", "mcp.server.method", method, "mcp.call.result", mcplog.Sanitize(jsonCompact(result)))
 		}
 		return result, err
 	}
@@ -189,6 +199,8 @@ func traceContextPropagationMiddleware(next mcp.MethodHandler) mcp.MethodHandler
 			return next(ctx, method, req)
 		}
 
+		logger := klog.FromContext(ctx)
+
 		// Extract trace context from request params metadata
 		if params := req.GetParams(); params != nil {
 			if callParams, ok := params.(interface{ GetMeta() map[string]any }); ok {
@@ -198,7 +210,7 @@ func traceContextPropagationMiddleware(next mcp.MethodHandler) mcp.MethodHandler
 				func() {
 					defer func() {
 						if r := recover(); r != nil {
-							klog.V(7).Infof("GetMeta() panicked (metadata not set): %v", r)
+							logger.V(7).Info("GetMeta() panicked (metadata not set)", "recover.value", r)
 						}
 					}()
 					meta = callParams.GetMeta()
@@ -213,7 +225,10 @@ func traceContextPropagationMiddleware(next mcp.MethodHandler) mcp.MethodHandler
 					scAfter := trace.SpanContextFromContext(ctx)
 
 					if scAfter.IsValid() && !scAfter.Equal(scBefore) {
-						klog.V(6).Infof("Extracted trace context from MCP request: trace_id=%s span_id=%s", scAfter.TraceID(), scAfter.SpanID())
+						logger.V(6).Info("Extracted trace context from MCP request",
+							"trace_id", scAfter.TraceID(),
+							"span_id", scAfter.SpanID(),
+						)
 					}
 				}
 			}

--- a/pkg/mcp/resources_gosdk_test.go
+++ b/pkg/mcp/resources_gosdk_test.go
@@ -303,7 +303,7 @@ func (s *ResourceSuite) TestReloadRemovesResources() {
 		newConfig.Toolsets = []string{"resource-test-empty"}
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 
-		err := s.mcpServer.ReloadConfiguration(newConfig)
+		err := s.mcpServer.ReloadConfiguration(s.T().Context(), newConfig)
 		s.Require().NoError(err)
 
 		result, err := s.ListResources()
@@ -346,7 +346,7 @@ func (s *ResourceSuite) TestReloadNotifiesResourceListChanged() {
 	newConfig.Toolsets = []string{"resource-test-empty"}
 	newConfig.KubeConfig = s.Cfg.KubeConfig
 
-	err := s.mcpServer.ReloadConfiguration(newConfig)
+	err := s.mcpServer.ReloadConfiguration(s.T().Context(), newConfig)
 	s.Require().NoError(err)
 
 	notification := capture.RequireNotification(s.T(), 2*time.Second, "notifications/resources/list_changed")
@@ -486,7 +486,7 @@ func (s *ResourceSuite) TestInvalidURITemplateReturnsError() {
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 
 		s.NotPanics(func() {
-			err := s.mcpServer.ReloadConfiguration(newConfig)
+			err := s.mcpServer.ReloadConfiguration(s.T().Context(), newConfig)
 			s.Require().Error(err)
 			s.Contains(err.Error(), "{{invalid")
 		})
@@ -514,7 +514,7 @@ func (s *ResourceSuite) TestInvalidURITemplateReturnsError() {
 		recoveryConfig.Toolsets = []string{"resource-test-good"}
 		recoveryConfig.KubeConfig = s.Cfg.KubeConfig
 
-		s.Require().NoError(s.mcpServer.ReloadConfiguration(recoveryConfig))
+		s.Require().NoError(s.mcpServer.ReloadConfiguration(s.T().Context(), recoveryConfig))
 
 		result, err := s.ReadResource("test://example/good")
 		s.Require().NoError(err)
@@ -569,7 +569,7 @@ func (s *ResourceSuite) TestInvalidResourceURIReturnsError() {
 		newConfig.KubeConfig = s.Cfg.KubeConfig
 
 		s.NotPanics(func() {
-			err := s.mcpServer.ReloadConfiguration(newConfig)
+			err := s.mcpServer.ReloadConfiguration(s.T().Context(), newConfig)
 			s.Require().Error(err)
 			s.Contains(err.Error(), "%zz")
 		})

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -256,9 +256,9 @@ func (s *ToolsetsSuite) TestInputSchemaEdgeCases() {
 }
 
 func (s *ToolsetsSuite) InitMcpClient() {
-	provider, err := kubernetes.NewProvider(s.Cfg)
+	provider, err := kubernetes.NewProvider(s.T().Context(), s.Cfg)
 	s.Require().NoError(err, "Expected no error creating kubernetes target provider")
-	s.mcpServer, err = NewServer(Configuration{StaticConfig: s.Cfg}, provider)
+	s.mcpServer, err = NewServer(s.T().Context(), Configuration{StaticConfig: s.Cfg}, provider)
 	s.Require().NoError(err, "Expected no error creating MCP server")
 	s.McpClient = test.NewMcpClient(s.T(), s.mcpServer.ServeHTTP())
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -29,14 +29,14 @@ type Metrics struct {
 
 // New creates a new Metrics instance with configured collectors.
 // If OTEL_EXPORTER_OTLP_ENDPOINT is set, metrics will also be exported to OTLP.
-func New(cfg Config) (*Metrics, error) {
+func New(ctx context.Context, cfg Config) (*Metrics, error) {
 	m := &Metrics{
 		collectors: []Collector{},
 	}
 
 	// Stats collector - always enabled for /stats endpoint
 	// Also exports to OTLP if OTEL_EXPORTER_OTLP_ENDPOINT is set or Telemetry config is provided
-	stats, err := NewOtelStatsCollectorWithConfig(CollectorConfig{
+	stats, err := NewOtelStatsCollectorWithConfig(ctx, CollectorConfig{
 		MeterName:      cfg.TracerName,
 		ServiceName:    cfg.ServiceName,
 		ServiceVersion: cfg.ServiceVersion,
@@ -47,7 +47,7 @@ func New(cfg Config) (*Metrics, error) {
 	}
 	m.stats = stats
 	m.collectors = append(m.collectors, m.stats)
-	klog.V(1).Info("Stats collector enabled")
+	klog.FromContext(ctx).V(1).Info("Stats collector enabled")
 
 	return m, nil
 }
@@ -70,8 +70,8 @@ func (m *Metrics) RecordHTTPRequest(ctx context.Context, method, path string, st
 
 // GetStats returns the current statistics from the StatsCollector.
 // This is used by the /stats HTTP endpoint.
-func (m *Metrics) GetStats() *Statistics {
-	return m.stats.GetStats()
+func (m *Metrics) GetStats(ctx context.Context) *Statistics {
+	return m.stats.GetStats(ctx)
 }
 
 // Shutdown gracefully shuts down the metrics system, flushing any pending metrics.

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -15,7 +15,7 @@ type MetricsSuite struct {
 
 func (s *MetricsSuite) TestNew() {
 	s.Run("creates metrics with stats collector enabled", func() {
-		m, err := New(Config{
+		m, err := New(s.T().Context(), Config{
 			TracerName:     "test",
 			ServiceName:    "test-service",
 			ServiceVersion: "1.0.0",
@@ -36,7 +36,7 @@ func (s *MetricsSuite) TestNew() {
 			Protocol: "grpc",
 		}
 
-		m, err := New(Config{
+		m, err := New(s.T().Context(), Config{
 			TracerName:     "test",
 			ServiceName:    "test-service",
 			ServiceVersion: "1.0.0",
@@ -51,7 +51,7 @@ func (s *MetricsSuite) TestNew() {
 
 func (s *MetricsSuite) TestRecordHTTPRequest() {
 	s.Run("fans out to all collectors", func() {
-		m, err := New(Config{
+		m, err := New(s.T().Context(), Config{
 			TracerName:     "test",
 			ServiceName:    "test-service",
 			ServiceVersion: "1.0.0",
@@ -63,7 +63,7 @@ func (s *MetricsSuite) TestRecordHTTPRequest() {
 		m.RecordHTTPRequest(ctx, "GET", "/test", 200, 50*time.Millisecond)
 
 		// Verify it was recorded in stats collector
-		stats := m.GetStats()
+		stats := m.GetStats(s.T().Context())
 		s.Equal(int64(1), stats.TotalHTTPRequests)
 		s.Equal(int64(1), stats.HTTPRequestsByPath["/test"])
 		s.Equal(int64(1), stats.HTTPRequestsByMethod["GET"])
@@ -73,7 +73,7 @@ func (s *MetricsSuite) TestRecordHTTPRequest() {
 
 func (s *MetricsSuite) TestGetStats() {
 	s.Run("returns stats from stats collector", func() {
-		m, err := New(Config{
+		m, err := New(s.T().Context(), Config{
 			TracerName:     "test",
 			ServiceName:    "test-service",
 			ServiceVersion: "1.0.0",
@@ -84,7 +84,7 @@ func (s *MetricsSuite) TestGetStats() {
 		m.RecordToolCall(ctx, "tool_a", 100*time.Millisecond, nil)
 		m.RecordHTTPRequest(ctx, "GET", "/test", 200, 50*time.Millisecond)
 
-		stats := m.GetStats()
+		stats := m.GetStats(s.T().Context())
 		s.Equal(int64(1), stats.TotalToolCalls)
 		s.Equal(int64(1), stats.TotalHTTPRequests)
 	})

--- a/pkg/metrics/otel_stats_collector.go
+++ b/pkg/metrics/otel_stats_collector.go
@@ -171,7 +171,7 @@ func NewOtelStatsCollectorWithConfig(ctx context.Context, cfg CollectorConfig) (
 		if cfg.Telemetry != nil && cfg.Telemetry.IsEnabled() {
 			logger.Error(err, "Failed to create OTLP metrics exporter, OTLP export disabled")
 		} else {
-			logger.V(1).Error(err, "Failed to create OTLP metrics exporter, OTLP export disabled")
+			logger.V(1).Info("Failed to create OTLP metrics exporter, OTLP export disabled", "exception.message", err.Error())
 		}
 	} else if exporter != nil {
 		attrs := []attribute.KeyValue{
@@ -325,7 +325,7 @@ func (c *OtelStatsCollector) GetStats(ctx context.Context) *Statistics {
 	// Collect current metrics from the manual reader
 	var rm metricdata.ResourceMetrics
 	if err := c.reader.Collect(context.Background(), &rm); err != nil {
-		klog.FromContext(ctx).V(1).Error(err, "Failed to collect metrics for stats endpoint")
+		klog.FromContext(ctx).V(1).Info("Failed to collect metrics for stats endpoint", "exception.message", err.Error())
 		return &Statistics{
 			ToolCallsByName:      make(map[string]int64),
 			ToolErrorsByName:     make(map[string]int64),

--- a/pkg/metrics/otel_stats_collector.go
+++ b/pkg/metrics/otel_stats_collector.go
@@ -85,8 +85,10 @@ type CollectorConfig struct {
 //
 // When nil is returned, metrics will only be collected in-memory for the /stats endpoint.
 func createMetricsExporter(ctx context.Context, cfg *config.TelemetryConfig) (sdkmetric.Exporter, error) {
+	logger := klog.FromContext(ctx)
+
 	if strings.ToLower(os.Getenv("OTEL_METRICS_EXPORTER")) == "none" {
-		klog.V(2).Info("OTLP metrics export disabled via OTEL_METRICS_EXPORTER=none")
+		logger.V(2).Info("OTLP metrics export disabled via OTEL_METRICS_EXPORTER=none")
 		return nil, nil
 	}
 
@@ -106,19 +108,21 @@ func createMetricsExporter(ctx context.Context, cfg *config.TelemetryConfig) (sd
 
 	switch protocol {
 	case "http/protobuf", "http":
-		klog.V(2).Infof("Using HTTP/protobuf OTLP metrics exporter (protocol=%s)", protocol)
+		logger.V(2).Info("Using HTTP/protobuf OTLP metrics exporter", "telemetry.metrics.exporter.protocol", protocol)
 		return otlpmetrichttp.New(ctx, otlpmetrichttp.WithEndpointURL(endpoint))
 
 	case "grpc", "":
 		if protocol == "" {
-			klog.V(2).Info("Using gRPC OTLP metrics exporter (default)")
+			logger.V(2).Info("Using gRPC OTLP metrics exporter (default)")
 		} else {
-			klog.V(2).Info("Using gRPC OTLP metrics exporter")
+			logger.V(2).Info("Using gRPC OTLP metrics exporter")
 		}
 		return otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithEndpointURL(endpoint))
 
 	default:
-		klog.V(1).Infof("Unknown OTEL_EXPORTER_OTLP_PROTOCOL '%s' for metrics, defaulting to gRPC", protocol)
+		logger.V(1).Info("Unknown OTEL_EXPORTER_OTLP_PROTOCOL for metrics, defaulting to gRPC",
+			"telemetry.metrics.exporter.protocol", protocol,
+		)
 		return otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithEndpointURL(endpoint))
 	}
 }
@@ -126,7 +130,7 @@ func createMetricsExporter(ctx context.Context, cfg *config.TelemetryConfig) (sd
 // NewOtelStatsCollector creates a new OtelStatsCollector with ManualReader.
 // If OTEL_EXPORTER_OTLP_ENDPOINT is set, metrics will also be exported to OTLP.
 func NewOtelStatsCollector(meterName string) (*OtelStatsCollector, error) {
-	return NewOtelStatsCollectorWithConfig(CollectorConfig{
+	return NewOtelStatsCollectorWithConfig(context.Background(), CollectorConfig{
 		MeterName:      meterName,
 		ServiceName:    "kubernetes-mcp-server",
 		ServiceVersion: "unknown",
@@ -134,9 +138,8 @@ func NewOtelStatsCollector(meterName string) (*OtelStatsCollector, error) {
 }
 
 // NewOtelStatsCollectorWithConfig creates a new OtelStatsCollector with full configuration.
-func NewOtelStatsCollectorWithConfig(cfg CollectorConfig) (*OtelStatsCollector, error) {
-	ctx := context.Background()
-
+func NewOtelStatsCollectorWithConfig(ctx context.Context, cfg CollectorConfig) (*OtelStatsCollector, error) {
+	logger := klog.FromContext(ctx)
 	// Create an in-memory manual reader for stats collection (/stats endpoint)
 	reader := sdkmetric.NewManualReader()
 
@@ -166,9 +169,9 @@ func NewOtelStatsCollectorWithConfig(cfg CollectorConfig) (*OtelStatsCollector, 
 	if err != nil {
 		// Use Warning if telemetry was explicitly configured, V(1) otherwise
 		if cfg.Telemetry != nil && cfg.Telemetry.IsEnabled() {
-			klog.Warningf("Failed to create OTLP metrics exporter, OTLP export disabled: %v", err)
+			logger.Error(err, "Failed to create OTLP metrics exporter, OTLP export disabled")
 		} else {
-			klog.V(1).Infof("Failed to create OTLP metrics exporter, OTLP export disabled: %v", err)
+			logger.V(1).Error(err, "Failed to create OTLP metrics exporter, OTLP export disabled")
 		}
 	} else if exporter != nil {
 		attrs := []attribute.KeyValue{
@@ -182,7 +185,7 @@ func NewOtelStatsCollectorWithConfig(cfg CollectorConfig) (*OtelStatsCollector, 
 			resource.WithAttributes(attrs...),
 		)
 		if err != nil {
-			klog.V(1).Infof("Failed to create resource for metrics, using default: %v", err)
+			logger.V(1).Info("Failed to create resource for metrics, using default", "exception.message", err.Error())
 		} else {
 			opts = append(opts, sdkmetric.WithResource(res))
 		}
@@ -192,7 +195,7 @@ func NewOtelStatsCollectorWithConfig(cfg CollectorConfig) (*OtelStatsCollector, 
 			sdkmetric.WithInterval(30*time.Second),
 		)
 		opts = append(opts, sdkmetric.WithReader(periodicReader))
-		klog.V(1).Info("OTLP metrics export enabled")
+		logger.V(1).Info("OTLP metrics export enabled")
 	}
 
 	provider := sdkmetric.NewMeterProvider(opts...)
@@ -318,11 +321,11 @@ func (c *OtelStatsCollector) RecordHTTPRequest(ctx context.Context, method, path
 
 // GetStats returns a snapshot of current statistics by reading from OTel metrics.
 // Thread-safety is handled by the OTel SDK's ManualReader.
-func (c *OtelStatsCollector) GetStats() *Statistics {
+func (c *OtelStatsCollector) GetStats(ctx context.Context) *Statistics {
 	// Collect current metrics from the manual reader
 	var rm metricdata.ResourceMetrics
 	if err := c.reader.Collect(context.Background(), &rm); err != nil {
-		klog.V(1).Infof("Failed to collect metrics for stats endpoint: %v", err)
+		klog.FromContext(ctx).V(1).Error(err, "Failed to collect metrics for stats endpoint")
 		return &Statistics{
 			ToolCallsByName:      make(map[string]int64),
 			ToolErrorsByName:     make(map[string]int64),

--- a/pkg/metrics/otel_stats_collector_test.go
+++ b/pkg/metrics/otel_stats_collector_test.go
@@ -39,7 +39,7 @@ func (s *OtelStatsCollectorSuite) TestRecordToolCall() {
 		collector.RecordToolCall(ctx, "failing_tool", 100*time.Millisecond, nil)
 		collector.RecordToolCall(ctx, "failing_tool", 200*time.Millisecond, &TestError{msg: "test error"})
 
-		stats := collector.GetStats()
+		stats := collector.GetStats(s.T().Context())
 		s.Equal(int64(2), stats.TotalToolCalls, "Should have 2 total tool calls")
 		s.Equal(int64(1), stats.ToolCallErrors, "Should have 1 error")
 		s.Equal(int64(1), stats.ToolErrorsByName["failing_tool"], "Should have 1 error for failing_tool")
@@ -54,7 +54,7 @@ func (s *OtelStatsCollectorSuite) TestRecordHTTPRequest() {
 		s.collector.RecordHTTPRequest(ctx, "GET", "/api/v2", 404, 30*time.Millisecond)
 		s.collector.RecordHTTPRequest(ctx, "POST", "/api/v1", 500, 200*time.Millisecond)
 
-		stats := s.collector.GetStats()
+		stats := s.collector.GetStats(s.T().Context())
 		s.Equal(int64(4), stats.TotalHTTPRequests, "Should have 4 total HTTP requests")
 		s.Equal(int64(2), stats.HTTPRequestsByStatus["2xx"], "Should have 2 successful requests")
 		s.Equal(int64(1), stats.HTTPRequestsByStatus["4xx"], "Should have 1 client error")
@@ -70,7 +70,7 @@ func (s *OtelStatsCollectorSuite) TestRecordHTTPRequest() {
 		collector.RecordHTTPRequest(ctx, "GET", "/api/v2", 200, 60*time.Millisecond)
 		collector.RecordHTTPRequest(ctx, "POST", "/api/v1", 201, 100*time.Millisecond)
 
-		stats := collector.GetStats()
+		stats := collector.GetStats(s.T().Context())
 		s.Equal(int64(2), stats.HTTPRequestsByMethod["GET"], "Should have 2 GET requests")
 		s.Equal(int64(1), stats.HTTPRequestsByMethod["POST"], "Should have 1 POST request")
 	})
@@ -84,7 +84,7 @@ func (s *OtelStatsCollectorSuite) TestRecordHTTPRequest() {
 		collector.RecordHTTPRequest(ctx, "GET", "/api/v1", 200, 60*time.Millisecond)
 		collector.RecordHTTPRequest(ctx, "POST", "/api/v2", 201, 100*time.Millisecond)
 
-		stats := collector.GetStats()
+		stats := collector.GetStats(s.T().Context())
 		s.Equal(int64(2), stats.HTTPRequestsByPath["/api/v1"], "Should have 2 requests to /api/v1")
 		s.Equal(int64(1), stats.HTTPRequestsByPath["/api/v2"], "Should have 1 request to /api/v2")
 	})
@@ -97,7 +97,7 @@ func (s *OtelStatsCollectorSuite) TestRecordHTTPRequest() {
 		collector.RecordHTTPRequest(ctx, "GET", "/old-path", 301, 10*time.Millisecond)
 		collector.RecordHTTPRequest(ctx, "GET", "/temp-redirect", 302, 10*time.Millisecond)
 
-		stats := collector.GetStats()
+		stats := collector.GetStats(s.T().Context())
 		s.Equal(int64(2), stats.HTTPRequestsByStatus["3xx"])
 	})
 
@@ -108,14 +108,14 @@ func (s *OtelStatsCollectorSuite) TestRecordHTTPRequest() {
 
 		collector.RecordHTTPRequest(ctx, "GET", "/info", 100, 10*time.Millisecond)
 
-		stats := collector.GetStats()
+		stats := collector.GetStats(s.T().Context())
 		s.Equal(int64(1), stats.HTTPRequestsByStatus["other"])
 	})
 }
 
 func (s *OtelStatsCollectorSuite) TestGetStats() {
 	s.Run("returns uptime and start time", func() {
-		stats := s.collector.GetStats()
+		stats := s.collector.GetStats(s.T().Context())
 		s.NotNil(stats, "Stats should not be nil")
 		s.True(stats.UptimeSeconds >= 0, "Uptime should be non-negative")
 		s.True(stats.StartTime > 0, "Start time should be set")
@@ -124,7 +124,7 @@ func (s *OtelStatsCollectorSuite) TestGetStats() {
 
 func (s *OtelStatsCollectorSuite) TestToolDurationHistogram() {
 	s.Run("records tool call duration", func() {
-		collector, err := NewOtelStatsCollectorWithConfig(CollectorConfig{
+		collector, err := NewOtelStatsCollectorWithConfig(s.T().Context(), CollectorConfig{
 			MeterName:      "test-meter-duration",
 			ServiceName:    "test-service",
 			ServiceVersion: "1.0.0",
@@ -164,7 +164,7 @@ func (s *OtelStatsCollectorSuite) TestToolDurationHistogram() {
 
 func (s *OtelStatsCollectorSuite) TestServerInfoGauge() {
 	s.Run("records server info with version labels", func() {
-		collector, err := NewOtelStatsCollectorWithConfig(CollectorConfig{
+		collector, err := NewOtelStatsCollectorWithConfig(s.T().Context(), CollectorConfig{
 			MeterName:      "test-meter-info",
 			ServiceName:    "test-service",
 			ServiceVersion: "1.2.3",
@@ -211,7 +211,7 @@ func (s *OtelStatsCollectorSuite) TestServerInfoGauge() {
 
 func (s *OtelStatsCollectorSuite) TestPrometheusHandler() {
 	s.Run("serves metrics in Prometheus format", func() {
-		collector, err := NewOtelStatsCollectorWithConfig(CollectorConfig{
+		collector, err := NewOtelStatsCollectorWithConfig(s.T().Context(), CollectorConfig{
 			MeterName:      "test-meter-prom-serve",
 			ServiceName:    "test-service",
 			ServiceVersion: "1.0.0",

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -302,7 +302,7 @@ func getSamplerFromConfig(ctx context.Context, cfg *config.TelemetryConfig) trac
 				"config.key", "traces_sampler_arg",
 				"config.provided", samplerArg,
 				"config.default", 1.0,
-				"exception.message", err,
+				"exception.message", err.Error(),
 			)
 		} else if parsed < 0.0 || parsed > 1.0 {
 			logger.V(1).Info("traces_sampler_arg out of range [0.0, 1.0], using default",

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -40,18 +40,28 @@ func Enabled() bool {
 //   - "parentbased_always_on": Respect parent span sampling decision, default to always_on
 //   - "parentbased_traceidratio": Respect parent span sampling decision, default to ratio
 //   - "" (empty/not set): Use default ParentBased(AlwaysSample)
-func getSamplerFromEnv() trace.Sampler {
+func getSamplerFromEnv(ctx context.Context) trace.Sampler {
 	samplerType := os.Getenv("OTEL_TRACES_SAMPLER")
 	samplerArg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
+	logger := klog.FromContext(ctx)
 
 	// Parse sampler argument (ratio) if provided
 	ratio := 1.0 // Default to 100% sampling
 	if samplerArg != "" {
 		parsed, err := strconv.ParseFloat(samplerArg, 64)
 		if err != nil {
-			klog.V(1).Infof("Invalid OTEL_TRACES_SAMPLER_ARG '%s', using default 1.0: %v", samplerArg, err)
+			logger.V(1).Info("Invalid OTEL_TRACES_SAMPLER_ARG, falling back to default",
+				"config.env_var", "OTEL_TRACES_SAMPLER_ARG",
+				"config.provided_value", samplerArg,
+				"config.default_value", 1.0,
+				"exception.message", err.Error(),
+			)
 		} else if parsed < 0.0 || parsed > 1.0 {
-			klog.V(1).Infof("OTEL_TRACES_SAMPLER_ARG '%f' out of range [0.0, 1.0], using default 1.0", parsed)
+			logger.V(1).Info("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], falling back to default",
+				"config.env_var", "OTEL_TRACES_SAMPLER_ARG",
+				"config.provided_value", parsed,
+				"config.default_value", 1.0,
+			)
 		} else {
 			ratio = parsed
 		}
@@ -60,36 +70,40 @@ func getSamplerFromEnv() trace.Sampler {
 	// Select sampler based on type
 	switch samplerType {
 	case "always_on":
-		klog.V(2).Info("Using AlwaysSample sampler")
+		logger.V(2).Info("Using AlwaysSample sampler")
 		return trace.AlwaysSample()
 
 	case "always_off":
-		klog.V(2).Info("Using NeverSample sampler")
+		logger.V(2).Info("Using NeverSample sampler")
 		return trace.NeverSample()
 
 	case "traceidratio":
-		klog.V(2).Infof("Using TraceIDRatioBased sampler with ratio %.2f", ratio)
+		logger.V(2).Info("Using TraceIDRatioBased sampler", "telemetry.sampler.ratio", ratio)
 		return trace.TraceIDRatioBased(ratio)
 
 	case "parentbased_always_on":
-		klog.V(2).Info("Using ParentBased(AlwaysSample) sampler")
+		logger.V(2).Info("Using ParentBased(AlwaysSample) sampler")
 		return trace.ParentBased(trace.AlwaysSample())
 
 	case "parentbased_always_off":
-		klog.V(2).Info("Using ParentBased(NeverSample) sampler")
+		logger.V(2).Info("Using ParentBased(NeverSample) sampler")
 		return trace.ParentBased(trace.NeverSample())
 
 	case "parentbased_traceidratio":
-		klog.V(2).Infof("Using ParentBased(TraceIDRatioBased(%.2f)) sampler", ratio)
+		logger.V(2).Info("Using ParentBased(TraceIDRatioBased) sampler", "telemetry.sampler.ratio", ratio)
 		return trace.ParentBased(trace.TraceIDRatioBased(ratio))
 
 	case "":
 		// Default: ParentBased(AlwaysSample) for development
-		klog.V(2).Info("Using default ParentBased(AlwaysSample) sampler")
+		logger.V(2).Info("Using default ParentBased(AlwaysSample) sampler")
 		return trace.ParentBased(trace.AlwaysSample())
 
 	default:
-		klog.V(1).Infof("Unknown OTEL_TRACES_SAMPLER '%s', using default ParentBased(AlwaysSample)", samplerType)
+		logger.V(1).Info("Unknown OTEL_TRACES_SAMPLER, using default",
+			"config.env_var", "OTEL_TRACES_SAMPLER",
+			"config.provided", samplerType,
+			"config.default", "ParentBased(AlwaysSample)",
+		)
 		return trace.ParentBased(trace.AlwaysSample())
 	}
 }
@@ -101,23 +115,28 @@ func getSamplerFromEnv() trace.Sampler {
 //   - "http": Alias for "http/protobuf"
 func createExporter(ctx context.Context) (*otlptrace.Exporter, error) {
 	protocol := strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL"))
+	logger := klog.FromContext(ctx)
 
 	switch protocol {
 	case "http/protobuf", "http":
-		klog.V(2).Infof("Using HTTP/protobuf OTLP exporter (protocol=%s)", protocol)
+		logger.V(2).Info("Using HTTP/protobuf OTLP exporter", "telemetry.exporter.protocol", protocol)
 		return otlptracehttp.New(ctx)
 
 	case "grpc", "":
 		// Default to gRPC
 		if protocol == "" {
-			klog.V(2).Info("Using gRPC OTLP exporter (default)")
+			logger.V(2).Info("Using gRPC OTLP exporter (default)")
 		} else {
-			klog.V(2).Info("Using gRPC OTLP exporter")
+			logger.V(2).Info("Using gRPC OTLP exporter")
 		}
 		return otlptracegrpc.New(ctx)
 
 	default:
-		klog.V(1).Infof("Unknown OTEL_EXPORTER_OTLP_PROTOCOL '%s', defaulting to gRPC", protocol)
+		logger.V(1).Info("Unknown OTEL_EXPORTER_OTLP_PROTOCOL falling back to default",
+			"config.env_var", "OTEL_EXPORTER_OTLP_PROTOCOL",
+			"config.provided", protocol,
+			"config.default", "grpc",
+		)
 		return otlptracegrpc.New(ctx)
 	}
 }
@@ -125,22 +144,21 @@ func createExporter(ctx context.Context) (*otlptrace.Exporter, error) {
 // InitTracer initializes the OpenTelemetry tracer provider.
 // Tracing is only enabled if OTEL_EXPORTER_OTLP_ENDPOINT is set.
 // Check telemetry.Enabled() to determine if tracing is active.
-func InitTracer(serviceName, serviceVersion string) (func(), error) {
+func InitTracer(ctx context.Context, serviceName, serviceVersion string) (func(), error) {
+	logger := klog.FromContext(ctx)
 	// Check if OTLP endpoint is configured - if not, skip all tracing setup
 	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 	if endpoint == "" {
-		klog.V(2).Info("OTEL_EXPORTER_OTLP_ENDPOINT not set, tracing disabled")
+		logger.V(2).Info("OTEL_EXPORTER_OTLP_ENDPOINT not set, tracing disabled")
 		return func() {}, nil
 	}
-
-	ctx := context.Background()
 
 	// Create OTLP exporter based on protocol configuration
 	// Endpoint is configured via OTEL_EXPORTER_OTLP_ENDPOINT env var
 	// Protocol is configured via OTEL_EXPORTER_OTLP_PROTOCOL env var
 	exporter, err := createExporter(ctx)
 	if err != nil {
-		klog.V(1).Infof("Failed to create OTLP exporter, tracing disabled: %v", err)
+		logger.V(1).Error(err, "Failed to create OTLP exporter, tracing disabled")
 		return func() {}, nil
 	}
 
@@ -152,12 +170,12 @@ func InitTracer(serviceName, serviceVersion string) (func(), error) {
 		),
 	)
 	if err != nil {
-		klog.V(1).Infof("Failed to create resource, tracing disabled: %v", err)
+		logger.V(1).Error(err, "Failed to create resource, tracing disabled")
 		return func() {}, nil
 	}
 
 	// Configure tracer provider with sampler from environment
-	sampler := getSamplerFromEnv()
+	sampler := getSamplerFromEnv(ctx)
 
 	// Create batch span processor with production settings
 	// - BatchTimeout: Maximum time to wait before exporting a batch (5 seconds)
@@ -187,16 +205,16 @@ func InitTracer(serviceName, serviceVersion string) (func(), error) {
 
 	// Mark tracing as enabled so middleware knows to create spans
 	tracingEnabled.Store(true)
-	klog.V(1).Info("OpenTelemetry tracing initialized successfully")
+	logger.V(1).Info("OpenTelemetry tracing initialized successfully")
 
 	cleanup := func() {
 		tracingEnabled.Store(false)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := tp.Shutdown(ctx); err != nil {
-			klog.Errorf("Failed to shutdown tracer provider: %v", err)
+			logger.Error(err, "Failed to shutdown tracer provider")
 		}
-		klog.V(1).Info("OpenTelemetry tracer provider shutdown complete")
+		logger.V(1).Info("OpenTelemetry tracer provider shutdown complete")
 	}
 
 	return cleanup, nil
@@ -205,17 +223,17 @@ func InitTracer(serviceName, serviceVersion string) (func(), error) {
 // InitTracerWithConfig initializes the OpenTelemetry tracer provider using the provided config.
 // The config values can be overridden by environment variables.
 // Check telemetry.Enabled() to determine if tracing is active.
-func InitTracerWithConfig(cfg *config.TelemetryConfig, serviceName, serviceVersion string) (func(), error) {
+func InitTracerWithConfig(ctx context.Context, cfg *config.TelemetryConfig, serviceName, serviceVersion string) (func(), error) {
+	logger := klog.FromContext(ctx)
+
 	if cfg == nil || !cfg.IsEnabled() {
-		klog.V(2).Info("Telemetry not enabled, tracing disabled")
+		logger.V(2).Info("Telemetry not enabled, tracing disabled")
 		return func() {}, nil
 	}
 
-	ctx := context.Background()
-
 	exporter, err := createExporterWithConfig(ctx, cfg)
 	if err != nil {
-		klog.V(1).Infof("Failed to create OTLP exporter, tracing disabled: %v", err)
+		logger.V(1).Error(err, "Failed to create OTLP exporter, tracing disabled")
 		return func() {}, nil
 	}
 
@@ -227,11 +245,11 @@ func InitTracerWithConfig(cfg *config.TelemetryConfig, serviceName, serviceVersi
 		),
 	)
 	if err != nil {
-		klog.V(1).Infof("Failed to create resource, tracing disabled: %v", err)
+		logger.V(1).Info("Failed to create resource, tracing disabled")
 		return func() {}, nil
 	}
 
-	sampler := getSamplerFromConfig(cfg)
+	sampler := getSamplerFromConfig(ctx, cfg)
 
 	bsp := trace.NewBatchSpanProcessor(
 		exporter,
@@ -254,16 +272,16 @@ func InitTracerWithConfig(cfg *config.TelemetryConfig, serviceName, serviceVersi
 	))
 
 	tracingEnabled.Store(true)
-	klog.V(1).Infof("OpenTelemetry tracing initialized successfully (endpoint=%s)", cfg.GetEndpoint())
+	logger.V(1).Info("OpenTelemetry tracing initialized successfully", "telemetry.exporter.endpoint", cfg.GetEndpoint())
 
 	cleanup := func() {
 		tracingEnabled.Store(false)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := tp.Shutdown(ctx); err != nil {
-			klog.Errorf("Failed to shutdown tracer provider: %v", err)
+			logger.Error(err, "Failed to shutdown tracer provider")
 		}
-		klog.V(1).Info("OpenTelemetry tracer provider shutdown complete")
+		logger.V(1).Info("OpenTelemetry tracer provider shutdown complete")
 	}
 
 	return cleanup, nil
@@ -271,17 +289,27 @@ func InitTracerWithConfig(cfg *config.TelemetryConfig, serviceName, serviceVersi
 
 // getSamplerFromConfig reads the sampler configuration from TelemetryConfig.
 // Environment variables take precedence over config values.
-func getSamplerFromConfig(cfg *config.TelemetryConfig) trace.Sampler {
+func getSamplerFromConfig(ctx context.Context, cfg *config.TelemetryConfig) trace.Sampler {
 	samplerType := cfg.GetTracesSampler()
 	samplerArg := cfg.GetTracesSamplerArg()
+	logger := klog.FromContext(ctx)
 
 	ratio := 1.0 // Default to 100% sampling
 	if samplerArg != "" {
 		parsed, err := strconv.ParseFloat(samplerArg, 64)
 		if err != nil {
-			klog.V(1).Infof("Invalid traces_sampler_arg '%s', using default 1.0: %v", samplerArg, err)
+			logger.V(1).Info("Invalid traces_sampler_arg, using",
+				"config.key", "traces_sampler_arg",
+				"config.provided", samplerArg,
+				"config.default", 1.0,
+				"exception.message", err,
+			)
 		} else if parsed < 0.0 || parsed > 1.0 {
-			klog.V(1).Infof("traces_sampler_arg '%f' out of range [0.0, 1.0], using default 1.0", parsed)
+			logger.V(1).Info("traces_sampler_arg out of range [0.0, 1.0], using default",
+				"config.key", "traces_sampler_arg",
+				"config.provided", parsed,
+				"config.default", 1.0,
+			)
 		} else {
 			ratio = parsed
 		}
@@ -289,36 +317,40 @@ func getSamplerFromConfig(cfg *config.TelemetryConfig) trace.Sampler {
 
 	switch samplerType {
 	case "always_on":
-		klog.V(2).Info("Using AlwaysSample sampler")
+		logger.V(2).Info("Using AlwaysSample sampler")
 		return trace.AlwaysSample()
 
 	case "always_off":
-		klog.V(2).Info("Using NeverSample sampler")
+		logger.V(2).Info("Using NeverSample sampler")
 		return trace.NeverSample()
 
 	case "traceidratio":
-		klog.V(2).Infof("Using TraceIDRatioBased sampler with ratio %.2f", ratio)
+		logger.V(2).Info("Using TraceIDRatioBased sampler", "telemetry.sampler.ratio", ratio)
 		return trace.TraceIDRatioBased(ratio)
 
 	case "parentbased_always_on":
-		klog.V(2).Info("Using ParentBased(AlwaysSample) sampler")
+		logger.V(2).Info("Using ParentBased(AlwaysSample) sampler")
 		return trace.ParentBased(trace.AlwaysSample())
 
 	case "parentbased_always_off":
-		klog.V(2).Info("Using ParentBased(NeverSample) sampler")
+		logger.V(2).Info("Using ParentBased(NeverSample) sampler")
 		return trace.ParentBased(trace.NeverSample())
 
 	case "parentbased_traceidratio":
-		klog.V(2).Infof("Using ParentBased(TraceIDRatioBased(%.2f)) sampler", ratio)
+		logger.V(2).Info("Using ParentBased(TraceIDRatioBased) sampler", "telemetry.sampler.ratio", ratio)
 		return trace.ParentBased(trace.TraceIDRatioBased(ratio))
 
 	case "":
 		// Default: ParentBased(AlwaysSample) for development
-		klog.V(2).Info("Using default ParentBased(AlwaysSample) sampler")
+		logger.V(2).Info("Using default ParentBased(AlwaysSample) sampler")
 		return trace.ParentBased(trace.AlwaysSample())
 
 	default:
-		klog.V(1).Infof("Unknown traces_sampler '%s', using default ParentBased(AlwaysSample)", samplerType)
+		logger.V(1).Info("Unknown traces_sampler, using default",
+			"config.key", "traces_sampler",
+			"config.provided", samplerType,
+			"config.default", "ParentBased(AlwaysSample)",
+		)
 		return trace.ParentBased(trace.AlwaysSample())
 	}
 }
@@ -328,22 +360,27 @@ func getSamplerFromConfig(cfg *config.TelemetryConfig) trace.Sampler {
 func createExporterWithConfig(ctx context.Context, cfg *config.TelemetryConfig) (*otlptrace.Exporter, error) {
 	protocol := strings.ToLower(cfg.GetProtocol())
 	endpoint := cfg.GetEndpoint()
+	logger := klog.FromContext(ctx)
 
 	switch protocol {
 	case "http/protobuf", "http":
-		klog.V(2).Infof("Using HTTP/protobuf OTLP exporter (protocol=%s)", protocol)
+		logger.V(2).Info("Using HTTP/protobuf OTLP exporter", "telemetry.exporter.protocol", protocol)
 		return otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(endpoint))
 
 	case "grpc", "":
 		if protocol == "" {
-			klog.V(2).Info("Using gRPC OTLP exporter (default)")
+			logger.V(2).Info("Using gRPC OTLP exporter (default)")
 		} else {
-			klog.V(2).Info("Using gRPC OTLP exporter")
+			logger.V(2).Info("Using gRPC OTLP exporter")
 		}
 		return otlptracegrpc.New(ctx, otlptracegrpc.WithEndpointURL(endpoint))
 
 	default:
-		klog.V(1).Infof("Unknown protocol '%s', defaulting to gRPC", protocol)
+		logger.V(1).Info("Unknown protocol, falling back to default",
+			"config.key", "protocol",
+			"config.provided", protocol,
+			"config.default", "grpc",
+		)
 		return otlptracegrpc.New(ctx, otlptracegrpc.WithEndpointURL(endpoint))
 	}
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -158,7 +158,7 @@ func InitTracer(ctx context.Context, serviceName, serviceVersion string) (func()
 	// Protocol is configured via OTEL_EXPORTER_OTLP_PROTOCOL env var
 	exporter, err := createExporter(ctx)
 	if err != nil {
-		logger.V(1).Error(err, "Failed to create OTLP exporter, tracing disabled")
+		logger.V(1).Info("Failed to create OTLP exporter, tracing disabled", "exception.message", err.Error())
 		return func() {}, nil
 	}
 
@@ -170,7 +170,7 @@ func InitTracer(ctx context.Context, serviceName, serviceVersion string) (func()
 		),
 	)
 	if err != nil {
-		logger.V(1).Error(err, "Failed to create resource, tracing disabled")
+		logger.V(1).Info("Failed to create resource, tracing disabled", "exception.message", err.Error())
 		return func() {}, nil
 	}
 
@@ -233,7 +233,7 @@ func InitTracerWithConfig(ctx context.Context, cfg *config.TelemetryConfig, serv
 
 	exporter, err := createExporterWithConfig(ctx, cfg)
 	if err != nil {
-		logger.V(1).Error(err, "Failed to create OTLP exporter, tracing disabled")
+		logger.V(1).Info("Failed to create OTLP exporter, tracing disabled", "exception.message", err.Error())
 		return func() {}, nil
 	}
 

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -23,7 +23,7 @@ func TestTelemetry(t *testing.T) {
 
 func (s *TelemetrySuite) TestInitTracer() {
 	s.Run("returns cleanup function when OTLP endpoint not configured", func() {
-		cleanup, err := InitTracer("test-service", "1.0.0")
+		cleanup, err := InitTracer(s.T().Context(), "test-service", "1.0.0")
 
 		s.NoError(err, "should not return error when OTLP endpoint is not configured")
 		s.NotNil(cleanup, "cleanup function should not be nil")
@@ -34,7 +34,7 @@ func (s *TelemetrySuite) TestInitTracer() {
 	})
 
 	s.Run("initializes with valid service name and version", func() {
-		cleanup, err := InitTracer("my-service", "2.0.0")
+		cleanup, err := InitTracer(s.T().Context(), "my-service", "2.0.0")
 		defer cleanup()
 
 		s.NoError(err, "initialization should succeed")
@@ -45,7 +45,7 @@ func (s *TelemetrySuite) TestInitTracer() {
 		s.T().Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 		initialProvider := otel.GetTracerProvider()
 
-		cleanup, err := InitTracer("test-service", "1.0.0")
+		cleanup, err := InitTracer(s.T().Context(), "test-service", "1.0.0")
 		s.Require().NoError(err)
 		defer cleanup()
 
@@ -60,7 +60,7 @@ func (s *TelemetrySuite) TestInitTracer() {
 
 func (s *TelemetrySuite) TestCleanupFunction() {
 	s.Run("can be called multiple times", func() {
-		cleanup, err := InitTracer("test-service", "1.0.0")
+		cleanup, err := InitTracer(s.T().Context(), "test-service", "1.0.0")
 		s.Require().NoError(err)
 
 		s.NotPanics(func() {
@@ -71,7 +71,7 @@ func (s *TelemetrySuite) TestCleanupFunction() {
 	})
 
 	s.Run("executes without blocking", func() {
-		cleanup, err := InitTracer("test-service", "1.0.0")
+		cleanup, err := InitTracer(s.T().Context(), "test-service", "1.0.0")
 		s.Require().NoError(err)
 
 		done := make(chan bool)
@@ -92,7 +92,7 @@ func (s *TelemetrySuite) TestCleanupFunction() {
 
 func (s *TelemetrySuite) TestInitTracerWithEmptyValues() {
 	s.Run("handles empty service name", func() {
-		cleanup, err := InitTracer("", "1.0.0")
+		cleanup, err := InitTracer(s.T().Context(), "", "1.0.0")
 		defer cleanup()
 
 		s.NoError(err, "should handle empty service name")
@@ -100,7 +100,7 @@ func (s *TelemetrySuite) TestInitTracerWithEmptyValues() {
 	})
 
 	s.Run("handles empty service version", func() {
-		cleanup, err := InitTracer("test-service", "")
+		cleanup, err := InitTracer(s.T().Context(), "test-service", "")
 		defer cleanup()
 
 		s.NoError(err, "should handle empty service version")
@@ -108,7 +108,7 @@ func (s *TelemetrySuite) TestInitTracerWithEmptyValues() {
 	})
 
 	s.Run("handles both empty", func() {
-		cleanup, err := InitTracer("", "")
+		cleanup, err := InitTracer(s.T().Context(), "", "")
 		defer cleanup()
 
 		s.NoError(err, "should handle both empty values")
@@ -134,7 +134,7 @@ func (s *TelemetrySuite) TestEnabled() {
 			Endpoint: server.URL,
 			Protocol: "http/protobuf",
 		}
-		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		cleanup, err := InitTracerWithConfig(s.T().Context(), cfg, "test-service", "1.0.0")
 		s.Require().NoError(err)
 		defer cleanup()
 
@@ -152,7 +152,7 @@ func (s *TelemetrySuite) TestEnabled() {
 			Endpoint: server.URL,
 			Protocol: "http/protobuf",
 		}
-		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		cleanup, err := InitTracerWithConfig(s.T().Context(), cfg, "test-service", "1.0.0")
 		s.Require().NoError(err)
 		s.Require().True(Enabled())
 
@@ -164,7 +164,7 @@ func (s *TelemetrySuite) TestEnabled() {
 
 func (s *TelemetrySuite) TestInitTracerWithConfig() {
 	s.Run("returns no-op cleanup when cfg is nil", func() {
-		cleanup, err := InitTracerWithConfig(nil, "test-service", "1.0.0")
+		cleanup, err := InitTracerWithConfig(s.T().Context(), nil, "test-service", "1.0.0")
 
 		s.NoError(err)
 		s.NotNil(cleanup)
@@ -178,7 +178,7 @@ func (s *TelemetrySuite) TestInitTracerWithConfig() {
 			Endpoint: "http://localhost:4317",
 		}
 
-		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		cleanup, err := InitTracerWithConfig(s.T().Context(), cfg, "test-service", "1.0.0")
 
 		s.NoError(err)
 		s.NotNil(cleanup)
@@ -188,7 +188,7 @@ func (s *TelemetrySuite) TestInitTracerWithConfig() {
 	s.Run("returns no-op cleanup when cfg has no endpoint", func() {
 		cfg := &config.TelemetryConfig{}
 
-		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		cleanup, err := InitTracerWithConfig(s.T().Context(), cfg, "test-service", "1.0.0")
 
 		s.NoError(err)
 		s.NotNil(cleanup)
@@ -207,7 +207,7 @@ func (s *TelemetrySuite) TestInitTracerWithConfig() {
 			Protocol: "http/protobuf",
 		}
 
-		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		cleanup, err := InitTracerWithConfig(s.T().Context(), cfg, "test-service", "1.0.0")
 		s.Require().NoError(err)
 		defer cleanup()
 
@@ -226,7 +226,7 @@ func (s *TelemetrySuite) TestInitTracerWithConfig() {
 			Protocol: "grpc",
 		}
 
-		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		cleanup, err := InitTracerWithConfig(s.T().Context(), cfg, "test-service", "1.0.0")
 		s.Require().NoError(err)
 		s.Require().True(Enabled())
 
@@ -248,7 +248,7 @@ func (s *TelemetrySuite) TestInitTracerWithConfig() {
 		}
 		initialProvider := otel.GetTracerProvider()
 
-		cleanup, err := InitTracerWithConfig(cfg, "test-service", "1.0.0")
+		cleanup, err := InitTracerWithConfig(s.T().Context(), cfg, "test-service", "1.0.0")
 		s.Require().NoError(err)
 		defer cleanup()
 
@@ -427,21 +427,21 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "")
 		s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil")
 	})
 
 	s.Run("returns AlwaysSample for always_on", func() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "always_on")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil")
 	})
 
 	s.Run("returns NeverSample for always_off", func() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "always_off")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil")
 	})
 
@@ -449,7 +449,7 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
 		s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "0.5")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil")
 	})
 
@@ -457,7 +457,7 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
 		s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil")
 	})
 
@@ -465,7 +465,7 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
 		s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "invalid")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil even with invalid arg")
 	})
 
@@ -473,7 +473,7 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
 		s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "1.5")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil even with out of range arg")
 	})
 
@@ -481,14 +481,14 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
 		s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "-0.1")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil even with negative arg")
 	})
 
 	s.Run("returns ParentBased(AlwaysSample) for parentbased_always_on", func() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "parentbased_always_on")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil")
 	})
 
@@ -496,14 +496,14 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
 		s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "0.1")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil")
 	})
 
 	s.Run("returns default for unknown sampler type", func() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "unknown_sampler")
 
-		sampler := getSamplerFromEnv()
+		sampler := getSamplerFromEnv(s.T().Context())
 		s.NotNil(sampler, "sampler should not be nil even with unknown type")
 	})
 
@@ -512,7 +512,7 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 			s.T().Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
 			s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "0.0")
 
-			sampler := getSamplerFromEnv()
+			sampler := getSamplerFromEnv(s.T().Context())
 			s.NotNil(sampler, "sampler should accept 0.0")
 		})
 
@@ -520,7 +520,7 @@ func (s *TelemetrySuite) TestGetSamplerFromEnv() {
 			s.T().Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
 			s.T().Setenv("OTEL_TRACES_SAMPLER_ARG", "1.0")
 
-			sampler := getSamplerFromEnv()
+			sampler := getSamplerFromEnv(s.T().Context())
 			s.NotNil(sampler, "sampler should accept 1.0")
 		})
 	})
@@ -530,21 +530,21 @@ func (s *TelemetrySuite) TestGetSamplerFromConfig() {
 	s.Run("returns default ParentBased(AlwaysSample) when sampler is empty", func() {
 		cfg := &config.TelemetryConfig{}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 
 	s.Run("returns AlwaysSample for always_on", func() {
 		cfg := &config.TelemetryConfig{TracesSampler: "always_on"}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 
 	s.Run("returns NeverSample for always_off", func() {
 		cfg := &config.TelemetryConfig{TracesSampler: "always_off"}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 
@@ -555,28 +555,28 @@ func (s *TelemetrySuite) TestGetSamplerFromConfig() {
 			TracesSamplerArg: &ratio,
 		}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 
 	s.Run("returns TraceIDRatioBased with default 1.0 for traceidratio without arg", func() {
 		cfg := &config.TelemetryConfig{TracesSampler: "traceidratio"}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 
 	s.Run("returns ParentBased(AlwaysSample) for parentbased_always_on", func() {
 		cfg := &config.TelemetryConfig{TracesSampler: "parentbased_always_on"}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 
 	s.Run("returns ParentBased(NeverSample) for parentbased_always_off", func() {
 		cfg := &config.TelemetryConfig{TracesSampler: "parentbased_always_off"}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 
@@ -587,14 +587,14 @@ func (s *TelemetrySuite) TestGetSamplerFromConfig() {
 			TracesSamplerArg: &ratio,
 		}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 
 	s.Run("returns default for unknown sampler type", func() {
 		cfg := &config.TelemetryConfig{TracesSampler: "unknown_sampler"}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 
@@ -606,7 +606,7 @@ func (s *TelemetrySuite) TestGetSamplerFromConfig() {
 				TracesSamplerArg: &ratio,
 			}
 
-			sampler := getSamplerFromConfig(cfg)
+			sampler := getSamplerFromConfig(s.T().Context(), cfg)
 			s.NotNil(sampler)
 		})
 
@@ -617,7 +617,7 @@ func (s *TelemetrySuite) TestGetSamplerFromConfig() {
 				TracesSamplerArg: &ratio,
 			}
 
-			sampler := getSamplerFromConfig(cfg)
+			sampler := getSamplerFromConfig(s.T().Context(), cfg)
 			s.NotNil(sampler)
 		})
 	})
@@ -626,7 +626,7 @@ func (s *TelemetrySuite) TestGetSamplerFromConfig() {
 		s.T().Setenv("OTEL_TRACES_SAMPLER", "always_off")
 		cfg := &config.TelemetryConfig{TracesSampler: "always_on"}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 		// The sampler returned should respect the env var override
 		// (GetTracesSampler returns the env var value)
@@ -640,7 +640,7 @@ func (s *TelemetrySuite) TestGetSamplerFromConfig() {
 			TracesSamplerArg: &ratio,
 		}
 
-		sampler := getSamplerFromConfig(cfg)
+		sampler := getSamplerFromConfig(s.T().Context(), cfg)
 		s.NotNil(sampler)
 	})
 }

--- a/pkg/tokenexchange/assertion.go
+++ b/pkg/tokenexchange/assertion.go
@@ -1,6 +1,7 @@
 package tokenexchange
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -122,7 +123,11 @@ func getSignatureAlgorithm(key crypto.Signer) (jose.SignatureAlgorithm, error) {
 }
 
 // BuildClientAssertion creates a signed JWT assertion for client authentication
-func BuildClientAssertion(clientID, tokenURL, certFile, keyFile string, lifetime time.Duration) (string, time.Time, error) {
+func BuildClientAssertion(
+	ctx context.Context,
+	clientID, tokenURL, certFile, keyFile string,
+	lifetime time.Duration,
+) (string, time.Time, error) {
 	if lifetime == 0 {
 		lifetime = DefaultAssertionLifetime
 	}
@@ -166,27 +171,40 @@ func BuildClientAssertion(clientID, tokenURL, certFile, keyFile string, lifetime
 		return "", time.Time{}, fmt.Errorf("failed to sign JWT assertion: %w", err)
 	}
 
-	klog.V(4).Infof("Built JWT client assertion: issuer=%s, audience=%s, jti=%s, x5t=%s, expires=%s",
-		clientID, tokenURL, claims.ID, computeX5TS256(cert), expiry.Format(time.RFC3339))
+	klog.FromContext(ctx).V(4).Info("Built JWT client assertion",
+		"jwt.client_assertion.issuer", clientID,
+		"jwt.client_assertion.audience", tokenURL,
+		"jwt.client_assertion.jti", claims.ID,
+		"jwt.client_assertion.x5t", computeX5TS256(cert),
+		"jwt.client_assertion.expires", expiry.Format(time.RFC3339),
+	)
 
 	return signedJWT, expiry, nil
 }
 
 // GetOrBuildAssertion returns a cached assertion or builds a new one
-func (c *TargetTokenExchangeConfig) GetOrBuildAssertion() (string, error) {
+func (c *TargetTokenExchangeConfig) GetOrBuildAssertion(ctx context.Context) (string, error) {
 	c.assertionMutex.Lock()
 	defer c.assertionMutex.Unlock()
 
+	logger := klog.FromContext(ctx)
+
 	// Check if cached assertion is still valid (with margin)
 	if c.cachedAssertion != "" && time.Now().Add(AssertionRefreshMargin).Before(c.cachedAssertionExpiry) {
-		klog.V(4).Infof("Using cached JWT client assertion, expires=%s", c.cachedAssertionExpiry.Format(time.RFC3339))
+		logger.V(4).Info("Using cached JWT client assertion",
+			"jwt.client_assertion.expires", c.cachedAssertionExpiry.Format(time.RFC3339),
+		)
 		return c.cachedAssertion, nil
 	}
 
-	klog.V(4).Infof("Building new JWT client assertion: client_id=%s, token_url=%s, cert_file=%s",
-		c.ClientID, c.TokenURL, c.ClientCertFile)
+	logger.V(4).Info("Building new JWT client assertion",
+		"jwt.client_assertion.client_id", c.ClientID,
+		"jwt.client_assertion.token_url", c.TokenURL,
+		"jwt.client_assertion.cert_file", c.ClientCertFile,
+	)
 
 	assertion, expiry, err := BuildClientAssertion(
+		ctx,
 		c.ClientID,
 		c.TokenURL,
 		c.ClientCertFile,

--- a/pkg/tokenexchange/assertion_test.go
+++ b/pkg/tokenexchange/assertion_test.go
@@ -70,7 +70,7 @@ func (s *AssertionTestSuite) TestBuildClientAssertion() {
 		clientID := "test-client-id"
 		tokenURL := "https://login.microsoftonline.com/tenant/oauth2/v2.0/token"
 
-		assertion, expiry, err := BuildClientAssertion(clientID, tokenURL, s.certFile, s.keyFile, 5*time.Minute)
+		assertion, expiry, err := BuildClientAssertion(s.T().Context(), clientID, tokenURL, s.certFile, s.keyFile, 5*time.Minute)
 		s.Require().NoError(err)
 		s.NotEmpty(assertion)
 		s.True(expiry.After(time.Now()))
@@ -89,7 +89,7 @@ func (s *AssertionTestSuite) TestBuildClientAssertion() {
 	})
 
 	s.Run("includes x5t#S256 header", func() {
-		assertion, _, err := BuildClientAssertion("client", "https://token.url", s.certFile, s.keyFile, 0)
+		assertion, _, err := BuildClientAssertion(s.T().Context(), "client", "https://token.url", s.certFile, s.keyFile, 0)
 		s.Require().NoError(err)
 
 		token, err := jwt.ParseSigned(assertion, []jose.SignatureAlgorithm{jose.RS256})
@@ -102,7 +102,7 @@ func (s *AssertionTestSuite) TestBuildClientAssertion() {
 	})
 
 	s.Run("uses default lifetime when zero", func() {
-		_, expiry, err := BuildClientAssertion("client", "https://token.url", s.certFile, s.keyFile, 0)
+		_, expiry, err := BuildClientAssertion(s.T().Context(), "client", "https://token.url", s.certFile, s.keyFile, 0)
 		s.Require().NoError(err)
 
 		expectedExpiry := time.Now().Add(DefaultAssertionLifetime)
@@ -110,13 +110,13 @@ func (s *AssertionTestSuite) TestBuildClientAssertion() {
 	})
 
 	s.Run("returns error for missing cert file", func() {
-		_, _, err := BuildClientAssertion("client", "https://token.url", "/nonexistent/cert.pem", s.keyFile, 0)
+		_, _, err := BuildClientAssertion(s.T().Context(), "client", "https://token.url", "/nonexistent/cert.pem", s.keyFile, 0)
 		s.Error(err)
 		s.Contains(err.Error(), "failed to read certificate file")
 	})
 
 	s.Run("returns error for missing key file", func() {
-		_, _, err := BuildClientAssertion("client", "https://token.url", s.certFile, "/nonexistent/key.pem", 0)
+		_, _, err := BuildClientAssertion(s.T().Context(), "client", "https://token.url", s.certFile, "/nonexistent/key.pem", 0)
 		s.Error(err)
 		s.Contains(err.Error(), "failed to read private key file")
 	})
@@ -125,7 +125,7 @@ func (s *AssertionTestSuite) TestBuildClientAssertion() {
 		invalidCert := filepath.Join(s.tempDir, "invalid-cert.pem")
 		s.Require().NoError(os.WriteFile(invalidCert, []byte("not a valid PEM"), 0644))
 
-		_, _, err := BuildClientAssertion("client", "https://token.url", invalidCert, s.keyFile, 0)
+		_, _, err := BuildClientAssertion(s.T().Context(), "client", "https://token.url", invalidCert, s.keyFile, 0)
 		s.Error(err)
 		s.Contains(err.Error(), "failed to decode PEM block")
 	})
@@ -134,7 +134,7 @@ func (s *AssertionTestSuite) TestBuildClientAssertion() {
 		invalidKey := filepath.Join(s.tempDir, "invalid-key.pem")
 		s.Require().NoError(os.WriteFile(invalidKey, []byte("not a valid PEM"), 0600))
 
-		_, _, err := BuildClientAssertion("client", "https://token.url", s.certFile, invalidKey, 0)
+		_, _, err := BuildClientAssertion(s.T().Context(), "client", "https://token.url", s.certFile, invalidKey, 0)
 		s.Error(err)
 		s.Contains(err.Error(), "failed to decode PEM block")
 	})
@@ -149,10 +149,10 @@ func (s *AssertionTestSuite) TestGetOrBuildAssertion() {
 			ClientKeyFile:  s.keyFile,
 		}
 
-		assertion1, err := cfg.GetOrBuildAssertion()
+		assertion1, err := cfg.GetOrBuildAssertion(s.T().Context())
 		s.Require().NoError(err)
 
-		assertion2, err := cfg.GetOrBuildAssertion()
+		assertion2, err := cfg.GetOrBuildAssertion(s.T().Context())
 		s.Require().NoError(err)
 
 		s.Equal(assertion1, assertion2, "should return cached assertion")
@@ -166,7 +166,7 @@ func (s *AssertionTestSuite) TestGetOrBuildAssertion() {
 			ClientKeyFile:  "/nonexistent/key.pem",
 		}
 
-		_, err := cfg.GetOrBuildAssertion()
+		_, err := cfg.GetOrBuildAssertion(s.T().Context())
 		s.Error(err)
 	})
 }
@@ -318,7 +318,7 @@ func (s *AssertionTestSuite) TestBuildClientAssertionWithECKey() {
 		clientID := "spiffe-client"
 		tokenURL := "https://login.microsoftonline.com/tenant/oauth2/v2.0/token"
 
-		assertion, expiry, err := BuildClientAssertion(clientID, tokenURL, ecCertFile, ecKeyFile, 5*time.Minute)
+		assertion, expiry, err := BuildClientAssertion(s.T().Context(), clientID, tokenURL, ecCertFile, ecKeyFile, 5*time.Minute)
 		s.Require().NoError(err)
 		s.NotEmpty(assertion)
 		s.True(expiry.After(time.Now()))
@@ -395,7 +395,7 @@ func (s *AssertionTestSuite) TestInjectClientAuthWithAssertion() {
 
 		data := url.Values{}
 		header := http.Header{}
-		err := injectClientAuth(cfg, data, header)
+		err := injectClientAuth(s.T().Context(), cfg, data, header)
 		s.Require().NoError(err)
 
 		s.Equal("test-client", data.Get(FormKeyClientID))
@@ -416,7 +416,7 @@ func (s *AssertionTestSuite) TestInjectClientAuthWithAssertion() {
 
 		data := url.Values{}
 		header := http.Header{}
-		err := injectClientAuth(cfg, data, header)
+		err := injectClientAuth(s.T().Context(), cfg, data, header)
 		s.Error(err)
 		s.Contains(err.Error(), "failed to build client assertion")
 	})
@@ -435,7 +435,7 @@ func (s *AssertionTestSuite) TestInjectClientAuthWithFederated() {
 
 		data := url.Values{}
 		header := http.Header{}
-		err := injectClientAuth(cfg, data, header)
+		err := injectClientAuth(s.T().Context(), cfg, data, header)
 		s.Require().NoError(err)
 
 		s.Equal("test-client", data.Get(FormKeyClientID))
@@ -457,7 +457,7 @@ func (s *AssertionTestSuite) TestInjectClientAuthWithFederated() {
 
 		data := url.Values{}
 		header := http.Header{}
-		err := injectClientAuth(cfg, data, header)
+		err := injectClientAuth(s.T().Context(), cfg, data, header)
 		s.Require().NoError(err)
 
 		s.Equal("eyJ0b2tlbi5qd3Q", data.Get(FormKeyClientAssertion))
@@ -472,7 +472,7 @@ func (s *AssertionTestSuite) TestInjectClientAuthWithFederated() {
 
 		data := url.Values{}
 		header := http.Header{}
-		err := injectClientAuth(cfg, data, header)
+		err := injectClientAuth(s.T().Context(), cfg, data, header)
 		s.Error(err)
 		s.Contains(err.Error(), "failed to read federated token file")
 	})
@@ -489,7 +489,7 @@ func (s *AssertionTestSuite) TestInjectClientAuthWithFederated() {
 
 		data := url.Values{}
 		header := http.Header{}
-		err := injectClientAuth(cfg, data, header)
+		err := injectClientAuth(s.T().Context(), cfg, data, header)
 		s.Error(err)
 		s.Contains(err.Error(), "is empty")
 	})
@@ -506,7 +506,7 @@ func (s *AssertionTestSuite) TestInjectClientAuthWithFederated() {
 
 		data := url.Values{}
 		header := http.Header{}
-		err := injectClientAuth(cfg, data, header)
+		err := injectClientAuth(s.T().Context(), cfg, data, header)
 		s.Error(err)
 		s.Contains(err.Error(), "is empty")
 	})

--- a/pkg/tokenexchange/entra_obo_exchanger.go
+++ b/pkg/tokenexchange/entra_obo_exchanger.go
@@ -46,7 +46,7 @@ func (e *entraOBOExchanger) Exchange(ctx context.Context, cfg *TargetTokenExchan
 	}
 
 	headers := make(http.Header)
-	if err := injectClientAuth(cfg, data, headers); err != nil {
+	if err := injectClientAuth(ctx, cfg, data, headers); err != nil {
 		return nil, err
 	}
 

--- a/pkg/tokenexchange/exchanger.go
+++ b/pkg/tokenexchange/exchanger.go
@@ -53,7 +53,7 @@ type TokenExchanger interface {
 }
 
 // injectClientAuth adds client credentials to the request based on auth style
-func injectClientAuth(cfg *TargetTokenExchangeConfig, data url.Values, header http.Header) error {
+func injectClientAuth(ctx context.Context, cfg *TargetTokenExchangeConfig, data url.Values, header http.Header) error {
 	if cfg.ClientID == "" {
 		return nil
 	}
@@ -63,7 +63,7 @@ func injectClientAuth(cfg *TargetTokenExchangeConfig, data url.Values, header ht
 		credentials := cfg.ClientID + ":" + cfg.ClientSecret
 		header.Set(HeaderAuthorization, "Basic "+base64.StdEncoding.EncodeToString([]byte(credentials)))
 	case AuthStyleAssertion:
-		assertion, err := cfg.GetOrBuildAssertion()
+		assertion, err := cfg.GetOrBuildAssertion(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to build client assertion: %w", err)
 		}
@@ -79,7 +79,10 @@ func injectClientAuth(cfg *TargetTokenExchangeConfig, data url.Values, header ht
 		if token == "" {
 			return fmt.Errorf("federated token file %q is empty: the external identity provider may not have written a token yet", cfg.FederatedTokenFile)
 		}
-		klog.V(4).Infof("Read federated token from file %q (%d bytes)", cfg.FederatedTokenFile, len(token))
+		klog.FromContext(ctx).V(4).Info("Read federated token from file",
+			"token_exchange.federated_token_file", cfg.FederatedTokenFile,
+			"token_exchange.token.size", len(token),
+		)
 		data.Set(FormKeyClientID, cfg.ClientID)
 		data.Set(FormKeyClientAssertionType, ClientAssertionType)
 		data.Set(FormKeyClientAssertion, token)

--- a/pkg/tokenexchange/keycloak_v1_exchanger.go
+++ b/pkg/tokenexchange/keycloak_v1_exchanger.go
@@ -36,7 +36,7 @@ func (e *keycloakV1Exchanger) Exchange(ctx context.Context, cfg *TargetTokenExch
 	}
 
 	headers := http.Header{}
-	if err := injectClientAuth(cfg, data, headers); err != nil {
+	if err := injectClientAuth(ctx, cfg, data, headers); err != nil {
 		return nil, err
 	}
 

--- a/pkg/tokenexchange/rfc8693_exchanger.go
+++ b/pkg/tokenexchange/rfc8693_exchanger.go
@@ -32,7 +32,7 @@ func (e *rfc8693Exchanger) Exchange(ctx context.Context, cfg *TargetTokenExchang
 	}
 
 	headers := http.Header{}
-	if err := injectClientAuth(cfg, data, headers); err != nil {
+	if err := injectClientAuth(ctx, cfg, data, headers); err != nil {
 		return nil, err
 	}
 

--- a/pkg/toolsets/core/health_check.go
+++ b/pkg/toolsets/core/health_check.go
@@ -63,7 +63,7 @@ func clusterHealthCheckHandler(params api.PromptHandlerParams) (*api.PromptCallR
 			// Namespace doesn't exist - show warning and proceed with cluster-wide check
 			namespaceWarning = fmt.Sprintf("Namespace '%s' not found or not accessible. Showing cluster-wide information instead.", namespace)
 			namespace = "" // Fall back to cluster-wide check
-			klogutil.Warn(params.Context, "Namespace not found, performing cluster-wide health check",
+			klogutil.WarnLogger(logger, "Namespace not found, performing cluster-wide health check",
 				"kubernetes.namespace.name", requestedNamespace,
 			)
 		} else {
@@ -144,7 +144,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.Nodes = nodeDiag
 		logger.Info("Node diagnostics collected")
 	} else {
-		logger.Error(err, "Failed to collect node diagnostics")
+		klogutil.WarnLogger(logger, "Failed to collect node diagnostics", "exception.message", err.Error())
 	}
 
 	// Gather pod diagnostics
@@ -154,7 +154,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.Pods = podDiag
 		logger.Info("Pod diagnostics collected")
 	} else {
-		logger.Error(err, "Failed to collect pod diagnostics")
+		klogutil.WarnLogger(logger, "Failed to collect pod diagnostics", "exception.message", err.Error())
 	}
 
 	// Gather workload diagnostics
@@ -164,7 +164,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.Deployments = deployDiag
 		logger.Info("Deployment diagnostics collected")
 	} else {
-		logger.Error(err, "Failed to collect deployment diagnostics")
+		klogutil.WarnLogger(logger, "Failed to collect deployment diagnostics", "exception.message", err.Error())
 	}
 
 	logger.Info("Collecting statefulset diagnostics...")
@@ -173,7 +173,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.StatefulSets = stsDiag
 		logger.Info("StatefulSet diagnostics collected")
 	} else {
-		logger.Error(err, "Failed to collect statefulset diagnostics")
+		klogutil.WarnLogger(logger, "Failed to collect statefulset diagnostics", "exception.message", err.Error())
 	}
 
 	logger.Info("Collecting daemonset diagnostics...")
@@ -182,7 +182,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.DaemonSets = dsDiag
 		logger.Info("DaemonSet diagnostics collected")
 	} else {
-		logger.Error(err, "Failed to collect daemonset diagnostics")
+		klogutil.WarnLogger(logger, "Failed to collect daemonset diagnostics", "exception.message", err.Error())
 	}
 
 	// Gather PVC diagnostics
@@ -192,7 +192,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.PVCs = pvcDiag
 		logger.Info("PVC diagnostics collected")
 	} else {
-		logger.Error(err, "Failed to collect PVC diagnostics")
+		klogutil.WarnLogger(logger, "Failed to collect PVC diagnostics", "exception.message", err.Error())
 	}
 
 	// Gather cluster operator diagnostics (OpenShift only)
@@ -211,7 +211,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 			diag.Events = eventDiag
 			logger.Info("Event diagnostics collected")
 		} else {
-			logger.Error(err, "Failed to collect event diagnostics")
+			klogutil.WarnLogger(logger, "Failed to collect event diagnostics", "exception.message", err.Error())
 		}
 	}
 

--- a/pkg/toolsets/core/health_check.go
+++ b/pkg/toolsets/core/health_check.go
@@ -50,7 +50,8 @@ func clusterHealthCheckHandler(params api.PromptHandlerParams) (*api.PromptCallR
 	namespace := args["namespace"]
 	checkEvents := args["check_events"] != "false" // default true
 
-	klog.Info("Starting cluster health check...")
+	logger := klog.FromContext(params.Context)
+	logger.Info("Starting cluster health check...")
 
 	// Check if namespace exists if specified
 	namespaceWarning := ""
@@ -61,12 +62,14 @@ func clusterHealthCheckHandler(params api.PromptHandlerParams) (*api.PromptCallR
 			// Namespace doesn't exist - show warning and proceed with cluster-wide check
 			namespaceWarning = fmt.Sprintf("Namespace '%s' not found or not accessible. Showing cluster-wide information instead.", namespace)
 			namespace = "" // Fall back to cluster-wide check
-			klog.Warningf("Namespace '%s' not found, performing cluster-wide health check", requestedNamespace)
+			logger.Info("Namespace not found, performing cluster-wide health check",
+				"kubernetes.namespace.name", requestedNamespace,
+			)
 		} else {
-			klog.Infof("Performing health check for namespace: %s", namespace)
+			logger.Info("Performing health check for namespace", "kubernetes.namespace.name", namespace)
 		}
 	} else {
-		klog.Info("Performing cluster-wide health check")
+		logger.Info("Performing cluster-wide health check")
 	}
 
 	diagnostics, err := gatherClusterDiagnostics(params, namespace, checkEvents)
@@ -131,93 +134,95 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		TargetNamespace: namespace,
 	}
 
+	logger := klog.FromContext(params.Context)
+
 	// Gather node diagnostics using ResourcesList
-	klog.Info("Collecting node diagnostics...")
+	logger.Info("Collecting node diagnostics...")
 	nodeDiag, err := gatherNodeDiagnostics(params)
 	if err == nil {
 		diag.Nodes = nodeDiag
-		klog.Info("Node diagnostics collected")
+		logger.Info("Node diagnostics collected")
 	} else {
-		klog.Warningf("Failed to collect node diagnostics: %v", err)
+		logger.Error(err, "Failed to collect node diagnostics")
 	}
 
 	// Gather pod diagnostics
-	klog.Info("Collecting pod diagnostics...")
+	logger.Info("Collecting pod diagnostics...")
 	podDiag, err := gatherPodDiagnostics(params, namespace)
 	if err == nil {
 		diag.Pods = podDiag
-		klog.Info("Pod diagnostics collected")
+		logger.Info("Pod diagnostics collected")
 	} else {
-		klog.Warningf("Failed to collect pod diagnostics: %v", err)
+		logger.Error(err, "Failed to collect pod diagnostics")
 	}
 
 	// Gather workload diagnostics
-	klog.Info("Collecting deployment diagnostics...")
+	logger.Info("Collecting deployment diagnostics...")
 	deployDiag, err := gatherWorkloadDiagnostics(params, "Deployment", namespace)
 	if err == nil {
 		diag.Deployments = deployDiag
-		klog.Info("Deployment diagnostics collected")
+		logger.Info("Deployment diagnostics collected")
 	} else {
-		klog.Warningf("Failed to collect deployment diagnostics: %v", err)
+		logger.Error(err, "Failed to collect deployment diagnostics")
 	}
 
-	klog.Info("Collecting statefulset diagnostics...")
+	logger.Info("Collecting statefulset diagnostics...")
 	stsDiag, err := gatherWorkloadDiagnostics(params, "StatefulSet", namespace)
 	if err == nil {
 		diag.StatefulSets = stsDiag
-		klog.Info("StatefulSet diagnostics collected")
+		logger.Info("StatefulSet diagnostics collected")
 	} else {
-		klog.Warningf("Failed to collect statefulset diagnostics: %v", err)
+		logger.Error(err, "Failed to collect statefulset diagnostics")
 	}
 
-	klog.Info("Collecting daemonset diagnostics...")
+	logger.Info("Collecting daemonset diagnostics...")
 	dsDiag, err := gatherWorkloadDiagnostics(params, "DaemonSet", namespace)
 	if err == nil {
 		diag.DaemonSets = dsDiag
-		klog.Info("DaemonSet diagnostics collected")
+		logger.Info("DaemonSet diagnostics collected")
 	} else {
-		klog.Warningf("Failed to collect daemonset diagnostics: %v", err)
+		logger.Error(err, "Failed to collect daemonset diagnostics")
 	}
 
 	// Gather PVC diagnostics
-	klog.Info("Collecting PVC diagnostics...")
+	logger.Info("Collecting PVC diagnostics...")
 	pvcDiag, err := gatherPVCDiagnostics(params, namespace)
 	if err == nil {
 		diag.PVCs = pvcDiag
-		klog.Info("PVC diagnostics collected")
+		logger.Info("PVC diagnostics collected")
 	} else {
-		klog.Warningf("Failed to collect PVC diagnostics: %v", err)
+		logger.Error(err, "Failed to collect PVC diagnostics")
 	}
 
 	// Gather cluster operator diagnostics (OpenShift only)
-	klog.Info("Checking for cluster operators (OpenShift)...")
+	logger.Info("Checking for cluster operators (OpenShift)...")
 	operatorDiag, err := gatherClusterOperatorDiagnostics(params)
 	if err == nil {
 		diag.ClusterOperators = operatorDiag
-		klog.Info("Cluster operator diagnostics collected")
+		logger.Info("Cluster operator diagnostics collected")
 	}
 
 	// Gather recent events if requested
 	if checkEvents {
-		klog.Info("Collecting recent events...")
+		logger.Info("Collecting recent events...")
 		eventDiag, err := gatherEventDiagnostics(params, namespace)
 		if err == nil {
 			diag.Events = eventDiag
-			klog.Info("Event diagnostics collected")
+			logger.Info("Event diagnostics collected")
 		} else {
-			klog.Warningf("Failed to collect event diagnostics: %v", err)
+			logger.Error(err, "Failed to collect event diagnostics")
 		}
 	}
 
 	// Count namespaces
-	klog.Info("Counting namespaces...")
+	logger.Info("Counting namespaces...")
 	namespaceList, err := params.CoreV1().Namespaces().List(params.Context, metav1.ListOptions{})
 	if err == nil {
 		diag.TotalNamespaces = len(namespaceList.Items)
-		klog.Infof("Found %d namespaces", diag.TotalNamespaces)
+		logger.Info("Found namespaces", "kubernetes.namespaces.count", diag.TotalNamespaces)
 	}
 
-	klog.Info("Cluster health check data collection completed")
+	logger.Info("Cluster health check data collection completed")
 	return diag, nil
 }
 

--- a/pkg/toolsets/core/health_check.go
+++ b/pkg/toolsets/core/health_check.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 )
 
@@ -62,7 +63,7 @@ func clusterHealthCheckHandler(params api.PromptHandlerParams) (*api.PromptCallR
 			// Namespace doesn't exist - show warning and proceed with cluster-wide check
 			namespaceWarning = fmt.Sprintf("Namespace '%s' not found or not accessible. Showing cluster-wide information instead.", namespace)
 			namespace = "" // Fall back to cluster-wide check
-			logger.Info("Namespace not found, performing cluster-wide health check",
+			klogutil.Warn(params.Context, "Namespace not found, performing cluster-wide health check",
 				"kubernetes.namespace.name", requestedNamespace,
 			)
 		} else {

--- a/pkg/toolsets/helm/helm.go
+++ b/pkg/toolsets/helm/helm.go
@@ -137,7 +137,7 @@ func helmList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list helm releases: %w", err)), nil
 	}
-	ret, err := newHelmClient(params).List(namespace, allNamespaces)
+	ret, err := newHelmClient(params).List(params.Context, namespace, allNamespaces)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list helm releases in namespace '%s': %w", namespace, err)), nil
 	}
@@ -154,7 +154,7 @@ func helmUninstall(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if v, ok := params.GetArguments()["namespace"].(string); ok {
 		namespace = v
 	}
-	ret, err := newHelmClient(params).Uninstall(name, namespace)
+	ret, err := newHelmClient(params).Uninstall(params.Context, name, namespace)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to uninstall helm chart '%s': %w", name, err)), nil
 	}


### PR DESCRIPTION
Currently, our logs are not correlated with the otel traces we export.

A prerequisite to fixing this is to use a contextual logger, instead of the global logger, so that logs can inherit trace_id/span_id from the context.

While switching from the global `klog` to `klog.FromContext()` (following https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/3077-contextual-logging/README.md#integration-with-logslog as closely as possible), I had to make a few switches to the existing logs:
1. the contextual logger is a structured logger, so it does not support `Infof`, just `Info` + k/v pairs
2. The contextual logger does not have a warn level, so some were switched to info and others to error

This also required wiring context through a whole bunch of places that probable should have wired context through before (especially those that were setting their own context from `context.Background()`