### PR TITLE
test(exec): de-flake TestPodsExec SPDY stream reset on slow runners

### DIFF
--- a/internal/test/mock_server.go
+++ b/internal/test/mock_server.go
@@ -112,11 +112,39 @@ type streamAndReply struct {
 }
 
 type StreamContext struct {
-	Closer       io.Closer
+	closer       io.Closer
 	StdinStream  io.ReadCloser
 	StdoutStream io.WriteCloser
 	StderrStream io.WriteCloser
+	errorStream  io.WriteCloser
 	writeStatus  func(status *apierrors.StatusError) error
+}
+
+// Close gracefully tears down the exec streams so the client always observes a
+// clean EOF (and a v4 success terminal status on the error stream) before the
+// SPDY connection is torn down. Closing each stream first blocks until that
+// stream's reply has been flushed and then sends a FIN, so the connection
+// teardown's stream resets reach the client only after it has received every
+// reply and a clean EOF, instead of racing them — the race that otherwise
+// surfaces intermittently as a "Stream reset" on slow runners. The underlying
+// connection is intentionally unexported, so handlers must defer Close to tear
+// the streams down — this graceful teardown is the only path.
+func (c *StreamContext) Close() error {
+	// Send the v4 success terminal status on the error stream.
+	if c.writeStatus != nil {
+		_ = c.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{Status: metav1.StatusSuccess}})
+	}
+	// Close every stream so each delivers a clean EOF (and flushes its reply)
+	// before the connection-level teardown.
+	for _, stream := range []io.Closer{c.StdoutStream, c.StderrStream, c.StdinStream, c.errorStream} {
+		if stream != nil {
+			_ = stream.Close()
+		}
+	}
+	if c.closer != nil {
+		return c.closer.Close()
+	}
+	return nil
 }
 
 type StreamOptions struct {
@@ -148,7 +176,7 @@ func CreateHTTPStreams(w http.ResponseWriter, req *http.Request, opts *StreamOpt
 		return nil
 	})
 	ctx := &StreamContext{
-		Closer: connection,
+		closer: connection,
 	}
 
 	// wait for stream
@@ -173,6 +201,7 @@ WaitForStreams:
 			switch streamType {
 			case v1.StreamTypeError:
 				replyChan <- struct{}{}
+				ctx.errorStream = stream
 				ctx.writeStatus = v4WriteStatusFunc(stream)
 			case v1.StreamTypeStdout:
 				replyChan <- struct{}{}

--- a/pkg/mcp/pods_exec_test.go
+++ b/pkg/mcp/pods_exec_test.go
@@ -50,7 +50,7 @@ func (s *PodsExecSuite) TestPodsExec() {
 			_, _ = w.Write([]byte(err.Error()))
 			return
 		}
-		defer func(conn io.Closer) { _ = conn.Close() }(ctx.Closer)
+		defer func() { _ = ctx.Close() }()
 		_, _ = io.WriteString(ctx.StdoutStream, "command:"+strings.Join(req.URL.Query()["command"], " ")+"\n")
 		_, _ = io.WriteString(ctx.StdoutStream, "container:"+strings.Join(req.URL.Query()["container"], " ")+"\n")
 	}))
@@ -124,7 +124,7 @@ func (s *PodsExecSuite) TestPodsExecDefaultContainer() {
 			_, _ = w.Write([]byte(err.Error()))
 			return
 		}
-		defer func(conn io.Closer) { _ = conn.Close() }(ctx.Closer)
+		defer func() { _ = ctx.Close() }()
 		_, _ = io.WriteString(ctx.StdoutStream, "container:"+strings.Join(req.URL.Query()["container"], " ")+"\n")
 	}))
 	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
## Summary

`TestPodsExec` (`pkg/mcp`) intermittently failed with a SPDY `Stream reset`
on slow / contended CI runners (e.g. `macos-latest`), reddening unrelated
branch and PR builds because the race lives in the shared exec mock.

## Root cause

The shared SPDY exec mock (`internal/test/mock_server.go`) closed the
connection immediately after writing stdout. `k8s.io/streaming`
`spdy.connection.Close()` resets (`RST_STREAM`) every still-registered
stream, so the teardown raced the client's stream-creation replies. When a
reset overtook a stream's `SYN_REPLY`, the `remotecommand` executor
surfaced `spdystream.ErrReset` ("Stream reset") from `WaitTimeout` during
stream creation — only on slow runners, and only intermittently.

## Fix

Add a graceful `StreamContext.Close()` that:

- writes the v4 `StatusSuccess` terminal status on the error stream, then
- closes each stream (stdout/stderr/stdin/error) — each `Close()` blocks
  until that stream's reply has been flushed and sends a FIN, giving the
  client a clean EOF, before
- closing the SPDY connection.

Because all frames are serialized by the framer, every reply and the
streamed stdout now reach the client ahead of the connection teardown's
resets. Both exec handlers call `ctx.Close()`, and the underlying
connection field is unexported so this graceful teardown is the only path.

## Verification

- Reproduced the flake in a CPU-constrained container under `-race`: the
  old immediate-close path failed 3/3 (`Stream reset` ×2, `Timeout` ×1);
  the graceful path ran 3000 iterations with zero failures.
- `go test -race` for `internal/test` and `pkg/mcp` `TestPodsExec` pass;
  `make lint` reports 0 issues.

Closes #1205