### PR TITLE
fix(auth): refresh STS config after reload

### DIFF
--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -335,8 +335,16 @@ func (m *MCPServerOptions) Run(ctx context.Context) error {
 		return err
 	}
 	oauthState := internaloauth.NewState(internaloauth.SnapshotFromConfig(m.StaticConfig, oidcProvider, httpClient))
+	cfgState := config.NewStaticConfigState(m.StaticConfig)
 
-	provider, err := kubernetes.NewProvider(ctx, m.StaticConfig, kubernetes.WithTokenExchange(oauthState))
+	provider, err := kubernetes.NewProvider(
+		ctx,
+		m.StaticConfig,
+		kubernetes.WithTokenExchange(oauthState),
+		kubernetes.WithBaseConfigProvider(func() api.BaseConfig {
+			return cfgState.Load()
+		}),
+	)
 	if err != nil {
 		return fmt.Errorf("unable to create kubernetes target provider: %w", err)
 	}
@@ -355,8 +363,6 @@ func (m *MCPServerOptions) Run(ctx context.Context) error {
 			klog.Errorf("MCP server shutdown error: %v", err)
 		}
 	}()
-
-	cfgState := config.NewStaticConfigState(m.StaticConfig)
 
 	// Set up SIGHUP handler for configuration reload. The returned stop
 	// function unregisters the signal handler and waits for the goroutine

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -58,12 +58,19 @@ type TokenExchangeProvider interface {
 type ProviderOption func(*providerOptions)
 
 type providerOptions struct {
-	oauthState *oauth.State
+	oauthState         *oauth.State
+	baseConfigProvider func() api.BaseConfig
 }
 
 func WithTokenExchange(oauthState *oauth.State) ProviderOption {
 	return func(opts *providerOptions) {
 		opts.oauthState = oauthState
+	}
+}
+
+func WithBaseConfigProvider(baseConfigProvider func() api.BaseConfig) ProviderOption {
+	return func(opts *providerOptions) {
+		opts.baseConfigProvider = baseConfigProvider
 	}
 }
 
@@ -86,9 +93,15 @@ func NewProvider(ctx context.Context, cfg api.BaseConfig, opts ...ProviderOption
 	}
 
 	if providerOpts.oauthState != nil {
+		baseConfigProvider := providerOpts.baseConfigProvider
+		if baseConfigProvider == nil {
+			baseConfigProvider = func() api.BaseConfig {
+				return cfg
+			}
+		}
 		provider = newTokenExchangingProvider(
 			provider,
-			cfg,
+			baseConfigProvider,
 			providerOpts.oauthState,
 		)
 	}

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -13,28 +14,28 @@ import (
 )
 
 type tokenExchangingProvider struct {
-	provider   Provider
-	baseConfig api.BaseConfig
-	oauthState *oauth.State
+	provider           Provider
+	baseConfigProvider func() api.BaseConfig
+	oauthState         *oauth.State
 	// stsConfig is cached and reused across calls so that assertion caching
-	// in TargetTokenExchangeConfig is effective. Rebuilt when the token URL changes
-	// (e.g., after SIGHUP reloads the OIDC provider).
-	stsConfig   *tokenexchange.TargetTokenExchangeConfig
-	stsConfigMu sync.Mutex
-	stsTokenURL string // tracks which token URL the cached config was built for
+	// in TargetTokenExchangeConfig is effective. Rebuilt when the token URL or
+	// any STS/TLS config field changes after a reload.
+	stsConfig    *tokenexchange.TargetTokenExchangeConfig
+	stsConfigMu  sync.Mutex
+	stsConfigKey stsConfigCacheKey
 }
 
 var _ Provider = &tokenExchangingProvider{}
 
 func newTokenExchangingProvider(
 	provider Provider,
-	baseConfig api.BaseConfig,
+	baseConfigProvider func() api.BaseConfig,
 	oauthState *oauth.State,
 ) Provider {
 	return &tokenExchangingProvider{
-		provider:   provider,
-		baseConfig: baseConfig,
-		oauthState: oauthState,
+		provider:           provider,
+		baseConfigProvider: baseConfigProvider,
+		oauthState:         oauthState,
 	}
 }
 
@@ -43,20 +44,31 @@ func (p *tokenExchangingProvider) GetDerivedKubernetes(ctx context.Context, targ
 	if snap == nil {
 		return p.provider.GetDerivedKubernetes(ctx, target)
 	}
-	stsConfig := p.getOrBuildStsConfig(ctx, snap)
-	ctx, err := ExchangeTokenInContext(ctx, p.baseConfig, snap.OIDCProvider, snap.HTTPClient, p.provider, target, stsConfig)
+	baseConfig := p.baseConfig()
+	if baseConfig == nil {
+		return p.provider.GetDerivedKubernetes(ctx, target)
+	}
+	stsConfig := p.getOrBuildStsConfig(ctx, snap, baseConfig)
+	ctx, err := ExchangeTokenInContext(ctx, baseConfig, snap.OIDCProvider, snap.HTTPClient, p.provider, target, stsConfig)
 	if err != nil {
 		return nil, err
 	}
 	return p.provider.GetDerivedKubernetes(ctx, target)
 }
 
+func (p *tokenExchangingProvider) baseConfig() api.BaseConfig {
+	if p.baseConfigProvider == nil {
+		return nil
+	}
+	return p.baseConfigProvider()
+}
+
 // getOrBuildStsConfig returns a cached STS config, rebuilding it when the
-// OIDC provider's token URL changes (e.g., after SIGHUP).
-func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap *oauth.Snapshot) *tokenexchange.TargetTokenExchangeConfig {
+// OIDC provider's token URL or STS/TLS config fields change.
+func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap *oauth.Snapshot, baseConfig api.BaseConfig) *tokenexchange.TargetTokenExchangeConfig {
 	logger := klog.FromContext(ctx)
 
-	strategy := p.baseConfig.GetStsStrategy()
+	strategy := baseConfig.GetStsStrategy()
 	if strategy == "" {
 		return nil
 	}
@@ -77,27 +89,28 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 	p.stsConfigMu.Lock()
 	defer p.stsConfigMu.Unlock()
 
-	// Return cached config if token URL hasn't changed
-	if p.stsConfig != nil && p.stsTokenURL == tokenURL {
+	key := newStsConfigCacheKey(tokenURL, baseConfig)
+	if p.stsConfig != nil && p.stsConfigKey == key {
 		return p.stsConfig
 	}
 
-	authStyle := p.baseConfig.GetStsAuthStyle()
+	authStyle := baseConfig.GetStsAuthStyle()
 	if authStyle == "" {
 		authStyle = tokenexchange.AuthStyleParams
 	}
+	scopes := append([]string(nil), baseConfig.GetStsScopes()...)
 
 	cfg := &tokenexchange.TargetTokenExchangeConfig{
 		TokenURL:           tokenURL,
-		ClientID:           p.baseConfig.GetStsClientId(),
-		ClientSecret:       p.baseConfig.GetStsClientSecret(),
-		Audience:           p.baseConfig.GetStsAudience(),
-		Scopes:             p.baseConfig.GetStsScopes(),
+		ClientID:           baseConfig.GetStsClientId(),
+		ClientSecret:       baseConfig.GetStsClientSecret(),
+		Audience:           baseConfig.GetStsAudience(),
+		Scopes:             scopes,
 		AuthStyle:          authStyle,
-		ClientCertFile:     p.baseConfig.GetStsClientCertFile(),
-		ClientKeyFile:      p.baseConfig.GetStsClientKeyFile(),
-		FederatedTokenFile: p.baseConfig.GetStsFederatedTokenFile(),
-		CAFile:             p.baseConfig.GetCertificateAuthority(),
+		ClientCertFile:     baseConfig.GetStsClientCertFile(),
+		ClientKeyFile:      baseConfig.GetStsClientKeyFile(),
+		FederatedTokenFile: baseConfig.GetStsFederatedTokenFile(),
+		CAFile:             baseConfig.GetCertificateAuthority(),
 	}
 	if err := cfg.Validate(); err != nil {
 		logger.Error(
@@ -108,8 +121,38 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 	}
 
 	p.stsConfig = cfg
-	p.stsTokenURL = tokenURL
+	p.stsConfigKey = key
 	return p.stsConfig
+}
+
+type stsConfigCacheKey struct {
+	TokenURL           string
+	Strategy           string
+	ClientID           string
+	ClientSecret       string
+	Audience           string
+	Scopes             string
+	AuthStyle          string
+	ClientCertFile     string
+	ClientKeyFile      string
+	FederatedTokenFile string
+	CAFile             string
+}
+
+func newStsConfigCacheKey(tokenURL string, cfg api.BaseConfig) stsConfigCacheKey {
+	return stsConfigCacheKey{
+		TokenURL:           tokenURL,
+		Strategy:           cfg.GetStsStrategy(),
+		ClientID:           cfg.GetStsClientId(),
+		ClientSecret:       cfg.GetStsClientSecret(),
+		Audience:           cfg.GetStsAudience(),
+		Scopes:             strings.Join(cfg.GetStsScopes(), "\x00"),
+		AuthStyle:          cfg.GetStsAuthStyle(),
+		ClientCertFile:     cfg.GetStsClientCertFile(),
+		ClientKeyFile:      cfg.GetStsClientKeyFile(),
+		FederatedTokenFile: cfg.GetStsFederatedTokenFile(),
+		CAFile:             cfg.GetCertificateAuthority(),
+	}
 }
 
 func (p *tokenExchangingProvider) IsOpenShift(ctx context.Context) bool {

--- a/pkg/kubernetes/provider_token_exchange_test.go
+++ b/pkg/kubernetes/provider_token_exchange_test.go
@@ -1,0 +1,194 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
+	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type TokenExchangingProviderSuite struct {
+	suite.Suite
+}
+
+type observedTokenRequest struct {
+	clientID     string
+	clientSecret string
+	audience     string
+	scope        string
+}
+
+type exchangeTestOIDCServer struct {
+	server   *httptest.Server
+	requests []observedTokenRequest
+}
+
+type fakeDerivedProvider struct{}
+
+func (fakeDerivedProvider) IsOpenShift(context.Context) bool             { return false }
+func (fakeDerivedProvider) IsMultiTarget() bool                          { return false }
+func (fakeDerivedProvider) GetTargets(context.Context) ([]string, error) { return []string{""}, nil }
+func (fakeDerivedProvider) GetDefaultTarget() string                     { return "" }
+func (fakeDerivedProvider) GetTargetParameterName() string               { return "" }
+func (fakeDerivedProvider) WatchTargets(context.Context, McpReload)      {}
+func (fakeDerivedProvider) Close()                                       {}
+func (fakeDerivedProvider) GetDerivedKubernetes(context.Context, string) (*Kubernetes, error) {
+	return &Kubernetes{}, nil
+}
+func (fakeDerivedProvider) HasGVKs(context.Context, []schema.GroupVersionKind) bool {
+	return true
+}
+
+func (s *TokenExchangingProviderSuite) TestGetDerivedKubernetes() {
+	s.Run("uses reloaded STS config from live config provider", func() {
+		authServer := s.newExchangeTestOIDCServer()
+		cfg := config.Default()
+		cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+		cfg.StsClientId = "old-client"
+		cfg.StsClientSecret = "old-secret"
+		cfg.StsAudience = "old-audience"
+		cfg.StsScopes = []string{"old-scope"}
+
+		provider, err := oidc.NewProvider(context.Background(), authServer.server.URL)
+		s.Require().NoError(err)
+		oauthState := oauth.NewState(&oauth.Snapshot{OIDCProvider: provider})
+		baseConfigProvider := func() api.BaseConfig {
+			return cfg
+		}
+		wrapped := newTokenExchangingProvider(fakeDerivedProvider{}, baseConfigProvider, oauthState)
+
+		ctx := context.WithValue(context.Background(), OAuthAuthorizationHeader, "Bearer original-token")
+		_, err = wrapped.GetDerivedKubernetes(ctx, "")
+		s.Require().NoError(err)
+
+		cfg = config.Default()
+		cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+		cfg.StsClientId = "new-client"
+		cfg.StsClientSecret = "new-secret"
+		cfg.StsAudience = "new-audience"
+		cfg.StsScopes = []string{"new-scope"}
+
+		_, err = wrapped.GetDerivedKubernetes(ctx, "")
+		s.Require().NoError(err)
+
+		s.Require().Len(authServer.requests, 2)
+		s.Equal(observedTokenRequest{
+			clientID:     "old-client",
+			clientSecret: "old-secret",
+			audience:     "old-audience",
+			scope:        "old-scope",
+		}, authServer.requests[0])
+		s.Equal(observedTokenRequest{
+			clientID:     "new-client",
+			clientSecret: "new-secret",
+			audience:     "new-audience",
+			scope:        "new-scope",
+		}, authServer.requests[1])
+	})
+}
+
+func (s *TokenExchangingProviderSuite) TestGetOrBuildStsConfig() {
+	s.Run("rebuilds cached config when STS fields change without token URL change", func() {
+		snap := s.newSnapshot()
+		cfg := config.Default()
+		cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+		cfg.StsClientId = "old-client"
+		cfg.StsClientSecret = "old-secret"
+		cfg.StsAudience = "old-audience"
+		cfg.StsScopes = []string{"old-scope"}
+		cfg.CertificateAuthority = "/old-ca.pem"
+
+		p := &tokenExchangingProvider{
+			baseConfigProvider: func() api.BaseConfig {
+				return cfg
+			},
+		}
+
+		first := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+		s.Require().NotNil(first)
+		s.Equal("old-client", first.ClientID)
+
+		cfg.StsClientId = "new-client"
+		cfg.StsClientSecret = "new-secret"
+		cfg.StsAudience = "new-audience"
+		cfg.StsScopes = []string{"new-scope"}
+		cfg.CertificateAuthority = "/new-ca.pem"
+
+		second := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+		s.Require().NotNil(second)
+		s.NotSame(first, second)
+		s.Equal("new-client", second.ClientID)
+		s.Equal("new-secret", second.ClientSecret)
+		s.Equal("new-audience", second.Audience)
+		s.Equal([]string{"new-scope"}, second.Scopes)
+		s.Equal("/new-ca.pem", second.CAFile)
+	})
+}
+
+func (s *TokenExchangingProviderSuite) newExchangeTestOIDCServer() *exchangeTestOIDCServer {
+	s.T().Helper()
+
+	authServer := &exchangeTestOIDCServer{}
+	authServer.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+				"issuer": "%s",
+				"authorization_endpoint": "%s/authorize",
+				"token_endpoint": "%s/token"
+			}`, authServer.server.URL, authServer.server.URL, authServer.server.URL)
+		case "/token":
+			s.Require().NoError(r.ParseForm())
+			authServer.requests = append(authServer.requests, observedTokenRequest{
+				clientID:     r.PostForm.Get(tokenexchange.FormKeyClientID),
+				clientSecret: r.PostForm.Get(tokenexchange.FormKeyClientSecret),
+				audience:     r.PostForm.Get(tokenexchange.FormKeyAudience),
+				scope:        strings.TrimSpace(r.PostForm.Get(tokenexchange.FormKeyScope)),
+			})
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"exchanged-token","token_type":"Bearer","expires_in":3600}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	s.T().Cleanup(authServer.server.Close)
+	return authServer
+}
+
+func (s *TokenExchangingProviderSuite) newSnapshot() *oauth.Snapshot {
+	s.T().Helper()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{
+			"issuer": "%s",
+			"authorization_endpoint": "%s/authorize",
+			"token_endpoint": "%s/token"
+		}`, server.URL, server.URL, server.URL)
+	}))
+	s.T().Cleanup(server.Close)
+
+	provider, err := oidc.NewProvider(context.Background(), server.URL)
+	s.Require().NoError(err)
+	return &oauth.Snapshot{OIDCProvider: provider}
+}
+
+func TestTokenExchangingProvider(t *testing.T) {
+	suite.Run(t, new(TokenExchangingProviderSuite))
+}

