### PR TITLE
feat(kubevirt): add HCO awareness using MCP tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,29 @@ local-env-setup-kubevirt: ## Setup complete local development environment with K
 	@echo "KubeVirt is now available!"
 	@echo "Check status with: make kubevirt-status"
 
+.PHONY: local-env-setup-hco
+local-env-setup-hco: ## Setup complete local development environment with Kind cluster and HCO
+	@echo "========================================="
+	@echo "Kubernetes MCP Server - Local Setup"
+	@echo "            with HCO"
+	@echo "========================================="
+	$(MAKE) kind-create-cluster
+	$(MAKE) hco-install
+	$(MAKE) build
+	@echo ""
+	@echo "========================================="
+	@echo "Local environment ready!"
+	@echo "========================================="
+	@echo ""
+	@echo "Run the MCP server with:"
+	@echo "  ./$(BINARY_NAME)"
+	@echo ""
+	@echo "Or run with MCP inspector:"
+	@echo "  npx @modelcontextprotocol/inspector@latest \$$(pwd)/$(BINARY_NAME)"
+	@echo ""
+	@echo "HCO is now available!"
+	@echo "Check status with: make hco-status"
+
 .PHONY: local-env-setup-tekton
 local-env-setup-tekton: ## Setup complete local development environment with Kind cluster and Tekton Pipelines
 	@echo "========================================="

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,29 @@ local-env-setup-kubevirt: ## Setup complete local development environment with M
 	@echo "KubeVirt is now available!"
 	@echo "Check status with: make kubevirt-status"
 
+.PHONY: local-env-setup-hco
+local-env-setup-hco: ## Setup complete local development environment with Kind cluster and HCO
+	@echo "========================================="
+	@echo "Kubernetes MCP Server - Local Setup"
+	@echo "            with HCO"
+	@echo "========================================="
+	$(MAKE) kind-create-cluster
+	$(MAKE) hco-install
+	$(MAKE) build
+	@echo ""
+	@echo "========================================="
+	@echo "Local environment ready!"
+	@echo "========================================="
+	@echo ""
+	@echo "Run the MCP server with:"
+	@echo "  ./$(BINARY_NAME)"
+	@echo ""
+	@echo "Or run with MCP inspector:"
+	@echo "  npx @modelcontextprotocol/inspector@latest \$$(pwd)/$(BINARY_NAME)"
+	@echo ""
+	@echo "HCO is now available!"
+	@echo "Check status with: make hco-status"
+
 .PHONY: local-env-setup-tekton
 local-env-setup-tekton: ## Setup complete local development environment with Minikube cluster and Tekton Pipelines
 	@echo "========================================="

--- a/README.md
+++ b/README.md
@@ -888,6 +888,8 @@ Examples:
   - `windowsVersion` (`string`) - Windows version: 10, 11, 2k22 (default), or 2k25
   - `pipelineVersion` (`string`) - Pipeline version (default: latest). Use specific version like 0.25.0 if needed
 
+- **hco-status** - Generate a status report for the HyperConverged Cluster Operator (HCO) managing KubeVirt and related components
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -876,6 +876,8 @@ Examples:
   - `windowsVersion` (`string`) - Windows version: 10, 11, 2k22 (default), or 2k25
   - `pipelineVersion` (`string`) - Pipeline version (default: latest). Use specific version like 0.25.0 if needed
 
+- **hco-status** - Generate a status report for the HyperConverged Cluster Operator (HCO) managing KubeVirt and related components
+
 </details>
 
 <details>

--- a/build/hco.mk
+++ b/build/hco.mk
@@ -1,0 +1,191 @@
+# HyperConverged Cluster Operator (HCO) installation and management
+#
+# Mirrors the official deploy flow from:
+#   https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/hack/deploy.sh
+#
+# HCO deploys and manages KubeVirt, CDI, Cluster Network Addons, and other
+# components as a single operator. This is an ALTERNATIVE to the standalone
+# KubeVirt install (kubevirt-install) — do not use both together.
+
+# HCO version configuration
+HCO_VERSION ?= v1.18.1
+HCO_NAMESPACE = kubevirt-hyperconverged
+HCO_RAW_URL = https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/$(HCO_VERSION)/deploy
+HCO_ARCHIVE_URL = https://github.com/kubevirt/hyperconverged-cluster-operator/archive/refs/tags/$(HCO_VERSION).tar.gz
+HCO_CRDS = $(eval HCO_CRDS := $(shell curl -sL $(HCO_ARCHIVE_URL) | tar -tz | grep '/deploy/crds/.*\.crd\.yaml$$' | sed 's#.*/##'))$(HCO_CRDS)
+HCO_CRD_NAME = hyperconvergeds.hco.kubevirt.io
+
+# cert-manager configuration
+CERT_MANAGER_VERSION ?= v1.18.2
+CERT_MANAGER_TIMEOUT ?= 120s
+
+##@ HCO (HyperConverged Cluster Operator)
+
+.PHONY: cert-manager-install
+cert-manager-install: ## Install cert-manager (required by HCO webhooks)
+	@if kubectl get namespace cert-manager > /dev/null 2>&1 && \
+		kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager --timeout=5s > /dev/null 2>&1; then \
+		echo "✅ cert-manager is already installed and running, skipping installation"; \
+	else \
+		echo "========================================="; \
+		echo "Installing cert-manager $(CERT_MANAGER_VERSION)"; \
+		echo "========================================="; \
+		echo ""; \
+		kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml; \
+		echo ""; \
+		echo "Waiting for cert-manager deployments to become ready..."; \
+		kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager --timeout=$(CERT_MANAGER_TIMEOUT); \
+		kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-cainjector --timeout=$(CERT_MANAGER_TIMEOUT); \
+		kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=$(CERT_MANAGER_TIMEOUT); \
+		echo ""; \
+		echo "Waiting for cert-manager webhook CA bundle to become valid..."; \
+		for i in $$(seq 1 60); do \
+			if kubectl get validatingwebhookconfigurations cert-manager-webhook -o jsonpath='{.webhooks[0].clientConfig.caBundle}' 2>/dev/null | base64 -d | openssl x509 -noout 2>/dev/null; then \
+				echo "cert-manager webhook CA bundle is valid"; \
+				break; \
+			fi; \
+			if [ $$i -eq 60 ]; then \
+				echo "Warning: cert-manager webhook CA bundle still not valid after 60 attempts"; \
+			fi; \
+			sleep 1; \
+		done; \
+		echo "✅ cert-manager $(CERT_MANAGER_VERSION) is ready"; \
+	fi
+
+.PHONY: cert-manager-uninstall
+cert-manager-uninstall: ## Uninstall cert-manager
+	@echo "Uninstalling cert-manager..."
+	@kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml --ignore-not-found 2>/dev/null || true
+	@echo "✅ cert-manager uninstalled"
+
+.PHONY: hco-install
+hco-install: cert-manager-install ## Install HCO on the cluster (manages KubeVirt, CDI, network addons)
+	@echo ""
+	@echo "========================================="
+	@echo "Installing HCO $(HCO_VERSION)"
+	@echo "========================================="
+	@echo ""
+	@echo "Creating namespace..."
+	@kubectl create namespace $(HCO_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	@echo ""
+	@echo "Installing HCO CRDs..."
+	@for crd in $(HCO_CRDS); do \
+		kubectl apply --server-side -f $(HCO_RAW_URL)/crds/$${crd}; \
+	done
+	@echo ""
+	@echo "Waiting for CRDs to become established..."
+	@for crd in $(HCO_CRDS); do \
+		kubectl wait --for=condition=Established crd/$$(basename $${crd} .crd.yaml) --timeout=60s 2>/dev/null || true; \
+	done
+	@if [ "$$(kubectl get crd $(HCO_CRD_NAME) -o=jsonpath='{.status.conditions[?(@.type=="NonStructuralSchema")].status}' 2>/dev/null)" = "True" ]; then \
+		echo "Warning: HCO CRD reports NonStructuralSchema condition"; \
+		kubectl get crd $(HCO_CRD_NAME) -o go-template='{{ range .status.conditions }}{{ .type }}{{ "\t" }}{{ .status }}{{ "\t" }}{{ .message }}{{ "\n" }}{{ end }}'; \
+	fi
+	@echo ""
+	@echo "Installing HCO RBAC..."
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/cluster_role.yaml
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/service_account.yaml
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/cluster_role_binding.yaml
+	@echo ""
+	@echo "Installing HCO webhooks..."
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/webhooks.yaml
+	@echo ""
+	@echo "Installing HCO operator (excluding OpenShift-only components)..."
+	@kubectl apply -n $(HCO_NAMESPACE) -l 'name!=ssp-operator,name!=hyperconverged-cluster-cli-download' -f $(HCO_RAW_URL)/operator.yaml
+	@echo ""
+	@echo "Enabling software emulation for Kind (no hardware virtualization)..."
+	@kubectl set env deployment/hyperconverged-cluster-operator -n $(HCO_NAMESPACE) KVM_EMULATION=true
+	@echo ""
+	@echo "Waiting for HCO operator to become ready..."
+	@kubectl wait deployment/hyperconverged-cluster-operator -n $(HCO_NAMESPACE) --for=condition=Available --timeout=10m
+	@echo "✅ HCO operator is ready"
+	@echo ""
+	@echo "Waiting for HCO webhook to become ready..."
+	@kubectl wait deployment/hyperconverged-cluster-webhook -n $(HCO_NAMESPACE) --for=condition=Available --timeout=5m
+	@echo "✅ HCO webhook is ready"
+	@echo ""
+	@echo "Waiting for sub-operators to become ready..."
+	@kubectl wait deployment/cdi-operator -n $(HCO_NAMESPACE) --for=condition=Available --timeout=9m
+	@kubectl wait deployment/cluster-network-addons-operator -n $(HCO_NAMESPACE) --for=condition=Available --timeout=9m
+	@kubectl wait deployment/kubevirt-migration-operator -n $(HCO_NAMESPACE) --for=condition=Available --timeout=9m 2>/dev/null || true
+	@echo "✅ Sub-operators are ready"
+	@echo ""
+	@echo "Creating HyperConverged CR..."
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/hco.cr.yaml
+	@echo ""
+	@echo "Waiting for HCO to become available (this can take several minutes)..."
+	@kubectl wait hyperconverged kubevirt-hyperconverged -n $(HCO_NAMESPACE) --for condition=Available --timeout=30m
+	@echo "✅ HCO is ready"
+	@echo ""
+	@echo "Waiting for component deployments..."
+	@kubectl wait deployment/cdi-apiserver -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@kubectl wait deployment/cdi-deployment -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@kubectl wait deployment/cdi-uploadproxy -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@kubectl wait deployment/virt-api -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@kubectl wait deployment/virt-controller -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@echo "✅ All component deployments are ready"
+	@echo ""
+	@echo "========================================="
+	@echo "HCO Installation Complete"
+	@echo "========================================="
+	@echo ""
+	@echo "HCO version: $(HCO_VERSION)"
+	@echo "Namespace: $(HCO_NAMESPACE)"
+	@echo ""
+	@echo "Managed components:"
+	@echo "  - KubeVirt"
+	@echo "  - CDI (Containerized Data Importer)"
+	@echo "  - Cluster Network Addons"
+	@echo ""
+	@echo "Verify installation with:"
+	@echo "  make hco-status"
+	@echo ""
+
+.PHONY: hco-uninstall
+hco-uninstall: ## Uninstall HCO and all managed components from the cluster
+	@echo "Uninstalling HCO..."
+	@kubectl delete hyperconverged kubevirt-hyperconverged -n $(HCO_NAMESPACE) --ignore-not-found --timeout=5m
+	@kubectl delete -n $(HCO_NAMESPACE) -l 'name!=ssp-operator,name!=hyperconverged-cluster-cli-download' -f $(HCO_RAW_URL)/operator.yaml --ignore-not-found 2>/dev/null || true
+	@kubectl delete -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/webhooks.yaml --ignore-not-found 2>/dev/null || true
+	@kubectl delete -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/cluster_role_binding.yaml --ignore-not-found 2>/dev/null || true
+	@kubectl delete -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/service_account.yaml --ignore-not-found 2>/dev/null || true
+	@kubectl delete -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/cluster_role.yaml --ignore-not-found 2>/dev/null || true
+	@for crd in $(HCO_CRDS); do \
+		kubectl delete -f $(HCO_RAW_URL)/crds/$${crd} --ignore-not-found 2>/dev/null || true; \
+	done
+	@kubectl delete namespace $(HCO_NAMESPACE) --ignore-not-found || true
+	@echo "✅ HCO uninstalled"
+
+.PHONY: hco-status
+hco-status: ## Show HCO and managed component status
+	@echo "========================================="
+	@echo "HCO Status"
+	@echo "========================================="
+	@echo ""
+	@echo "HyperConverged CR:"
+	@kubectl get hyperconverged -n $(HCO_NAMESPACE) -o wide || echo "HCO not installed"
+	@echo ""
+	@echo "HyperConverged Conditions:"
+	@kubectl get hyperconverged kubevirt-hyperconverged -n $(HCO_NAMESPACE) -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}' 2>/dev/null || echo "HCO not installed"
+	@echo ""
+	@echo "KubeVirt (managed by HCO):"
+	@kubectl get kubevirt -A -o wide 2>/dev/null || echo "KubeVirt not found"
+	@echo ""
+	@echo "CDI (managed by HCO):"
+	@kubectl get cdi -o wide 2>/dev/null || echo "CDI not found"
+	@echo ""
+	@echo "Network Addons (managed by HCO):"
+	@kubectl get networkaddonsconfig -o wide 2>/dev/null || echo "Network Addons not found"
+	@echo ""
+	@echo "HCO Operator Pods:"
+	@kubectl get pods -n $(HCO_NAMESPACE) -l name=hyperconverged-cluster-operator
+	@echo ""
+	@echo "KubeVirt Pods:"
+	@kubectl get pods -n $(HCO_NAMESPACE) -l kubevirt.io 2>/dev/null || echo "No KubeVirt pods found"
+	@echo ""
+	@echo "CDI Pods:"
+	@kubectl get pods -n $(HCO_NAMESPACE) -l cdi.kubevirt.io 2>/dev/null || echo "No CDI pods found"
+	@echo ""
+	@echo "Component Versions:"
+	@kubectl get hyperconverged kubevirt-hyperconverged -n $(HCO_NAMESPACE) -o jsonpath='{range .status.versions[*]}  {.name}: {.version}{"\n"}{end}' 2>/dev/null || echo "  N/A"
+	@echo ""

