### PR TITLE
feat(core): add structuredContent to resources_get and resources_list

### DIFF
--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -66,6 +66,18 @@ func (s *ResourcesSuite) TestResourcesList() {
 		s.Run("returns more than 2 items", func() {
 			s.Truef(len(decodedNamespaces) >= 3, "invalid namespace count, expected >2, got %v", len(decodedNamespaces))
 		})
+		s.Run("returns structured content with items", func() {
+			s.Require().NotNil(namespaces.StructuredContent, "expected structuredContent for resources_list")
+			structured, ok := namespaces.StructuredContent.(map[string]interface{})
+			s.Require().True(ok, "expected structuredContent to be wrapped in an object per MCP spec")
+			items, ok := structured["items"].([]interface{})
+			s.Require().True(ok, "expected items array in structured content")
+			s.Truef(len(items) >= 3, "expected >=3 structured items, got %d", len(items))
+			first, ok := items[0].(map[string]interface{})
+			s.Require().True(ok, "expected each item to be a map")
+			s.Equal("Namespace", first["kind"], "structured item kind should be Namespace")
+			s.Equal("v1", first["apiVersion"], "structured item apiVersion should be v1")
+		})
 	})
 	s.Run("resources_list with label selector returns filtered pods", func() {
 		s.Run("list pods with app=nginx label", func() {
@@ -261,6 +273,26 @@ func (s *ResourcesSuite) TestResourcesListAsTable() {
 			s.Truef(m, "Expected row '%s' not found in output:\n%s", expectedRow, outConfigMapList)
 			s.NoErrorf(e, "Error matching row regex: %v", e)
 		})
+		s.Run("returns structured content from table", func() {
+			s.Require().NotNil(configMapList.StructuredContent, "expected structuredContent for table output")
+			structured, ok := configMapList.StructuredContent.(map[string]interface{})
+			s.Require().True(ok, "expected structuredContent to be wrapped in an object per MCP spec")
+			items, ok := structured["items"].([]interface{})
+			s.Require().True(ok, "expected items array in structured content")
+			s.Truef(len(items) >= 1, "expected >=1 structured items, got %d", len(items))
+			var found bool
+			for _, item := range items {
+				row, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if name, _ := row["Name"].(string); name == "a-configmap-to-list-as-table" {
+					found = true
+					break
+				}
+			}
+			s.True(found, "expected to find a-configmap-to-list-as-table in structured content items")
+		})
 	})
 
 	s.Run("resources_list(apiVersion=route.openshift.io/v1, kind=Route) (list_output=table)", func() {
@@ -360,6 +392,16 @@ func (s *ResourcesSuite) TestResourcesGet() {
 		})
 		s.Run("returns default namespace", func() {
 			s.Equalf("default", decodedNamespace.GetName(), "invalid namespace name, expected default, got %v", decodedNamespace.GetName())
+		})
+		s.Run("returns structured content", func() {
+			s.Require().NotNil(namespace.StructuredContent, "expected structuredContent for resources_get")
+			structured, ok := namespace.StructuredContent.(map[string]interface{})
+			s.Require().True(ok, "expected structuredContent to be a map")
+			s.Equal("Namespace", structured["kind"], "structured kind should be Namespace")
+			s.Equal("v1", structured["apiVersion"], "structured apiVersion should be v1")
+			metadata, ok := structured["metadata"].(map[string]interface{})
+			s.Require().True(ok, "expected metadata map in structured content")
+			s.Equal("default", metadata["name"], "structured metadata.name should be default")
 		})
 	})
 }

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -225,7 +225,11 @@ func resourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list resources: %w", err)), nil
 	}
-	return api.NewToolCallResult(params.ListOutput.PrintObj(ret)), nil
+	printed, err := params.ListOutput.PrintObjStructured(ret)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to format resources: %w", err)), nil
+	}
+	return api.NewToolCallResultFull(printed.Text, printed.Structured, nil), nil
 }
 
 func resourcesGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
@@ -256,7 +260,11 @@ func resourcesGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get resource: %w", err)), nil
 	}
-	return api.NewToolCallResult(output.MarshalYaml(ret)), nil
+	printed, err := output.Yaml.PrintObjStructured(ret)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to format resource: %w", err)), nil
+	}
+	return api.NewToolCallResultFull(printed.Text, printed.Structured, nil), nil
 }
 
 func resourcesCreateOrUpdate(params api.ToolHandlerParams) (*api.ToolCallResult, error) {


### PR DESCRIPTION
## What

`resources_get` and `resources_list` now return `structuredContent` alongside the existing text output, enabling programmatic MCP clients to consume K8s objects directly without parsing YAML or table strings.

This extracts the K8s resource tool retrofit from #920 as a standalone change, following Recipe 1 from `docs/specs/structured-output.md`.

## Why

We maintain an MCP client ([kubernaut](https://github.com/jordigilh/kubernaut)) that consumes `resources_get` and `resources_list` programmatically to build `unstructured.Unstructured` objects for fleet metadata caching. Today we have to parse the text content (YAML or table strings) back into structured data, which is fragile and loses type fidelity. With `structuredContent`, our client can consume the K8s object directly as `map[string]any`.

The infrastructure is already on main (PR #960: `PrintObjStructured`, `NewToolCallResultFull`, `ensureStructuredObject`) and the structured-output spec documents Recipe 1 as the intended pattern for K8s resource tools — but notes "has no in-tree adopter yet." This PR is that first adopter for the core resource tools.

## Changes

**`pkg/toolsets/core/resources.go`** (2 handlers, ~10 lines changed):

- `resourcesGet`: `output.MarshalYaml(ret)` + `NewToolCallResult` → `output.Yaml.PrintObjStructured(ret)` + `NewToolCallResultFull`
- `resourcesList`: `params.ListOutput.PrintObj(ret)` + `NewToolCallResult` → `params.ListOutput.PrintObjStructured(ret)` + `NewToolCallResultFull`

**`pkg/mcp/resources_test.go`** (3 new subtests):

- `resources_get returns namespace / returns structured content` — asserts `StructuredContent` is a map with `kind`, `apiVersion`, `metadata.name`
- `resources_list returns namespaces / returns structured content with items` — asserts `StructuredContent` is `{"items": [...]}` per MCP spec wrapping
- `resources_list as table / returns structured content from table` — asserts table output also produces `StructuredContent`

## Backward compatibility

Fully backward compatible. The `Content[0].Text` field is unchanged — existing clients that only read text see no difference. `structuredContent` is additive per the MCP spec. This is the same pattern used by `configuration_contexts_list` (#1151).

## Checks

```bash
make build    # clean
make lint     # 0 issues
go test ./pkg/mcp/ -run "TestResources$" -v -count=1  # all pass
```

Refs #920

Made with [Cursor](https://cursor.com)