### PR TITLE
refactor(auth): finish STS reload follow-ups from #1110

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -73,6 +73,12 @@ type StsConfigProvider interface {
 	GetStsClientCertFile() string
 	GetStsClientKeyFile() string
 	GetStsFederatedTokenFile() string
+}
+
+// CertificateAuthorityProvider provides access to the top-level certificate_authority
+// TLS setting. It is a general OAuth/TLS option (also consumed by pkg/oauth) rather
+// than an STS-specific one, so it is kept separate from StsConfigProvider.
+type CertificateAuthorityProvider interface {
 	GetCertificateAuthority() string
 }
 
@@ -98,6 +104,7 @@ type BaseConfig interface {
 	DeniedResourcesProvider
 	ExtendedConfigProvider
 	StsConfigProvider
+	CertificateAuthorityProvider
 	ValidationEnabledProvider
 	RequireTLSProvider
 	RequireOAuthProvider

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -46,6 +46,11 @@ func (p *tokenExchangingProvider) GetDerivedKubernetes(ctx context.Context, targ
 	}
 	baseConfig := p.baseConfig()
 	if baseConfig == nil {
+		// Defensive only: production wiring always supplies a non-nil config
+		// (NewProvider defaults the provider to return cfg, and the cmd path
+		// passes cfgState.Load(), which is non-nil by the StaticConfigState
+		// invariant). If a caller ever omits it, fall back to the wrapped
+		// provider rather than panicking; token exchange is simply skipped.
 		return p.provider.GetDerivedKubernetes(ctx, target)
 	}
 	stsConfig := p.getOrBuildStsConfig(ctx, snap, baseConfig)
@@ -120,6 +125,11 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 		return nil
 	}
 
+	// Release the previous client's idle connections before swapping in the
+	// rebuilt config so they don't linger until garbage collection.
+	if p.stsConfig != nil {
+		p.stsConfig.CloseIdleConnections()
+	}
 	p.stsConfig = cfg
 	p.stsConfigKey = key
 	return p.stsConfig

--- a/pkg/kubernetes/provider_token_exchange_test.go
+++ b/pkg/kubernetes/provider_token_exchange_test.go
@@ -2,10 +2,15 @@ package kubernetes
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -30,7 +35,20 @@ type observedTokenRequest struct {
 
 type exchangeTestOIDCServer struct {
 	server   *httptest.Server
+	mu       sync.Mutex
 	requests []observedTokenRequest
+}
+
+func (a *exchangeTestOIDCServer) record(req observedTokenRequest) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.requests = append(a.requests, req)
+}
+
+func (a *exchangeTestOIDCServer) recordedRequests() []observedTokenRequest {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]observedTokenRequest(nil), a.requests...)
 }
 
 type fakeDerivedProvider struct{}