--- a/build/hco.mk
+++ b/build/hco.mk
@@ -1,0 +1,191 @@
+# HyperConverged Cluster Operator (HCO) installation and management
+#
+# Mirrors the official deploy flow from:
+#   https://github.com/kubevirt/hyperconverged-cluster-operator/blob/main/hack/deploy.sh
+#
+# HCO deploys and manages KubeVirt, CDI, Cluster Network Addons, and other
+# components as a single operator. This is an ALTERNATIVE to the standalone
+# KubeVirt install (kubevirt-install) — do not use both together.
+
+# HCO version configuration
+HCO_VERSION ?= v1.18.1
+HCO_NAMESPACE = kubevirt-hyperconverged
+HCO_RAW_URL = https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/$(HCO_VERSION)/deploy
+HCO_API_URL = https://api.github.com/repos/kubevirt/hyperconverged-cluster-operator/contents/deploy/crds?ref=$(HCO_VERSION)
+HCO_CRDS = $(eval HCO_CRDS := $(shell curl -sL $(HCO_API_URL) | grep -o '"name": *"[^"]*\.crd\.yaml"' | sed 's/"name": *"//;s/"//'))$(HCO_CRDS)
+HCO_CRD_NAME = hyperconvergeds.hco.kubevirt.io
+
+# cert-manager configuration
+CERT_MANAGER_VERSION ?= v1.18.2
+CERT_MANAGER_TIMEOUT ?= 120s
+
+##@ HCO (HyperConverged Cluster Operator)
+
+.PHONY: cert-manager-install
+cert-manager-install: ## Install cert-manager (required by HCO webhooks)
+	@if kubectl get namespace cert-manager > /dev/null 2>&1 && \
+		kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager --timeout=5s > /dev/null 2>&1; then \
+		echo "✅ cert-manager is already installed and running, skipping installation"; \
+	else \
+		echo "========================================="; \
+		echo "Installing cert-manager $(CERT_MANAGER_VERSION)"; \
+		echo "========================================="; \
+		echo ""; \
+		kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml; \
+		echo ""; \
+		echo "Waiting for cert-manager deployments to become ready..."; \
+		kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager --timeout=$(CERT_MANAGER_TIMEOUT); \
+		kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-cainjector --timeout=$(CERT_MANAGER_TIMEOUT); \
+		kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=$(CERT_MANAGER_TIMEOUT); \
+		echo ""; \
+		echo "Waiting for cert-manager webhook CA bundle to become valid..."; \
+		for i in $$(seq 1 60); do \
+			if kubectl get validatingwebhookconfigurations cert-manager-webhook -o jsonpath='{.webhooks[0].clientConfig.caBundle}' 2>/dev/null | base64 -d | openssl x509 -noout 2>/dev/null; then \
+				echo "cert-manager webhook CA bundle is valid"; \
+				break; \
+			fi; \
+			if [ $$i -eq 60 ]; then \
+				echo "Warning: cert-manager webhook CA bundle still not valid after 60 attempts"; \
+			fi; \
+			sleep 1; \
+		done; \
+		echo "✅ cert-manager $(CERT_MANAGER_VERSION) is ready"; \
+	fi
+
+.PHONY: cert-manager-uninstall
+cert-manager-uninstall: ## Uninstall cert-manager
+	@echo "Uninstalling cert-manager..."
+	@kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml --ignore-not-found 2>/dev/null || true
+	@echo "✅ cert-manager uninstalled"
+
+.PHONY: hco-install
+hco-install: cert-manager-install ## Install HCO on the cluster (manages KubeVirt, CDI, network addons)
+	@echo ""
+	@echo "========================================="
+	@echo "Installing HCO $(HCO_VERSION)"
+	@echo "========================================="
+	@echo ""
+	@echo "Creating namespace..."
+	@kubectl create namespace $(HCO_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	@echo ""
+	@echo "Installing HCO CRDs..."
+	@for crd in $(HCO_CRDS); do \
+		kubectl apply --server-side -f $(HCO_RAW_URL)/crds/$${crd}; \
+	done
+	@echo ""
+	@echo "Waiting for CRDs to become established..."
+	@for crd in $(HCO_CRDS); do \
+		kubectl wait --for=condition=Established crd/$$(basename $${crd} .crd.yaml) --timeout=60s 2>/dev/null || true; \
+	done
+	@if [ "$$(kubectl get crd $(HCO_CRD_NAME) -o=jsonpath='{.status.conditions[?(@.type=="NonStructuralSchema")].status}' 2>/dev/null)" = "True" ]; then \
+		echo "Warning: HCO CRD reports NonStructuralSchema condition"; \
+		kubectl get crd $(HCO_CRD_NAME) -o go-template='{{ range .status.conditions }}{{ .type }}{{ "\t" }}{{ .status }}{{ "\t" }}{{ .message }}{{ "\n" }}{{ end }}'; \
+	fi
+	@echo ""
+	@echo "Installing HCO RBAC..."
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/cluster_role.yaml
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/service_account.yaml
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/cluster_role_binding.yaml
+	@echo ""
+	@echo "Installing HCO webhooks..."
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/webhooks.yaml
+	@echo ""
+	@echo "Installing HCO operator (excluding OpenShift-only components)..."
+	@kubectl apply -n $(HCO_NAMESPACE) -l 'name!=ssp-operator,name!=hyperconverged-cluster-cli-download' -f $(HCO_RAW_URL)/operator.yaml
+	@echo ""
+	@echo "Enabling software emulation for Kind (no hardware virtualization)..."
+	@kubectl set env deployment/hyperconverged-cluster-operator -n $(HCO_NAMESPACE) KVM_EMULATION=true
+	@echo ""
+	@echo "Waiting for HCO operator to become ready..."
+	@kubectl wait deployment/hyperconverged-cluster-operator -n $(HCO_NAMESPACE) --for=condition=Available --timeout=10m
+	@echo "✅ HCO operator is ready"
+	@echo ""
+	@echo "Waiting for HCO webhook to become ready..."
+	@kubectl wait deployment/hyperconverged-cluster-webhook -n $(HCO_NAMESPACE) --for=condition=Available --timeout=5m
+	@echo "✅ HCO webhook is ready"
+	@echo ""
+	@echo "Waiting for sub-operators to become ready..."
+	@kubectl wait deployment/cdi-operator -n $(HCO_NAMESPACE) --for=condition=Available --timeout=9m
+	@kubectl wait deployment/cluster-network-addons-operator -n $(HCO_NAMESPACE) --for=condition=Available --timeout=9m
+	@kubectl wait deployment/kubevirt-migration-operator -n $(HCO_NAMESPACE) --for=condition=Available --timeout=9m 2>/dev/null || true
+	@echo "✅ Sub-operators are ready"
+	@echo ""
+	@echo "Creating HyperConverged CR..."
+	@kubectl apply -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/hco.cr.yaml
+	@echo ""
+	@echo "Waiting for HCO to become available (this can take several minutes)..."
+	@kubectl wait hyperconverged kubevirt-hyperconverged -n $(HCO_NAMESPACE) --for condition=Available --timeout=30m
+	@echo "✅ HCO is ready"
+	@echo ""
+	@echo "Waiting for component deployments..."
+	@kubectl wait deployment/cdi-apiserver -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@kubectl wait deployment/cdi-deployment -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@kubectl wait deployment/cdi-uploadproxy -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@kubectl wait deployment/virt-api -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@kubectl wait deployment/virt-controller -n $(HCO_NAMESPACE) --for=condition=Available --timeout=6m
+	@echo "✅ All component deployments are ready"
+	@echo ""
+	@echo "========================================="
+	@echo "HCO Installation Complete"
+	@echo "========================================="
+	@echo ""
+	@echo "HCO version: $(HCO_VERSION)"
+	@echo "Namespace: $(HCO_NAMESPACE)"
+	@echo ""
+	@echo "Managed components:"
+	@echo "  - KubeVirt"
+	@echo "  - CDI (Containerized Data Importer)"
+	@echo "  - Cluster Network Addons"
+	@echo ""
+	@echo "Verify installation with:"
+	@echo "  make hco-status"
+	@echo ""
+
+.PHONY: hco-uninstall
+hco-uninstall: ## Uninstall HCO and all managed components from the cluster
+	@echo "Uninstalling HCO..."
+	@kubectl delete hyperconverged kubevirt-hyperconverged -n $(HCO_NAMESPACE) --ignore-not-found --timeout=5m
+	@kubectl delete -n $(HCO_NAMESPACE) -l 'name!=ssp-operator,name!=hyperconverged-cluster-cli-download' -f $(HCO_RAW_URL)/operator.yaml --ignore-not-found 2>/dev/null || true
+	@kubectl delete -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/webhooks.yaml --ignore-not-found 2>/dev/null || true
+	@kubectl delete -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/cluster_role_binding.yaml --ignore-not-found 2>/dev/null || true
+	@kubectl delete -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/service_account.yaml --ignore-not-found 2>/dev/null || true
+	@kubectl delete -n $(HCO_NAMESPACE) -f $(HCO_RAW_URL)/cluster_role.yaml --ignore-not-found 2>/dev/null || true
+	@for crd in $(HCO_CRDS); do \
+		kubectl delete -f $(HCO_RAW_URL)/crds/$${crd} --ignore-not-found 2>/dev/null || true; \
+	done
+	@kubectl delete namespace $(HCO_NAMESPACE) --ignore-not-found || true
+	@echo "✅ HCO uninstalled"
+
+.PHONY: hco-status
+hco-status: ## Show HCO and managed component status
+	@echo "========================================="
+	@echo "HCO Status"
+	@echo "========================================="
+	@echo ""
+	@echo "HyperConverged CR:"
+	@kubectl get hyperconverged -n $(HCO_NAMESPACE) -o wide || echo "HCO not installed"
+	@echo ""
+	@echo "HyperConverged Conditions:"
+	@kubectl get hyperconverged kubevirt-hyperconverged -n $(HCO_NAMESPACE) -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}' 2>/dev/null || echo "HCO not installed"
+	@echo ""
+	@echo "KubeVirt (managed by HCO):"
+	@kubectl get kubevirt -A -o wide 2>/dev/null || echo "KubeVirt not found"
+	@echo ""
+	@echo "CDI (managed by HCO):"
+	@kubectl get cdi -o wide 2>/dev/null || echo "CDI not found"
+	@echo ""
+	@echo "Network Addons (managed by HCO):"
+	@kubectl get networkaddonsconfig -o wide 2>/dev/null || echo "Network Addons not found"
+	@echo ""
+	@echo "HCO Operator Pods:"
+	@kubectl get pods -n $(HCO_NAMESPACE) -l name=hyperconverged-cluster-operator
+	@echo ""
+	@echo "KubeVirt Pods:"
+	@kubectl get pods -n $(HCO_NAMESPACE) -l kubevirt.io 2>/dev/null || echo "No KubeVirt pods found"
+	@echo ""
+	@echo "CDI Pods:"
+	@kubectl get pods -n $(HCO_NAMESPACE) -l cdi.kubevirt.io 2>/dev/null || echo "No CDI pods found"
+	@echo ""
+	@echo "Component Versions:"
+	@kubectl get hyperconverged kubevirt-hyperconverged -n $(HCO_NAMESPACE) -o jsonpath='{range .status.versions[*]}  {.name}: {.version}{"\n"}{end}' 2>/dev/null || echo "  N/A"
+	@echo ""

