### PR TITLE
fix(deps): remove replace directive to restore go install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	golang.org/x/mod v0.36.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/time v0.15.0
@@ -165,12 +166,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
-
-// tektoncd/pipeline v1.12.0 pins gen-crd-api-reference-docs to a pseudo-version
-// whose commit (6bbddc29119c) exists on GitHub but is not reachable from any
-// branch, tag, or PR ref in the upstream repo. proxy.golang.org and
-// `GOPROXY=direct` both 404, which breaks `go list -m all` and IDE indexing.
-// Pinned here to a real tag so module resolution succeeds; the tool itself is
-// not imported by any compiled code in this repo.
-// Track: https://github.com/tektoncd/pipeline/issues/9997
-replace github.com/ahmetb/gen-crd-api-reference-docs => github.com/ahmetb/gen-crd-api-reference-docs v0.3.0

--- a/internal/test/gomod_test.go
+++ b/internal/test/gomod_test.go
@@ -1,0 +1,63 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/mod/modfile"
+)
+
+type GoModSuite struct {
+	suite.Suite
+	parsed *modfile.File
+}
+
+func (s *GoModSuite) SetupSuite() {
+	_, thisFile, _, ok := runtime.Caller(0)
+	s.Require().True(ok, "Expected to determine test file location")
+	goModPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "go.mod")
+	data, err := os.ReadFile(goModPath)
+	s.Require().NoError(err, "Expected to read root go.mod")
+	// Strict Parse is required here: ParseLax silently drops main-module-only
+	// directives (replace and exclude) before recording them, which are exactly
+	// the directives this guard inspects, so it would make the assertions below
+	// permanent no-ops. Strict Parse surfaces them. Its only downside is that it
+	// errors on a directive unknown to the pinned x/mod version, i.e. a brand-new
+	// Go directive — a loud, one-line x/mod bump to fix, far preferable to a
+	// guard that can never fail.
+	s.parsed, err = modfile.Parse(goModPath, data, nil)
+	s.Require().NoError(err, "Expected to parse root go.mod")
+}
+
+// TestInstallableAsDependency guards against re-introducing directives that make
+// the module impossible to `go install <module>/...@version` (or `go get` as a
+// dependency). Go refuses such an install when the target module's go.mod
+// "contains one or more replace directives" — and the same restriction applies
+// to exclude directives, since both would cause the module to be interpreted
+// differently than if it were the main module (see `go help install`). Either
+// directive therefore breaks installing the server from source for downstream
+// consumers, even though neither has any effect on `make build` of a local
+// clone. See issue #1231.
+func (s *GoModSuite) TestInstallableAsDependency() {
+	s.Run("go.mod has no replace directives", func() {
+		replaced := make([]string, 0, len(s.parsed.Replace))
+		for _, r := range s.parsed.Replace {
+			replaced = append(replaced, r.Old.Path)
+		}
+		s.Emptyf(replaced, "go.mod must not contain replace directives (found %v); they break `go install <module>/...@version` for downstream consumers (see issue #1231)", replaced)
+	})
+	s.Run("go.mod has no exclude directives", func() {
+		excluded := make([]string, 0, len(s.parsed.Exclude))
+		for _, e := range s.parsed.Exclude {
+			excluded = append(excluded, e.Mod.Path)
+		}
+		s.Emptyf(excluded, "go.mod must not contain exclude directives (found %v); they break `go install <module>/...@version` for downstream consumers (see issue #1231)", excluded)
+	})
+}
+
+func TestGoMod(t *testing.T) {
+	suite.Run(t, new(GoModSuite))
+}


### PR DESCRIPTION
## What

Removes the `replace github.com/ahmetb/gen-crd-api-reference-docs => ... v0.3.0` directive from `go.mod`.

## Why

`go install github.com/containers/kubernetes-mcp-server/cmd/kubernetes-mcp-server@latest` (and `go get`) fails with:

> The go.mod file for the module providing named packages contains one or more replace directives.

Go rejects any module whose `go.mod` carries `replace` (or `exclude`) directives when it's pulled in as a dependency. Building a local clone with `make build` was never affected, which is why this went unnoticed.

The directive was added in #1145 to work around tektoncd/pipeline pinning `gen-crd-api-reference-docs` to a commit that wasn't reachable from any ref (tektoncd/pipeline#9997). That has since been fixed upstream (tektoncd/pipeline#9999, backported in tektoncd/pipeline#10001), and we picked the fix up when bumping to tektoncd/pipeline v1.13.1. The transitive dependency now resolves to a fetchable pseudo-version, so the workaround is obsolete.

## Changes

- Remove the obsolete `replace` directive from `go.mod`. `go.sum` is unchanged, since the module is never imported or compiled.
- Add `internal/test/gomod_test.go`, a regression test that fails if a `replace` or `exclude` directive is reintroduced into `go.mod` (both break `go install ...@version`). This promotes `golang.org/x/mod` to a direct, test-only dependency.

## Verification

- `go mod edit -json` reports zero replace directives, so `go install` no longer rejects the module.
- `make test` passes (`go test -race ./...`), including the new guard.
- `go mod tidy -diff` is clean and `go mod verify` passes.

Fixes #1231