### PR TITLE
refactor(klogutil): type-safe composable log attributes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -517,10 +517,10 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 			return fmt.Errorf("--authorization-url must be a valid URL")
 		}
 		if u.Scheme == "http" {
-			klogutil.Warn(
-				ctx,
+			klogutil.LogWarn(
+				klog.FromContext(ctx),
 				"authorization-url is using insecure scheme, this is not recommended production use",
-				"url.scheme", "http",
+				klogutil.Field("url.scheme", "http"),
 			)
 		}
 	}
@@ -591,7 +591,7 @@ func (c *StaticConfig) validateSkipJWTVerification(ctx context.Context) error {
 		return nil
 	}
 	if c.SkipJWTVerification {
-		klogutil.Warn(ctx,
+		klogutil.LogWarn(klog.FromContext(ctx),
 			"skip_jwt_verification is enabled with no authorization_url: bearer tokens will be forwarded without any local validation. "+
 				"The cluster (or a trusted upstream) is the sole authority. Only use this when cluster_auth_mode=passthrough and the cluster validates tokens directly.")
 		return nil

--- a/pkg/confirmation/confirmation.go
+++ b/pkg/confirmation/confirmation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/klog/v2"
 )
 
 // ErrConfirmationDenied is returned when the user declines a confirmation prompt
@@ -56,7 +57,7 @@ func CheckConfirmation(ctx context.Context, elicitor api.Elicitor, message, fall
 			if fallback == "deny" {
 				return ErrConfirmationDenied
 			}
-			klogutil.Warn(ctx, "Confirmation rules matched but client does not support elicitation, proceeding with fallback \"allow\"", "message", message)
+			klogutil.LogWarn(klog.FromContext(ctx), "Confirmation rules matched but client does not support elicitation, proceeding with fallback \"allow\"", klogutil.Field("message", message))
 			return nil
 		}
 		return err

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -117,7 +117,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 			// Cluster is the sole authority for validating token (ex. sha256 token with OpenShift)
 			if staticConfig.SkipJWTVerification && staticConfig.AuthorizationURL == "" {
 				skipJWTWarningOnce.Do(func() {
-					klogutil.WarnLogger(logger, "Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
+					klogutil.LogWarn(logger, "Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
 				})
 				ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
 				next.ServeHTTP(w, r.WithContext(ctx))
@@ -162,11 +162,11 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 				}
 			}
 			if err != nil {
-				logger.V(1).Info("Authentication failed - JWT validation error",
-					"http.request.method", r.Method,
-					"url.path", r.URL.Path,
-					"client.address", r.RemoteAddr,
-					"exception.message", err.Error(),
+				klogutil.LogInfo(logger.V(1), "Authentication failed - JWT validation error",
+					klogutil.Field("http.request.method", r.Method),
+					klogutil.Field("url.path", r.URL.Path),
+					klogutil.Field("client.address", r.RemoteAddr),
+					klogutil.Err(err),
 				)
 				write401(w, wwwAuthenticateHeader, "invalid_token", "Unauthorized: Invalid token")
 				return

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcp"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 )
@@ -97,7 +98,7 @@ func statsHandler(mcpServer *mcp.Server) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(stats); err != nil {
-			klog.FromContext(r.Context()).V(1).Info("Failed to encode stats response", "exception.message", err.Error())
+			klogutil.LogInfo(klog.FromContext(r.Context()).V(1), "Failed to encode stats response", klogutil.Err(err))
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}

--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 	"k8s.io/klog/v2"
 )
@@ -153,9 +154,9 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 	// Try direct proxy first (works for Keycloak and other providers that support all endpoints)
 	resourceMetadata, respHeaders, err := w.fetchWellKnownEndpoint(request, upstreamURL)
 	if err != nil {
-		logger.V(1).Info("Well-known proxy failed to fetch endpoint",
-			"url.path", requestPath,
-			"exception.message", err.Error(),
+		klogutil.LogInfo(logger.V(1), "Well-known proxy failed to fetch endpoint",
+			klogutil.Field("url.path", requestPath),
+			klogutil.Err(err),
 		)
 		http.Error(writer, "Failed to fetch well-known metadata", http.StatusInternalServerError)
 		return
@@ -169,8 +170,8 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 		case strings.HasPrefix(requestPath, oauthAuthorizationServerEndpoint):
 			resourceMetadata, err = w.generateAuthorizationServerMetadata(request)
 			if err != nil {
-				logger.V(1).Info("Well-known proxy failed to generate authorization server metadata",
-					"exception.message", err.Error(),
+				klogutil.LogInfo(logger.V(1), "Well-known proxy failed to generate authorization server metadata",
+					klogutil.Err(err),
 				)
 				http.Error(writer, "Failed to generate well-known metadata", http.StatusInternalServerError)
 				return
@@ -179,8 +180,8 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 		case strings.HasPrefix(requestPath, oauthProtectedResourceEndpoint):
 			resourceMetadata, err = w.generateProtectedResourceMetadata(request)
 			if err != nil {
-				logger.V(1).Info("Well-known proxy failed to generate protected resource metadata",
-					"exception.message", err.Error(),
+				klogutil.LogInfo(logger.V(1), "Well-known proxy failed to generate protected resource metadata",
+					klogutil.Err(err),
 				)
 				http.Error(writer, "Failed to generate well-known metadata", http.StatusInternalServerError)
 				return
@@ -197,9 +198,9 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 
 	body, err := json.Marshal(resourceMetadata)
 	if err != nil {
-		logger.V(1).Info("Well-known proxy failed to marshal response",
-			"url.path", request.URL.Path,
-			"exception.message", err.Error(),
+		klogutil.LogInfo(logger.V(1), "Well-known proxy failed to marshal response",
+			klogutil.Field("url.path", request.URL.Path),
+			klogutil.Err(err),
 		)
 		http.Error(writer, "Internal server error", http.StatusInternalServerError)
 		return

--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -101,7 +101,7 @@ func (p *kcpClusterProvider) reset(ctx context.Context) error {
 	// Discover workspaces
 	workspaceList, err := p.discoverWorkspaces(baseManager)
 	if err != nil {
-		klogutil.Warn(ctx, "Failed to discover workspaces via API, falling back to kubeconfig", "exception.message", err.Error())
+		klogutil.LogWarn(klog.FromContext(ctx), "Failed to discover workspaces via API, falling back to kubeconfig", klogutil.Err(err))
 		workspaceList, err = p.workspacesFromKubeconfig(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to discover workspaces: %w", err)

--- a/pkg/kcp/workspace.go
+++ b/pkg/kcp/workspace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -64,7 +65,7 @@ func DiscoverWorkspacesRecursive(
 
 	dynamicClient, err := dynamic.NewForConfig(workspaceRestConfig)
 	if err != nil {
-		logger.V(3).Info("Failed to create client for workspace", "workspace", parentWorkspace, "exception.message", err.Error())
+		klogutil.LogInfo(logger.V(3), "Failed to create client for workspace", klogutil.Field("workspace", parentWorkspace), klogutil.Err(err))
 		return nil // Don't fail entirely, just skip this workspace
 	}
 
@@ -72,7 +73,7 @@ func DiscoverWorkspacesRecursive(
 	workspaceList, err := dynamicClient.Resource(WorkspaceGVR).
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		logger.V(3).Info("Failed to list workspaces in parent workspace", "parent_workspace", parentWorkspace, "exception.message", err.Error())
+		klogutil.LogInfo(logger.V(3), "Failed to list workspaces in parent workspace", klogutil.Field("parent_workspace", parentWorkspace), klogutil.Err(err))
 		return nil // Don't fail entirely, just skip
 	}
 
@@ -98,7 +99,7 @@ func DiscoverWorkspacesRecursive(
 		// Recursively discover children of this workspace
 		err = DiscoverWorkspacesRecursive(ctx, baseRestConfig, fullPath, discovered)
 		if err != nil {
-			logger.V(3).Info("Failed to recurse into workspace", "workspace_path", fullPath, "exception.message", err.Error())
+			klogutil.LogInfo(logger.V(3), "Failed to recurse into workspace", klogutil.Field("workspace_path", fullPath), klogutil.Err(err))
 			// Continue with other workspaces
 		}
 	}

--- a/pkg/kcp/workspace_watcher.go
+++ b/pkg/kcp/workspace_watcher.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes/watcher"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
@@ -180,7 +181,7 @@ func (w *WorkspaceWatcher) captureState(ctx context.Context) workspaceState {
 	list, err := w.dynamicClient.Resource(WorkspaceGVR).
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		logger.V(2).Info("Unable to list workspaces from kcp API (this is expected if tenancy API is not available)", "exception.message", err.Error())
+		klogutil.LogInfo(logger.V(2), "Unable to list workspaces from kcp API (this is expected if tenancy API is not available)", klogutil.Err(err))
 		// Return empty state - this means workspace watching won't work,
 		// but the provider will still function using kubeconfig-based discovery
 		return state

--- a/pkg/klogutil/util.go
+++ b/pkg/klogutil/util.go
@@ -1,21 +1,51 @@
 package klogutil
 
 import (
-	"context"
-
 	"k8s.io/klog/v2"
 )
 
-// Warn obtains a klog logger from context and logs the provided message + kvs
-// with a log.severity=WARN. This is done as klog.Logger interface does not have
-// a native Warn method
-func Warn(ctx context.Context, msg string, kv ...any) {
-	klog.FromContext(ctx).Info(msg, append([]any{"log.severity", "WARN"}, kv...)...)
+// Attr is a single, complete key/value log attribute. Because every constructor
+// returns a complete pair, attributes compose through the variadic logr/klog
+// logging API without the "even number of varargs" footgun: keys and values
+// cannot get out of sync.
+type Attr struct {
+	K string
+	V any
 }
 
-// WarnLogger logs the provided message + kvs with a log.severity=WARN on the
-// provided logger. This is done as klog.Logger interface does not have a native
-// Warn method
-func WarnLogger(logger klog.Logger, msg string, kv ...any) {
-	logger.Info(msg, append([]any{"log.severity", "WARN"}, kv...)...)
+// Err returns an Attr carrying the error message under the OpenTelemetry
+// semantic-convention key "exception.message". It centralizes that key so there
+// is a single source of truth across every error log site. A nil error yields an
+// empty message rather than panicking.
+func Err(err error) Attr {
+	if err == nil {
+		return Attr{"exception.message", ""}
+	}
+	return Attr{"exception.message", err.Error()}
+}
+
+// Field returns an Attr for an arbitrary key/value pair.
+func Field(k string, v any) Attr { return Attr{k, v} }
+
+// toKV flattens a slice of Attr into the alternating key/value slice expected by
+// the logr/klog variadic logging API.
+func toKV(attrs []Attr) []any {
+	kv := make([]any, 0, len(attrs)*2)
+	for _, a := range attrs {
+		kv = append(kv, a.K, a.V)
+	}
+	return kv
+}
+
+// LogInfo logs msg with the provided attributes on the given logger. Pass a
+// V-leveled logger (e.g. logger.V(4)) to preserve verbosity gating.
+func LogInfo(logger klog.Logger, msg string, attrs ...Attr) {
+	logger.Info(msg, toKV(attrs)...)
+}
+
+// LogWarn logs msg with a log.severity=WARN tag and the provided attributes.
+// This is done because the klog.Logger interface has no native Warn method. Pass
+// a V-leveled logger (e.g. logger.V(1)) to preserve verbosity gating.
+func LogWarn(logger klog.Logger, msg string, attrs ...Attr) {
+	logger.Info(msg, append([]any{"log.severity", "WARN"}, toKV(attrs)...)...)
 }

--- a/pkg/klogutil/util_test.go
+++ b/pkg/klogutil/util_test.go
@@ -1,13 +1,12 @@
 package klogutil
 
 import (
-	"context"
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
 	"github.com/stretchr/testify/suite"
-	"k8s.io/klog/v2"
 )
 
 type KlogUtilSuite struct {
@@ -18,73 +17,133 @@ func TestKlogUtil(t *testing.T) {
 	suite.Run(t, new(KlogUtilSuite))
 }
 
-// newCapturingLogger returns a logr.Logger that appends each log line to the
-// provided slice, making it easy to assert on log output.
-func newCapturingLogger(lines *[]string) logr.Logger {
+// newCapturingLogger returns a logr.Logger that appends each rendered log line
+// to the provided slice, making it easy to assert on actual log output.
+func newCapturingLogger(lines *[]string, opts funcr.Options) logr.Logger {
 	return funcr.New(func(prefix, args string) {
 		*lines = append(*lines, prefix+args)
-	}, funcr.Options{})
+	}, opts)
 }
 
-func (s *KlogUtilSuite) TestWarn() {
-	s.Run("logs message with WARN severity", func() {
-		var lines []string
-		logger := newCapturingLogger(&lines)
-		ctx := klog.NewContext(context.Background(), logger)
-
-		Warn(ctx, "something happened")
-
-		s.Require().Len(lines, 1)
-		s.Contains(lines[0], "something happened")
-		s.Contains(lines[0], "log.severity")
-		s.Contains(lines[0], "WARN")
+func (s *KlogUtilSuite) TestErr() {
+	s.Run("constructs exception.message attribute", func() {
+		attr := Err(errors.New("connection refused"))
+		s.Equal("exception.message", attr.K)
+		s.Equal("connection refused", attr.V)
 	})
 
-	s.Run("includes extra key-value pairs", func() {
-		var lines []string
-		logger := newCapturingLogger(&lines)
-		ctx := klog.NewContext(context.Background(), logger)
+	s.Run("handles nil error without panicking", func() {
+		var attr Attr
+		s.Require().NotPanics(func() { attr = Err(nil) })
+		s.Equal("exception.message", attr.K)
+		s.Equal("", attr.V)
+	})
+}
 
-		Warn(ctx, "disk full", "path", "/var/log")
+func (s *KlogUtilSuite) TestField() {
+	s.Run("constructs arbitrary key/value attribute", func() {
+		attr := Field("validator_name", "rbac")
+		s.Equal("validator_name", attr.K)
+		s.Equal("rbac", attr.V)
+	})
+}
+
+func (s *KlogUtilSuite) TestLogInfo() {
+	s.Run("renders field and error as real attributes", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines, funcr.Options{})
+
+		LogInfo(logger, "RBAC pre-validation failed",
+			Field("validator_name", "rbac"), Err(errors.New("connection refused")))
 
 		s.Require().Len(lines, 1)
-		s.Contains(lines[0], "path")
-		s.Contains(lines[0], "/var/log")
+		s.Contains(lines[0], "RBAC pre-validation failed")
+		s.Contains(lines[0], `"validator_name"="rbac"`)
+		s.Contains(lines[0], `"exception.message"="connection refused"`)
 	})
 
-	s.Run("works with no extra key-value pairs", func() {
+	s.Run("does not produce a non-string key (regression for reverted WithError)", func() {
 		var lines []string
-		logger := newCapturingLogger(&lines)
-		ctx := klog.NewContext(context.Background(), logger)
+		logger := newCapturingLogger(&lines, funcr.Options{})
 
-		Warn(ctx, "bare warning")
+		LogInfo(logger, "boom", Err(errors.New("connection refused")))
+
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], `"exception.message"="connection refused"`)
+		s.NotContains(lines[0], "non-string-key")
+		s.NotContains(lines[0], "<no-value>")
+	})
+
+	s.Run("renders non-string attribute values", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines, funcr.Options{})
+
+		LogInfo(logger, "typed values", Field("config.default_value", 1.0), Field("attempt", 3))
+
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], `"config.default_value"=1`)
+		s.Contains(lines[0], `"attempt"=3`)
+	})
+
+	s.Run("works with no attributes", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines, funcr.Options{})
+
+		LogInfo(logger, "bare message")
+
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], "bare message")
+	})
+
+	s.Run("respects .V(n) verbosity gating", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines, funcr.Options{Verbosity: 3})
+
+		LogInfo(logger.V(4), "too verbose", Field("k", "v"))
+		s.Empty(lines, "a V(4) call must emit nothing when verbosity is 3")
+
+		LogInfo(logger.V(3), "visible", Field("k", "v"))
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], "visible")
+	})
+}
+
+func (s *KlogUtilSuite) TestLogWarn() {
+	s.Run("renders WARN severity with field and error", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines, funcr.Options{})
+
+		LogWarn(logger, "disk full",
+			Field("path", "/var/log"), Err(errors.New("boom")))
+
+		s.Require().Len(lines, 1)
+		s.Contains(lines[0], "disk full")
+		s.Contains(lines[0], `"log.severity"="WARN"`)
+		s.Contains(lines[0], `"path"="/var/log"`)
+		s.Contains(lines[0], `"exception.message"="boom"`)
+	})
+
+	s.Run("carries WARN severity with no extra attributes", func() {
+		var lines []string
+		logger := newCapturingLogger(&lines, funcr.Options{})
+
+		LogWarn(logger, "bare warning")
 
 		s.Require().Len(lines, 1)
 		s.Contains(lines[0], "bare warning")
-	})
-}
-
-func (s *KlogUtilSuite) TestWarnLogger() {
-	s.Run("logs message with WARN severity", func() {
-		var lines []string
-		logger := newCapturingLogger(&lines)
-
-		WarnLogger(logger, "timeout exceeded")
-
-		s.Require().Len(lines, 1)
-		s.Contains(lines[0], "timeout exceeded")
-		s.Contains(lines[0], "log.severity")
-		s.Contains(lines[0], "WARN")
+		s.Contains(lines[0], `"log.severity"="WARN"`)
 	})
 
-	s.Run("includes extra key-value pairs", func() {
+	s.Run("respects .V(n) verbosity gating", func() {
 		var lines []string
-		logger := newCapturingLogger(&lines)
+		logger := newCapturingLogger(&lines, funcr.Options{Verbosity: 3})
 
-		WarnLogger(logger, "retry", "attempt", 3)
+		LogWarn(logger.V(4), "too verbose")
+		s.Empty(lines, "a V(4) warn must emit nothing when verbosity is 3")
 
+		LogWarn(logger.V(3), "visible warning")
 		s.Require().Len(lines, 1)
-		s.Contains(lines[0], "attempt")
-		s.Contains(lines[0], "3")
+		s.Contains(lines[0], "visible warning")
+		s.Contains(lines[0], `"log.severity"="WARN"`)
 	})
 }

--- a/pkg/kubernetes/accesscontrol_round_tripper.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper.go
@@ -45,10 +45,10 @@ func NewAccessControlRoundTripper(ctx context.Context, cfg AccessControlRoundTri
 	var apiPathPrefix string
 	if cfg.HostURL != "" {
 		if hostURL, err := url.Parse(cfg.HostURL); err != nil {
-			klogutil.Warn(ctx,
+			klogutil.LogWarn(klog.FromContext(ctx),
 				"failed to parse Kubernetes API server host to determine API path prefix",
-				"url.full", cfg.HostURL,
-				"exception.message", err.Error(),
+				klogutil.Field("url.full", cfg.HostURL),
+				klogutil.Err(err),
 			)
 		} else {
 			apiPathPrefix = hostURL.Path
@@ -143,7 +143,7 @@ func (rt *AccessControlRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	for _, v := range rt.validators {
 		if validationErr := v.Validate(req.Context(), validationReq); validationErr != nil {
 			if ve, ok := validationErr.(*api.ValidationError); ok {
-				logger.V(4).Info("Validation failed", "validator_name", v.Name(), "exception.message", ve.Error())
+				klogutil.LogInfo(logger.V(4), "Validation failed", klogutil.Field("validator_name", v.Name()), klogutil.Err(ve))
 			}
 			return nil, validationErr
 		}

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes/watcher"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 // singleClusterProvider implements Provider for managing a single
@@ -129,7 +130,7 @@ func (p *singleClusterProvider) HasGVKs(ctx context.Context, gvks []schema.Group
 		return true
 	}
 	if p.manager == nil {
-		klogutil.Warn(ctx, "HasGVKs called with nil manager, assuming all GVKs are available")
+		klogutil.LogWarn(klog.FromContext(ctx), "HasGVKs called with nil manager, assuming all GVKs are available")
 		return true
 	}
 	mapper := p.manager.kubernetes.RESTMapper()

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -68,8 +68,8 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 		}
 	}
 	if tokenURL == "" {
-		klogutil.WarnLogger(logger, "token exchange strategy configured but OIDC provider returned empty token URL",
-			"token_exchange.strategy", strategy,
+		klogutil.LogWarn(logger, "token exchange strategy configured but OIDC provider returned empty token URL",
+			klogutil.Field("token_exchange.strategy", strategy),
 		)
 		return nil
 	}

--- a/pkg/kubernetes/rbac_validator.go
+++ b/pkg/kubernetes/rbac_validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	authv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/klog/v2"
 )
@@ -36,7 +37,7 @@ func (v *RBACValidator) Validate(ctx context.Context, req *api.HTTPValidationReq
 
 	allowed, err := CanI(ctx, authClient, req.GVR, req.Namespace, req.ResourceName, req.Verb)
 	if err != nil {
-		klog.FromContext(ctx).V(4).Info("RBAC pre-validation failed", "exception.message", err.Error())
+		klogutil.LogInfo(klog.FromContext(ctx).V(4), "RBAC pre-validation failed", klogutil.Err(err))
 		return nil
 	}
 

--- a/pkg/kubernetes/schema_validator.go
+++ b/pkg/kubernetes/schema_validator.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/klog/v2"
@@ -51,7 +52,7 @@ func (v *SchemaValidator) Validate(ctx context.Context, req *api.HTTPValidationR
 
 	validator, err := v.getValidator(ctx)
 	if err != nil {
-		logger.V(4).Info("Failed to get schema validator", "exception.message", err.Error())
+		klogutil.LogInfo(logger.V(4), "Failed to get schema validator", klogutil.Err(err))
 		return nil
 	}
 
@@ -65,7 +66,7 @@ func (v *SchemaValidator) Validate(ctx context.Context, req *api.HTTPValidationR
 		// In that case, skip validation rather than blocking the request
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "yaml:") || strings.Contains(errMsg, "json:") {
-			logger.V(4).Info("Schema validation skipped due to parsing error", "exception.message", err.Error())
+			klogutil.LogInfo(logger.V(4), "Schema validation skipped due to parsing error", klogutil.Err(err))
 			return nil
 		}
 		return convertKubectlValidationError(err)

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
+	"k8s.io/klog/v2"
 )
 
 // ExchangeTokenInContext exchanges the OAuth token in the context for a token
@@ -44,8 +45,8 @@ func ExchangeTokenInContext(
 
 	exchanger, ok := tokenexchange.GetTokenExchanger(tep.GetTokenExchangeStrategy())
 	if !ok {
-		klogutil.Warn(ctx, "token exchange strategy not found in registry, falling back to sts exchange",
-			"token_exchange.strategy", tep.GetTokenExchangeStrategy(),
+		klogutil.LogWarn(klog.FromContext(ctx), "token exchange strategy not found in registry, falling back to sts exchange",
+			klogutil.Field("token_exchange.strategy", tep.GetTokenExchangeStrategy()),
 		)
 		return stsExchangeTokenInContext(ctx, baseConfig, oidcProvider, httpClient, subjectToken, stsConfig)
 	}

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
 	"github.com/containers/kubernetes-mcp-server/pkg/telemetry"
@@ -91,7 +92,8 @@ func protocolReceivingMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 		}
 		result, err := next(ctx, method, req)
 		if err != nil {
-			logger.V(6).Info("mcp protocol", "mcp.client.method", method, "exception.message", mcplog.Sanitize(fmt.Sprintf("%v", err)))
+			// Field (not Err) so the error is routed through mcplog.Sanitize; Err would log the raw err.Error().
+			klogutil.LogInfo(logger.V(6), "mcp protocol", klogutil.Field("mcp.client.method", method), klogutil.Field("exception.message", mcplog.Sanitize(fmt.Sprintf("%v", err))))
 		} else if logger.V(6).Enabled() {
 			logger.V(6).Info("mcp protocol", "mcp.client.method", method, "mcp.call.result", mcplog.Sanitize(jsonCompact(result)))
 		}
@@ -115,7 +117,8 @@ func protocolSendingMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 		}
 		result, err := next(ctx, method, req)
 		if err != nil {
-			logger.V(6).Info("mcp protocol", "mcp.server.method", method, "exception.message", mcplog.Sanitize(fmt.Sprintf("%v", err)))
+			// Field (not Err) so the error is routed through mcplog.Sanitize; Err would log the raw err.Error().
+			klogutil.LogInfo(logger.V(6), "mcp protocol", klogutil.Field("mcp.server.method", method), klogutil.Field("exception.message", mcplog.Sanitize(fmt.Sprintf("%v", err))))
 		} else if result != nil && logger.V(6).Enabled() {
 			// Notifications return nil result; only requests have one.
 			logger.V(6).Info("mcp protocol", "mcp.server.method", method, "mcp.call.result", mcplog.Sanitize(jsonCompact(result)))

--- a/pkg/metrics/otel_stats_collector.go
+++ b/pkg/metrics/otel_stats_collector.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/attribute"
@@ -171,7 +172,7 @@ func NewOtelStatsCollectorWithConfig(ctx context.Context, cfg CollectorConfig) (
 		if cfg.Telemetry != nil && cfg.Telemetry.IsEnabled() {
 			logger.Error(err, "Failed to create OTLP metrics exporter, OTLP export disabled")
 		} else {
-			logger.V(1).Info("Failed to create OTLP metrics exporter, OTLP export disabled", "exception.message", err.Error())
+			klogutil.LogInfo(logger.V(1), "Failed to create OTLP metrics exporter, OTLP export disabled", klogutil.Err(err))
 		}
 	} else if exporter != nil {
 		attrs := []attribute.KeyValue{
@@ -185,7 +186,7 @@ func NewOtelStatsCollectorWithConfig(ctx context.Context, cfg CollectorConfig) (
 			resource.WithAttributes(attrs...),
 		)
 		if err != nil {
-			logger.V(1).Info("Failed to create resource for metrics, using default", "exception.message", err.Error())
+			klogutil.LogInfo(logger.V(1), "Failed to create resource for metrics, using default", klogutil.Err(err))
 		} else {
 			opts = append(opts, sdkmetric.WithResource(res))
 		}
@@ -325,7 +326,7 @@ func (c *OtelStatsCollector) GetStats(ctx context.Context) *Statistics {
 	// Collect current metrics from the manual reader
 	var rm metricdata.ResourceMetrics
 	if err := c.reader.Collect(context.Background(), &rm); err != nil {
-		klog.FromContext(ctx).V(1).Info("Failed to collect metrics for stats endpoint", "exception.message", err.Error())
+		klogutil.LogInfo(klog.FromContext(ctx).V(1), "Failed to collect metrics for stats endpoint", klogutil.Err(err))
 		return &Statistics{
 			ToolCallsByName:      make(map[string]int64),
 			ToolErrorsByName:     make(map[string]int64),

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -50,11 +51,11 @@ func getSamplerFromEnv(ctx context.Context) trace.Sampler {
 	if samplerArg != "" {
 		parsed, err := strconv.ParseFloat(samplerArg, 64)
 		if err != nil {
-			logger.V(1).Info("Invalid OTEL_TRACES_SAMPLER_ARG, falling back to default",
-				"config.env_var", "OTEL_TRACES_SAMPLER_ARG",
-				"config.provided_value", samplerArg,
-				"config.default_value", 1.0,
-				"exception.message", err.Error(),
+			klogutil.LogInfo(logger.V(1), "Invalid OTEL_TRACES_SAMPLER_ARG, falling back to default",
+				klogutil.Field("config.env_var", "OTEL_TRACES_SAMPLER_ARG"),
+				klogutil.Field("config.provided_value", samplerArg),
+				klogutil.Field("config.default_value", 1.0),
+				klogutil.Err(err),
 			)
 		} else if parsed < 0.0 || parsed > 1.0 {
 			logger.V(1).Info("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], falling back to default",
@@ -158,7 +159,7 @@ func InitTracer(ctx context.Context, serviceName, serviceVersion string) (func()
 	// Protocol is configured via OTEL_EXPORTER_OTLP_PROTOCOL env var
 	exporter, err := createExporter(ctx)
 	if err != nil {
-		logger.V(1).Info("Failed to create OTLP exporter, tracing disabled", "exception.message", err.Error())
+		klogutil.LogInfo(logger.V(1), "Failed to create OTLP exporter, tracing disabled", klogutil.Err(err))
 		return func() {}, nil
 	}
 
@@ -170,7 +171,7 @@ func InitTracer(ctx context.Context, serviceName, serviceVersion string) (func()
 		),
 	)
 	if err != nil {
-		logger.V(1).Info("Failed to create resource, tracing disabled", "exception.message", err.Error())
+		klogutil.LogInfo(logger.V(1), "Failed to create resource, tracing disabled", klogutil.Err(err))
 		return func() {}, nil
 	}
 
@@ -233,7 +234,7 @@ func InitTracerWithConfig(ctx context.Context, cfg *config.TelemetryConfig, serv
 
 	exporter, err := createExporterWithConfig(ctx, cfg)
 	if err != nil {
-		logger.V(1).Info("Failed to create OTLP exporter, tracing disabled", "exception.message", err.Error())
+		klogutil.LogInfo(logger.V(1), "Failed to create OTLP exporter, tracing disabled", klogutil.Err(err))
 		return func() {}, nil
 	}
 
@@ -298,11 +299,11 @@ func getSamplerFromConfig(ctx context.Context, cfg *config.TelemetryConfig) trac
 	if samplerArg != "" {
 		parsed, err := strconv.ParseFloat(samplerArg, 64)
 		if err != nil {
-			logger.V(1).Info("Invalid traces_sampler_arg, using",
-				"config.key", "traces_sampler_arg",
-				"config.provided", samplerArg,
-				"config.default", 1.0,
-				"exception.message", err.Error(),
+			klogutil.LogInfo(logger.V(1), "Invalid traces_sampler_arg, using",
+				klogutil.Field("config.key", "traces_sampler_arg"),
+				klogutil.Field("config.provided", samplerArg),
+				klogutil.Field("config.default", 1.0),
+				klogutil.Err(err),
 			)
 		} else if parsed < 0.0 || parsed > 1.0 {
 			logger.V(1).Info("traces_sampler_arg out of range [0.0, 1.0], using default",

--- a/pkg/toolsets/core/health_check.go
+++ b/pkg/toolsets/core/health_check.go
@@ -63,8 +63,8 @@ func clusterHealthCheckHandler(params api.PromptHandlerParams) (*api.PromptCallR
 			// Namespace doesn't exist - show warning and proceed with cluster-wide check
 			namespaceWarning = fmt.Sprintf("Namespace '%s' not found or not accessible. Showing cluster-wide information instead.", namespace)
 			namespace = "" // Fall back to cluster-wide check
-			klogutil.WarnLogger(logger, "Namespace not found, performing cluster-wide health check",
-				"kubernetes.namespace.name", requestedNamespace,
+			klogutil.LogWarn(logger, "Namespace not found, performing cluster-wide health check",
+				klogutil.Field("kubernetes.namespace.name", requestedNamespace),
 			)
 		} else {
 			logger.Info("Performing health check for namespace", "kubernetes.namespace.name", namespace)
@@ -144,7 +144,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.Nodes = nodeDiag
 		logger.Info("Node diagnostics collected")
 	} else {
-		klogutil.WarnLogger(logger, "Failed to collect node diagnostics", "exception.message", err.Error())
+		klogutil.LogWarn(logger, "Failed to collect node diagnostics", klogutil.Err(err))
 	}
 
 	// Gather pod diagnostics
@@ -154,7 +154,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.Pods = podDiag
 		logger.Info("Pod diagnostics collected")
 	} else {
-		klogutil.WarnLogger(logger, "Failed to collect pod diagnostics", "exception.message", err.Error())
+		klogutil.LogWarn(logger, "Failed to collect pod diagnostics", klogutil.Err(err))
 	}
 
 	// Gather workload diagnostics
@@ -164,7 +164,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.Deployments = deployDiag
 		logger.Info("Deployment diagnostics collected")
 	} else {
-		klogutil.WarnLogger(logger, "Failed to collect deployment diagnostics", "exception.message", err.Error())
+		klogutil.LogWarn(logger, "Failed to collect deployment diagnostics", klogutil.Err(err))
 	}
 
 	logger.Info("Collecting statefulset diagnostics...")
@@ -173,7 +173,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.StatefulSets = stsDiag
 		logger.Info("StatefulSet diagnostics collected")
 	} else {
-		klogutil.WarnLogger(logger, "Failed to collect statefulset diagnostics", "exception.message", err.Error())
+		klogutil.LogWarn(logger, "Failed to collect statefulset diagnostics", klogutil.Err(err))
 	}
 
 	logger.Info("Collecting daemonset diagnostics...")
@@ -182,7 +182,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.DaemonSets = dsDiag
 		logger.Info("DaemonSet diagnostics collected")
 	} else {
-		klogutil.WarnLogger(logger, "Failed to collect daemonset diagnostics", "exception.message", err.Error())
+		klogutil.LogWarn(logger, "Failed to collect daemonset diagnostics", klogutil.Err(err))
 	}
 
 	// Gather PVC diagnostics
@@ -192,7 +192,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 		diag.PVCs = pvcDiag
 		logger.Info("PVC diagnostics collected")
 	} else {
-		klogutil.WarnLogger(logger, "Failed to collect PVC diagnostics", "exception.message", err.Error())
+		klogutil.LogWarn(logger, "Failed to collect PVC diagnostics", klogutil.Err(err))
 	}
 
 	// Gather cluster operator diagnostics (OpenShift only)
@@ -211,7 +211,7 @@ func gatherClusterDiagnostics(params api.PromptHandlerParams, namespace string, 
 			diag.Events = eventDiag
 			logger.Info("Event diagnostics collected")
 		} else {
-			klogutil.WarnLogger(logger, "Failed to collect event diagnostics", "exception.message", err.Error())
+			klogutil.LogWarn(logger, "Failed to collect event diagnostics", klogutil.Err(err))
 		}
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #1202 (contextual logging). Introduces a small, type-safe,
composable helper layer in `pkg/klogutil` for attaching errors and fields to
structured (logr/klog) log records, replacing the repeated inline
`"exception.message", err.Error()` key/value pairs across the codebase.

During the #1202 review a `WithError(err) []string` helper was added to DRY the
`exception.message` key, but it had to be reverted: a fragment-returning helper
cannot compose with logr's variadic API (`[]string` does not spread into
`...any`, so klog received the whole slice as a single non-string key). This
change fixes that by returning *complete* pairs.

## What's included

- New `Attr{K string; V any}` type with `Err(err)` and `Field(k, v)`
  constructors — each returns a complete key/value pair, so keys and values
  cannot get out of sync.
- `LogInfo(logger, msg, ...Attr)` and `LogWarn(logger, msg, ...Attr)` helpers
  that flatten attributes into the variadic logr/klog API. `LogWarn` preserves
  the `log.severity=WARN` tag.
- `Err` centralizes the OpenTelemetry `exception.message` semantic-convention
  key (single source of truth) and is nil-safe.
- The previous `Warn`/`WarnLogger` helpers are folded into `LogWarn`; ctx call
  sites use `LogWarn(klog.FromContext(ctx), …)`.
- Converted ~30 error/field log sites across `pkg/http`, `pkg/kubernetes`,
  `pkg/kcp`, `pkg/telemetry`, `pkg/metrics`, `pkg/config`, `pkg/confirmation`,
  `pkg/mcp`, and `pkg/toolsets/core`.

## Properties preserved

- `.V(n)` verbosity gating (pass the V-leveled logger).
- `log.severity=WARN` for warnings.
- Renders `exception.message="…"` as a real attribute.
- No varargs footgun — keys/values cannot desync.

## Testing

- Unit tests assert the **rendered** log line (via `funcr`), not just
  constructed values — covering `exception.message` rendering, the
  reverted-`WithError` regression, `.V(n)` gating in both directions,
  `log.severity=WARN`, non-string values, and nil-error safety.
- `make test` (32 packages ok), `make lint` (0 issues), `go vet`, `gofmt`
  all clean.

## Out of scope

- Standardizing the mixed snake_case vs dotted-OTel key naming (deferred).
- Wiring real OTel log severity / a logs exporter.

Closes #1208