--- a/evals/tasks/kubevirt/README.md
+++ b/evals/tasks/kubevirt/README.md
@@ -58,6 +58,44 @@ KubeVirt-focused MCP tasks live here. Each folder under this directory represent
   - **Prompt:** *There is a VirtualMachine named "broken-vm" in the vm-test namespace that is not working correctly. Please use the vm-troubleshoot prompt to diagnose the issue with this VirtualMachine. Follow the troubleshooting guide and report your findings, including the root cause and recommended action.*
   - **Tests:** Agent's ability to use MCP prompts for guided troubleshooting workflows
 
+### HCO (HyperConverged Cluster Operator)
+
+These tasks evaluate the agent's ability to work with the HyperConverged Cluster Operator, which manages KubeVirt, CDI, and other components as a single operator. They test whether the agent can discover and use appropriate tools and prompts to diagnose and report on HCO state.
+
+**Prerequisites:** HCO must be deployed — use `make local-env-setup-hco` to set up a Kind cluster with HCO.
+
+- **[easy] hco-get-status** - Retrieve and interpret the HyperConverged CR status and conditions
+  - **Prompt:** *Describe the current status of HCO and whether the cluster is healthy.*
+  - **Tests:** Can the agent retrieve and interpret HCO conditions?
+
+- **[easy] hco-check-version** - Determine the installed HCO version and managed component versions
+  - **Prompt:** *What version of HCO is installed, and what versions of its managed components are running?*
+  - **Tests:** Can the agent extract version info from the HCO CR status?
+
+- **[easy] hco-get-feature-gates** - List the feature gates configured in the HyperConverged CR
+  - **Prompt:** *What feature gates are configured in HCO, and which ones are currently enabled?*
+  - **Tests:** Can the agent navigate the HCO spec structure to find feature gate configuration?
+
+- **[medium] hco-check-component-health** - Check health of individual HCO-managed components
+  - **Prompt:** *Check the health of each component managed by HCO and report any issues.*
+  - **Tests:** Can the agent correlate HCO with individual component CRs?
+
+- **[medium] hco-get-live-migration-config** - Retrieve and explain the live migration configuration
+  - **Prompt:** *What are the current live migration settings in HCO? Report each setting, explain what it controls, and whether the value is custom or default.*
+  - **Tests:** Can the agent find and interpret the liveMigrationConfig section?
+
+- **[medium] hco-list-managed-components** - List all components managed by HCO with their status
+  - **Prompt:** *List all components managed by HCO, their versions, and whether each one is healthy.*
+  - **Tests:** Can the agent discover the relationship between HCO and its managed operators?
+
+- **[medium] hco-status-prompt** - Generate a full HCO status report and interpret the results
+  - **Prompt:** *Generate a comprehensive status report for the HyperConverged Cluster Operator. Summarize the overall health of HCO (conditions), the status of each managed component (KubeVirt, CDI, Network Addons), and any warnings or non-default configuration.*
+  - **Tests:** Can the agent discover and use the HCO status prompt to produce and interpret a status report?
+
+- **[hard] hco-diagnose-degraded** - Diagnose why HCO is reporting an unusual condition
+  - **Prompt:** *HCO seems to be reporting an unusual condition. Investigate the issue, determine the root cause, and recommend remediation steps.*
+  - **Tests:** Can the agent correlate HCO conditions with underlying component states to diagnose issues?
+
 ## Helper Scripts
 
 Some verification steps rely on helper scripts located in `helpers/`:

--- a/evals/tasks/kubevirt/hco-check-component-health/task.yaml
+++ b/evals/tasks/kubevirt/hco-check-component-health/task.yaml
@@ -1,0 +1,39 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-check-component-health"
+  difficulty: medium
+  description: "Check health of individual components managed by HCO (KubeVirt, CDI, Network Addons)"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          if ! kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          kubectl wait hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged --for condition=Available --timeout=60s 2>/dev/null || { echo "✗ HyperConverged is not Available"; exit 1; }
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "KubeVirt"
+    - llmJudge:
+        contains: "CDI"
+  prompt:
+    inline: |-
+      Check the health of each component managed by HCO. For each one, report whether its
+      CR exists, its current conditions, and the component version.

--- a/evals/tasks/kubevirt/hco-check-component-health/task.yaml
+++ b/evals/tasks/kubevirt/hco-check-component-health/task.yaml
@@ -1,0 +1,45 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-check-component-health"
+  difficulty: medium
+  description: "Check health of individual components managed by HCO (KubeVirt, CDI, Network Addons)"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          # Discover the HCO namespace/name so the eval works on both Kind
+          # (kubevirt-hyperconverged) and OpenShift (openshift-cnv).
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=60s 2>/dev/null || { echo "✗ HyperConverged is not Available"; exit 1; }
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "KubeVirt"
+    - llmJudge:
+        contains: "CDI"
+  prompt:
+    inline: |-
+      Check the health of each component managed by HCO. For each one, report whether its
+      CR exists, its current conditions, and the component version.

--- a/evals/tasks/kubevirt/hco-check-version/task.yaml
+++ b/evals/tasks/kubevirt/hco-check-version/task.yaml
@@ -1,0 +1,55 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-check-version"
+  difficulty: easy
+  description: "Determine the installed HCO version and the versions of components it manages"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          # Discover the HCO namespace/name so the eval works on both Kind
+          # (kubevirt-hyperconverged) and OpenShift (openshift-cnv).
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          # The HyperConverged status only reports the operator version (this holds on
+          # both Kind/HCO and OpenShift/HCO v1). Component versions are reported on the
+          # component CRs themselves, so query the KubeVirt CR directly for its version.
+          OPERATOR_VERSION=$(kubectl get hyperconverged "$HCO_NAME" -n "$NS" \
+              -o jsonpath='{.status.versions[?(@.name=="operator")].version}' 2>/dev/null)
+          [[ -n "$OPERATOR_VERSION" ]] || { echo "✗ Could not determine HCO operator version"; exit 1; }
+          echo "✓ HCO operator version: $OPERATOR_VERSION"
+          KUBEVIRT_VERSION=$(kubectl get kubevirt -n "$NS" \
+              -o jsonpath='{.items[0].status.observedKubeVirtVersion}' 2>/dev/null || true)
+          if [[ -n "$KUBEVIRT_VERSION" ]]; then
+              echo "✓ KubeVirt version: $KUBEVIRT_VERSION"
+          else
+              echo "! KubeVirt version not reported by the KubeVirt CR (informational)"
+          fi
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "operator"
+  prompt:
+    inline: |-
+      What version of HCO is installed, and what versions of its managed components are running?

--- a/evals/tasks/kubevirt/hco-check-version/task.yaml
+++ b/evals/tasks/kubevirt/hco-check-version/task.yaml
@@ -1,0 +1,43 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-check-version"
+  difficulty: easy
+  description: "Determine the installed HCO version and the versions of components it manages"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          if ! kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          OPERATOR_VERSION=$(kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged \
+              -o jsonpath='{.status.versions[?(@.name=="operator")].version}' 2>/dev/null)
+          [[ -n "$OPERATOR_VERSION" ]] || { echo "✗ Could not determine HCO operator version"; exit 1; }
+          echo "✓ HCO operator version: $OPERATOR_VERSION"
+          KUBEVIRT_VERSION=$(kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged \
+              -o jsonpath='{.status.versions[?(@.name=="kubevirt")].version}' 2>/dev/null)
+          [[ -n "$KUBEVIRT_VERSION" ]] || { echo "✗ Could not determine KubeVirt version"; exit 1; }
+          echo "✓ KubeVirt version: $KUBEVIRT_VERSION"
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "operator"
+  prompt:
+    inline: |-
+      What version of HCO is installed, and what versions of its managed components are running?

