### PR TITLE
feat(evals): add auto-generated validated projects section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,26 @@ The Kubernetes MCP server supports enabling or disabling specific groups of tool
 This allows you to control which Kubernetes functionalities are available to your AI tools.
 Enabling only the toolsets you need can help reduce the context size and improve the LLM's tool selection accuracy.
 
+### Validated Kubernetes Ecosystem Projects
+
+The following CNCF and Kubernetes ecosystem projects are covered by
+automated evaluation scenarios in [`evals/tasks`](evals/tasks). Most scenarios
+work with just the `core` toolset. The dedicated toolsets below are optional
+and only needed for the project-specific scenarios noted.
+
+<!-- VALIDATED-PROJECTS-START -->
+
+| Project | Optional toolset(s) | Eval scenarios |
+|---------|---------------------|----------------|
+| [Helm](https://helm.sh) | `helm` | 3 |
+| [Istio](https://istio.io) | `kiali` | 5 |
+| [Kiali](https://kiali.io) | `kiali` | 16 |
+| [Kubernetes](https://kubernetes.io) | - | 32 |
+| [KubeVirt](https://kubevirt.io) | `kubevirt`, `tekton` | 19 |
+| [Tekton](https://tekton.dev) | `tekton` | 9 |
+
+<!-- VALIDATED-PROJECTS-END -->
+
 ### Available Toolsets
 
 The following sets of tools are available (toolsets marked with ✓ in the Default column are enabled by default):

--- a/evals/tasks/README.md
+++ b/evals/tasks/README.md
@@ -24,7 +24,11 @@ Most subdirectories under `core/`, `config/`, `helm/`, `kiali/`, `kubevirt/`, or
 1. Pick the closest family and create a new subfolder.
 2. Author the task YAML referencing MCP tools, expected observations, and any artifacts.
 3. Provide helper scripts if the scenario needs deterministic setup or verification.
-4. Document nuances in a local `README.md` so future contributors and eval authors can replay the scenario manually.
+4. Add project metadata so the task appears in the README validated-projects table (unlabeled tasks are skipped).
+   - The toolset column comes from the `requires` label, not `project`; set `requires` when a scenario needs a non-core toolset.
+   - `project` is a label; `project-name` and `project-url` are annotations. The generator panics if `project` is set without both.
+   - Example: [helm/install-chart/install-chart.yaml](helm/install-chart/install-chart.yaml).
+5. Document nuances in a local `README.md` so future contributors and eval authors can replay the scenario manually.
 
 Well-scoped, deterministic tasks make it easier to compare agents and regressions over time, so keep inputs minimal, outputs explicit, and always clean up what you create.
 

--- a/evals/tasks/config/identify-context-for-task/identify-context-for-task.yaml
+++ b/evals/tasks/config/identify-context-for-task/identify-context-for-task.yaml
@@ -3,6 +3,10 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: config
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: "identify-context-for-task"
   difficulty: medium
 spec:

--- a/evals/tasks/config/list-contexts/list-contexts.yaml
+++ b/evals/tasks/config/list-contexts/list-contexts.yaml
@@ -3,6 +3,10 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: config
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: "list-contexts"
   difficulty: easy
 spec:

--- a/evals/tasks/config/view-current-config/view-current-config.yaml
+++ b/evals/tasks/config/view-current-config/view-current-config.yaml
@@ -3,6 +3,10 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: config
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: "view-current-config"
   difficulty: easy
 spec:

--- a/evals/tasks/core/ahoy/ahoy.yaml
+++ b/evals/tasks/core/ahoy/ahoy.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: "ahoy"
   difficulty: easy
 steps:

--- a/evals/tasks/core/create-canary-deployment/create-canary-deployment.yaml
+++ b/evals/tasks/core/create-canary-deployment/create-canary-deployment.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: create-canary-deployment
   difficulty: hard
 steps:

--- a/evals/tasks/core/create-network-policy/create-network-policy.yaml
+++ b/evals/tasks/core/create-network-policy/create-network-policy.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: create-network-policy
   difficulty: medium
 steps:

--- a/evals/tasks/core/create-nginx-pod/create-nginx-pod.yaml
+++ b/evals/tasks/core/create-nginx-pod/create-nginx-pod.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: "create-nginx-pod"
   difficulty: easy
 steps:

--- a/evals/tasks/core/create-pod-mount-configmaps/create-pod-mount-configmaps.yaml
+++ b/evals/tasks/core/create-pod-mount-configmaps/create-pod-mount-configmaps.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: create-pod-mount-configmaps
   difficulty: medium
 steps:

--- a/evals/tasks/core/create-pod-resources-limits/create-pod-resources-limits.yaml
+++ b/evals/tasks/core/create-pod-resources-limits/create-pod-resources-limits.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: create-pod-resources-limits
   difficulty: easy
 steps:

--- a/evals/tasks/core/create-simple-rbac/create-simple-rbac.yaml
+++ b/evals/tasks/core/create-simple-rbac/create-simple-rbac.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: create-simple-rbac
   difficulty: medium
 steps:

--- a/evals/tasks/core/debug-app-logs/debug-app-logs.yaml
+++ b/evals/tasks/core/debug-app-logs/debug-app-logs.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: debug-app-logs
   difficulty: medium
 steps:

--- a/evals/tasks/core/deployment-traffic-switch/deployment-traffix-switch.yaml
+++ b/evals/tasks/core/deployment-traffic-switch/deployment-traffix-switch.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: deployment-traffic-switch
   difficulty: easy
 steps:

--- a/evals/tasks/core/filter-events-by-type/filter-events-by-type.yaml
+++ b/evals/tasks/core/filter-events-by-type/filter-events-by-type.yaml
@@ -3,6 +3,10 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: filter-events-by-type
   difficulty: easy
 spec:

--- a/evals/tasks/core/filter-namespace-by-name/filter-namespace-by-name.yaml
+++ b/evals/tasks/core/filter-namespace-by-name/filter-namespace-by-name.yaml
@@ -3,6 +3,10 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: filter-namespace-by-name
   difficulty: easy
 spec:

--- a/evals/tasks/core/fix-crashloop/fix-crashloop.yaml
+++ b/evals/tasks/core/fix-crashloop/fix-crashloop.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: "fix-crashloop"
   difficulty: medium
 steps:

--- a/evals/tasks/core/fix-image-pull/fix-image-pull.yaml
+++ b/evals/tasks/core/fix-image-pull/fix-image-pull.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: "fix-image-pull"
   difficulty: medium
 steps:

--- a/evals/tasks/core/fix-pending-pod/fix-pending-pod.yaml
+++ b/evals/tasks/core/fix-pending-pod/fix-pending-pod.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: fix-pending-pod
   difficulty: easy
 steps:

--- a/evals/tasks/core/fix-probes/fix-probes.yaml
+++ b/evals/tasks/core/fix-probes/fix-probes.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: fix-probes
   difficulty: medium
 steps:

--- a/evals/tasks/core/fix-rbac-wrong-resource/fix-rbac-wrong-resource.yaml
+++ b/evals/tasks/core/fix-rbac-wrong-resource/fix-rbac-wrong-resource.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: fix-rbac-wrong-resource
   difficulty: easy
 steps:

--- a/evals/tasks/core/fix-service-routing/fix-service-routing.yaml
+++ b/evals/tasks/core/fix-service-routing/fix-service-routing.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: fix-service-routing
   difficulty: medium
 steps:

--- a/evals/tasks/core/fix-service-with-no-endpoints/fix-service-with-no-endpoints.yaml
+++ b/evals/tasks/core/fix-service-with-no-endpoints/fix-service-with-no-endpoints.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: fix-service-with-no-endpoints
   difficulty: medium
 steps:

--- a/evals/tasks/core/horizontal-pod-autoscaler/horizontal-pod-autoscaler.yaml
+++ b/evals/tasks/core/horizontal-pod-autoscaler/horizontal-pod-autoscaler.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: horizontal-pod-autoscaler
   difficulty: hard
 steps:

--- a/evals/tasks/core/list-images-for-pods/list-images-for-pods.yaml
+++ b/evals/tasks/core/list-images-for-pods/list-images-for-pods.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: list-images-for-pods
   difficulty: medium
 steps:

--- a/evals/tasks/core/multi-container-pod-communication/multi-container-pod-communication.yaml
+++ b/evals/tasks/core/multi-container-pod-communication/multi-container-pod-communication.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: multi-container-pod-communication
   difficulty: medium
 steps:

--- a/evals/tasks/core/nodes-top/nodes-top.yaml
+++ b/evals/tasks/core/nodes-top/nodes-top.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: nodes-top
   difficulty: easy
 steps:

--- a/evals/tasks/core/resize-pvc/resize-pvc.yaml
+++ b/evals/tasks/core/resize-pvc/resize-pvc.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: resize-pvc
   difficulty: easy
 steps:

--- a/evals/tasks/core/rolling-update-deployment/rolling-update-deployment.yaml
+++ b/evals/tasks/core/rolling-update-deployment/rolling-update-deployment.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: rolling-update-deployment
   difficulty: medium
 steps:

--- a/evals/tasks/core/scale-deployment/scale-deployment.yaml
+++ b/evals/tasks/core/scale-deployment/scale-deployment.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: scale-deployment
   difficulty: medium
 steps:

--- a/evals/tasks/core/scale-down-deployment/scale-down-deployment.yaml
+++ b/evals/tasks/core/scale-down-deployment/scale-down-deployment.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: scale-down-deployment
   difficulty: medium
 steps:

--- a/evals/tasks/core/setup-dev-cluster/setup-dev-cluster.yaml
+++ b/evals/tasks/core/setup-dev-cluster/setup-dev-cluster.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: setup-dev-cluster
   difficulty: hard
 steps:

--- a/evals/tasks/core/ssa-field-preservation/ssa-field-preservation.yaml
+++ b/evals/tasks/core/ssa-field-preservation/ssa-field-preservation.yaml
@@ -5,6 +5,10 @@ metadata:
   difficulty: medium
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/core/statefulset-lifecycle/statefulset-lifecycle.yaml
+++ b/evals/tasks/core/statefulset-lifecycle/statefulset-lifecycle.yaml
@@ -2,6 +2,10 @@ kind: Task
 metadata:
   labels:
     suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
   name: statefulset-lifecycle
   difficulty: hard
 steps:

--- a/evals/tasks/helm/install-chart/install-chart.yaml
+++ b/evals/tasks/helm/install-chart/install-chart.yaml
@@ -5,6 +5,11 @@ metadata:
   difficulty: medium
   labels:
     suite: helm
+    project: helm
+    requires: helm
+  annotations:
+    project-name: "Helm"
+    project-url: "https://helm.sh"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/helm/list-releases/list-releases.yaml
+++ b/evals/tasks/helm/list-releases/list-releases.yaml
@@ -5,6 +5,11 @@ metadata:
   difficulty: easy
   labels:
     suite: helm
+    project: helm
+    requires: helm
+  annotations:
+    project-name: "Helm"
+    project-url: "https://helm.sh"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/helm/uninstall-release/uninstall-release.yaml
+++ b/evals/tasks/helm/uninstall-release/uninstall-release.yaml
@@ -5,6 +5,11 @@ metadata:
   difficulty: medium
   labels:
     suite: helm
+    project: helm
+    requires: helm
+  annotations:
+    project-name: "Helm"
+    project-url: "https://helm.sh"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/kiali/istio-create/istio-create.yaml
+++ b/evals/tasks/kiali/istio-create/istio-create.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: istio
+    requires: kiali
+  annotations:
+    project-name: "Istio"
+    project-url: "https://istio.io"
   name: "Create Istio Gateway"
   category: "Configuration Management"
   description: "Creates a new Istio Gateway in the istio-system namespace to manage ingress traffic."

--- a/evals/tasks/kiali/istio-delete/istio-delete.yaml
+++ b/evals/tasks/kiali/istio-delete/istio-delete.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: istio
+    requires: kiali
+  annotations:
+    project-name: "Istio"
+    project-url: "https://istio.io"
   name: "Remove Fault Injection"
   category: "Configuration Management"
   description: "Identifies and removes fault injection configurations (aborts/delays) from a VirtualService."

--- a/evals/tasks/kiali/istio-list-destination-rules/istio-list-destination-rules.yaml
+++ b/evals/tasks/kiali/istio-list-destination-rules/istio-list-destination-rules.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: istio
+    requires: kiali
+  annotations:
+    project-name: "Istio"
+    project-url: "https://istio.io"
   name: "List and Validate DestinationRules"
   category: "Configuration Management"
   description: "Lists all DestinationRules in a namespace and reports any Istio validation errors."

--- a/evals/tasks/kiali/istio-list/istio-list.yaml
+++ b/evals/tasks/kiali/istio-list/istio-list.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: istio
+    requires: kiali
+  annotations:
+    project-name: "Istio"
+    project-url: "https://istio.io"
   name: "List and Validate VirtualServices"
   category: "Configuration Management"
   description: "Lists all VirtualServices in a namespace and checks for configuration validation issues."

--- a/evals/tasks/kiali/istio-patch/istio-patch.yaml
+++ b/evals/tasks/kiali/istio-patch/istio-patch.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: istio
+    requires: kiali
+  annotations:
+    project-name: "Istio"
+    project-url: "https://istio.io"
   name: "Update Traffic Shifting"
   category: "Configuration Management"
   description: "Applies a patch to a VirtualService to implement weight-based traffic shifting between versions."

--- a/evals/tasks/kiali/metrics-service-request-rate/metrics-service-request-rate.yaml
+++ b/evals/tasks/kiali/metrics-service-request-rate/metrics-service-request-rate.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Analyze Service Traffic Volume"
   category: "Performance Analysis"
   description: "Retrieves and analyzes request and error rate metrics for a specific service over a time window."

--- a/evals/tasks/kiali/metrics-workload-latency/metrics-workload-latency.yaml
+++ b/evals/tasks/kiali/metrics-workload-latency/metrics-workload-latency.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Analyze Workload Response Times"
   category: "Performance Analysis"
   description: "Retrieves p50, p95, and p99 latency quantiles for a specific workload to identify performance bottlenecks."

--- a/evals/tasks/kiali/obs-unhealthy-namespaces/obs-unhealthy-namespaces.yaml
+++ b/evals/tasks/kiali/obs-unhealthy-namespaces/obs-unhealthy-namespaces.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Identify Degraded Namespaces"
   category: "Mesh Health & Status"
   description: "Scans the entire mesh to identify namespaces with health issues or degraded performance."

--- a/evals/tasks/kiali/resource-get-namespaces/resource-get-namespaces.yaml
+++ b/evals/tasks/kiali/resource-get-namespaces/resource-get-namespaces.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "List Mesh-Enabled Namespaces"
   category: "Resource Inspection"
   description: "Retrieves a list of all namespaces currently managed or observed by the Istio service mesh."

--- a/evals/tasks/kiali/resource-get-service-detail/resource-get-service-detail.yaml
+++ b/evals/tasks/kiali/resource-get-service-detail/resource-get-service-detail.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Inspect Service Details"
   category: "Resource Inspection"
   description: "Retrieves comprehensive information about a service, including its endpoints, health, and configuration."

--- a/evals/tasks/kiali/resource-get-workload-detail/resource-get-workload-detail.yaml
+++ b/evals/tasks/kiali/resource-get-workload-detail/resource-get-workload-detail.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Inspect Workload Details"
   category: "Resource Inspection"
   description: "Retrieves detailed status and health information for a specific workload within the mesh."

--- a/evals/tasks/kiali/resource-list-services/resource-list-services.yaml
+++ b/evals/tasks/kiali/resource-list-services/resource-list-services.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Inventory Namespace Services"
   category: "Resource Inspection"
   description: "Lists all services within a specific namespace to provide an inventory of available resources."

--- a/evals/tasks/kiali/resource-list-workloads/resource-list-workloads.yaml
+++ b/evals/tasks/kiali/resource-list-workloads/resource-list-workloads.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Inventory Workloads with Sidecar Status"
   category: "Resource Inspection"
   description: "Lists workloads in a namespace and identifies those missing the Istio sidecar proxy."

--- a/evals/tasks/kiali/resource-mesh-status/resource-mesh-status.yaml
+++ b/evals/tasks/kiali/resource-mesh-status/resource-mesh-status.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Comprehensive Mesh Health Audit"
   category: "Mesh Health & Status"
   description: "Performs a high-level audit of the mesh health, including control plane and data plane status."

--- a/evals/tasks/kiali/show-topology/show-topology.yaml
+++ b/evals/tasks/kiali/show-topology/show-topology.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Visualize Namespace Traffic"
   category: "Traffic Observability"
   description: "Generates a traffic graph for a specific namespace to visualize service-to-service communication."

--- a/evals/tasks/kiali/status-kiali-istio/status-kiali-istio.yaml
+++ b/evals/tasks/kiali/status-kiali-istio/status-kiali-istio.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Audit Control Plane Connectivity"
   category: "Mesh Health & Status"
   description: "Verifies the connectivity and status of Kiali's interaction with Istio control plane components."

--- a/evals/tasks/kiali/topology-mesh-namespaces/topology-mesh-namespaces.yaml
+++ b/evals/tasks/kiali/topology-mesh-namespaces/topology-mesh-namespaces.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Visualize Cross-Namespace Traffic"
   category: "Traffic Observability"
   description: "Generates a multi-namespace traffic graph to visualize dependencies across namespace boundaries."

--- a/evals/tasks/kiali/topology-workload-graph/topology-workload-graph.yaml
+++ b/evals/tasks/kiali/topology-workload-graph/topology-workload-graph.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Visualize Workload-Level Topology"
   category: "Traffic Observability"
   description: "Generates a detailed workload-level traffic graph to see individual pod-to-pod communication patterns."

--- a/evals/tasks/kiali/troubleshooting-log/troubleshooting-log.yaml
+++ b/evals/tasks/kiali/troubleshooting-log/troubleshooting-log.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Debug Service Errors via Logs"
   category: "Troubleshooting & Diagnostics"
   description: "Investigates HTTP 500 errors using workload logs and Istio VirtualService rules (e.g. fault injection)."

--- a/evals/tasks/kiali/troubleshooting-trace-lagging/troubleshooting-trace-lagging.yaml
+++ b/evals/tasks/kiali/troubleshooting-trace-lagging/troubleshooting-trace-lagging.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Analyze Latency with Distributed Tracing"
   category: "Troubleshooting & Diagnostics"
   description: "Uses distributed tracing plus Istio config (VirtualService/DestinationRule) review to find latency causes."

--- a/evals/tasks/kiali/troubleshooting-workload-logs/troubleshooting-workload-logs.yaml
+++ b/evals/tasks/kiali/troubleshooting-workload-logs/troubleshooting-workload-logs.yaml
@@ -3,6 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kiali
+    project: kiali
+    requires: kiali
+  annotations:
+    project-name: "Kiali"
+    project-url: "https://kiali.io"
   name: "Retrieve Recent Workload Logs"
   category: "Troubleshooting & Diagnostics"
   description: "Fetches the most recent log entries for a specific workload to aid in immediate troubleshooting."

--- a/evals/tasks/kubevirt/clone-vm/task.yaml
+++ b/evals/tasks/kubevirt/clone-vm/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "clone-vm"
   difficulty: medium
 spec:

--- a/evals/tasks/kubevirt/create-vm-basic/task.yaml
+++ b/evals/tasks/kubevirt/create-vm-basic/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "create-basic-vm"
   difficulty: easy
 spec:

--- a/evals/tasks/kubevirt/create-vm-ubuntu/task.yaml
+++ b/evals/tasks/kubevirt/create-vm-ubuntu/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "create-ubuntu-vm"
   difficulty: easy
 spec:

--- a/evals/tasks/kubevirt/create-vm-with-instancetype/task.yaml
+++ b/evals/tasks/kubevirt/create-vm-with-instancetype/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "create-vm-with-instancetype"
   difficulty: easy
 spec:

--- a/evals/tasks/kubevirt/create-vm-with-size/task.yaml
+++ b/evals/tasks/kubevirt/create-vm-with-size/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "create-vm-with-size"
   difficulty: easy
 spec:

--- a/evals/tasks/kubevirt/create-vm-with-vlan/task.yaml
+++ b/evals/tasks/kubevirt/create-vm-with-vlan/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "create-vm-with-vlan"
   difficulty: hard
 spec:

--- a/evals/tasks/kubevirt/delete-vm/task.yaml
+++ b/evals/tasks/kubevirt/delete-vm/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "delete-vm"
   difficulty: medium
 spec:

--- a/evals/tasks/kubevirt/get-vm-filesystems/task.yaml
+++ b/evals/tasks/kubevirt/get-vm-filesystems/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "get-vm-filesystems"
   difficulty: easy
 spec:

--- a/evals/tasks/kubevirt/get-vm-ip-address/task.yaml
+++ b/evals/tasks/kubevirt/get-vm-ip-address/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "get-vm-ip-address"
   difficulty: easy
 spec:

--- a/evals/tasks/kubevirt/get-vm-os-info/task.yaml
+++ b/evals/tasks/kubevirt/get-vm-os-info/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "get-vm-os-info"
   difficulty: easy
 spec:

--- a/evals/tasks/kubevirt/list-vm-users/task.yaml
+++ b/evals/tasks/kubevirt/list-vm-users/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "list-vm-users"
   difficulty: easy
 spec:

--- a/evals/tasks/kubevirt/restore-vm/task.yaml
+++ b/evals/tasks/kubevirt/restore-vm/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "restore-vm"
   difficulty: medium
 spec:

--- a/evals/tasks/kubevirt/snapshot-vm/task.yaml
+++ b/evals/tasks/kubevirt/snapshot-vm/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "snapshot-vm"
   difficulty: medium
 spec:

--- a/evals/tasks/kubevirt/troubleshoot-vm/task.yaml
+++ b/evals/tasks/kubevirt/troubleshoot-vm/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "troubleshoot-vm"
   difficulty: hard
   description: "Use the vm-troubleshoot prompt to diagnose and fix VirtualMachine issues"

--- a/evals/tasks/kubevirt/update-vm-instancetype/task.yaml
+++ b/evals/tasks/kubevirt/update-vm-instancetype/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "update-vm-instancetype"
   difficulty: hard
 spec:

--- a/evals/tasks/kubevirt/update-vm-resources/task.yaml
+++ b/evals/tasks/kubevirt/update-vm-resources/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "update-vm-resources"
   difficulty: hard
 spec:

--- a/evals/tasks/kubevirt/vm-guest-info/task.yaml
+++ b/evals/tasks/kubevirt/vm-guest-info/task.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "vm-guest-info"
   difficulty: medium
 spec:

--- a/evals/tasks/kubevirt/windows-golden-image-no-eula/prompt.yaml
+++ b/evals/tasks/kubevirt/windows-golden-image-no-eula/prompt.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt,tekton
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "windows-golden-image-no-eula"
   difficulty: medium
   description: "Test the windows-golden-image prompt output and EULA handling"

--- a/evals/tasks/kubevirt/windows-golden-image-success/prompt.yaml
+++ b/evals/tasks/kubevirt/windows-golden-image-success/prompt.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: kubevirt
+    project: kubevirt
     requires: kubevirt,tekton
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
   name: "windows-golden-image-success"
   difficulty: hard
   description: "Use the windows-golden-image prompt to generate a Windows golden image creation guide"

--- a/evals/tasks/tekton/create-pipeline/task.yaml
+++ b/evals/tasks/tekton/create-pipeline/task.yaml
@@ -5,7 +5,11 @@ metadata:
   difficulty: easy
   labels:
     suite: tekton
+    project: tekton
     requires: tekton
+  annotations:
+    project-name: "Tekton"
+    project-url: "https://tekton.dev"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/tekton/create-task/task.yaml
+++ b/evals/tasks/tekton/create-task/task.yaml
@@ -5,7 +5,11 @@ metadata:
   difficulty: easy
   labels:
     suite: tekton
+    project: tekton
     requires: tekton
+  annotations:
+    project-name: "Tekton"
+    project-url: "https://tekton.dev"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/tekton/delete-pipelinerun/task.yaml
+++ b/evals/tasks/tekton/delete-pipelinerun/task.yaml
@@ -5,7 +5,11 @@ metadata:
   difficulty: medium
   labels:
     suite: tekton
+    project: tekton
     requires: tekton
+  annotations:
+    project-name: "Tekton"
+    project-url: "https://tekton.dev"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/tekton/get-pipeline/task.yaml
+++ b/evals/tasks/tekton/get-pipeline/task.yaml
@@ -5,7 +5,11 @@ metadata:
   difficulty: easy
   labels:
     suite: tekton
+    project: tekton
     requires: tekton
+  annotations:
+    project-name: "Tekton"
+    project-url: "https://tekton.dev"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/tekton/list-pipelineruns/task.yaml
+++ b/evals/tasks/tekton/list-pipelineruns/task.yaml
@@ -5,7 +5,11 @@ metadata:
   difficulty: easy
   labels:
     suite: tekton
+    project: tekton
     requires: tekton
+  annotations:
+    project-name: "Tekton"
+    project-url: "https://tekton.dev"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/tekton/list-pipelines/task.yaml
+++ b/evals/tasks/tekton/list-pipelines/task.yaml
@@ -5,7 +5,11 @@ metadata:
   difficulty: easy
   labels:
     suite: tekton
+    project: tekton
     requires: tekton
+  annotations:
+    project-name: "Tekton"
+    project-url: "https://tekton.dev"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/tekton/restart-pipelinerun/task.yaml
+++ b/evals/tasks/tekton/restart-pipelinerun/task.yaml
@@ -5,7 +5,11 @@ metadata:
   difficulty: medium
   labels:
     suite: tekton
+    project: tekton
     requires: tekton
+  annotations:
+    project-name: "Tekton"
+    project-url: "https://tekton.dev"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/tekton/start-pipeline/task.yaml
+++ b/evals/tasks/tekton/start-pipeline/task.yaml
@@ -5,7 +5,11 @@ metadata:
   difficulty: medium
   labels:
     suite: tekton
+    project: tekton
     requires: tekton
+  annotations:
+    project-name: "Tekton"
+    project-url: "https://tekton.dev"
 spec:
   requires:
     - extension: kubernetes

--- a/evals/tasks/tekton/start-task/task.yaml
+++ b/evals/tasks/tekton/start-task/task.yaml
@@ -5,7 +5,11 @@ metadata:
   difficulty: medium
   labels:
     suite: tekton
+    project: tekton
     requires: tekton
+  annotations:
+    project-name: "Tekton"
+    project-url: "https://tekton.dev"
 spec:
   requires:
     - extension: kubernetes

--- a/internal/tools/update-readme/main.go
+++ b/internal/tools/update-readme/main.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 
+	"sigs.k8s.io/yaml"
+
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
@@ -31,6 +33,21 @@ func (p *FilterProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVer
 
 var _ api.FilteringProvider = (*FilterProvider)(nil)
 
+type evalTask struct {
+	Kind     string `json:"kind"`
+	Metadata struct {
+		Labels      map[string]string `json:"labels"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"metadata"`
+}
+
+type projectInfo struct {
+	Name     string
+	URL      string
+	Toolsets map[string]bool
+	Count    int
+}
+
 func main() {
 	// Snyk reports false positive unless we flow the args through filepath.Clean and filepath.Localize in this specific order
 	var err error
@@ -43,6 +60,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	// Validated Projects
+	updated := generateValidatedProjects(string(readme))
+
 	// Available Toolsets
 	toolsetsList := toolsets.Toolsets()
 
@@ -75,8 +96,8 @@ func main() {
 		}
 		fmt.Fprintf(&availableToolsets, "| %-*s | %-*s | %-*s |\n", maxNameLen, toolset.GetName(), maxDescLen, toolset.GetDescription(), defaultHeaderLen, defaultIndicator)
 	}
-	updated := replaceBetweenMarkers(
-		string(readme),
+	updated = replaceBetweenMarkers(
+		updated,
 		"<!-- AVAILABLE-TOOLSETS-START -->",
 		"<!-- AVAILABLE-TOOLSETS-END -->",
 		availableToolsets.String(),
@@ -195,4 +216,118 @@ func replaceBetweenMarkers(content, startMarker, endMarker, replacement string) 
 		return content
 	}
 	return content[:startIdx+len(startMarker)] + "\n\n" + replacement + "\n" + content[endIdx:]
+}
+
+func generateValidatedProjects(content string) string {
+	evalsDir := "evals/tasks"
+	projects := make(map[string]*projectInfo)
+	displayNameToKey := make(map[string]string)
+
+	err := filepath.Walk(evalsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".yaml" {
+			return nil
+		}
+		if strings.Contains(path, "/artifacts/") {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		var task evalTask
+		if err := yaml.Unmarshal(data, &task); err != nil {
+			panic(fmt.Sprintf("failed to parse %q: %v", path, err))
+		}
+
+		if task.Kind != "Task" && task.Kind != "Prompt" {
+			return nil
+		}
+
+		projectKey := task.Metadata.Labels["project"]
+		if projectKey == "" {
+			return nil
+		}
+
+		projectName := task.Metadata.Annotations["project-name"]
+		projectURL := task.Metadata.Annotations["project-url"]
+
+		if projectName == "" || projectURL == "" {
+			panic(fmt.Sprintf("task %q has project label %q but is missing project-name or project-url annotations", path, projectKey))
+		}
+
+		if existingKey, ok := displayNameToKey[projectName]; ok && existingKey != projectKey {
+			panic(fmt.Sprintf("display name %q is used by both project keys %q and %q", projectName, existingKey, projectKey))
+		}
+		displayNameToKey[projectName] = projectKey
+
+		p, exists := projects[projectKey]
+		if !exists {
+			p = &projectInfo{
+				Name:     projectName,
+				URL:      projectURL,
+				Toolsets: map[string]bool{},
+			}
+			projects[projectKey] = p
+		} else {
+			if p.Name != projectName {
+				panic(fmt.Sprintf("project %q has conflicting names: %q vs %q", projectKey, p.Name, projectName))
+			}
+			if p.URL != projectURL {
+				panic(fmt.Sprintf("project %q has conflicting URLs: %q vs %q", projectKey, p.URL, projectURL))
+			}
+		}
+
+		p.Count++
+
+		if requires := task.Metadata.Labels["requires"]; requires != "" {
+			for _, ts := range strings.Split(requires, ",") {
+				if ts = strings.TrimSpace(ts); ts != "" {
+					p.Toolsets[ts] = true
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	type row struct {
+		name     string
+		url      string
+		toolsets string
+		count    int
+	}
+	var rows []row
+	for _, p := range projects {
+		extras := slices.Sorted(maps.Keys(p.Toolsets))
+		var toolsetsStr string
+		if len(extras) == 0 {
+			toolsetsStr = "-"
+		} else {
+			toolsetsStr = "`" + strings.Join(extras, "`, `") + "`"
+		}
+		rows = append(rows, row{name: p.Name, url: p.URL, toolsets: toolsetsStr, count: p.Count})
+	}
+	slices.SortFunc(rows, func(a, b row) int {
+		return strings.Compare(strings.ToLower(a.name), strings.ToLower(b.name))
+	})
+
+	table := strings.Builder{}
+	table.WriteString("| Project | Optional toolset(s) | Eval scenarios |\n")
+	table.WriteString("|---------|---------------------|----------------|\n")
+	for _, r := range rows {
+		fmt.Fprintf(&table, "| [%s](%s) | %s | %d |\n", r.name, r.url, r.toolsets, r.count)
+	}
+
+	return replaceBetweenMarkers(content, "<!-- VALIDATED-PROJECTS-START -->", "<!-- VALIDATED-PROJECTS-END -->", table.String())
 }


### PR DESCRIPTION
### Summary

Adds a new auto-generated section to README.md that surfaces which CNCF/Kubernetes ecosystem projects are continuously validated by the eval suite. The table is maintained by the same `make update-readme-tools` pipeline (and `check-readme` CI job) that already keeps the toolsets documentation in sync.

Changes:

- Seeded all current Task/Prompt YAML files with `project` label, `project-name`/`project-url` annotations, and `requires` label backfills where missing.
- Extended `internal/tools/update-readme/main.go` with a `generateValidatedProjects()` function that walks `evals/tasks/`, aggregates tasks by `project` label, and emits a markdown table between pre-defined markers.
- Updated `evals/tasks/README.md` with contributor guidance on the metadata schema.

Additional decisions undocumented in the issue:

- KubeVirt row includes `tekton` in toolsets, while the issue's illustrative table didn't account for this.
  - Fact: Two pre-existing tasks (`windows-golden-image-no-eula`, `windows-golden-image-success`) carry `requires: kubevirt,tekton`, so the generator produces `core`, `kubevirt`, `tekton`.
  - Current implementation: The generator unions all requires values across a project's tasks, surfacing `tekton`.
- Added one sentence documenting the schema in `evals/tasks/README.md` for future contributors.
- YAML parse errors would panic and fail the build loudly.

### Motivation

Resolves #1230 