--- a/pkg/tokenexchange/config.go
+++ b/pkg/tokenexchange/config.go
@@ -67,6 +67,8 @@ type TargetTokenExchangeConfig struct {
 
 	// client is a http client configured to work with the IdP for this target
 	client *http.Client `toml:"-"`
+	// clientCAFile tracks which CAFile was used to build the cached client
+	clientCAFile string `toml:"-"`
 	// cachedAssertion stores the most recently generated JWT assertion
 	cachedAssertion string `toml:"-"`
 	// cachedAssertionExpiry is when the cached assertion expires
@@ -103,7 +105,7 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 	c.clientMutex.Lock()
 	defer c.clientMutex.Unlock()
 
-	if c.client != nil {
+	if c.client != nil && c.clientCAFile == c.CAFile {
 		return c.client, nil
 	}
 
@@ -130,10 +132,14 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 
 	transport.TLSClientConfig = tlsConfig
 
+	if c.client != nil {
+		c.client.CloseIdleConnections()
+	}
 	c.client = &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: transport,
 	}
+	c.clientCAFile = c.CAFile
 
 	return c.client, nil
 }

--- a/pkg/tokenexchange/config_test.go
+++ b/pkg/tokenexchange/config_test.go
@@ -1,0 +1,150 @@
+package tokenexchange
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TargetTokenExchangeConfigSuite struct {
+	suite.Suite
+}
+
+func (s *TargetTokenExchangeConfigSuite) TestHTTPClientCAFile() {
+	s.Run("without CAFile uses system roots", func() {
+		client, err := (&TargetTokenExchangeConfig{}).HTTPClient()
+		s.Require().NoError(err)
+
+		transport, ok := client.Transport.(*http.Transport)
+		s.Require().True(ok)
+		s.Require().NotNil(transport.TLSClientConfig)
+		s.Equal(uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
+		s.Nil(transport.TLSClientConfig.RootCAs)
+	})
+
+	s.Run("trusts configured CA and rejects another CA", func() {
+		trustedServer := s.newTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("ok"))
+		}))
+		defer trustedServer.Close()
+		untrustedServer := s.newTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("ok"))
+		}))
+		defer untrustedServer.Close()
+
+		cfg := &TargetTokenExchangeConfig{
+			CAFile: s.writeCAFile(trustedServer.Certificate()),
+		}
+
+		client, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+		resp, err := client.Get(trustedServer.URL)
+		s.Require().NoError(err)
+		s.Require().NoError(resp.Body.Close())
+
+		_, err = client.Get(untrustedServer.URL)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "certificate signed by unknown authority")
+	})
+
+	s.Run("rebuilds TLS roots after CAFile changes", func() {
+		oldServer := s.newTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("old"))
+		}))
+		defer oldServer.Close()
+		newServer := s.newTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("new"))
+		}))
+		defer newServer.Close()
+
+		cfg := &TargetTokenExchangeConfig{
+			CAFile: s.writeCAFile(oldServer.Certificate()),
+		}
+
+		oldClient, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+		resp, err := oldClient.Get(oldServer.URL)
+		s.Require().NoError(err)
+		s.Require().NoError(resp.Body.Close())
+
+		cfg.CAFile = s.writeCAFile(newServer.Certificate())
+		newClient, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+		resp, err = newClient.Get(newServer.URL)
+		s.Require().NoError(err)
+		s.Require().NoError(resp.Body.Close())
+	})
+
+	s.Run("invalid CA file returns parse error", func() {
+		path := filepath.Join(s.T().TempDir(), "ca.pem")
+		s.Require().NoError(os.WriteFile(path, []byte("not a certificate"), 0o600))
+
+		_, err := (&TargetTokenExchangeConfig{CAFile: path}).HTTPClient()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "failed to parse CA certificate")
+	})
+
+	s.Run("missing CA file returns read error", func() {
+		_, err := (&TargetTokenExchangeConfig{CAFile: filepath.Join(s.T().TempDir(), "missing.pem")}).HTTPClient()
+		s.Require().Error(err)
+		s.Contains(err.Error(), "failed to read CA file")
+	})
+}
+
+func (s *TargetTokenExchangeConfigSuite) newTLSServer(handler http.Handler) *httptest.Server {
+	s.T().Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	s.Require().NoError(err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	s.Require().NoError(err)
+
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{der},
+			PrivateKey:  key,
+		}},
+	}
+	server.StartTLS()
+	return server
+}
+
+func (s *TargetTokenExchangeConfigSuite) writeCAFile(cert *x509.Certificate) string {
+	s.T().Helper()
+
+	path := filepath.Join(s.T().TempDir(), "ca.pem")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	s.Require().NoError(os.WriteFile(path, certPEM, 0o600))
+	return path
+}
+
+func TestTargetTokenExchangeConfig(t *testing.T) {
+	suite.Run(t, new(TargetTokenExchangeConfigSuite))
+}