--- a/evals/tasks/kubevirt/hco-diagnose-degraded/task.yaml
+++ b/evals/tasks/kubevirt/hco-diagnose-degraded/task.yaml
@@ -1,0 +1,82 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-diagnose-degraded"
+  difficulty: hard
+  description: "Diagnose why HCO is reporting an issue by correlating conditions across managed components"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          # Discover the HCO namespace/name so the eval works on both Kind
+          # (kubevirt-hyperconverged) and OpenShift (openshift-cnv).
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+
+          echo "Injecting bad infra nodePlacements to trigger degraded state..."
+          kubectl patch hco "$HCO_NAME" -n "$NS" --type merge \
+              -p '{"spec":{"deployment":{"nodePlacements":{"infra":{"nodeSelector":{"non-existent-node/test":"true"}}}}}}'
+
+          sleep 15
+
+          echo "Forcing infra pod rescheduling..."
+          kubectl delete pods -n "$NS" -l kubevirt.io=virt-api 2>/dev/null || true
+          kubectl delete pods -n "$NS" -l kubevirt.io=virt-controller 2>/dev/null || true
+
+          echo "Waiting for HCO to report degraded state..."
+          for i in $(seq 1 36); do
+              CONDITIONS=$(kubectl get hyperconverged "$HCO_NAME" -n "$NS" \
+                  -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}' 2>/dev/null)
+              if echo "$CONDITIONS" | grep -q "Degraded=True" || \
+                 echo "$CONDITIONS" | grep -q "Available=False"; then
+                  echo "HCO is now in a degraded state"
+                  exit 0
+              fi
+              sleep 5
+          done
+
+          echo "Warning: timed out waiting for degraded state, continuing anyway"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          kubectl get hyperconverged "$HCO_NAME" -n "$NS" \
+              -o jsonpath='{.status.conditions}' > /dev/null 2>&1 \
+              || { echo "✗ HyperConverged CR not found"; exit 1; }
+          echo "✓ HCO is accessible for investigation"
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "non-existent-node"
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+
+          kubectl patch hco "$HCO_NAME" -n "$NS" --type merge \
+              -p '{"spec":{"deployment":{"nodePlacements":{"infra":null}}}}' 2>/dev/null || true
+
+          echo "Waiting for HCO to recover..."
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=300s 2>/dev/null || true
+          echo "Degraded scenario cleaned up"
+  prompt:
+    inline: |-
+      HCO seems to be reporting an unusual condition. Investigate the issue, determine the
+      root cause, and recommend remediation steps.

--- a/evals/tasks/kubevirt/hco-diagnose-degraded/task.yaml
+++ b/evals/tasks/kubevirt/hco-diagnose-degraded/task.yaml
@@ -1,0 +1,63 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-diagnose-degraded"
+  difficulty: hard
+  description: "Diagnose why HCO is reporting an issue by correlating conditions across managed components"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS="kubevirt-hyperconverged"
+          HCO_NAME="kubevirt-hyperconverged"
+
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+
+          # Set an elevated log verbosity for virtLauncher using the supported HCO API
+          # (spec.deployment.logVerbosityConfig) instead of the emergency-only jsonpatch annotation.
+          echo "Setting elevated virtLauncher log verbosity via HCO API..."
+          kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type merge -p \
+              '{"spec":{"deployment":{"logVerbosityConfig":{"kubevirt":{"virtLauncher":5}}}}}'
+
+          echo "Waiting for HCO to reconcile..."
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=60s
+          echo "Log verbosity scenario configured"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          echo "✓ HCO is accessible for investigation"
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "logVerbosity"
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS="kubevirt-hyperconverged"
+          HCO_NAME="kubevirt-hyperconverged"
+
+          # Remove the logVerbosityConfig using the HCO API (merge patch with null)
+          kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type merge \
+              -p '{"spec":{"deployment":{"logVerbosityConfig":null}}}' 2>/dev/null || true
+
+          echo "Waiting for HCO to reconcile..."
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=120s 2>/dev/null || true
+          echo "Log verbosity scenario cleaned up"
+  prompt:
+    inline: |-
+      HCO seems to be reporting an unusual condition. Investigate the issue, determine the
+      root cause, and recommend remediation steps.

--- a/evals/tasks/kubevirt/hco-get-feature-gates/task.yaml
+++ b/evals/tasks/kubevirt/hco-get-feature-gates/task.yaml
@@ -1,0 +1,78 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-get-feature-gates"
+  difficulty: easy
+  description: "List the feature gates configured in the HyperConverged CR"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          # Discover the HCO namespace/name so the eval works on both Kind
+          # (kubevirt-hyperconverged) and OpenShift (openshift-cnv).
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+
+          echo "Enabling deployKubeSecondaryDNS feature gate..."
+          if [[ $(kubectl get hyperconverged "$HCO_NAME" -n "$NS" -o jsonpath='{.spec.featureGates}') != "" ]]; then
+            kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=json \
+                -p '[{"op":"add","path":"/spec/featureGates/-","value":{"name":"deployKubeSecondaryDNS"}}]'
+          else
+            # featureGates is nil — create the array with our entry
+            kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=json \
+                -p '[{"op":"add","path":"/spec/featureGates","value":[{"name":"deployKubeSecondaryDNS"}]}]'
+          fi
+
+          echo "Waiting for HCO to reconcile..."
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=120s
+          echo "Feature gate configured"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          ACTUAL=$(kubectl get hyperconverged "$HCO_NAME" -n "$NS" \
+              -o jsonpath='{.spec.featureGates[?(@.name=="deployKubeSecondaryDNS")].name}' 2>/dev/null)
+          [[ "$ACTUAL" == "deployKubeSecondaryDNS" ]] || { echo "✗ Feature gate 'deployKubeSecondaryDNS' not found"; exit 1; }
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "deployKubeSecondaryDNS"
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+
+          # Remove only the feature gate we added, finding its index dynamically
+          # so we don't disturb pre-existing gates at other positions.
+          IDX=$(kubectl get hyperconverged "$HCO_NAME" -n "$NS" \
+              -o jsonpath='{range .spec.featureGates[*]}{.name}{"\n"}{end}' 2>/dev/null \
+              | grep -n '^deployKubeSecondaryDNS$' | head -1 | cut -d: -f1)
+          if [ -n "$IDX" ]; then
+            IDX=$((IDX - 1))
+            kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=json \
+                -p "[{\"op\":\"test\",\"path\":\"/spec/featureGates/$IDX/name\",\"value\":\"deployKubeSecondaryDNS\"},{\"op\":\"remove\",\"path\":\"/spec/featureGates/$IDX\"}]" 2>/dev/null || true
+          fi
+
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=120s 2>/dev/null || true
+          echo "Feature gate reverted"
+  prompt:
+    inline: |-
+      What feature gates are configured in HCO? List them with their current values and
+      identify which ones are enabled.

--- a/evals/tasks/kubevirt/hco-get-feature-gates/task.yaml
+++ b/evals/tasks/kubevirt/hco-get-feature-gates/task.yaml
@@ -1,0 +1,74 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-get-feature-gates"
+  difficulty: easy
+  description: "List the feature gates configured in the HyperConverged CR"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS="kubevirt-hyperconverged"
+          HCO_NAME="kubevirt-hyperconverged"
+
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+
+          echo "Enabling deployKubeSecondaryDNS feature gate..."
+          if [[ $(kubectl get hyperconverged "$HCO_NAME" -n "$NS" -o jsonpath='{.spec.featureGates}') != "" ]]; then
+            kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=json \
+                -p '[{"op":"add","path":"/spec/featureGates/-","value":{"name":"deployKubeSecondaryDNS"}}]'
+          else
+            # featureGates is nil — create the array with our entry
+            kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=json \
+                -p '[{"op":"add","path":"/spec/featureGates","value":[{"name":"deployKubeSecondaryDNS"}]}]'
+          fi
+
+          echo "Waiting for HCO to reconcile..."
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=120s
+          echo "Feature gate configured"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          ACTUAL=$(kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged \
+              -o jsonpath='{.spec.featureGates[?(@.name=="deployKubeSecondaryDNS")].name}' 2>/dev/null)
+          [[ "$ACTUAL" == "deployKubeSecondaryDNS" ]] || { echo "✗ Feature gate 'deployKubeSecondaryDNS' not found"; exit 1; }
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "deployKubeSecondaryDNS"
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS="kubevirt-hyperconverged"
+          HCO_NAME="kubevirt-hyperconverged"
+
+          # Remove only the feature gate we added, finding its index dynamically
+          # so we don't disturb pre-existing gates at other positions.
+          IDX=$(kubectl get hyperconverged "$HCO_NAME" -n "$NS" \
+              -o jsonpath='{range .spec.featureGates[*]}{.name}{"\n"}{end}' 2>/dev/null \
+              | grep -n '^deployKubeSecondaryDNS$' | head -1 | cut -d: -f1)
+          if [ -n "$IDX" ]; then
+            IDX=$((IDX - 1))
+            kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=json \
+                -p "[{\"op\":\"test\",\"path\":\"/spec/featureGates/$IDX/name\",\"value\":\"deployKubeSecondaryDNS\"},{\"op\":\"remove\",\"path\":\"/spec/featureGates/$IDX\"}]" 2>/dev/null || true
+          fi
+
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=120s 2>/dev/null || true
+          echo "Feature gate reverted"
+  prompt:
+    inline: |-
+      What feature gates are configured in HCO? List them with their current values and
+      identify which ones are enabled.

--- a/evals/tasks/kubevirt/hco-get-live-migration-config/task.yaml
+++ b/evals/tasks/kubevirt/hco-get-live-migration-config/task.yaml
@@ -1,0 +1,69 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-get-live-migration-config"
+  difficulty: medium
+  description: "Retrieve and explain the live migration configuration from HCO"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          # Discover the HCO namespace/name so the eval works on both Kind
+          # (kubevirt-hyperconverged) and OpenShift (openshift-cnv).
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+
+          # Configure specific live migration settings
+          echo "Setting custom live migration configuration..."
+          kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=merge \
+              -p '{"spec":{"virtualization":{"liveMigrationConfig":{"bandwidthPerMigration":"128Mi","completionTimeoutPerGiB":300,"parallelMigrationsPerCluster":3,"parallelOutboundMigrationsPerNode":1,"progressTimeout":300}}}}'
+
+          echo "Waiting for HCO to reconcile..."
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=120s
+          echo "Live migration configuration updated"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          BANDWIDTH=$(kubectl get hyperconverged "$HCO_NAME" -n "$NS" \
+              -o jsonpath='{.spec.virtualization.liveMigrationConfig.bandwidthPerMigration}' 2>/dev/null)
+          [[ "$BANDWIDTH" == "128Mi" ]] || { echo "✗ Expected bandwidthPerMigration '128Mi', got '$BANDWIDTH'"; exit 1; }
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "128Mi"
+    - llmJudge:
+        contains: "completionTimeoutPerGiB"
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+
+          # Remove the custom liveMigrationConfig so HCO reverts to its built-in defaults
+          kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=merge \
+              -p '{"spec":{"virtualization":{"liveMigrationConfig":null}}}' 2>/dev/null || true
+
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=120s 2>/dev/null || true
+          echo "Live migration configuration reverted"
+  prompt:
+    inline: |-
+      What are the current live migration settings in HCO? Report each setting, explain what
+      it controls, and whether the value is custom or default.

