### PR TITLE
feat(kiali): add meshCluster parameter for multi-cluster support

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,17 +456,17 @@ In case multi-cluster support is enabled (default) and you have access to multip
 <summary>kiali</summary>
 
 - **kiali_get_mesh_traffic_graph** - Returns service-to-service traffic topology, dependencies, and network metrics (throughput, response time, mTLS) for the specified namespaces. Use this to diagnose routing issues, latency, or find upstream/downstream dependencies.
-  - `clusterName` (`string`) - Optional cluster name to include in the graph. Default is the cluster name in the Kiali configuration (KubeConfig).
   - `graphType` (`string`) - Granularity of the graph. 'app' aggregates by app name, 'versionedApp' separates by versions, 'workload' maps specific pods/deployments. Default: versionedApp.
+  - `meshCluster` (`string`) - Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.
   - `namespaces` (`string`) **(required)** - Comma-separated list of namespaces to map
 
 - **kiali_get_mesh_status** - Retrieves the high-level health, topology, and environment details of the Istio service mesh. Returns multi-cluster control plane status (istiod), data plane namespace health (including ambient mesh status), observability stack health (Prometheus, Grafana...), and component connectivity. Use this tool as the first step to diagnose mesh-wide issues, verify Istio/Kiali versions, or check overall health before drilling into specific workloads.
 
 - **kiali_manage_istio_config_read** - Read Istio, Gateway API, and Inference API config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names; omit group/kind to retrieve ALL config types in a single call. Supports Istio (networking.istio.io, security.istio.io), Gateway API (gateway.networking.k8s.io), and Inference API (inference.networking.k8s.io) when installed. 'get' returns full YAML. For writes use manage_istio_config.
   - `action` (`string`) **(required)** - Action to perform (read-only)
-  - `clusterName` (`string`) - Optional cluster name. Defaults to the cluster name in the Kiali configuration.
   - `group` (`string`) - API group of the Istio object. Required ONLY for 'get' action. For 'list', OMIT group and kind to retrieve ALL config types in a single call. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.
   - `kind` (`string`) - Kind of the Istio object. Required ONLY for 'get' action. For 'list', OMIT to return all kinds at once — do NOT call separately for each kind.
+  - `meshCluster` (`string`) - Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.
   - `namespace` (`string`) - Namespace containing the Istio object. For 'list', if not provided, returns objects across all namespaces. For 'get', required.
   - `object` (`string`) - Name of the Istio object. Required for 'get' action.
   - `serviceName` (`string`) - Filter Istio configurations (VirtualServices, DestinationRules, and their referenced Gateways) that affect a specific service. Only applicable for 'list' action
@@ -474,25 +474,27 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 - **kiali_manage_istio_config** - Create, patch, or delete Istio, Gateway API, and Inference API config. Supports Istio resources (networking.istio.io, security.istio.io), Gateway API resources (gateway.networking.k8s.io), and Inference API resources (inference.networking.k8s.io) when installed on the cluster. For list and get (read-only) use manage_istio_config_read.
   - `action` (`string`) **(required)** - Action to perform (write)
-  - `clusterName` (`string`) - Optional cluster name. Defaults to the cluster name in the Kiali configuration.
   - `data` (`string`) - JSON or YAML data for the resource. Required for create and patch actions. For create, you can provide partial content (e.g. only spec) and it will be merged onto a valid template with defaults. Arrays (like servers, http, etc.) are REPLACED entirely, so include ALL elements you want.
   - `group` (`string`) **(required)** - API group of the Istio object. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.
   - `kind` (`string`) **(required)** - Kind of the Istio object (e.g., 'VirtualService', 'DestinationRule').
+  - `meshCluster` (`string`) - Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.
   - `namespace` (`string`) **(required)** - Namespace containing the Istio object.
   - `object` (`string`) **(required)** - Name of the Istio object.
   - `version` (`string`) **(required)** - API version. Use 'v1' for all resource types.
 
+- **kiali_list_mesh_clusters** - Returns the list of Istio mesh clusters that Kiali can access. Each entry includes its name and whether it is the home cluster (where Kiali is deployed). Call this tool before using meshCluster on other Kiali tools when the target cluster is unknown.
+
 - **kiali_get_resource_details** - Fetches a list of resources OR retrieves detailed data for a specific resource. If 'resourceName' is omitted, it returns a list. If 'resourceName' is provided, it returns details for that specific resource.
-  - `clusterName` (`string`) - Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig
+  - `meshCluster` (`string`) - Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.
   - `namespaces` (`string`) - Comma-separated list of namespaces to query (e.g., 'bookinfo' or 'bookinfo,default'). If not provided, it will query across all accessible namespaces.
   - `resourceName` (`string`) - Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.
   - `resourceType` (`string`) **(required)** - The type of resource to query. Use 'app' for Kiali applications (grouped by the Kubernetes 'app' label). Use 'argoapp' for ArgoCD Application CRDs (requires ArgoCD installed and the Kiali service account must have read permissions on applications.argoproj.io).
 
 - **kiali_list_traces** - Lists distributed traces for a service in a namespace. Returns a summary (namespace, service, total_found, avg_duration_ms) and a list of traces with id, duration_ms, spans_count, root_op, slowest_service, has_errors. Use get_trace_details with a trace id to get full hierarchy.
