### PR TITLE
test(mcp): cover output schema typed-nil guard (follow-up to #1215)

### DIFF
--- a/docs/specs/structured-output.md
+++ b/docs/specs/structured-output.md
@@ -177,6 +177,11 @@ This repo takes an **opportunistic** stance:
 When in doubt, leave it off and add it later in a follow-up PR — declaring
 nothing is preferable to declaring something inaccurate.
 
+A declared `outputSchema` is set on the tool definition and surfaced to clients
+through `tools/list`; it is **advertising, not enforcement**. The server does
+not validate a handler's `structuredContent` against the declared schema, so the
+tool author owns keeping the two aligned — see "Wire-contract discipline" below.
+
 ## Wire-contract discipline
 
 Once a tool emits `structuredContent`, its JSON shape is public API and

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -47,6 +47,11 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 	// A nil *jsonschema.Schema assigned to an "any" field (goSdkTool.OutputSchema)
 	// becomes a typed nil (non-nil interface), triggering a panic in AddTool.
 	// Therefore, only assign this field when non-nil.
+	//
+	// Unlike InputSchema above, Properties is intentionally left untouched: the
+	// Properties initialization there is an OpenAI-input-specific workaround
+	// (#717), whereas the output schema is advertised to MCP clients rather than
+	// sent as OpenAI function parameters, so it needs no equivalent.
 	outputSchema := tool.Tool.OutputSchema
 	if outputSchema != nil {
 		if outputSchema.Type != "object" {

--- a/pkg/mcp/tools_gosdk_test.go
+++ b/pkg/mcp/tools_gosdk_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -65,6 +66,25 @@ func (s *ToolsGoSdkSuite) TestOutputSchemaValidation() {
 		s.Nil(mcpTool.OutputSchema)
 	})
 
+	s.Run("nil output schema registers with the SDK without panicking", func() {
+		// Regression guard for the conditional assignment in ServerToolToGoSdkTool:
+		// a nil *jsonschema.Schema assigned to the SDK's any-typed OutputSchema
+		// field is a non-nil interface, which makes AddTool dereference a nil
+		// pointer and panic. s.Nil(mcpTool.OutputSchema) above cannot detect that
+		// regression (reflect.IsNil sees through the interface), so exercise the
+		// real registration path here.
+		tool := api.ServerTool{
+			Tool: api.Tool{
+				Name:        "register-no-output-schema",
+				InputSchema: &jsonschema.Schema{Type: "object"},
+			},
+		}
+		mcpTool, handler, err := ServerToolToGoSdkTool(nil, tool)
+		s.Require().NoError(err)
+		server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+		s.NotPanics(func() { server.AddTool(mcpTool, handler) })
+	})
+
 	s.Run("non-object output schema returns error", func() {
 		tool := api.ServerTool{
 			Tool: api.Tool{
@@ -95,6 +115,25 @@ func (s *ToolsGoSdkSuite) TestOutputSchemaValidation() {
 		mcpTool, _, err := ServerToolToGoSdkTool(nil, tool)
 		s.Require().NoError(err)
 		s.Equal(tool.Tool.OutputSchema, mcpTool.OutputSchema)
+	})
+
+	s.Run("object output schema with nil properties converts and registers without panicking", func() {
+		// The output path intentionally does not initialize Properties the way the
+		// input path does (that init is an OpenAI-input-specific workaround, #717).
+		// An object schema with nil Properties is still valid and must convert and
+		// register without error.
+		tool := api.ServerTool{
+			Tool: api.Tool{
+				Name:         "nil-properties-output-schema",
+				InputSchema:  &jsonschema.Schema{Type: "object"},
+				OutputSchema: &jsonschema.Schema{Type: "object"},
+			},
+		}
+		mcpTool, handler, err := ServerToolToGoSdkTool(nil, tool)
+		s.Require().NoError(err)
+		s.Equal(tool.Tool.OutputSchema, mcpTool.OutputSchema)
+		server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+		s.NotPanics(func() { server.AddTool(mcpTool, handler) })
 	})
 }
 


### PR DESCRIPTION
Follow-up to #1215.

## Why

#1215 added `TestOutputSchemaValidation`, but its nil-schema case asserts
`s.Nil(mcpTool.OutputSchema)`. testify's `Nil` reflects through the interface to
the underlying pointer, so it returns true for both a true `nil` interface and an
interface wrapping a typed-nil `*jsonschema.Schema`. As a result the suite stayed
green even when the typed-nil guard in `ServerToolToGoSdkTool` was removed — i.e.
the test meant to protect the guard could not detect its removal, even though
removing the guard reintroduces the `AddTool` nil-pointer panic the guard prevents.

Verified locally: making the output-schema assignment unconditional leaves the
original suite passing, yet panics at go-sdk `server.go:264` during `AddTool`.

## What

- **Regression test** — `nil output schema registers with the SDK without
  panicking`: converts the tool and calls a real `mcp.Server.AddTool`, asserting
  `NotPanics`. Fails if the guard is removed (verified), passes with it.
- **Coverage** — `object output schema with nil properties converts and registers
  without panicking`: pins the intentional behavior that the output path does not
  initialize `Properties` (the input-path init is an OpenAI-specific workaround,
  #717).
- **Docs/comments** — documents the intentional `InputSchema`/`OutputSchema`
  `Properties` asymmetry in code, and notes in `docs/specs/structured-output.md`
  that a declared `outputSchema` is advertising, not server-enforced (the raw
  `ToolHandler` path does not validate `structuredContent` against it).

No production behavior changes beyond comments.

## Scope: why `NotPanics` and not an explicit registration assert

The new tests assert `AddTool` does not panic, but deliberately **not** that the
tool actually landed in the registry (e.g. via a `tools/list` count). That gap is
already covered end-to-end: `BaseMcpSuite.ListTools()` drives the real
server → `tools/list` path, and `pkg/mcp/mcp_tools_test.go` asserts real tools
register through that same `AddTool` call (`TestEnabledTools` even pins an exact
count). A silently no-op'd `AddTool` would fail those tests.

`ToolsGoSdkSuite` is intentionally scoped to the conversion + panic-safety of
`ServerToolToGoSdkTool`; pulling the full session harness in here just to re-assert
registration would duplicate existing coverage. Hence the panic-focused assertion,
which is exactly the regression this guard exists to prevent.

## Testing

- `go build ./...` — clean
- `gofmt -l` / `go vet ./pkg/mcp/` — clean
- `go test ./pkg/mcp/ -run TestToolsGoSdkSuite` — 9 subtests pass
- Confirmed the new regression test fails with the guard removed and passes when restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