--- a/evals/tasks/kubevirt/hco-get-live-migration-config/task.yaml
+++ b/evals/tasks/kubevirt/hco-get-live-migration-config/task.yaml
@@ -1,0 +1,65 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-get-live-migration-config"
+  difficulty: medium
+  description: "Retrieve and explain the live migration configuration from HCO"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS="kubevirt-hyperconverged"
+          HCO_NAME="kubevirt-hyperconverged"
+
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+
+          # Configure specific live migration settings
+          echo "Setting custom live migration configuration..."
+          kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=merge \
+              -p '{"spec":{"virtualization":{"liveMigrationConfig":{"bandwidthPerMigration":"128Mi","completionTimeoutPerGiB":300,"parallelMigrationsPerCluster":3,"parallelOutboundMigrationsPerNode":1,"progressTimeout":300}}}}'
+
+          echo "Waiting for HCO to reconcile..."
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=120s
+          echo "Live migration configuration updated"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          BANDWIDTH=$(kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged \
+              -o jsonpath='{.spec.virtualization.liveMigrationConfig.bandwidthPerMigration}' 2>/dev/null)
+          [[ "$BANDWIDTH" == "128Mi" ]] || { echo "✗ Expected bandwidthPerMigration '128Mi', got '$BANDWIDTH'"; exit 1; }
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "128Mi"
+    - llmJudge:
+        contains: "completionTimeoutPerGiB"
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS="kubevirt-hyperconverged"
+          HCO_NAME="kubevirt-hyperconverged"
+
+          # Remove the custom liveMigrationConfig so HCO reverts to its built-in defaults
+          kubectl patch hyperconverged "$HCO_NAME" -n "$NS" --type=merge \
+              -p '{"spec":{"virtualization":{"liveMigrationConfig":null}}}' 2>/dev/null || true
+
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=120s 2>/dev/null || true
+          echo "Live migration configuration reverted"
+  prompt:
+    inline: |-
+      What are the current live migration settings in HCO? Report each setting, explain what
+      it controls, and whether the value is custom or default.

--- a/evals/tasks/kubevirt/hco-get-status/task.yaml
+++ b/evals/tasks/kubevirt/hco-get-status/task.yaml
@@ -1,0 +1,44 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-get-status"
+  difficulty: easy
+  description: "Retrieve and interpret the HyperConverged CR status and conditions"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          # Verify HCO is deployed and available before running the eval
+          if ! kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          ACTUAL=$(kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged \
+              -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)
+          [[ "$ACTUAL" == "True" ]] || { echo "✗ Available condition is '$ACTUAL', expected 'True'"; exit 1; }
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "Available"
+    - llmJudge:
+        contains: "Progressing"
+    - llmJudge:
+        contains: "Degraded"
+  prompt:
+    inline: |-
+      Describe the status of HCO. Report the current conditions (Available, Progressing, Degraded),
+      whether the cluster is healthy, and any conditions that indicate problems.

--- a/evals/tasks/kubevirt/hco-get-status/task.yaml
+++ b/evals/tasks/kubevirt/hco-get-status/task.yaml
@@ -1,0 +1,50 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-get-status"
+  difficulty: easy
+  description: "Retrieve and interpret the HyperConverged CR status and conditions"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          # Verify HCO is deployed and available before running the eval.
+          # Discover the HCO namespace/name so the eval works on both Kind
+          # (kubevirt-hyperconverged) and OpenShift (openshift-cnv).
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          ACTUAL=$(kubectl get hyperconverged "$HCO_NAME" -n "$NS" \
+              -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)
+          [[ "$ACTUAL" == "True" ]] || { echo "✗ Available condition is '$ACTUAL', expected 'True'"; exit 1; }
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "Available"
+    - llmJudge:
+        contains: "Progressing"
+    - llmJudge:
+        contains: "Degraded"
+  prompt:
+    inline: |-
+      Describe the status of HCO. Report the current conditions (Available, Progressing, Degraded),
+      whether the cluster is healthy, and any conditions that indicate problems.

--- a/evals/tasks/kubevirt/hco-list-managed-components/task.yaml
+++ b/evals/tasks/kubevirt/hco-list-managed-components/task.yaml
@@ -1,0 +1,42 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-list-managed-components"
+  difficulty: medium
+  description: "List all components managed by HCO and their individual status and versions"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          if ! kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          kubectl wait hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged --for condition=Available --timeout=60s 2>/dev/null || { echo "✗ HyperConverged is not Available"; exit 1; }
+          VERSIONS=$(kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged \
+              -o jsonpath='{.status.versions}' 2>/dev/null)
+          [[ -n "$VERSIONS" ]] || { echo "✗ No version information found in HCO status"; exit 1; }
+          echo "✓ HCO status contains version information"
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "KubeVirt"
+    - llmJudge:
+        contains: "CDI"
+  prompt:
+    inline: |-
+      List all components managed by HCO, their versions, and whether each one is healthy.

--- a/evals/tasks/kubevirt/hco-list-managed-components/task.yaml
+++ b/evals/tasks/kubevirt/hco-list-managed-components/task.yaml
@@ -1,0 +1,48 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-list-managed-components"
+  difficulty: medium
+  description: "List all components managed by HCO and their individual status and versions"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          # Discover the HCO namespace/name so the eval works on both Kind
+          # (kubevirt-hyperconverged) and OpenShift (openshift-cnv).
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=60s 2>/dev/null || { echo "✗ HyperConverged is not Available"; exit 1; }
+          VERSIONS=$(kubectl get hyperconverged "$HCO_NAME" -n "$NS" \
+              -o jsonpath='{.status.versions}' 2>/dev/null)
+          [[ -n "$VERSIONS" ]] || { echo "✗ No version information found in HCO status"; exit 1; }
+          echo "✓ HCO status contains version information"
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "KubeVirt"
+    - llmJudge:
+        contains: "CDI"
+  prompt:
+    inline: |-
+      List all components managed by HCO, their versions, and whether each one is healthy.

--- a/evals/tasks/kubevirt/hco-status-prompt/task.yaml
+++ b/evals/tasks/kubevirt/hco-status-prompt/task.yaml
@@ -1,0 +1,51 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-status-prompt"
+  difficulty: medium
+  description: "Generate a full HCO status report and interpret the results"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          # Discover the HCO namespace/name so the eval works on both Kind
+          # (kubevirt-hyperconverged) and OpenShift (openshift-cnv).
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          if ! kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          NS=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          HCO_NAME=$(kubectl get hyperconverged -A -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "kubevirt-hyperconverged")
+          kubectl get hyperconverged "$HCO_NAME" -n "$NS" > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          kubectl wait hyperconverged "$HCO_NAME" -n "$NS" --for condition=Available --timeout=60s 2>/dev/null || { echo "✗ HyperConverged is not Available"; exit 1; }
+          echo "✓ HCO is available"
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "Available"
+    - llmJudge:
+        contains: "KubeVirt"
+    - llmJudge:
+        contains: "CDI"
+  prompt:
+    inline: |-
+      Generate a comprehensive status report for the HyperConverged Cluster Operator.
+      Summarize:
+      - The overall health of HCO (conditions)
+      - The status of each managed component (KubeVirt, CDI, Network Addons)
+      - Any warnings or non-default configuration

--- a/evals/tasks/kubevirt/hco-status-prompt/task.yaml
+++ b/evals/tasks/kubevirt/hco-status-prompt/task.yaml
@@ -1,0 +1,45 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "hco-status-prompt"
+  difficulty: medium
+  description: "Generate a full HCO status report and interpret the results"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          if ! kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1; then
+              echo "HCO is not deployed — skipping eval"
+              exit 1
+          fi
+          echo "HCO is deployed and ready for evaluation"
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          kubectl get hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged > /dev/null 2>&1 || { echo "✗ HyperConverged CR not found"; exit 1; }
+          kubectl wait hyperconverged kubevirt-hyperconverged -n kubevirt-hyperconverged --for condition=Available --timeout=60s 2>/dev/null || { echo "✗ HyperConverged is not Available"; exit 1; }
+          echo "✓ HCO is available"
+          echo "All validations passed"
+          exit 0
+    - llmJudge:
+        contains: "Available"
+    - llmJudge:
+        contains: "KubeVirt"
+    - llmJudge:
+        contains: "CDI"
+  prompt:
+    inline: |-
+      Generate a comprehensive status report for the HyperConverged Cluster Operator.
+      Summarize:
+      - The overall health of HCO (conditions)
+      - The status of each managed component (KubeVirt, CDI, Network Addons)
+      - Any warnings or non-default configuration

--- a/internal/test/envtest.go
+++ b/internal/test/envtest.go
@@ -104,6 +104,11 @@ func EnvTest() *envtest.Environment {
 				CRD("operator.tekton.dev", "v1alpha1", "tektonconfigs", "TektonConfig", "tektonconfig", false),
 				// virt-template
 				CRD("template.kubevirt.io", "v1beta1", "virtualmachinetemplates", "VirtualMachineTemplate", "virtualmachinetemplate", true),
+				// HCO
+				CRD("hco.kubevirt.io", "v1", "hyperconvergeds", "HyperConverged", "hyperconverged", true),
+				CRD("kubevirt.io", "v1", "kubevirts", "KubeVirt", "kubevirt", true),
+				CRD("cdi.kubevirt.io", "v1beta1", "cdis", "CDI", "cdi", false),
+				CRD("networkaddonsoperator.network.kubevirt.io", "v1", "networkaddonsconfigs", "NetworkAddonsConfig", "networkaddonsconfig", false),
 			},
 		}
 

--- a/internal/test/envtest.go
+++ b/internal/test/envtest.go
@@ -102,6 +102,11 @@ func EnvTest() *envtest.Environment {
 				CRD("tekton.dev", "v1", "taskruns", "TaskRun", "taskrun", true),
 				CRD("pipelinesascode.tekton.dev", "v1alpha1", "repositories", "Repository", "repository", true),
 				CRD("operator.tekton.dev", "v1alpha1", "tektonconfigs", "TektonConfig", "tektonconfig", false),
+				// HCO
+				CRD("hco.kubevirt.io", "v1", "hyperconvergeds", "HyperConverged", "hyperconverged", true),
+				CRD("kubevirt.io", "v1", "kubevirts", "KubeVirt", "kubevirt", true),
+				CRD("cdi.kubevirt.io", "v1beta1", "cdis", "CDI", "cdi", false),
+				CRD("networkaddonsoperator.network.kubevirt.io", "v1", "networkaddonsconfigs", "NetworkAddonsConfig", "networkaddonsconfig", false),
 			},
 		}
 

--- a/pkg/kubevirt/gvr.go
+++ b/pkg/kubevirt/gvr.go
@@ -135,6 +135,37 @@ func HasVirtualMachineTemplate(p api.FilteringProvider) func() bool {
 	}
 }
 
+// HCO (HyperConverged Cluster Operator) resources
+var (
+	// HyperConvergedGVR is the GroupVersionResource for HyperConverged resources
+	HyperConvergedGVR = schema.GroupVersionResource{
+		Group:    "hco.kubevirt.io",
+		Version:  "v1",
+		Resource: "hyperconvergeds",
+	}
+
+	// KubeVirtCRGVR is the GroupVersionResource for KubeVirt operator CR resources
+	KubeVirtCRGVR = schema.GroupVersionResource{
+		Group:    "kubevirt.io",
+		Version:  "v1",
+		Resource: "kubevirts",
+	}
+
+	// CDIGVR is the GroupVersionResource for CDI operator CR resources
+	CDIGVR = schema.GroupVersionResource{
+		Group:    "cdi.kubevirt.io",
+		Version:  "v1beta1",
+		Resource: "cdis",
+	}
+
+	// NetworkAddonsConfigGVR is the GroupVersionResource for NetworkAddonsConfig resources
+	NetworkAddonsConfigGVR = schema.GroupVersionResource{
+		Group:    "networkaddonsoperator.network.kubevirt.io",
+		Version:  "v1",
+		Resource: "networkaddonsconfigs",
+	}
+)
+
 // HasVirtualMachine returns a TargetCompatibilityFilter that checks whether any
 // target cluster has the VirtualMachine GVK registered.
 func HasVirtualMachine(p api.FilteringProvider) func() bool {

--- a/pkg/kubevirt/gvr.go
+++ b/pkg/kubevirt/gvr.go
@@ -103,6 +103,37 @@ var (
 	}
 )
 