@@ -81,23 +99,46 @@ func (s *TokenExchangingProviderSuite) TestGetDerivedKubernetes() {
 		_, err = wrapped.GetDerivedKubernetes(ctx, "")
 		s.Require().NoError(err)
 
-		s.Require().Len(authServer.requests, 2)
+		requests := authServer.recordedRequests()
+		s.Require().Len(requests, 2)
 		s.Equal(observedTokenRequest{
 			clientID:     "old-client",
 			clientSecret: "old-secret",
 			audience:     "old-audience",
 			scope:        "old-scope",
-		}, authServer.requests[0])
+		}, requests[0])
 		s.Equal(observedTokenRequest{
 			clientID:     "new-client",
 			clientSecret: "new-secret",
 			audience:     "new-audience",
 			scope:        "new-scope",
-		}, authServer.requests[1])
+		}, requests[1])
 	})
 }
 
 func (s *TokenExchangingProviderSuite) TestGetOrBuildStsConfig() {
+	newProvider := func(cfg *config.StaticConfig) *tokenExchangingProvider {
+		return &tokenExchangingProvider{
+			baseConfigProvider: func() api.BaseConfig {
+				return cfg
+			},
+		}
+	}
+
+	s.Run("reuses the cached config when nothing changes", func() {
+		snap := s.newSnapshot()
+		cfg := config.Default()
+		cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+		cfg.StsClientId = "client"
+		cfg.StsAudience = "audience"
+		p := newProvider(cfg)
+
+		first := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+		s.Require().NotNil(first)
+		second := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+		s.Same(first, second, "unchanged config must reuse the cached struct so assertion caching stays effective")
+	})
+
 	s.Run("rebuilds cached config when STS fields change without token URL change", func() {
 		snap := s.newSnapshot()
 		cfg := config.Default()
@@ -107,12 +148,7 @@ func (s *TokenExchangingProviderSuite) TestGetOrBuildStsConfig() {
 		cfg.StsAudience = "old-audience"
 		cfg.StsScopes = []string{"old-scope"}
 		cfg.CertificateAuthority = "/old-ca.pem"
-
-		p := &tokenExchangingProvider{
-			baseConfigProvider: func() api.BaseConfig {
-				return cfg
-			},
-		}
+		p := newProvider(cfg)
 
 		first := p.getOrBuildStsConfig(context.Background(), snap, cfg)
 		s.Require().NotNil(first)
@@ -133,6 +169,70 @@ func (s *TokenExchangingProviderSuite) TestGetOrBuildStsConfig() {
 		s.Equal([]string{"new-scope"}, second.Scopes)
 		s.Equal("/new-ca.pem", second.CAFile)
 	})
+
+	s.Run("rebuilds when a single rotated field changes", func() {
+		s.Run("sts_auth_style", func() {
+			snap := s.newSnapshot()
+			cfg := config.Default()
+			cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+			cfg.StsClientId = "client"
+			cfg.StsAudience = "audience"
+			cfg.StsAuthStyle = tokenexchange.AuthStyleParams
+			p := newProvider(cfg)
+
+			first := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(first)
+
+			cfg.StsAuthStyle = tokenexchange.AuthStyleHeader
+			second := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(second)
+			s.NotSame(first, second)
+			s.Equal(tokenexchange.AuthStyleHeader, second.AuthStyle)
+		})
+
+		s.Run("sts_client_cert_file and sts_client_key_file", func() {
+			snap := s.newSnapshot()
+			cfg := config.Default()
+			cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+			cfg.StsClientId = "client"
+			cfg.StsAudience = "audience"
+			cfg.StsAuthStyle = tokenexchange.AuthStyleAssertion
+			cfg.StsClientCertFile = "/old-cert.pem"
+			cfg.StsClientKeyFile = "/old-key.pem"
+			p := newProvider(cfg)
+
+			first := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(first)
+
+			cfg.StsClientCertFile = "/new-cert.pem"
+			cfg.StsClientKeyFile = "/new-key.pem"
+			second := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(second)
+			s.NotSame(first, second)
+			s.Equal("/new-cert.pem", second.ClientCertFile)
+			s.Equal("/new-key.pem", second.ClientKeyFile)
+		})
+
+		s.Run("sts_federated_token_file", func() {
+			snap := s.newSnapshot()
+			cfg := config.Default()
+			cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+			cfg.StsClientId = "client"
+			cfg.StsAudience = "audience"
+			cfg.StsAuthStyle = tokenexchange.AuthStyleFederated
+			cfg.StsFederatedTokenFile = "/old-token"
+			p := newProvider(cfg)
+
+			first := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(first)
+
+			cfg.StsFederatedTokenFile = "/new-token"
+			second := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(second)
+			s.NotSame(first, second)
+			s.Equal("/new-token", second.FederatedTokenFile)
+		})
+	})
 }
 
 func (s *TokenExchangingProviderSuite) newExchangeTestOIDCServer() *exchangeTestOIDCServer {
@@ -150,7 +250,7 @@ func (s *TokenExchangingProviderSuite) newExchangeTestOIDCServer() *exchangeTest
 			}`, authServer.server.URL, authServer.server.URL, authServer.server.URL)
 		case "/token":
 			s.Require().NoError(r.ParseForm())
-			authServer.requests = append(authServer.requests, observedTokenRequest{
+			authServer.record(observedTokenRequest{
 				clientID:     r.PostForm.Get(tokenexchange.FormKeyClientID),
 				clientSecret: r.PostForm.Get(tokenexchange.FormKeyClientSecret),
 				audience:     r.PostForm.Get(tokenexchange.FormKeyAudience),
@@ -187,6 +287,113 @@ func (s *TokenExchangingProviderSuite) newSnapshot() *oauth.Snapshot {
 	provider, err := oidc.NewProvider(context.Background(), server.URL)
 	s.Require().NoError(err)
 	return &oauth.Snapshot{OIDCProvider: provider}
+}
+
+// tlsTokenServer is an HTTPS STS token endpoint backed by a self-signed
+// certificate, used to observe certificate_authority propagation end to end.
+type tlsTokenServer struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	count  int
+}
+
+func (t *tlsTokenServer) requestCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.count
+}
+
+func (s *TokenExchangingProviderSuite) TestGetDerivedKubernetesCAFile() {
+	s.Run("certificate_authority lets the STS exchange trust the token endpoint", func() {
+		tokenServer := s.newTLSTokenServer()
+		caFile := s.writeCAFile(tokenServer.server.Certificate())
+		oidcProvider := s.newOIDCProviderWithTokenEndpoint(tokenServer.server.URL + "/token")
+
+		cfg := config.Default()
+		cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+		cfg.StsClientId = "client"
+		cfg.StsAudience = "audience"
+		cfg.CertificateAuthority = caFile
+
+		oauthState := oauth.NewState(&oauth.Snapshot{OIDCProvider: oidcProvider})
+		wrapped := newTokenExchangingProvider(fakeDerivedProvider{}, func() api.BaseConfig { return cfg }, oauthState)
+
+		ctx := context.WithValue(context.Background(), OAuthAuthorizationHeader, "Bearer original-token")
+		_, err := wrapped.GetDerivedKubernetes(ctx, "")
+		s.Require().NoError(err)
+		s.Equal(1, tokenServer.requestCount(), "the exchange must reach the TLS token endpoint when the CA is trusted")
+	})
+
+	s.Run("missing certificate_authority fails against the self-signed token endpoint", func() {
+		tokenServer := s.newTLSTokenServer()
+		oidcProvider := s.newOIDCProviderWithTokenEndpoint(tokenServer.server.URL + "/token")
+
+		cfg := config.Default()
+		cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+		cfg.StsClientId = "client"
+		cfg.StsAudience = "audience"
+		// CertificateAuthority deliberately unset: the self-signed endpoint is untrusted.
+
+		oauthState := oauth.NewState(&oauth.Snapshot{OIDCProvider: oidcProvider})
+		wrapped := newTokenExchangingProvider(fakeDerivedProvider{}, func() api.BaseConfig { return cfg }, oauthState)
+
+		ctx := context.WithValue(context.Background(), OAuthAuthorizationHeader, "Bearer original-token")
+		_, err := wrapped.GetDerivedKubernetes(ctx, "")
+		s.Require().Error(err)
+		s.Contains(err.Error(), "certificate signed by unknown authority")
+		s.Equal(0, tokenServer.requestCount(), "the exchange must not reach an untrusted endpoint")
+	})
+}
+
+func (s *TokenExchangingProviderSuite) newTLSTokenServer() *tlsTokenServer {
+	s.T().Helper()
+
+	tokenServer := &tlsTokenServer{}
+	tokenServer.server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/token" {
+			http.NotFound(w, r)
+			return
+		}
+		tokenServer.mu.Lock()
+		tokenServer.count++
+		tokenServer.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"exchanged-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	s.T().Cleanup(tokenServer.server.Close)
+	return tokenServer
+}
+
+func (s *TokenExchangingProviderSuite) newOIDCProviderWithTokenEndpoint(tokenEndpoint string) *oidc.Provider {
+	s.T().Helper()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{
+			"issuer": "%s",
+			"authorization_endpoint": "%s/authorize",
+			"token_endpoint": "%s"
+		}`, server.URL, server.URL, tokenEndpoint)
+	}))
+	s.T().Cleanup(server.Close)
+
+	provider, err := oidc.NewProvider(context.Background(), server.URL)
+	s.Require().NoError(err)
+	return provider
+}
+
+func (s *TokenExchangingProviderSuite) writeCAFile(cert *x509.Certificate) string {
+	s.T().Helper()
+
+	path := filepath.Join(s.T().TempDir(), "ca.pem")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	s.Require().NoError(os.WriteFile(path, certPEM, 0o600))
+	return path
 }
 
 func TestTokenExchangingProvider(t *testing.T) {

--- a/pkg/tokenexchange/config.go
+++ b/pkg/tokenexchange/config.go
@@ -101,6 +101,14 @@ func (c *TargetTokenExchangeConfig) Validate() error {
 	return nil
 }
 
+// HTTPClient returns a memoized *http.Client configured to talk to the IdP.
+// The client is rebuilt (and the previous one's idle connections closed) when
+// CAFile changes, so a CA rotation takes effect on the next call. Concurrent
+// calls are safe, but CAFile itself must not be mutated concurrently with this
+// method: writes to CAFile are not guarded by clientMutex, so a caller that
+// reuses a TargetTokenExchangeConfig across CA changes must set CAFile and call
+// HTTPClient from the same goroutine (the provider builds a fresh config per
+// cache-key change, which satisfies this).
 func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 	c.clientMutex.Lock()
 	defer c.clientMutex.Unlock()
@@ -142,4 +150,17 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 	c.clientCAFile = c.CAFile
 
 	return c.client, nil
+}
+
+// CloseIdleConnections closes any idle keep-alive connections held by the
+// memoized HTTP client. It is a no-op if no client has been built yet. Callers
+// that discard a TargetTokenExchangeConfig (e.g. when a reload produces a fresh
+// config) should call this first so the old client's connections are released
+// promptly instead of lingering until garbage collection.
+func (c *TargetTokenExchangeConfig) CloseIdleConnections() {
+	c.clientMutex.Lock()
+	defer c.clientMutex.Unlock()
+	if c.client != nil {
+		c.client.CloseIdleConnections()
+	}
 }