### PR DESCRIPTION
Fixes #1110

## Summary

STS token exchange kept using stale settings after a SIGHUP reload when the IdP token URL stayed the same. That meant rotated client credentials, audience, scopes, auth style, cert/key paths, or CA path could be ignored by later exchange attempts.

## Changes

- Read token exchange settings from the live config state when the wrapper handles a derived Kubernetes request.
- Rebuild the cached STS config when any token exchange or TLS input changes, not only when the token URL changes.
- Invalidate the token exchange HTTP client when `CAFile` changes and add CAFile regression coverage.

## Verification

```bash
go test ./pkg/kubernetes ./pkg/tokenexchange ./pkg/oauth ./pkg/kubernetes-mcp-server/cmd -count=1
go test ./pkg/http -run 'Test.*Token|Test.*OAuth|Test.*Authorization|Test.*WellKnown|Test.*STS|Test.*MCP' -count=1
go test -race ./pkg/kubernetes ./pkg/tokenexchange ./pkg/oauth ./pkg/kubernetes-mcp-server/cmd -count=1
make lint
```

Note: `go test ./pkg/http -run 'TestHealthCheck|TestMiddlewareLogging' -count=1` currently fails on my checkout with health/logging assertions caused by the mock discovery handler returning `unexpected end of JSON input`. I reproduced the same failure on an unmodified `origin/main` checkout, so I did not count it as part of this patch's passing verification.