+// HCO (HyperConverged Cluster Operator) resources
+var (
+	// HyperConvergedGVR is the GroupVersionResource for HyperConverged resources
+	HyperConvergedGVR = schema.GroupVersionResource{
+		Group:    "hco.kubevirt.io",
+		Version:  "v1",
+		Resource: "hyperconvergeds",
+	}
+
+	// KubeVirtCRGVR is the GroupVersionResource for KubeVirt operator CR resources
+	KubeVirtCRGVR = schema.GroupVersionResource{
+		Group:    "kubevirt.io",
+		Version:  "v1",
+		Resource: "kubevirts",
+	}
+
+	// CDIGVR is the GroupVersionResource for CDI operator CR resources
+	CDIGVR = schema.GroupVersionResource{
+		Group:    "cdi.kubevirt.io",
+		Version:  "v1beta1",
+		Resource: "cdis",
+	}
+
+	// NetworkAddonsConfigGVR is the GroupVersionResource for NetworkAddonsConfig resources
+	NetworkAddonsConfigGVR = schema.GroupVersionResource{
+		Group:    "networkaddonsoperator.network.kubevirt.io",
+		Version:  "v1",
+		Resource: "networkaddonsconfigs",
+	}
+)
+
 // HasVirtualMachine returns a TargetCompatibilityFilter that checks whether any
 // target cluster has the VirtualMachine GVK registered.
 func HasVirtualMachine(p api.FilteringProvider) func() bool {

--- a/pkg/mcp/kubevirt_test.go
+++ b/pkg/mcp/kubevirt_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
+	kubevirtgvr "github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
 	kubevirttesting "github.com/containers/kubernetes-mcp-server/pkg/kubevirt/testing"
 	kubevirttoolset "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -31,6 +32,10 @@ var kubevirtApis = []schema.GroupVersionResource{
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachineclusterpreferences"},
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinepreferences"},
 	{Group: "template.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinetemplates"},
+	{Group: "hco.kubevirt.io", Version: "v1", Resource: "hyperconvergeds"},
+	{Group: "kubevirt.io", Version: "v1", Resource: "kubevirts"},
+	{Group: "cdi.kubevirt.io", Version: "v1beta1", Resource: "cdis"},
+	{Group: "networkaddonsoperator.network.kubevirt.io", Version: "v1", Resource: "networkaddonsconfigs"},
 }
 
 type KubevirtSuite struct {
@@ -46,9 +51,11 @@ func (s *KubevirtSuite) SetupSuite() {
 	}
 	s.Require().NoError(tasks.Wait())
 
-	_, err := kubernetes.NewForConfigOrDie(test.EnvTestRestConfig()).CoreV1().Namespaces().
-		Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-virtualization-os-images"}}, metav1.CreateOptions{})
+	nsClient := kubernetes.NewForConfigOrDie(test.EnvTestRestConfig()).CoreV1().Namespaces()
+	_, err := nsClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-virtualization-os-images"}}, metav1.CreateOptions{})
 	s.Require().NoError(err, "failed to create test namespace openshift-virtualization-os-images")
+	_, err = nsClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kubevirt-hyperconverged"}}, metav1.CreateOptions{})
+	s.Require().NoError(err, "failed to create test namespace kubevirt-hyperconverged")
 }
 
 func (s *KubevirtSuite) TearDownSuite() {
@@ -1296,6 +1303,77 @@ func (s *KubevirtSuite) TestCreateFromTemplate() {
 		s.Nilf(err, "call tool failed %v", err)
 		s.Truef(toolResult.IsError, "expected call tool to fail for invalid parameter types")
 		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "must be a string")
+	})
+}
+
+func (s *KubevirtSuite) TestHCOStatusPrompt() {
+	s.Run("hco-status prompt returns report when no HCO CR exists", func() {
+		result, err := s.GetPrompt("hco-status", map[string]string{})
+
+		s.Run("returns error for missing HCO", func() {
+			s.Error(err, "expected error when HCO is not installed")
+			s.Nil(result)
+			s.Contains(err.Error(), "not installed")
+		})
+	})
+
+	s.Run("hco-status prompt returns report with HCO CR present", func() {
+		dynamicClient := dynamic.NewForConfigOrDie(test.EnvTestRestConfig())
+		ctx := s.T().Context()
+
+		// Create a HyperConverged CR
+		hcoCR := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "hco.kubevirt.io/v1",
+				"kind":       "HyperConverged",
+				"metadata": map[string]any{
+					"name":      "kubevirt-hyperconverged",
+					"namespace": "kubevirt-hyperconverged",
+				},
+				"spec": map[string]any{
+					"featureGates": []any{
+						map[string]string{
+							"name":  "downwardMetrics",
+							"state": "Disabled",
+						},
+					},
+					"virtualization": map[string]any{
+						"liveMigrationConfig": map[string]any{
+							"completionTimeoutPerGiB":           int64(150),
+							"parallelMigrationsPerCluster":      int64(5),
+							"parallelOutboundMigrationsPerNode": int64(2),
+							"progressTimeout":                   int64(150),
+						},
+					},
+				},
+			},
+		}
+
+		_, err := dynamicClient.Resource(kubevirtgvr.HyperConvergedGVR).Namespace("kubevirt-hyperconverged").Create(ctx, hcoCR, metav1.CreateOptions{})
+		s.Require().NoError(err, "failed to create HyperConverged CR")
+
+		defer func() {
+			_ = dynamicClient.Resource(kubevirtgvr.HyperConvergedGVR).Namespace("kubevirt-hyperconverged").Delete(ctx, "kubevirt-hyperconverged", metav1.DeleteOptions{})
+		}()
+
+		result, err := s.GetPrompt("hco-status", map[string]string{})
+
+		s.Run("no error", func() {
+			s.NoError(err, "GetPrompt failed")
+			s.NotNil(result)
+		})
+
+		s.Run("returns status report with correct details", func() {
+			s.Require().NotNil(result)
+			s.Require().Len(result.Messages, 2, "Expected 2 messages")
+
+			textContent, ok := result.Messages[0].Content.(*mcp.TextContent)
+			s.Require().True(ok, "expected TextContent")
+			s.Contains(textContent.Text, "HyperConverged Cluster Operator Status Report")
+			s.Contains(textContent.Text, "kubevirt-hyperconverged")
+			s.Contains(textContent.Text, "Feature Gates")
+			s.Contains(textContent.Text, "Virtualization Configuration")
+		})
 	})
 }
 

--- a/pkg/mcp/kubevirt_test.go
+++ b/pkg/mcp/kubevirt_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
+	kubevirtgvr "github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
 	kubevirttesting "github.com/containers/kubernetes-mcp-server/pkg/kubevirt/testing"
 	kubevirttoolset "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -30,6 +31,10 @@ var kubevirtApis = []schema.GroupVersionResource{
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachineinstancetypes"},
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachineclusterpreferences"},
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinepreferences"},
+	{Group: "hco.kubevirt.io", Version: "v1", Resource: "hyperconvergeds"},
+	{Group: "kubevirt.io", Version: "v1", Resource: "kubevirts"},
+	{Group: "cdi.kubevirt.io", Version: "v1beta1", Resource: "cdis"},
+	{Group: "networkaddonsoperator.network.kubevirt.io", Version: "v1", Resource: "networkaddonsconfigs"},
 }
 
 type KubevirtSuite struct {
@@ -45,9 +50,11 @@ func (s *KubevirtSuite) SetupSuite() {
 	}
 	s.Require().NoError(tasks.Wait())
 
-	_, err := kubernetes.NewForConfigOrDie(test.EnvTestRestConfig()).CoreV1().Namespaces().
-		Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-virtualization-os-images"}}, metav1.CreateOptions{})
+	nsClient := kubernetes.NewForConfigOrDie(test.EnvTestRestConfig()).CoreV1().Namespaces()
+	_, err := nsClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-virtualization-os-images"}}, metav1.CreateOptions{})
 	s.Require().NoError(err, "failed to create test namespace openshift-virtualization-os-images")
+	_, err = nsClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kubevirt-hyperconverged"}}, metav1.CreateOptions{})
+	s.Require().NoError(err, "failed to create test namespace kubevirt-hyperconverged")
 }
 
 func (s *KubevirtSuite) TearDownSuite() {
@@ -1040,6 +1047,77 @@ func (s *KubevirtSuite) TestVMGuestInfo() {
 			Version:  "v1",
 			Resource: "virtualmachineinstances",
 		}).Namespace("default").Delete(s.T().Context(), "default-info-vm", metav1.DeleteOptions{})
+	})
+}
+
+func (s *KubevirtSuite) TestHCOStatusPrompt() {
+	s.Run("hco-status prompt returns report when no HCO CR exists", func() {
+		result, err := s.GetPrompt("hco-status", map[string]string{})
+
+		s.Run("returns error for missing HCO", func() {
+			s.Error(err, "expected error when HCO is not installed")
+			s.Nil(result)
+			s.Contains(err.Error(), "not installed")
+		})
+	})
+
+	s.Run("hco-status prompt returns report with HCO CR present", func() {
+		dynamicClient := dynamic.NewForConfigOrDie(test.EnvTestRestConfig())
+		ctx := s.T().Context()
+
+		// Create a HyperConverged CR
+		hcoCR := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "hco.kubevirt.io/v1",
+				"kind":       "HyperConverged",
+				"metadata": map[string]any{
+					"name":      "kubevirt-hyperconverged",
+					"namespace": "kubevirt-hyperconverged",
+				},
+				"spec": map[string]any{
+					"featureGates": []any{
+						map[string]string{
+							"name":  "downwardMetrics",
+							"state": "Disabled",
+						},
+					},
+					"virtualization": map[string]any{
+						"liveMigrationConfig": map[string]any{
+							"completionTimeoutPerGiB":           int64(150),
+							"parallelMigrationsPerCluster":      int64(5),
+							"parallelOutboundMigrationsPerNode": int64(2),
+							"progressTimeout":                   int64(150),
+						},
+					},
+				},
+			},
+		}
+
+		_, err := dynamicClient.Resource(kubevirtgvr.HyperConvergedGVR).Namespace("kubevirt-hyperconverged").Create(ctx, hcoCR, metav1.CreateOptions{})
+		s.Require().NoError(err, "failed to create HyperConverged CR")
+
+		defer func() {
+			_ = dynamicClient.Resource(kubevirtgvr.HyperConvergedGVR).Namespace("kubevirt-hyperconverged").Delete(ctx, "kubevirt-hyperconverged", metav1.DeleteOptions{})
+		}()
+
+		result, err := s.GetPrompt("hco-status", map[string]string{})
+
+		s.Run("no error", func() {
+			s.NoError(err, "GetPrompt failed")
+			s.NotNil(result)
+		})
+
+		s.Run("returns status report with correct details", func() {
+			s.Require().NotNil(result)
+			s.Require().Len(result.Messages, 2, "Expected 2 messages")
+
+			textContent, ok := result.Messages[0].Content.(*mcp.TextContent)
+			s.Require().True(ok, "expected TextContent")
+			s.Contains(textContent.Text, "HyperConverged Cluster Operator Status Report")
+			s.Contains(textContent.Text, "kubevirt-hyperconverged")
+			s.Contains(textContent.Text, "Feature Gates")
+			s.Contains(textContent.Text, "Virtualization Configuration")
+		})
 	})
 }
 

