### PR TITLE
feat(api): add output schema support for MCP tools

### DIFF
--- a/docs/specs/structured-output.md
+++ b/docs/specs/structured-output.md
@@ -177,12 +177,6 @@ This repo takes an **opportunistic** stance:
 When in doubt, leave it off and add it later in a follow-up PR — declaring
 nothing is preferable to declaring something inaccurate.
 
-> **Wiring note:** `api.Tool` (see
-> [`pkg/api/toolsets.go`](../../pkg/api/toolsets.go)) carries `InputSchema` but
-> does not yet expose an `OutputSchema` field. Adding the field, surfacing it
-> through the MCP go-sdk transport, and generating it from typed structs is a
-> follow-up; until then this section is forward-looking guidance.
-
 ## Wire-contract discipline
 
 Once a tool emits `structuredContent`, its JSON shape is public API and

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -233,6 +233,9 @@ type Tool struct {
 	Meta map[string]any `json:"_meta,omitempty"`
 	// A JSON Schema object defining the expected parameters for the tool.
 	InputSchema *jsonschema.Schema
+	// A JSON Schema object defining the structure of the tool's output
+	// returned in the StructuredContent field of a CallToolResult.
+	OutputSchema *jsonschema.Schema
 }
 
 type ToolAnnotations struct {

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -44,6 +44,16 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 		},
 		InputSchema: inputSchema,
 	}
+	// A nil *jsonschema.Schema assigned to an "any" field (goSdkTool.OutputSchema)
+	// becomes a typed nil (non-nil interface), triggering a panic in AddTool.
+	// Therefore, only assign this field when non-nil.
+	outputSchema := tool.Tool.OutputSchema
+	if outputSchema != nil {
+		if outputSchema.Type != "object" {
+			return nil, nil, fmt.Errorf("tool %q: output schema must have type %q (got %q)", tool.Tool.Name, "object", outputSchema.Type)
+		}
+		goSdkTool.OutputSchema = outputSchema
+	}
 	goSdkHandler := func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		toolCallRequest, err := GoSdkToolCallRequestToToolCallRequest(request)
 		if err != nil {

--- a/pkg/mcp/tools_gosdk_test.go
+++ b/pkg/mcp/tools_gosdk_test.go
@@ -52,6 +52,52 @@ func (s *ToolsGoSdkSuite) TestInputSchemaValidation() {
 	})
 }
 
+func (s *ToolsGoSdkSuite) TestOutputSchemaValidation() {
+	s.Run("nil output schema converts successfully", func() {
+		tool := api.ServerTool{
+			Tool: api.Tool{
+				Name:        "no-output-schema",
+				InputSchema: &jsonschema.Schema{Type: "object"},
+			},
+		}
+		mcpTool, _, err := ServerToolToGoSdkTool(nil, tool)
+		s.Require().NoError(err)
+		s.Nil(mcpTool.OutputSchema)
+	})
+
+	s.Run("non-object output schema returns error", func() {
+		tool := api.ServerTool{
+			Tool: api.Tool{
+				Name:         "string-schema",
+				InputSchema:  &jsonschema.Schema{Type: "object"},
+				OutputSchema: &jsonschema.Schema{Type: "string"},
+			},
+		}
+		_, _, err := ServerToolToGoSdkTool(nil, tool)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "string-schema")
+		s.Contains(err.Error(), `"object"`)
+	})
+
+	s.Run("object output schema converts successfully", func() {
+		tool := api.ServerTool{
+			Tool: api.Tool{
+				Name:        "with-output-schema",
+				InputSchema: &jsonschema.Schema{Type: "object"},
+				OutputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"result": {Type: "string"},
+					},
+				},
+			},
+		}
+		mcpTool, _, err := ServerToolToGoSdkTool(nil, tool)
+		s.Require().NoError(err)
+		s.Equal(tool.Tool.OutputSchema, mcpTool.OutputSchema)
+	})
+}
+
 func TestToolsGoSdkSuite(t *testing.T) {
 	suite.Run(t, new(ToolsGoSdkSuite))
 }


### PR DESCRIPTION
Allow tools to declare an OutputSchema that describes the structure of their StructuredContent response, forwarded to the Go SDK's mcp.Tool.