--- a/pkg/tokenexchange/config_test.go
+++ b/pkg/tokenexchange/config_test.go
@@ -80,9 +80,14 @@ func (s *TargetTokenExchangeConfigSuite) TestHTTPClientCAFile() {
 		s.Require().NoError(err)
 		s.Require().NoError(resp.Body.Close())
 
+		sameClient, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+		s.Same(oldClient, sameClient, "unchanged CAFile must reuse the memoized client")
+
 		cfg.CAFile = s.writeCAFile(newServer.Certificate())
 		newClient, err := cfg.HTTPClient()
 		s.Require().NoError(err)
+		s.NotSame(oldClient, newClient, "changed CAFile must rebuild the client")
 		resp, err = newClient.Get(newServer.URL)
 		s.Require().NoError(err)
 		s.Require().NoError(resp.Body.Close())


### PR DESCRIPTION
## Summary

#1217 fixed the stale STS config cache on SIGHUP reload. This finishes the remaining follow-up items tracked in #1110.

## Changes

- **Extract `CertificateAuthorityProvider`** (`pkg/api/config.go`): `certificate_authority` is a general OAuth/TLS setting, also consumed by `pkg/oauth`, so it no longer belongs on `StsConfigProvider`. It now lives in its own interface embedded in `BaseConfig`. No behavior change.
- **Complete the reload test coverage** (`pkg/kubernetes/provider_token_exchange_test.go`):
  - End-to-end `certificate_authority` propagation: the STS exchange runs through the provider against a real `httptest.NewTLSServer` token endpoint, proving the configured CA is trusted, and that a missing CA fails with `certificate signed by unknown authority`.
  - Per-field rotation coverage for `sts_auth_style`, `sts_client_cert_file`/`sts_client_key_file`, and `sts_federated_token_file`.
  - Cache-hit assertion so an unchanged config keeps reusing the cached struct (which is what keeps assertion caching effective).
- **Release idle connections on rebuild** (`pkg/tokenexchange/config.go`, `pkg/kubernetes/provider_token_exchange.go`): add `TargetTokenExchangeConfig.CloseIdleConnections()` and call it when a reload swaps in a freshly built STS config, so the old client's connections are released promptly instead of waiting for GC.
- **Document contracts**: the `CAFile` mutation/concurrency contract on `HTTPClient()`, and the defensive nil-config fallback in the provider.

## Verification

```
go build ./...
go vet ./pkg/api/ ./pkg/config/ ./pkg/kubernetes/ ./pkg/tokenexchange/ ./pkg/oauth/
go test -race ./pkg/kubernetes/ ./pkg/tokenexchange/ -count=1
go test ./pkg/api/... ./pkg/config/... ./pkg/oauth/... -count=1
make lint
```

Refs #1110, #1217