--- a/pkg/toolsets/kubevirt/hco_status.go
+++ b/pkg/toolsets/kubevirt/hco_status.go
@@ -1,0 +1,301 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
+)
+
+func initHCOStatus() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "hco-status",
+				Title:       fmt.Sprintf("%s HyperConverged Status", defaults.ProductName()),
+				Description: fmt.Sprintf("Generate a status report for the HyperConverged Cluster Operator (HCO) managing %s and related components", defaults.ProductName()),
+			},
+			Handler: hcoStatusHandler,
+		},
+	}
+}
+
+func hcoStatusHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	ctx := params.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	dynamicClient := params.DynamicClient()
+
+	hco, namespace, err := discoverHyperConvergedCR(ctx, dynamicClient)
+	if err != nil {
+		return nil, err
+	}
+
+	hcoStatusYaml := fetchHCOConditionsAndVersions(hco)
+	hcoConfigYaml := fetchHCOConfiguration(hco)
+	componentsYaml := fetchManagedComponentStatus(ctx, dynamicClient, namespace)
+	eventsYaml := fetchHCOEvents(ctx, params.KubernetesClient, namespace)
+
+	reportText := fmt.Sprintf(`# %s HyperConverged Cluster Operator Status Report
+
+## HCO: %s (namespace: %s)
+
+Use this report to understand the current state of the HyperConverged Cluster Operator and all components it manages.
+
+---
+
+## Step 1: HCO Conditions and Versions
+
+Check the HCO conditions:
+- **Available** should be True — the operator and all components are running
+- **Progressing** should be False — no reconciliation in progress
+- **Degraded** should be False — no component failures
+- **TaintedConfiguration** indicates manual modifications to managed CRs via jsonpatch annotations
+- **Upgradeable** indicates whether the operator can be safely upgraded
+
+%s
+
+---
+
+## Step 2: HCO Configuration
+
+Review the active configuration including feature gates and virtualization settings:
+
+%s
+
+---
+
+## Step 3: Managed Component Status
+
+HCO manages several components. Each should have its own CR with conditions:
+
+%s
+
+---
+
+## Step 4: Events
+
+Review events in the HCO namespace for warnings or errors:
+
+%s
+
+---
+
+## Analysis
+
+Based on the data above, determine:
+
+1. **Overall Health**: Are all HCO conditions healthy (Available=True, Degraded=False)?
+2. **Component Health**: Are all managed components (KubeVirt, CDI, Network Addons) available?
+3. **Configuration**: Are there any non-default feature gates or virtualization settings?
+4. **Warnings**: Are there any Warning events or TaintedConfiguration conditions?
+5. **Versions**: What versions are installed for each component?
+`, defaults.ProductName(), hco.GetName(), namespace, hcoStatusYaml, hcoConfigYaml, componentsYaml, eventsYaml)
+
+	return api.NewPromptCallResult(
+		"HyperConverged status report generated",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: reportText,
+				},
+			},
+			{
+				Role: "assistant",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: "I'll analyze the HyperConverged Cluster Operator status report to assess the overall health and configuration.",
+				},
+			},
+		},
+		nil,
+	), nil
+}
+
+func discoverHyperConvergedCR(ctx context.Context, dynamicClient dynamic.Interface) (*unstructured.Unstructured, string, error) {
+	hcoList, err := dynamicClient.Resource(kubevirt.HyperConvergedGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, "", fmt.Errorf("HyperConverged Cluster Operator is not installed (failed to list HyperConverged resources: %v)", err)
+	}
+
+	if len(hcoList.Items) == 0 {
+		return nil, "", fmt.Errorf("HyperConverged Cluster Operator is not installed (no HyperConverged CR found)")
+	}
+
+	hco := &hcoList.Items[0]
+	return hco, hco.GetNamespace(), nil
+}
+
+func fetchHCOConditionsAndVersions(hco *unstructured.Unstructured) string {
+	var result strings.Builder
+
+	conditions, found, err := unstructured.NestedSlice(hco.Object, "status", "conditions")
+	if err != nil {
+		return fmt.Sprintf("### HCO Conditions\n\n*Error extracting conditions: %v*", err)
+	}
+	if !found || len(conditions) == 0 {
+		result.WriteString("### HCO Conditions\n\n*No conditions found*\n\n")
+	} else {
+		yamlStr, err := output.MarshalYaml(conditions)
+		if err != nil {
+			fmt.Fprintf(&result, "### HCO Conditions\n\n*Error marshaling conditions: %v*\n\n", err)
+		} else {
+			fmt.Fprintf(&result, "### HCO Conditions\n\n```yaml\n%s```\n\n", yamlStr)
+		}
+	}
+
+	versions, found, err := unstructured.NestedSlice(hco.Object, "status", "versions")
+	if err != nil {
+		fmt.Fprintf(&result, "### Component Versions\n\n*Error extracting versions: %v*", err)
+		return result.String()
+	}
+	if !found || len(versions) == 0 {
+		result.WriteString("### Component Versions\n\n*No version information found*")
+		return result.String()
+	}
+
+	yamlStr, err := output.MarshalYaml(versions)
+	if err != nil {
+		fmt.Fprintf(&result, "### Component Versions\n\n*Error marshaling versions: %v*", err)
+	} else {
+		fmt.Fprintf(&result, "### Component Versions\n\n```yaml\n%s```", yamlStr)
+	}
+
+	return result.String()
+}
+
+func fetchHCOConfiguration(hco *unstructured.Unstructured) string {
+	var result strings.Builder
+
+	featureGates, found, err := unstructured.NestedSlice(hco.Object, "spec", "featureGates")
+	if err != nil {
+		fmt.Fprintf(&result, "### Feature Gates\n\n*Error extracting feature gates: %v*\n\n", err)
+	} else if !found || len(featureGates) == 0 {
+		result.WriteString("### Feature Gates\n\n*No feature gates configured*\n\n")
+	} else {
+		yamlStr, err := output.MarshalYaml(featureGates)
+		if err != nil {
+			fmt.Fprintf(&result, "### Feature Gates\n\n*Error marshaling feature gates: %v*\n\n", err)
+		} else {
+			fmt.Fprintf(&result, "### Feature Gates\n\n```yaml\n%s```\n\n", yamlStr)
+		}
+	}
+
+	virtualization, found, err := unstructured.NestedMap(hco.Object, "spec", "virtualization")
+	if err != nil {
+		fmt.Fprintf(&result, "### Virtualization Configuration\n\n*Error extracting virtualization config: %v*", err)
+	} else if !found || len(virtualization) == 0 {
+		result.WriteString("### Virtualization Configuration\n\n*Using default virtualization settings*")
+	} else {
+		yamlStr, err := output.MarshalYaml(virtualization)
+		if err != nil {
+			fmt.Fprintf(&result, "### Virtualization Configuration\n\n*Error marshaling virtualization config: %v*", err)
+		} else {
+			fmt.Fprintf(&result, "### Virtualization Configuration\n\n```yaml\n%s```", yamlStr)
+		}
+	}
+
+	return result.String()
+}
+
+func fetchManagedComponentStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace string) string {
+	var result strings.Builder
+
+	result.WriteString(fetchComponentCR(ctx, dynamicClient, "KubeVirt", kubevirt.KubeVirtCRGVR, namespace))
+	result.WriteString("\n\n")
+	result.WriteString(fetchComponentCR(ctx, dynamicClient, "CDI", kubevirt.CDIGVR, ""))
+	result.WriteString("\n\n")
+	result.WriteString(fetchComponentCR(ctx, dynamicClient, "NetworkAddonsConfig", kubevirt.NetworkAddonsConfigGVR, ""))
+
+	return result.String()
+}
+
+func fetchComponentCR(ctx context.Context, dynamicClient dynamic.Interface, name string, gvr schema.GroupVersionResource, namespace string) string {
+	list, err := dynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		switch {
+		case apierrors.IsForbidden(err):
+			// Access problem, not a component problem — tell the model not to infer health.
+			return fmt.Sprintf("### %s\n\n*Access denied — no RBAC permission to read %s. "+
+				"Component health is unknown (tooling limitation, not a failure).*", name, name)
+		case apierrors.IsNotFound(err):
+			return fmt.Sprintf("### %s\n\n*%s CRD not registered — this component is not installed.*", name, name)
+		default:
+			return fmt.Sprintf("### %s\n\n*Error fetching %s: %v*", name, name, err)
+		}
+	}
+
+	if len(list.Items) == 0 {
+		return fmt.Sprintf("### %s\n\n*%s CR not found*", name, name)
+	}
+
+	cr := &list.Items[0]
+
+	conditions, found, err := unstructured.NestedSlice(cr.Object, "status", "conditions")
+	if err != nil {
+		return fmt.Sprintf("### %s: %s/%s\n\n*Error extracting conditions: %v*", name, cr.GetNamespace(), cr.GetName(), err)
+	}
+	if !found {
+		status, sFound, sErr := unstructured.NestedMap(cr.Object, "status")
+		if sErr != nil {
+			return fmt.Sprintf("### %s: %s/%s\n\n*Error extracting status: %v*", name, cr.GetNamespace(), cr.GetName(), sErr)
+		}
+		if !sFound {
+			return fmt.Sprintf("### %s: %s/%s\n\n*No status available*", name, cr.GetNamespace(), cr.GetName())
+		}
+		yamlStr, err := output.MarshalYaml(status)
+		if err != nil {
+			return fmt.Sprintf("### %s: %s/%s\n\n*Error marshaling status: %v*", name, cr.GetNamespace(), cr.GetName(), err)
+		}
+		return fmt.Sprintf("### %s: %s/%s\n\n```yaml\n%s```", name, cr.GetNamespace(), cr.GetName(), yamlStr)
+	}
+
+	yamlStr, err := output.MarshalYaml(conditions)
+	if err != nil {
+		return fmt.Sprintf("### %s: %s/%s\n\n*Error marshaling conditions: %v*", name, cr.GetNamespace(), cr.GetName(), err)
+	}
+	return fmt.Sprintf("### %s: %s/%s\n\n```yaml\n%s```", name, cr.GetNamespace(), cr.GetName(), yamlStr)
+}
+
+func fetchHCOEvents(ctx context.Context, client api.KubernetesClient, namespace string) string {
+	core := kubernetes.NewCore(client)
+
+	allEvents, err := core.EventsList(ctx, namespace, api.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("### Events\n\n*Error listing events: %v*", err)
+	}
+
+	var warningEvents []map[string]any
+	for _, event := range allEvents {
+		eventType, _ := event["Type"].(string)
+		if eventType == "Warning" {
+			warningEvents = append(warningEvents, event)
+		}
+	}
+
+	if len(warningEvents) == 0 {
+		return "### Events\n\n*No warning events found in the HCO namespace*"
+	}
+
+	yamlStr, err := output.MarshalYaml(warningEvents)
+	if err != nil {
+		return fmt.Sprintf("### Events\n\n*Error marshaling events: %v*", err)
+	}
+
+	return fmt.Sprintf("### Warning Events in %s namespace\n\n```yaml\n%s```", namespace, yamlStr)
+}