-  - `clusterName` (`string`) - Optional cluster name. Defaults to the cluster name in the Kiali configuration.
   - `errorOnly` (`boolean`) - If true, only consider traces that contain errors. Default false.
   - `limit` (`integer`) - Maximum number of traces to return. Default 10.
   - `lookbackSeconds` (`integer`) - How far back to search. Default 600 (10m).
+  - `meshCluster` (`string`) - Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.
   - `namespace` (`string`) **(required)** - Kubernetes namespace of the service.
   - `serviceName` (`string`) **(required)** - Service name to search traces for (required). Returns multiple traces up to limit.
 
@@ -500,7 +502,7 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `traceId` (`string`) **(required)** - Trace ID to fetch and summarize. If provided, namespace/service_name are ignored.
 
 - **kiali_get_pod_performance** - Returns a human-readable text summary with current Pod CPU/memory usage (from Prometheus) compared to Kubernetes requests/limits (from the Pod spec). Useful to answer questions like 'Is this workload using too much memory?'
-  - `clusterName` (`string`) - Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig
+  - `meshCluster` (`string`) - Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.
   - `namespace` (`string`) **(required)** - Kubernetes namespace of the Pod.
   - `podName` (`string`) - Kubernetes Pod name. If workloadName is provided, the tool will attempt to resolve a Pod from that workload first.
   - `queryTime` (`string`) - Optional end timestamp (RFC3339) for the query. Defaults to now.
@@ -508,9 +510,9 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `workloadName` (`string`) - Kubernetes Workload name (e.g. Deployment/StatefulSet/etc). Tool will look up the workload and pick one of its Pods. If not found, it will fall back to treating this value as a podName.
 
 - **kiali_get_logs** - Get the logs of a Kubernetes Pod (or workload name that will be resolved to a pod) in a namespace. Output is plain text, matching kubernetes-mcp-server pods_log. The line_count field tells you the total number of log lines returned. Analyze ALL of them, but summarize the results unless the user explicitly asks for the raw output. Do not omit any error or warning lines.
-  - `clusterName` (`string`) - Optional. Name of the cluster to get the logs from. If not provided, will use the default cluster name in the Kiali KubeConfig
   - `container` (`string`) - Optional. Name of the Pod container to get the logs from.
   - `format` (`string`) - Output formatting for chat. 'codeblock' wraps logs in ~~~ fences (recommended). 'plain' returns raw text like kubernetes-mcp-server pods_log.
+  - `meshCluster` (`string`) - Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.
   - `name` (`string`) **(required)** - Name of the Pod to get the logs from. If it does not exist, it will be treated as a workload name and a running pod will be selected.
   - `namespace` (`string`) **(required)** - Namespace to get the Pod logs from
   - `previous` (`boolean`) - Optional. Return previous terminated container logs
@@ -520,8 +522,8 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 - **kiali_get_metrics** - Returns a compact JSON summary of Istio metrics (latency quantiles, traffic trends, throughput, payload sizes) for the given resource.
   - `byLabels` (`string`) - Comma-separated list of labels to group metrics by (e.g., 'source_workload,destination_service'). Optional
-  - `clusterName` (`string`) - Cluster name to get metrics from. Optional, defaults to the cluster name in the Kiali configuration (KubeConfig)
   - `direction` (`string`) - Traffic direction. Optional, defaults to 'outbound'
+  - `meshCluster` (`string`) - Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.
   - `namespace` (`string`) **(required)** - Namespace to get metrics from
   - `quantiles` (`string`) - Comma-separated list of quantiles for histogram metrics (e.g., '0.5,0.95,0.99'). Optional
   - `rateInterval` (`string`) - Rate interval for metrics (e.g., '1m', '5m'). Optional, defaults to '10m'

--- a/docs/KIALI.md
+++ b/docs/KIALI.md
@@ -25,6 +25,14 @@ When the `kiali` toolset is enabled, a Kiali toolset configuration is required v
 - The server uses your existing Kubernetes credentials (from kubeconfig or in-cluster) to set a bearer token for Kiali calls.
 - If you pass an HTTP Authorization header to the MCP HTTP endpoint, that is not required for Kiali; Kiali calls use the server's configured token.
 
+### Multi-cluster support
+
+Kiali can manage multiple Kubernetes clusters within an Istio service mesh. Most Kiali tools accept an optional `meshCluster` parameter to target a specific mesh cluster. When omitted, Kiali defaults to its home cluster (where Kiali is deployed).
+
+Use `kiali_list_mesh_clusters` to discover available mesh cluster names before calling other tools. The `name` field from that response is the only valid value for `meshCluster`.
+
+Kiali tools are not cluster-aware: the MCP server does not inject a `context` parameter on them. Use `meshCluster` to select mesh scope. Core Kubernetes tools still use `context` when multi-cluster is enabled.
+
 ### Troubleshooting
 
 - Missing Kiali configuration when `kiali` toolset is enabled → set `[toolset_configs.kiali].url` in the config TOML.

--- a/docs/KIALI.md
+++ b/docs/KIALI.md
@@ -29,9 +29,9 @@ When the `kiali` toolset is enabled, a Kiali toolset configuration is required v
 
 Kiali can manage multiple Kubernetes clusters within an Istio service mesh. Most Kiali tools accept an optional `meshCluster` parameter to target a specific mesh cluster. When omitted, Kiali defaults to its home cluster (where Kiali is deployed).
 
-Use `kiali_list_mesh_clusters` to discover available mesh cluster names before calling other tools. The `name` field from that response is the only valid value for `meshCluster`.
+Use `<toolset>_list_mesh_clusters` (e.g. `kiali_list_mesh_clusters`) to discover available mesh cluster names before calling other tools. The `name` field from that response is the only valid value for `meshCluster`.
 
-Kiali tools are not cluster-aware: the MCP server does not inject a `context` parameter on them. Use `meshCluster` to select mesh scope. Core Kubernetes tools still use `context` when multi-cluster is enabled.
+Kiali tools and prompts are not cluster-aware: the MCP server does not inject a `context` parameter on them. Use `meshCluster` to select mesh scope. Core Kubernetes tools still use `context` when multi-cluster is enabled.
 
 ### Troubleshooting
 

--- a/pkg/mcp/kiali_test.go
+++ b/pkg/mcp/kiali_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	kialiToolset "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 type KialiSuite struct {
@@ -132,6 +134,32 @@ func (s *KialiSuite) TestGetMeshStatus() {
 		})
 		s.Run("response contains status", func() {
 			s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "healthy", "Response should contain status")
+		})
+	})
+}
+
+func (s *KialiSuite) TestListClusters() {
+	var capturedURL *url.URL
+	s.mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := *r.URL
+		capturedURL = &u
+		_, _ = w.Write([]byte(`[{"name":"cluster-east","isHomeCluster":true},{"name":"cluster-west","isHomeCluster":false}]`))
+	}))
+	s.InitMcpClient()
+
+	s.Run("list_mesh_clusters", func() {
+		toolResult, err := s.CallTool(fmt.Sprintf("%s_list_mesh_clusters", s.toolsetName), map[string]interface{}{})
+		s.Run("no error", func() {
+			s.Nilf(err, "call tool failed %v", err)
+			s.Falsef(toolResult.IsError, "call tool failed")
+		})
+		s.Run("sends POST to MCP endpoint", func() {
+			s.Equal("/api/chat/mcp/list_clusters", capturedURL.Path, "Unexpected path")
+		})
+		s.Run("response contains cluster names", func() {
+			text := toolResult.Content[0].(*mcp.TextContent).Text
+			s.Contains(text, "cluster-east", "Response should contain home cluster name")
+			s.Contains(text, "cluster-west", "Response should contain remote cluster name")
 		})
 	})
 }
@@ -622,6 +650,29 @@ func (s *KialiSuite) TestTraceAnalysisPrompt() {
 		s.Require().Len(result.Messages, 2)
 		s.Equal("user", string(result.Messages[0].Role))
 	})