--- a/pkg/toolsets/kubevirt/hco_status.go
+++ b/pkg/toolsets/kubevirt/hco_status.go
@@ -1,0 +1,285 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
+)
+
+func initHCOStatus() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "hco-status",
+				Title:       fmt.Sprintf("%s HyperConverged Status", defaults.ProductName()),
+				Description: fmt.Sprintf("Generate a status report for the HyperConverged Cluster Operator (HCO) managing %s and related components", defaults.ProductName()),
+			},
+			Handler: hcoStatusHandler,
+		},
+	}
+}
+
+func hcoStatusHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	ctx := params.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	dynamicClient := params.DynamicClient()
+
+	hco, namespace, err := discoverHyperConvergedCR(ctx, dynamicClient)
+	if err != nil {
+		return nil, err
+	}
+
+	hcoStatusYaml := fetchHCOConditionsAndVersions(hco)
+	hcoConfigYaml := fetchHCOConfiguration(hco)
+	componentsYaml := fetchManagedComponentStatus(ctx, dynamicClient, namespace)
+	eventsYaml := fetchHCOEvents(ctx, params.KubernetesClient, namespace)
+
+	reportText := fmt.Sprintf(`# %s HyperConverged Cluster Operator Status Report
+
+## HCO: %s (namespace: %s)
+
+Use this report to understand the current state of the HyperConverged Cluster Operator and all components it manages.
+
+---
+
+## Step 1: HCO Conditions and Versions
+
+Check the HCO conditions:
+- **Available** should be True — the operator and all components are running
+- **Progressing** should be False — no reconciliation in progress
+- **Degraded** should be False — no component failures
+- **TaintedConfiguration** indicates manual modifications to managed CRs via jsonpatch annotations
+- **Upgradeable** indicates whether the operator can be safely upgraded
+
+%s
+
+---
+
+## Step 2: HCO Configuration
+
+Review the active configuration including feature gates and virtualization settings:
+
+%s
+
+---
+
+## Step 3: Managed Component Status
+
+HCO manages several components. Each should have its own CR with conditions:
+
+%s
+
+---
+
+## Step 4: Events
+
+Review events in the HCO namespace for warnings or errors:
+
+%s
+
+---
+
+## Analysis
+
+Based on the data above, determine:
+
+1. **Overall Health**: Are all HCO conditions healthy (Available=True, Degraded=False)?
+2. **Component Health**: Are all managed components (KubeVirt, CDI, Network Addons) available?
+3. **Configuration**: Are there any non-default feature gates or virtualization settings?
+4. **Warnings**: Are there any Warning events or TaintedConfiguration conditions?
+5. **Versions**: What versions are installed for each component?
+`, defaults.ProductName(), hco.GetName(), namespace, hcoStatusYaml, hcoConfigYaml, componentsYaml, eventsYaml)
+
+	return api.NewPromptCallResult(
+		"HyperConverged status report generated",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: reportText,
+				},
+			},
+			{
+				Role: "assistant",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: "I'll analyze the HyperConverged Cluster Operator status report to assess the overall health and configuration.",
+				},
+			},
+		},
+		nil,
+	), nil
+}
+
+func discoverHyperConvergedCR(ctx context.Context, dynamicClient dynamic.Interface) (*unstructured.Unstructured, string, error) {
+	hcoList, err := dynamicClient.Resource(kubevirt.HyperConvergedGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, "", fmt.Errorf("HyperConverged Cluster Operator is not installed (failed to list HyperConverged resources: %v)", err)
+	}
+
+	if len(hcoList.Items) == 0 {
+		return nil, "", fmt.Errorf("HyperConverged Cluster Operator is not installed (no HyperConverged CR found)")
+	}
+
+	hco := &hcoList.Items[0]
+	return hco, hco.GetNamespace(), nil
+}
+
+func fetchHCOConditionsAndVersions(hco *unstructured.Unstructured) string {
+	var result strings.Builder
+
+	conditions, found, err := unstructured.NestedSlice(hco.Object, "status", "conditions")
+	if err != nil {
+		return fmt.Sprintf("### HCO Conditions\n\n*Error extracting conditions: %v*", err)
+	}
+	if !found || len(conditions) == 0 {
+		result.WriteString("### HCO Conditions\n\n*No conditions found*\n\n")
+	} else {
+		yamlStr, err := output.MarshalYaml(conditions)
+		if err != nil {
+			fmt.Fprintf(&result, "### HCO Conditions\n\n*Error marshaling conditions: %v*\n\n", err)
+		} else {
+			fmt.Fprintf(&result, "### HCO Conditions\n\n```yaml\n%s```\n\n", yamlStr)
+		}
+	}
+
+	versions, found, err := unstructured.NestedSlice(hco.Object, "status", "versions")
+	if err != nil {
+		fmt.Fprintf(&result, "### Component Versions\n\n*Error extracting versions: %v*", err)
+		return result.String()
+	}
+	if !found || len(versions) == 0 {
+		result.WriteString("### Component Versions\n\n*No version information found*")
+		return result.String()
+	}
+
+	yamlStr, err := output.MarshalYaml(versions)
+	if err != nil {
+		fmt.Fprintf(&result, "### Component Versions\n\n*Error marshaling versions: %v*", err)
+	} else {
+		fmt.Fprintf(&result, "### Component Versions\n\n```yaml\n%s```", yamlStr)
+	}
+
+	return result.String()
+}
+
+func fetchHCOConfiguration(hco *unstructured.Unstructured) string {
+	var result strings.Builder
+
+	featureGates, found, err := unstructured.NestedSlice(hco.Object, "spec", "featureGates")
+	if err != nil {
+		fmt.Fprintf(&result, "### Feature Gates\n\n*Error extracting feature gates: %v*\n\n", err)
+	} else if !found || len(featureGates) == 0 {
+		result.WriteString("### Feature Gates\n\n*No feature gates configured*\n\n")
+	} else {
+		yamlStr, err := output.MarshalYaml(featureGates)
+		if err != nil {
+			fmt.Fprintf(&result, "### Feature Gates\n\n*Error marshaling feature gates: %v*\n\n", err)
+		} else {
+			fmt.Fprintf(&result, "### Feature Gates\n\n```yaml\n%s```\n\n", yamlStr)
+		}
+	}
+
+	virtualization, found, err := unstructured.NestedMap(hco.Object, "spec", "virtualization")
+	if err != nil {
+		fmt.Fprintf(&result, "### Virtualization Configuration\n\n*Error extracting virtualization config: %v*", err)
+	} else if !found || len(virtualization) == 0 {
+		result.WriteString("### Virtualization Configuration\n\n*Using default virtualization settings*")
+	} else {
+		yamlStr, err := output.MarshalYaml(virtualization)
+		if err != nil {
+			fmt.Fprintf(&result, "### Virtualization Configuration\n\n*Error marshaling virtualization config: %v*", err)
+		} else {
+			fmt.Fprintf(&result, "### Virtualization Configuration\n\n```yaml\n%s```", yamlStr)
+		}
+	}
+
+	return result.String()
+}
+
+func fetchManagedComponentStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace string) string {
+	var result strings.Builder
+
+	result.WriteString(fetchComponentCR(ctx, dynamicClient, "KubeVirt", kubevirt.KubeVirtCRGVR, namespace))
+	result.WriteString("\n\n")
+	result.WriteString(fetchComponentCR(ctx, dynamicClient, "CDI", kubevirt.CDIGVR, ""))
+	result.WriteString("\n\n")
+	result.WriteString(fetchComponentCR(ctx, dynamicClient, "NetworkAddonsConfig", kubevirt.NetworkAddonsConfigGVR, ""))
+
+	return result.String()
+}
+
+func fetchComponentCR(ctx context.Context, dynamicClient dynamic.Interface, name string, gvr schema.GroupVersionResource, namespace string) string {
+	list, err := dynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("### %s\n\n*Error fetching %s: %v*", name, name, err)
+	}
+
+	if len(list.Items) == 0 {
+		return fmt.Sprintf("### %s\n\n*%s CR not found*", name, name)
+	}
+
+	cr := &list.Items[0]
+
+	conditions, found, err := unstructured.NestedSlice(cr.Object, "status", "conditions")
+	if err != nil || !found {
+		status, sFound, sErr := unstructured.NestedMap(cr.Object, "status")
+		if sErr != nil || !sFound {
+			return fmt.Sprintf("### %s: %s/%s\n\n*No status available*", name, cr.GetNamespace(), cr.GetName())
+		}
+		yamlStr, err := output.MarshalYaml(status)
+		if err != nil {
+			return fmt.Sprintf("### %s: %s/%s\n\n*Error marshaling status: %v*", name, cr.GetNamespace(), cr.GetName(), err)
+		}
+		return fmt.Sprintf("### %s: %s/%s\n\n```yaml\n%s```", name, cr.GetNamespace(), cr.GetName(), yamlStr)
+	}
+
+	yamlStr, err := output.MarshalYaml(conditions)
+	if err != nil {
+		return fmt.Sprintf("### %s: %s/%s\n\n*Error marshaling conditions: %v*", name, cr.GetNamespace(), cr.GetName(), err)
+	}
+	return fmt.Sprintf("### %s: %s/%s\n\n```yaml\n%s```", name, cr.GetNamespace(), cr.GetName(), yamlStr)
+}
+
+func fetchHCOEvents(ctx context.Context, client api.KubernetesClient, namespace string) string {
+	core := kubernetes.NewCore(client)
+
+	allEvents, err := core.EventsList(ctx, namespace, api.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("### Events\n\n*Error listing events: %v*", err)
+	}
+
+	var warningEvents []map[string]any
+	for _, event := range allEvents {
+		eventType, _ := event["Type"].(string)
+		if eventType == "Warning" {
+			warningEvents = append(warningEvents, event)
+		}
+	}
+
+	if len(warningEvents) == 0 {
+		return "### Events\n\n*No warning events found in the HCO namespace*"
+	}
+
+	yamlStr, err := output.MarshalYaml(warningEvents)
+	if err != nil {
+		return fmt.Sprintf("### Events\n\n*Error marshaling events: %v*", err)
+	}
+
+	return fmt.Sprintf("### Warning Events in %s namespace\n\n```yaml\n%s```", namespace, yamlStr)
+}

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -37,6 +37,7 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return slices.Concat(
 		initVMTroubleshoot(),
 		initWindowsGoldenImage(),
+		initHCOStatus(),
 	)
 }
 

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -41,6 +41,7 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 	return slices.Concat(
 		initVMTroubleshoot(),
 		initWindowsGoldenImage(),
+		initHCOStatus(),
 	)
 }
 


### PR DESCRIPTION
Add HyperConverged Cluster Operator (HCO) support to the KubeVirt toolset. The hco-status MCP prompt auto-discovers the HyperConverged CR and reports on conditions, component health, configuration, and events.

Includes build/hco.mk for deploying HCO on Kind clusters and eval tasks that exercise HCO workflows to identify gaps in current tooling.