+}
+
+func (s *KialiSuite) TestKialiToolsNotClusterAware() {
+	kubeconfig := s.mockServer.Kubeconfig()
+	for i := range 10 {
+		kubeconfig.Contexts[strconv.Itoa(i)] = clientcmdapi.NewContext()
+	}
+	s.Cfg.KubeConfig = test.KubeconfigFile(s.T(), kubeconfig)
+	s.InitMcpClient()
+
+	tools, err := s.ListTools()
+	s.Require().NoError(err)
+	s.Require().NotEmpty(tools.Tools)
+
+	for _, tool := range tools.Tools {
+		s.Run(tool.Name, func() {
+			schema, ok := tool.InputSchema.(map[string]any)
+			s.Require().True(ok, "expected InputSchema map for tool %s", tool.Name)
+			properties, ok := schema["properties"].(map[string]any)
+			s.Require().True(ok, "expected properties map for tool %s", tool.Name)
+			s.NotContains(properties, "context", "kiali tool %s must not expose context parameter", tool.Name)
+		})
+	}
 }
 
 func TestKiali(t *testing.T) {

--- a/pkg/mcp/testdata/toolsets-kiali-tools.json
+++ b/pkg/mcp/testdata/toolsets-kiali-tools.json
@@ -9,10 +9,6 @@
     "description": "Get the logs of a Kubernetes Pod (or workload name that will be resolved to a pod) in a namespace. Output is plain text, matching kubernetes-mcp-server pods_log. The line_count field tells you the total number of log lines returned. Analyze ALL of them, but summarize the results unless the user explicitly asks for the raw output. Do not omit any error or warning lines.",
     "inputSchema": {
       "properties": {
-        "clusterName": {
-          "description": "Optional. Name of the cluster to get the logs from. If not provided, will use the default cluster name in the Kiali KubeConfig",
-          "type": "string"
-        },
         "container": {
           "description": "Optional. Name of the Pod container to get the logs from.",
           "type": "string"
@@ -23,6 +19,10 @@
             "codeblock",
             "plain"
           ],
+          "type": "string"
+        },
+        "meshCluster": {
+          "description": "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.",
           "type": "string"
         },
         "name": {
@@ -86,10 +86,6 @@
     "description": "Returns service-to-service traffic topology, dependencies, and network metrics (throughput, response time, mTLS) for the specified namespaces. Use this to diagnose routing issues, latency, or find upstream/downstream dependencies.",
     "inputSchema": {
       "properties": {
-        "clusterName": {
-          "description": "Optional cluster name to include in the graph. Default is the cluster name in the Kiali configuration (KubeConfig).",
-          "type": "string"
-        },
         "graphType": {
           "default": "versionedApp",
           "description": "Granularity of the graph. 'app' aggregates by app name, 'versionedApp' separates by versions, 'workload' maps specific pods/deployments. Default: versionedApp.",
@@ -99,6 +95,10 @@
             "service",
             "workload"
           ],
+          "type": "string"
+        },
+        "meshCluster": {
+          "description": "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.",
           "type": "string"
         },
         "namespaces": {
@@ -129,10 +129,6 @@
           "description": "Comma-separated list of labels to group metrics by (e.g., 'source_workload,destination_service'). Optional",
           "type": "string"
         },
-        "clusterName": {
-          "description": "Cluster name to get metrics from. Optional, defaults to the cluster name in the Kiali configuration (KubeConfig)",
-          "type": "string"
-        },
         "direction": {
           "default": "outbound",
           "description": "Traffic direction. Optional, defaults to 'outbound'",
@@ -140,6 +136,10 @@
             "inbound",
             "outbound"
           ],
+          "type": "string"
+        },
+        "meshCluster": {
+          "description": "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.",
           "type": "string"
         },
         "namespace": {
@@ -205,8 +205,8 @@
     "description": "Returns a human-readable text summary with current Pod CPU/memory usage (from Prometheus) compared to Kubernetes requests/limits (from the Pod spec). Useful to answer questions like 'Is this workload using too much memory?'",
     "inputSchema": {
       "properties": {
-        "clusterName": {
-          "description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig",
+        "meshCluster": {
+          "description": "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.",
           "type": "string"
         },
         "namespace": {
@@ -255,8 +255,8 @@
         ]
       },
       "properties": {
-        "clusterName": {
-          "description": "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig",
+        "meshCluster": {
+          "description": "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.",
           "type": "string"
         },
         "namespaces": {
@@ -317,15 +317,27 @@
       "idempotentHint": true,
       "openWorldHint": true,
       "readOnlyHint": true,
+      "title": "List Mesh Clusters"
+    },
+    "description": "Returns the list of Istio mesh clusters that Kiali can access. Each entry includes its name and whether it is the home cluster (where Kiali is deployed). Call this tool before using meshCluster on other Kiali tools when the target cluster is unknown.",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "kiali_list_mesh_clusters",
+    "title": "List Mesh Clusters"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
       "title": "List Traces by Service Name"
     },
     "description": "Lists distributed traces for a service in a namespace. Returns a summary (namespace, service, total_found, avg_duration_ms) and a list of traces with id, duration_ms, spans_count, root_op, slowest_service, has_errors. Use get_trace_details with a trace id to get full hierarchy.",
     "inputSchema": {
       "properties": {
-        "clusterName": {
-          "description": "Optional cluster name. Defaults to the cluster name in the Kiali configuration.",
-          "type": "string"
-        },
         "errorOnly": {
           "default": false,
           "description": "If true, only consider traces that contain errors. Default false.",
@@ -340,6 +352,10 @@
           "default": 600,
           "description": "How far back to search. Default 600 (10m).",
           "type": "integer"
+        },
+        "meshCluster": {
+          "description": "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.",
+          "type": "string"
         },
         "namespace": {
           "description": "Kubernetes namespace of the service.",
@@ -378,10 +394,6 @@
           ],
           "type": "string"
         },
-        "clusterName": {
-          "description": "Optional cluster name. Defaults to the cluster name in the Kiali configuration.",
-          "type": "string"
-        },
         "data": {
           "description": "JSON or YAML data for the resource. Required for create and patch actions. For create, you can provide partial content (e.g. only spec) and it will be merged onto a valid template with defaults. Arrays (like servers, http, etc.) are REPLACED entirely, so include ALL elements you want.",
           "type": "string"
@@ -417,6 +429,10 @@
             "TLSRoute",
             "InferencePool"
           ],
+          "type": "string"
+        },
+        "meshCluster": {
+          "description": "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.",
           "type": "string"
         },
         "namespace": {
@@ -472,10 +488,6 @@
           ],
           "type": "string"
         },
-        "clusterName": {
-          "description": "Optional cluster name. Defaults to the cluster name in the Kiali configuration.",
-          "type": "string"
-        },
         "group": {
           "description": "API group of the Istio object. Required ONLY for 'get' action. For 'list', OMIT group and kind to retrieve ALL config types in a single call. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.",
           "enum": [
@@ -507,6 +519,10 @@
             "TLSRoute",
             "InferencePool"
           ],
+          "type": "string"
+        },
+        "meshCluster": {
+          "description": "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). When omitted, Kiali defaults to its home cluster.",
           "type": "string"
         },
         "namespace": {

--- a/pkg/toolsets/kiali/tools/defaults.go
+++ b/pkg/toolsets/kiali/tools/defaults.go
@@ -1,5 +1,7 @@
 package tools
 
+import "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
+
 // Default values for Kiali API parameters shared across this package.
 const (
 	// DefaultRateInterval is the default rate interval for fetching error rates and metrics.
@@ -17,8 +19,11 @@ const (
 )
 
 // meshClusterDescription is the shared schema description for the meshCluster tool parameter.
-const meshClusterDescription = "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). " +
-	"When omitted, Kiali defaults to its home cluster."
+// Uses ToolsetName() so downstream overrides (e.g. ossm) keep the discovery tool name consistent.
+func meshClusterDescription() string {
+	return "Optional Istio mesh cluster name from " + defaults.ToolsetName() + "_list_mesh_clusters (e.g. west). " +
+		"When omitted, Kiali defaults to its home cluster."
+}
 
 // remapMeshCluster translates the MCP-facing "meshCluster" parameter to the
 // Kiali API's "clusterName" before forwarding the request. This avoids a

--- a/pkg/toolsets/kiali/tools/defaults.go
+++ b/pkg/toolsets/kiali/tools/defaults.go
@@ -15,3 +15,19 @@ const (
 	DefaultLookbackSeconds = 600
 	DefaultErrorOnly       = false
 )
+
+// meshClusterDescription is the shared schema description for the meshCluster tool parameter.
+const meshClusterDescription = "Optional Istio mesh cluster name from kiali_list_mesh_clusters (e.g. west). " +
+	"When omitted, Kiali defaults to its home cluster."
+
+// remapMeshCluster translates the MCP-facing "meshCluster" parameter to the
+// Kiali API's "clusterName" before forwarding the request. This avoids a
+// naming collision with the provider-level target parameter (e.g. "context"
+// from the kubeconfig provider) while keeping the Kiali backend API unchanged.
+func remapMeshCluster(arguments map[string]any) map[string]any {
+	if v, ok := arguments["meshCluster"]; ok {
+		arguments["clusterName"] = v
+		delete(arguments, "meshCluster")
+	}
+	return arguments
+}

--- a/pkg/toolsets/kiali/tools/endpoints.go
+++ b/pkg/toolsets/kiali/tools/endpoints.go
@@ -14,4 +14,5 @@ const (
 	KialiManageIstioConfigEndpoint     = KialiMCPPath + "/manage_istio_config"
 	KialiManageIstioConfigReadEndpoint = KialiMCPPath + "/manage_istio_config_read"
 	KialiGetPodPerformanceEndpoint     = KialiMCPPath + "/get_pod_performance"
+	KialiListClustersEndpoint          = KialiMCPPath + "/list_clusters"
 )

--- a/pkg/toolsets/kiali/tools/get_logs.go
+++ b/pkg/toolsets/kiali/tools/get_logs.go
@@ -59,7 +59,7 @@ func InitGetLogs() []api.ServerTool {
 					},
 					"meshCluster": {
 						Type:        "string",
-						Description: meshClusterDescription,
+						Description: meshClusterDescription(),
 					},
 				},
 				Required: []string{"namespace", "name"},

--- a/pkg/toolsets/kiali/tools/get_logs.go
+++ b/pkg/toolsets/kiali/tools/get_logs.go
@@ -57,9 +57,9 @@ func InitGetLogs() []api.ServerTool {
 						Description: "Output formatting for chat. 'codeblock' wraps logs in ~~~ fences (recommended). 'plain' returns raw text like kubernetes-mcp-server pods_log.",
 						Enum:        []any{"codeblock", "plain"},
 					},
-					"clusterName": {
+					"meshCluster": {
 						Type:        "string",
-						Description: "Optional. Name of the cluster to get the logs from. If not provided, will use the default cluster name in the Kiali KubeConfig",
+						Description: meshClusterDescription,
 					},
 				},
 				Required: []string{"namespace", "name"},
@@ -80,7 +80,7 @@ func InitGetLogs() []api.ServerTool {
 func workloadLogsHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 	arguments := params.GetArguments()
-	content, err := kiali.ExecuteRequest(params.Context, KialiGetLogsEndpoint, arguments)
+	content, err := kiali.ExecuteRequest(params.Context, KialiGetLogsEndpoint, remapMeshCluster(arguments))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get logs: %w", err)), nil
 	}

--- a/pkg/toolsets/kiali/tools/get_mesh_traffic_graph.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_traffic_graph.go
@@ -33,7 +33,7 @@ func InitGetMeshTrafficGraph() []api.ServerTool {
 					},
 					"meshCluster": {
 						Type:        "string",
-						Description: meshClusterDescription,
+						Description: meshClusterDescription(),
 					},
 				},
 				Required: []string{"namespaces"},

--- a/pkg/toolsets/kiali/tools/get_mesh_traffic_graph.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_traffic_graph.go
@@ -31,9 +31,9 @@ func InitGetMeshTrafficGraph() []api.ServerTool {
 						Default:     api.ToRawMessage(DefaultGraphType),
 						Enum:        []any{"app", "versionedApp", "service", "workload"},
 					},
-					"clusterName": {
+					"meshCluster": {
 						Type:        "string",
-						Description: "Optional cluster name to include in the graph. Default is the cluster name in the Kiali configuration (KubeConfig).",
+						Description: meshClusterDescription,
 					},
 				},
 				Required: []string{"namespaces"},
@@ -53,7 +53,7 @@ func InitGetMeshTrafficGraph() []api.ServerTool {
 func getMeshGraphHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 	arguments := params.GetArguments()
-	content, err := kiali.ExecuteRequest(params.Context, KialiGetMeshTrafficGraphEndpoint, arguments)
+	content, err := kiali.ExecuteRequest(params.Context, KialiGetMeshTrafficGraphEndpoint, remapMeshCluster(arguments))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to retrieve mesh traffic graph: %w", err)), nil
 	}

--- a/pkg/toolsets/kiali/tools/get_metrics.go
+++ b/pkg/toolsets/kiali/tools/get_metrics.go
@@ -30,9 +30,9 @@ func InitGetMetrics() []api.ServerTool {
 						Type:        "string",
 						Description: "Namespace to get metrics from",
 					},
-					"clusterName": {
+					"meshCluster": {
 						Type:        "string",
-						Description: "Cluster name to get metrics from. Optional, defaults to the cluster name in the Kiali configuration (KubeConfig)",
+						Description: meshClusterDescription,
 					},
 					"resourceName": {
 						Type:        "string",
@@ -91,7 +91,7 @@ func InitGetMetrics() []api.ServerTool {
 func resourceMetricsHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 	arguments := params.GetArguments()
-	content, err := kiali.ExecuteRequest(params.Context, KialiGetMetricsEndpoint, arguments)
+	content, err := kiali.ExecuteRequest(params.Context, KialiGetMetricsEndpoint, remapMeshCluster(arguments))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to retrieve metrics: %w", err)), nil
 	}

--- a/pkg/toolsets/kiali/tools/get_metrics.go
+++ b/pkg/toolsets/kiali/tools/get_metrics.go
@@ -32,7 +32,7 @@ func InitGetMetrics() []api.ServerTool {
 					},
 					"meshCluster": {
 						Type:        "string",
-						Description: meshClusterDescription,
+						Description: meshClusterDescription(),
 					},
 					"resourceName": {
 						Type:        "string",

--- a/pkg/toolsets/kiali/tools/get_pod_performance.go
+++ b/pkg/toolsets/kiali/tools/get_pod_performance.go
@@ -42,9 +42,9 @@ func InitGetPodPerformance() []api.ServerTool {
 						Type:        "string",
 						Description: "Optional end timestamp (RFC3339) for the query. Defaults to now.",
 					},
-					"clusterName": {
+					"meshCluster": {
 						Type:        "string",
-						Description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig",
+						Description: meshClusterDescription,
 					},
 				},
 				Required: []string{"namespace"},
@@ -65,7 +65,7 @@ func InitGetPodPerformance() []api.ServerTool {
 func getPodPerformanceHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 	arguments := params.GetArguments()
-	content, err := kiali.ExecuteRequest(params.Context, KialiGetPodPerformanceEndpoint, arguments)
+	content, err := kiali.ExecuteRequest(params.Context, KialiGetPodPerformanceEndpoint, remapMeshCluster(arguments))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod performance: %w", err)), nil
 	}

--- a/pkg/toolsets/kiali/tools/get_pod_performance.go
+++ b/pkg/toolsets/kiali/tools/get_pod_performance.go
@@ -44,7 +44,7 @@ func InitGetPodPerformance() []api.ServerTool {
 					},
 					"meshCluster": {
 						Type:        "string",
-						Description: meshClusterDescription,
+						Description: meshClusterDescription(),
 					},
 				},
 				Required: []string{"namespace"},

--- a/pkg/toolsets/kiali/tools/list_clusters.go
+++ b/pkg/toolsets/kiali/tools/list_clusters.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/utils/ptr"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
+)
+
+func InitListMeshClusters() []api.ServerTool {
+	ret := make([]api.ServerTool, 0)
+	name := defaults.ToolsetName() + "_list_mesh_clusters"
+	ret = append(ret, api.ServerTool{
+		Tool: api.Tool{
+			Name:        name,
+			Description: "Returns the list of Istio mesh clusters that Kiali can access. Each entry includes its name and whether it is the home cluster (where Kiali is deployed). Call this tool before using meshCluster on other Kiali tools when the target cluster is unknown.",
+			InputSchema: &jsonschema.Schema{
+				Type:     "object",
+				Required: []string{},
+			},
+			Annotations: api.ToolAnnotations{
+				Title:           "List Mesh Clusters",
+				ReadOnlyHint:    ptr.To(true),
+				DestructiveHint: ptr.To(false),
+				IdempotentHint:  ptr.To(true),
+				OpenWorldHint:   ptr.To(true),
+			},
+		}, Handler: listMeshClustersHandler,
+	})
+	return ret
+}
+
+func listMeshClustersHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	kiali := kialiclient.NewKiali(params, params.RESTConfig())
+	content, err := kiali.ExecuteRequest(params.Context, KialiListClustersEndpoint, nil)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list mesh clusters: %w", err)), nil
+	}
+	return api.NewToolCallResult(content, nil), nil
+}

--- a/pkg/toolsets/kiali/tools/list_or_get_resources.go
+++ b/pkg/toolsets/kiali/tools/list_or_get_resources.go
@@ -34,9 +34,9 @@ func InitListOrGetResources() []api.ServerTool {
 						Type:        "string",
 						Description: "Optional. The specific name of the resource. If left empty, the tool returns a list of all resources of the specified type. If provided, the tool returns deep details for this specific resource.",
 					},
-					"clusterName": {
+					"meshCluster": {
 						Type:        "string",
-						Description: "Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig",
+						Description: meshClusterDescription,
 					},
 				},
 				Required: []string{"resourceType"},
@@ -60,7 +60,7 @@ func InitListOrGetResources() []api.ServerTool {
 func listOrGetResourcesHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 	arguments := params.GetArguments()
-	content, err := kiali.ExecuteRequest(params.Context, KialiListOrGetResourcesEndpoint, arguments)
+	content, err := kiali.ExecuteRequest(params.Context, KialiListOrGetResourcesEndpoint, remapMeshCluster(arguments))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list or get resources: %w", err)), nil
 	}

--- a/pkg/toolsets/kiali/tools/list_or_get_resources.go
+++ b/pkg/toolsets/kiali/tools/list_or_get_resources.go
@@ -36,7 +36,7 @@ func InitListOrGetResources() []api.ServerTool {
 					},
 					"meshCluster": {
 						Type:        "string",
-						Description: meshClusterDescription,
+						Description: meshClusterDescription(),
 					},
 				},
 				Required: []string{"resourceType"},

--- a/pkg/toolsets/kiali/tools/list_traces.go
+++ b/pkg/toolsets/kiali/tools/list_traces.go
@@ -34,9 +34,9 @@ func InitListTraces() []api.ServerTool {
 						Description: "If true, only consider traces that contain errors. Default false.",
 						Default:     api.ToRawMessage(DefaultErrorOnly),
 					},
-					"clusterName": {
+					"meshCluster": {
 						Type:        "string",
-						Description: "Optional cluster name. Defaults to the cluster name in the Kiali configuration.",
+						Description: meshClusterDescription,
 					},
 					"lookbackSeconds": {
 						Type:        "integer",
@@ -67,7 +67,7 @@ func InitListTraces() []api.ServerTool {
 func listTracesHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 	arguments := params.GetArguments()
-	content, err := kiali.ExecuteRequest(params.Context, KialiListTracesEndpoint, arguments)
+	content, err := kiali.ExecuteRequest(params.Context, KialiListTracesEndpoint, remapMeshCluster(arguments))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to retrieve list of traces: %w", err)), nil
 	}

--- a/pkg/toolsets/kiali/tools/list_traces.go
+++ b/pkg/toolsets/kiali/tools/list_traces.go
@@ -36,7 +36,7 @@ func InitListTraces() []api.ServerTool {
 					},
 					"meshCluster": {
 						Type:        "string",
-						Description: meshClusterDescription,
+						Description: meshClusterDescription(),
 					},
 					"lookbackSeconds": {
 						Type:        "integer",

--- a/pkg/toolsets/kiali/tools/manage_istio_config.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config.go
@@ -54,7 +54,7 @@ func InitManageIstioConfig() []api.ServerTool {
 					},
 					"meshCluster": {
 						Type:        "string",
-						Description: meshClusterDescription,
+						Description: meshClusterDescription(),
 					},
 				},
 				Required: []string{"action", "namespace", "group", "version", "kind", "object"},

--- a/pkg/toolsets/kiali/tools/manage_istio_config.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config.go
@@ -52,9 +52,9 @@ func InitManageIstioConfig() []api.ServerTool {
 						Type:        "string",
 						Description: "JSON or YAML data for the resource. Required for create and patch actions. For create, you can provide partial content (e.g. only spec) and it will be merged onto a valid template with defaults. Arrays (like servers, http, etc.) are REPLACED entirely, so include ALL elements you want.",
 					},
-					"clusterName": {
+					"meshCluster": {
 						Type:        "string",
-						Description: "Optional cluster name. Defaults to the cluster name in the Kiali configuration.",
+						Description: meshClusterDescription,
 					},
 				},
 				Required: []string{"action", "namespace", "group", "version", "kind", "object"},
@@ -74,7 +74,7 @@ func InitManageIstioConfig() []api.ServerTool {
 func istioConfigHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 	arguments := params.GetArguments()
-	content, err := kiali.ExecuteRequest(params.Context, KialiManageIstioConfigEndpoint, arguments)
+	content, err := kiali.ExecuteRequest(params.Context, KialiManageIstioConfigEndpoint, remapMeshCluster(arguments))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to manage istio config: %w", err)), nil
 	}

--- a/pkg/toolsets/kiali/tools/manage_istio_config_read.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config_read.go
@@ -51,9 +51,9 @@ func InitManageIstioConfigRead() []api.ServerTool {
 						Type:        "string",
 						Description: "Name of the Istio object. Required for 'get' action.",
 					},
-					"clusterName": {
+					"meshCluster": {
 						Type:        "string",
-						Description: "Optional cluster name. Defaults to the cluster name in the Kiali configuration.",
+						Description: meshClusterDescription,
 					},
 					"serviceName": {
 						Type:        "string",
@@ -80,7 +80,7 @@ func InitManageIstioConfigRead() []api.ServerTool {
 func istioConfigHandlerRead(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	kiali := kialiclient.NewKiali(params, params.RESTConfig())
 	arguments := params.GetArguments()
-	content, err := kiali.ExecuteRequest(params.Context, KialiManageIstioConfigReadEndpoint, arguments)
+	content, err := kiali.ExecuteRequest(params.Context, KialiManageIstioConfigReadEndpoint, remapMeshCluster(arguments))
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to retrieve istio config: %w", err)), nil
 	}

--- a/pkg/toolsets/kiali/tools/manage_istio_config_read.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config_read.go
@@ -53,7 +53,7 @@ func InitManageIstioConfigRead() []api.ServerTool {
 					},
 					"meshCluster": {
 						Type:        "string",
-						Description: meshClusterDescription,
+						Description: meshClusterDescription(),
 					},
 					"serviceName": {
 						Type:        "string",

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -3,6 +3,8 @@ package kiali
 import (
 	"slices"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
@@ -23,11 +25,12 @@ func (t *Toolset) GetDescription() string {
 }
 
 func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
-	return slices.Concat(
+	tools := slices.Concat(
 		kialiTools.InitGetMeshTrafficGraph(),
 		kialiTools.InitGetMeshStatus(),
 		kialiTools.InitManageIstioConfigRead(),
 		kialiTools.InitManageIstioConfig(),
+		kialiTools.InitListMeshClusters(),
 		kialiTools.InitListOrGetResources(),
 		kialiTools.InitListTraces(),
 		kialiTools.InitGetTraceDetails(),
@@ -35,6 +38,12 @@ func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
 		kialiTools.InitGetLogs(),
 		kialiTools.InitGetMetrics(),
 	)
+	// Kiali calls a single configured endpoint; mesh scope is selected via meshCluster,
+	// not the provider-level context parameter injected for core Kubernetes tools.
+	for i := range tools {
+		tools[i].ClusterAware = ptr.To(false)
+	}
+	return tools
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -47,7 +47,7 @@ func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {
-	return slices.Concat(
+	prompts := slices.Concat(
 		kialiPrompts.InitListApplications(),
 		kialiPrompts.InitListIstioConfig(),
 		kialiPrompts.InitListNamespaces(),
@@ -60,6 +60,11 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 		kialiPrompts.InitTraceAnalysis(),
 		kialiPrompts.InitIstioConfigReview(),
 	)
+	// Same as tools: mesh scope is not selected via provider context.
+	for i := range prompts {
+		prompts[i].ClusterAware = ptr.To(false)
+	}
+	return prompts
 }
 
 func (t *Toolset) GetResources() []api.ServerResource {


### PR DESCRIPTION
## Summary

Adds multi-cluster support to the Kiali toolset for [kiali/kiali#9895](https://github.com/kiali/kiali/issues/9895).

- **`meshCluster`** on eight Kiali tools — optional Istio mesh cluster name (e.g. `west`). Remapped internally to Kiali's `clusterName` API parameter via `remapMeshCluster()`.
- **`kiali_list_mesh_clusters`** — discovery tool returning mesh cluster `name` and `isHome`.
- **`ClusterAware: false`** on all Kiali tools — the MCP server does not inject `context` on Kiali tools; mesh scope is selected only via `meshCluster`. Core Kubernetes tools still use `context` when multi-cluster is enabled.
- **Multicluster mcpchecker evals** — 6 tasks under `evals/tasks/kiali/multicluster/` (mesh status, list clusters, remote metrics/workloads/topology/traces), plus `setup-kiali-multicluster` / `run-evals-multicluster` Makefile targets and CI job when `suite=kiali`.

Tools with `meshCluster`: `get_mesh_traffic_graph`, `get_metrics`, `get_logs`, `get_pod_performance`, `list_or_get_resources`, `list_traces`, `manage_istio_config`, `manage_istio_config_read`.

## Why

Kiali exposes mesh cluster **names** (`east`, `west`, …), not kubeconfig context names. Auto-mapping MCP `context` → mesh cluster would fail silently in production and conflate two different concepts:

| Parameter | Layer | Meaning |
|-----------|-------|---------|
| `context` | MCP provider (core tools only) | Which kubeconfig context / credentials |
| `meshCluster` | Kiali toolset | Which Istio mesh cluster Kiali should query |

Models should call `kiali_list_mesh_clusters` when the target cluster is unknown, then pass the `name` value as `meshCluster`. Prompt guidance for the Kiali chatbot lives upstream in [kiali/kiali#9981](https://github.com/kiali/kiali/pull/9981).

## Test plan

- [x] `go test ./pkg/mcp/...` (includes `list_mesh_clusters` integration test and `TestKialiToolsNotClusterAware`)
- [x] Multicluster mcpchecker evals (6 tasks) + CI `run-evaluation-multicluster` for `suite=kiali`
- [ ] Manual: MCP server + Kiali in multi-cluster mode (`east`/`west`)
- [ ] Ask: *metrics for productpage-v1 in bookinfo on cluster west* → tool uses `meshCluster=west`
- [ ] Ask with ambiguous cluster → model calls `kiali_list_mesh_clusters` first

## Related

- Issue: https://github.com/kiali/kiali/issues/9895
- Kiali MCP tools: https://github.com/kiali/kiali/pull/9927
- Kiali chatbot prompts: https://github.com/kiali/kiali/pull/9981
- Multicluster evals (source): https://github.com/hhovsepy/kubernetes-mcp-server/pull/4