### PR TITLE
chore(evals): fix stale docs and drifted Makefile defaults

### DIFF
--- a/build/evals.mk
+++ b/build/evals.mk
@@ -7,6 +7,7 @@ MCP_CONFIG_DIR ?= dev/config/mcp-configs
 
 MCPCHECKER = $(shell pwd)/_output/tools/bin/mcpchecker
 MCPCHECKER_VERSION ?= latest
+CLAUDE_AGENT_ACP_VERSION ?= latest
 
 # High-level knobs for local single-suite runs, e.g.:
 #   make run-evals SUITE=kubevirt AGENT=claude-code MODEL=sonnet
@@ -41,8 +42,10 @@ mcpchecker:
 .PHONY: claude-agent-acp
 claude-agent-acp: ## Install the claude-agent-acp adapter for the claude-code eval agent
 	@command -v claude-agent-acp >/dev/null 2>&1 || { \
-		echo "Installing claude-agent-acp (npm install -g @agentclientprotocol/claude-agent-acp)..." ;\
-		npm install -g @agentclientprotocol/claude-agent-acp ;\
+		set -e ;\
+		echo "Installing claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) (npm install -g)..." ;\
+		npm install -g @agentclientprotocol/claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) ;\
+		echo "✅ claude-agent-acp installed" ;\
 	}
 
 .PHONY: run-evals

--- a/build/evals.mk
+++ b/build/evals.mk
@@ -7,8 +7,20 @@ MCP_CONFIG_DIR ?= dev/config/mcp-configs
 
 MCPCHECKER = $(shell pwd)/_output/tools/bin/mcpchecker
 MCPCHECKER_VERSION ?= latest
-EVAL_CONFIG ?= evals/openai-agent/eval.yaml
-EVAL_LABEL_SELECTOR ?= suite=kubernetes
+
+# High-level knobs for local single-suite runs, e.g.:
+#   make run-evals SUITE=kubevirt AGENT=claude-code MODEL=sonnet
+# AGENT selects the eval config, SUITE selects the task suite label, and MODEL
+# sets ANTHROPIC_MODEL for the claude-agent-acp adapter (the openai-agent ignores it).
+AGENT ?= openai-agent
+SUITE ?= core
+MODEL ?=
+
+# Prefer a per-suite eval config when one exists: those carry no llmJudge, so a
+# local run needs no OpenAI key. Otherwise fall back to the agent's top-level
+# config (the one CI uses; its llmJudge requires an OpenAI key).
+EVAL_CONFIG ?= $(or $(wildcard evals/tasks/$(SUITE)/$(AGENT)/eval.yaml),evals/$(AGENT)/eval.yaml)
+EVAL_LABEL_SELECTOR ?= suite=$(SUITE)
 EVAL_TASK_FILTER ?=
 EVAL_VERBOSE ?= false
 
@@ -24,9 +36,18 @@ mcpchecker:
 
 ##@ Evals
 
+# Install the claude-agent-acp adapter, required by the claude-code eval agent
+# (evals/claude-code/agent.yaml runs `claude-agent-acp`). No-op if already present.
+.PHONY: claude-agent-acp
+claude-agent-acp: ## Install the claude-agent-acp adapter for the claude-code eval agent
+	@command -v claude-agent-acp >/dev/null 2>&1 || { \
+		echo "Installing claude-agent-acp (npm install -g @agentclientprotocol/claude-agent-acp)..." ;\
+		npm install -g @agentclientprotocol/claude-agent-acp ;\
+	}
+
 .PHONY: run-evals
-run-evals: mcpchecker ## Run mcpchecker evaluations against the MCP server
-	$(MCPCHECKER) check $(EVAL_CONFIG) \
+run-evals: mcpchecker $(if $(filter claude-code,$(AGENT)),claude-agent-acp) ## Run mcpchecker evals (knobs: SUITE, AGENT, MODEL; see evals/README.md)
+	$(if $(MODEL),ANTHROPIC_MODEL=$(MODEL) )$(MCPCHECKER) check $(EVAL_CONFIG) \
 		$(if $(EVAL_LABEL_SELECTOR),--label-selector $(EVAL_LABEL_SELECTOR),) \
 		$(if $(EVAL_TASK_FILTER),--run "$(EVAL_TASK_FILTER)",) \
 		$(if $(filter true,$(EVAL_VERBOSE)),--verbose,) \
@@ -61,7 +82,7 @@ run-server: build ## Start MCP server in background and wait for health check
 	@echo "Waiting for MCP server to be ready..."
 	@elapsed=0; \
 	while [ $$elapsed -lt $(MCP_HEALTH_TIMEOUT) ]; do \
-		if curl -s http://localhost:$(MCP_PORT)/health > /dev/null 2>&1; then \
+		if curl -fsS http://localhost:$(MCP_PORT)/healthz > /dev/null 2>&1; then \
 			echo "MCP server is ready"; \
 			exit 0; \
 		fi; \

--- a/evals/README.md
+++ b/evals/README.md
@@ -49,7 +49,8 @@ Tasks are grouped into suites via a `suite: <name>` label. The available suites 
 ## Quickstart: run one suite locally with Claude Code
 
 This runs the `kubevirt` suite end to end with the Claude Code agent on a Sonnet
-model, with **no OpenAI key required** (per-suite configs carry no LLM judge, see
+model, with **no OpenAI key required**. With the Claude Code agent both the agent
+and the LLM judge run on your Claude subscription, so every suite is keyless (see
 [Eval configs](#eval-configs-top-level-vs-per-suite) below).
 
 ```bash
@@ -100,7 +101,9 @@ environment variable (for example `ANTHROPIC_MODEL=sonnet`), which
 model for the run, overriding whatever default your Claude Code session would
 otherwise use, and it runs on your existing Claude subscription (no API key
 needed). `make run-evals` sets it for you from the `MODEL` variable, so
-`make run-evals ... MODEL=sonnet` is how you pin the eval to Sonnet.
+`make run-evals ... MODEL=sonnet` is how you pin the eval to Sonnet. The same
+variable also drives the Claude Code judge (see [Eval configs](#eval-configs-top-level-vs-per-suite)),
+so agent and judge share the model.
 
 The OpenAI-compatible agent instead takes its model from
 `evals/openai-agent/agent.yaml` plus the `MODEL_BASE_URL` and `MODEL_KEY`
@@ -124,22 +127,30 @@ task. The assertions accept either, for example `toolPattern: "(pods_.*|resource
 
 ## Eval configs: top-level vs per-suite
 
-There are two eval-config trees:
+There are two top-level eval configs, one per agent:
 
-- **Top-level** (`evals/{claude-code,openai-agent}/eval.yaml`): one config per agent,
-  globbing every suite. These are what **CI** runs. They declare an
-  `llmJudge: { model: "openai:gpt-5" }`. That judge only runs for tasks that
-  include an `llmJudge` verify step, and **only those tasks need an OpenAI key**.
-  The `core` and `helm` suites have no such tasks, so they run key-free even here;
-  `config`, `kiali`, and `tekton` (and 4 `kubevirt` tasks) include `llmJudge` steps
-  that need a key under these configs. Filter with `--label-selector suite=<name>`.
-- **Per-suite** (`evals/tasks/<suite>/{claude-code,openai-agent}/eval.yaml`):
-  a scoped config with **no** config-level `llmJudge`, so any `llmJudge` verify step
-  degrades to a no-op pass (mcpchecker's `noopLLMJudge`) and no OpenAI key is ever
-  needed. Currently only `kubevirt` ships these.
+- **`evals/claude-code/eval.yaml`** (Claude Code): the agent runs via
+  `claude-agent-acp`, and the LLM judge is also `builtin.claude-code`, so **both
+  agent and judge run on your Claude subscription — fully keyless, for every
+  suite**. Judge-backed tasks are really evaluated (semantic), not skipped. This
+  is the recommended local path.
+- **`evals/openai-agent/eval.yaml`** (OpenAI-compatible, what **CI** runs): the
+  agent uses `MODEL_BASE_URL`/`MODEL_KEY` and the judge is `openai:gpt-5`, so its
+  judge-backed tasks need an OpenAI key.
 
-`make run-evals` prefers a per-suite config when one exists for the chosen
-`SUITE`/`AGENT`, and otherwise falls back to the agent's top-level config.
+A task is "judge-backed" when its verify phase has an `llmJudge` step —
+**including the legacy `verify: contains:` short form, which is judge-evaluated
+(semantic), not a literal string match.** Judge-backed task counts per suite:
+`helm` 0, `core` 4, `kubevirt` 4, `tekton` 5, `config` 3, `kiali` 18. With the
+OpenAI agent those tasks need a key; with the Claude Code agent none do. Filter
+either config to one suite with `--label-selector suite=<name>`.
+
+**Per-suite** configs (`evals/tasks/<suite>/{claude-code,openai-agent}/eval.yaml`,
+currently only `kubevirt`) are scoped to a single suite. The claude-code one
+judges with claude-code (keyless); the openai-agent one declares no judge, so its
+judge steps degrade to a no-op pass (mcpchecker's `noopLLMJudge`). `make run-evals`
+prefers a per-suite config when one exists for the chosen `SUITE`/`AGENT`, and
+otherwise falls back to the agent's top-level config.
 
 ## Agent configuration
 
@@ -181,10 +192,10 @@ make run-evals SUITE=kiali AGENT=claude-code MODEL=sonnet
 If you omit `--label-selector`, the eval config's own `labelSelector` settings in
 each `taskSets` entry determine which tasks run.
 
-Note: suites other than `kubevirt` use the agent's top-level config, which has a
-real `llmJudge`. `core` and `helm` have no `llmJudge` tasks, so they run with no
-OpenAI key; `config`, `kiali`, and `tekton` include `llmJudge` tasks that do need
-one there (see [Eval configs](#eval-configs-top-level-vs-per-suite)).
+Note: with `AGENT=claude-code` every suite is keyless (agent and judge both run on
+your Claude subscription). With `AGENT=openai-agent` the judge-backed tasks need an
+OpenAI key — `core` 4, `config` 3, `kiali` 18, `tekton` 5, `kubevirt` 4, `helm` 0
+(see [Eval configs](#eval-configs-top-level-vs-per-suite)).
 
 ## Versions
 
@@ -192,6 +203,11 @@ one there (see [Eval configs](#eval-configs-top-level-vs-per-suite)).
 `.github/workflows/mcpchecker.yaml` calls `mcpchecker-action` (currently pinned at
 `v0.0.18`) with `mcpchecker-version: latest`. If you need to reproduce CI exactly,
 pin the binary with `make mcpchecker MCPCHECKER_VERSION=<version>`.
+
+`make claude-agent-acp` likewise installs `@agentclientprotocol/claude-agent-acp@latest`;
+pin it with `make claude-agent-acp CLAUDE_AGENT_ACP_VERSION=<version>` for local
+reproducibility. CI never installs the adapter (it runs the OpenAI agent), so this
+knob is purely local.
 
 ## Expected results
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,156 +1,200 @@
-# Kubernetes MCP Server Test Examples
+# Kubernetes MCP Server Evals
 
-This directory contains examples for testing the **same Kubernetes MCP server** using different AI agents.
+This directory contains the [mcpchecker](https://github.com/mcpchecker/mcpchecker)
+evaluations for the **Kubernetes MCP server**. The same tasks are run against the
+same MCP server using different AI agents (Claude Code, an OpenAI-compatible agent,
+and others), so agents can be compared on an identical benchmark.
 
 ## Structure
 
 ```
-kube-mcp-server/
-└── evals/
-    ├── README.md                        # This file
-    ├── mcp-config.yaml                  # Shared MCP server configuration
-    ├── core-eval-testing/               # Core eval configurations per provider/agent type
-    │   ├── acp-anthropic/               # ACP agent with Anthropic
-    │   ├── acp-google/                  # ACP agent with Google
-    │   ├── builtin-anthropic/           # Built-in agent with Anthropic
-    │   ├── builtin-google/              # Built-in agent with Google
-    │   └── builtin-openai/              # Built-in agent with OpenAI
-    ├── claude-code/                     # Claude Code agent configuration
-    ├── openai-agent/                    # OpenAI-compatible agent configuration
-    ├── results/                         # Weekly eval results
-    └── tasks/                           # Shared test tasks organized by suite (see tasks/README.md)
-        └── <toolset>/
-            └── <task-name>/
-                ├── task.yaml            # Task definition (prompt, verify, labels)
-                ├── setup.sh             # Pre-task cluster setup
-                ├── verify.sh            # Post-task verification
-                ├── cleanup.sh           # Resource cleanup
-                └── artifacts/           # Optional K8s manifests
-
+evals/
+├── README.md                       # This file
+├── mcp-config.yaml                 # Shared MCP server connection (http://localhost:8080/mcp)
+├── claude-code/                    # Claude Code agent config (ACP) + top-level eval.yaml
+├── openai-agent/                   # OpenAI-compatible agent config + top-level eval.yaml
+├── core-eval-testing/              # Extra agent/provider combinations for core tasks
+├── results/                        # Committed eval results (baselines)
+└── tasks/                          # Shared task library, grouped by suite (see tasks/README.md)
+    └── <suite>/                    # core, config, helm, kiali, kubevirt, tekton
+        └── <task-name>/
+            ├── <task-name>.yaml    # Task definition (prompt, verify, labels). kubevirt/tekton use task.yaml
+            ├── setup.sh            # Optional pre-task cluster setup
+            ├── verify.sh           # Optional post-task verification
+            ├── cleanup.sh          # Optional resource cleanup
+            └── artifacts/          # Optional K8s manifests
 ```
 
-## What This Tests
-
-Both examples test the **same Kubernetes MCP server** using **shared task definitions**:
-- Creates an nginx pod named `web-server` in the `create-pod-test` namespace
-- Verifies the pod is running
-- Validates that the agent called appropriate Kubernetes tools
-- Cleans up resources
-
-The tasks and MCP configuration are shared - only the agent configuration differs.
+Tasks are grouped into suites via a `suite: <name>` label. The available suites are
+`core`, `config`, `helm`, `kiali`, `kubevirt`, and `tekton`.
 
 ## Prerequisites
 
-- Kubernetes cluster (kind, minikube, or any cluster)
-- kubectl configured
-- Kubernetes MCP server running at `http://localhost:8080/mcp`
-- Built binaries: `mcpchecker` and `agent`
+- A Kubernetes cluster (kind, minikube, or any cluster) and `kubectl` configured for it
+- The Kubernetes MCP server running at `http://localhost:8080/mcp` (see `make run-server`)
+- `mcpchecker`: `make mcpchecker` installs it under `_output/tools/bin/`. The
+  `make run-evals` target calls that path directly; to run the bare `mcpchecker …`
+  commands shown below by hand, add `_output/tools/bin` to your `PATH`.
+- For the **Claude Code** agent only:
+  - The `claude` CLI (Claude Code) installed, on your `PATH`, and **signed in**.
+    The agent runs through your existing Claude Code session, so your Claude
+    subscription (or an `ANTHROPIC_API_KEY`) covers the agent and no separate key
+    is needed. Run `claude` once interactively to log in if you have not already.
+  - The `claude-agent-acp` adapter, which bridges mcpchecker to that `claude` CLI,
+    installed with `make claude-agent-acp` (runs
+    `npm install -g @agentclientprotocol/claude-agent-acp`, so it needs Node.js/npm).
+    Without it, `mcpchecker check` fails at agent-spec load with
+    `'claude-agent-acp' binary not found in PATH`.
 
-## Running Examples
+## Quickstart: run one suite locally with Claude Code
 
-### Option 1: Claude Code
+This runs the `kubevirt` suite end to end with the Claude Code agent on a Sonnet
+model, with **no OpenAI key required** (per-suite configs carry no LLM judge, see
+[Eval configs](#eval-configs-top-level-vs-per-suite) below).
 
 ```bash
-mcpchecker check examples/kube-mcp-server/claude-code/eval.yaml
+# 1. Build the server and install the eval tooling
+make build mcpchecker claude-agent-acp
+
+# 2. Create a cluster and point KUBECONFIG at it.
+#    KUBECONFIG must be EXPORTED so both the kubernetes extension's setup steps
+#    and each task's verify.sh kubectl target the same cluster.
+kind create cluster --name mcp-eval-cluster --kubeconfig "$PWD/_output/kubeconfig"
+export KUBECONFIG="$PWD/_output/kubeconfig"
+
+# 3. Install KubeVirt (only needed for the kubevirt suite).
+#    This also auto-deploys the common-instancetypes (u1.small, u1.medium, ...)
+#    via virt-operator, so instancetype tasks work without a separate step.
+make kubevirt-install
+
+# 4. Start the MCP server with the toolsets the suite needs
+make run-server TOOLSETS=core,config,kubevirt
+
+# 5. Run the suite. AGENT selects the agent, SUITE selects the tasks, MODEL sets
+#    ANTHROPIC_MODEL for the Claude Code agent. Add EVAL_TASK_FILTER=<name> to run one task.
+make run-evals SUITE=kubevirt AGENT=claude-code MODEL=sonnet
+
+# 6. Tear down
+make stop-server
+kind delete cluster --name mcp-eval-cluster
 ```
 
-**Requirements:**
-- Claude Code installed and in PATH
+> A bare `kind create cluster` is enough for kubevirt and most toolset suites.
+> `make kind-create-cluster` also installs nginx-ingress, cert-manager, and a
+> Keycloak hosts entry, which toolset evals do not need (and which pull from
+> registries that are not always reachable).
 
-**Tool Usage:**
-- Claude typically uses pod-specific tools like `pods_run`, `pods_create`
+The make-target invocation in step 5 is equivalent to the underlying command:
 
----
+```bash
+KUBECONFIG="$PWD/_output/kubeconfig" ANTHROPIC_MODEL=sonnet mcpchecker check \
+  evals/tasks/kubevirt/claude-code/eval.yaml \
+  --label-selector suite=kubevirt --output json
+```
 
-### Option 2: OpenAI-Compatible Agent (Built-in)
+### Model selection
+
+The model for the Claude Code agent is chosen with the `ANTHROPIC_MODEL`
+environment variable (for example `ANTHROPIC_MODEL=sonnet`), which
+`claude-agent-acp` reads as its first-priority model source. It **forces** that
+model for the run, overriding whatever default your Claude Code session would
+otherwise use, and it runs on your existing Claude subscription (no API key
+needed). `make run-evals` sets it for you from the `MODEL` variable, so
+`make run-evals ... MODEL=sonnet` is how you pin the eval to Sonnet.
+
+The OpenAI-compatible agent instead takes its model from
+`evals/openai-agent/agent.yaml` plus the `MODEL_BASE_URL` and `MODEL_KEY`
+environment variables.
+
+## Running with the OpenAI-compatible agent
 
 ```bash
 # Set your model credentials
 export MODEL_BASE_URL='https://your-api-endpoint.com/v1'
 export MODEL_KEY='your-api-key'
 
-# Run the test
-mcpchecker check examples/kube-mcp-server/openai-agent/eval.yaml
+# Run the core suite (this is what CI runs)
+make run-evals SUITE=core AGENT=openai-agent
+# equivalently:
+mcpchecker check evals/openai-agent/eval.yaml --label-selector suite=core
 ```
 
-**Note:** Different AI models may choose different tools from the MCP server (`pods_*` or `resources_*`) to accomplish the same task. Both approaches work correctly.
+Different models may pick different tools (`pods_*` or `resources_*`) for the same
+task. The assertions accept either, for example `toolPattern: "(pods_.*|resources_.*)"`.
 
-## Assertions
+## Eval configs: top-level vs per-suite
 
-Both examples use flexible assertions that accept either tool approach:
+There are two eval-config trees:
+
+- **Top-level** (`evals/{claude-code,openai-agent}/eval.yaml`): one config per agent,
+  globbing every suite. These are what **CI** runs. They declare an
+  `llmJudge: { model: "openai:gpt-5" }`. That judge only runs for tasks that
+  include an `llmJudge` verify step, and **only those tasks need an OpenAI key**.
+  The `core` and `helm` suites have no such tasks, so they run key-free even here;
+  `config`, `kiali`, and `tekton` (and 4 `kubevirt` tasks) include `llmJudge` steps
+  that need a key under these configs. Filter with `--label-selector suite=<name>`.
+- **Per-suite** (`evals/tasks/<suite>/{claude-code,openai-agent}/eval.yaml`):
+  a scoped config with **no** config-level `llmJudge`, so any `llmJudge` verify step
+  degrades to a no-op pass (mcpchecker's `noopLLMJudge`) and no OpenAI key is ever
+  needed. Currently only `kubevirt` ships these.
+
+`make run-evals` prefers a per-suite config when one exists for the chosen
+`SUITE`/`AGENT`, and otherwise falls back to the agent's top-level config.
+
+## Agent configuration
+
+### Claude Code (`claude-code/agent.yaml`)
+
+The Claude Code agent runs over the Agent Client Protocol (ACP) through the
+`claude-agent-acp` adapter:
 
 ```yaml
-toolPattern: "(pods_.*|resources_.*)"  # Accepts both pod-specific and generic resource tools
+kind: Agent
+metadata:
+  name: "claude-code-acp"
+acp:
+  cmd: "claude-agent-acp"
 ```
 
-This makes the tests robust across different AI models that may prefer different tools.
+### OpenAI-compatible agent (`openai-agent/agent.yaml`)
 
-## Key Difference: Agent Configuration
+The OpenAI-compatible agent uses mcpchecker's built-in LLM agent:
 
-### Claude Code (claude-code/agent.yaml)
-```yaml
-commands:
-  argTemplateMcpServer: "--mcp-config {{ .File }}"
-  argTemplateAllowedTools: "mcp__{{ .ServerName }}__{{ .ToolName }}"
-  runPrompt: |-
-    claude {{ .McpServerFileArgs }} --print "{{ .Prompt }}"
-```
-
-### OpenAI ACP (openai-agent/agent.yaml)
 ```yaml
 builtin:
   type: "llm-agent"
   model: "openai:gpt-5"
 ```
 
-Uses the built-in OpenAI ACP agent with model configuration.
+## Filtering tasks by suite
 
-## Filtering Tasks by Suite
-
-Tasks are organized into suites using labels. You can filter which tasks to run using the `--label-selector` flag:
-
-### Run only core tasks (default)
+The `--label-selector` flag (or the `SUITE` make variable) chooses which tasks run.
 
 ```bash
-# Using OpenAI agent
-mcpchecker check evals/openai-agent/eval.yaml --label-selector suite=core
+# core tasks
+make run-evals SUITE=core AGENT=claude-code MODEL=sonnet
 
-# Using Claude Code agent
-mcpchecker check evals/claude-code/eval.yaml --label-selector suite=core
+# kiali tasks (needs Istio + Kiali installed; see `make setup-kiali`)
+make run-evals SUITE=kiali AGENT=claude-code MODEL=sonnet
 ```
 
-**Requirements:**
-- Kubernetes cluster (kind, minikube, etc.)
-- MCP server running with default toolsets
+If you omit `--label-selector`, the eval config's own `labelSelector` settings in
+each `taskSets` entry determine which tasks run.
 
-### Run only Kiali tasks
+Note: suites other than `kubevirt` use the agent's top-level config, which has a
+real `llmJudge`. `core` and `helm` have no `llmJudge` tasks, so they run with no
+OpenAI key; `config`, `kiali`, and `tekton` include `llmJudge` tasks that do need
+one there (see [Eval configs](#eval-configs-top-level-vs-per-suite)).
 
-```bash
-# Using OpenAI agent
-mcpchecker check evals/openai-agent/eval.yaml --label-selector suite=kiali
+## Versions
 
-# Using Claude Code agent
-mcpchecker check evals/claude-code/eval.yaml --label-selector suite=kiali
-```
+`make mcpchecker` installs `mcpchecker@latest`. CI runs the same binary version:
+`.github/workflows/mcpchecker.yaml` calls `mcpchecker-action` (currently pinned at
+`v0.0.18`) with `mcpchecker-version: latest`. If you need to reproduce CI exactly,
+pin the binary with `make mcpchecker MCPCHECKER_VERSION=<version>`.
 
-**Requirements:**
-- Kubernetes cluster with Istio and Kiali installed
-- MCP server running with kiali toolset enabled (`TOOLSETS=kiali`)
+## Expected results
 
-To set up Kiali infrastructure:
-```bash
-make setup-kiali
-```
-
-### Run all tasks
-
-If you omit the `--label-selector` flag, the eval configuration's `labelSelector` settings in the YAML file determine which tasks run. See the taskSets section in the eval.yaml files.
-
-## Expected Results
-
-Both examples should produce:
-- ✅ Task passed - pod created successfully
-- ✅ Assertions passed - appropriate tools were called
-- ✅ Verification passed - pod exists and is running
-
-Results saved to: `mcpchecker-<eval-name>-out.json`
+A successful run reports tasks passed, assertions passed (the expected tools were
+called), and verification passed (the cluster ends in the expected state). Results
+are written to `mcpchecker-<eval-name>-out.json`.

--- a/evals/claude-code/eval.yaml
+++ b/evals/claude-code/eval.yaml
@@ -9,10 +9,12 @@ config:
   extensions:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
+  # The claude-code agent judges with claude-code too, so the whole flow (agent +
+  # judge) runs on one Anthropic/Claude-subscription auth with no OpenAI key.
+  # (The openai-agent config keeps an independent openai:gpt-5 judge for CI.)
   llmJudge:
     ref:
-      type: builtin.llm-agent
-      model: "openai:gpt-5"
+      type: builtin.claude-code
   taskSets:
     # Kubernetes tasks
     - glob: ../tasks/*/*/*.yaml

--- a/evals/core-eval-testing/acp-anthropic/eval-config.yaml
+++ b/evals/core-eval-testing/acp-anthropic/eval-config.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/acp-anthropic/eval-core.yaml
+++ b/evals/core-eval-testing/acp-anthropic/eval-core.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/acp-anthropic/eval-helm.yaml
+++ b/evals/core-eval-testing/acp-anthropic/eval-helm.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/acp-google/eval-config.yaml
+++ b/evals/core-eval-testing/acp-google/eval-config.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/acp-google/eval-core.yaml
+++ b/evals/core-eval-testing/acp-google/eval-core.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/acp-google/eval-helm.yaml
+++ b/evals/core-eval-testing/acp-google/eval-helm.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/builtin-anthropic/eval-config.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-config.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/builtin-anthropic/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-core.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/builtin-anthropic/eval-helm.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-helm.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/builtin-google/eval-config.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-config.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/builtin-google/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-core.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/builtin-google/eval-helm.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-helm.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/builtin-openai/eval-config.yaml
+++ b/evals/core-eval-testing/builtin-openai/eval-config.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/builtin-openai/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-openai/eval-core.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/core-eval-testing/builtin-openai/eval-helm.yaml
+++ b/evals/core-eval-testing/builtin-openai/eval-helm.yaml
@@ -8,7 +8,7 @@ config:
   mcpConfigFile: ../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     env:
       baseUrlKey: JUDGE_BASE_URL

--- a/evals/tasks/README.md
+++ b/evals/tasks/README.md
@@ -13,7 +13,7 @@ This directory hosts the reusable task scenarios that power MCP evaluations for 
 
 ## Anatomy of a Task
 
-Every subdirectory under `core/`, `config/`, `helm/`, `kiali/`, `kubevirt/`, or `tekton/` defines a single scenario:
+Most subdirectories under `core/`, `config/`, `helm/`, `kiali/`, `kubevirt/`, or `tekton/` define a single scenario (a few, like `kiali/scripts/`, `kubevirt/helpers/`, and `tekton/helpers/`, hold shared helpers instead):
 
 1. `*.yaml` – declarative description consumed by the evaluation harness (prompts, success criteria, required tools).
 2. `setup.sh` / `verify.sh` / `cleanup.sh` – shell hooks (optional) that prime the cluster, assert post-conditions, and reset resources so tasks stay idempotent.

--- a/evals/tasks/README.md
+++ b/evals/tasks/README.md
@@ -4,13 +4,16 @@ This directory hosts the reusable task scenarios that power MCP evaluations for 
 
 ## Task Families
 
-- [Kubernetes tasks](kubernetes/) – core cluster workflows such as creating pods, fixing deployments, managing RBAC, or debugging state issues.
+- [Core tasks](core/) – core cluster workflows such as creating pods, fixing deployments, managing RBAC, or debugging state issues.
+- [Config tasks](config/) – workflows that exercise the configuration toolset (contexts, current config).
+- [Helm tasks](helm/) – workflows that exercise the Helm toolset (install, list, uninstall releases).
 - [Kiali tasks](kiali/) – service-mesh and observability workflows that exercise the Kiali MCP toolset (Istio config, topology, mesh health, tracing).
 - [KubeVirt tasks](kubevirt/) – virtual machine management workflows that exercise the KubeVirt MCP toolset (VM creation, lifecycle management, resource updates).
+- [Tekton tasks](tekton/) – CI/CD workflows that exercise the Tekton toolset (pipelines, tasks, pipeline runs).
 
 ## Anatomy of a Task
 
-Every subdirectory under `core/`, `kiali/`, or `kubevirt/` defines a single scenario:
+Every subdirectory under `core/`, `config/`, `helm/`, `kiali/`, `kubevirt/`, or `tekton/` defines a single scenario:
 
 1. `*.yaml` – declarative description consumed by the evaluation harness (prompts, success criteria, required tools).
 2. `setup.sh` / `verify.sh` / `cleanup.sh` – shell hooks (optional) that prime the cluster, assert post-conditions, and reset resources so tasks stay idempotent.
@@ -27,7 +30,7 @@ Well-scoped, deterministic tasks make it easier to compare agents and regression
 
 ## Adding a New Task Stack
 
-When a new MCP toolset lands , keep its evaluations isolated by creating a sibling directory under `tasks/` named after the toolset (`tasks/<name>>`, etc.). Populate it with:
+When a new MCP toolset lands, keep its evaluations isolated by creating a sibling directory under `tasks/` named after the toolset (`tasks/<name>`, etc.). Populate it with:
 
 1. A scoped `README.md` describing the toolset focus and prerequisite context.
 2. One subfolder per scenario that follows the same layout described above (`*.yaml`, scripts, `artifacts/`).

--- a/evals/tasks/kubevirt/claude-code/eval.yaml
+++ b/evals/tasks/kubevirt/claude-code/eval.yaml
@@ -8,6 +8,11 @@ config:
   extensions:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
+  # Judge with claude-code so judge-backed tasks (verify: contains / llmJudge)
+  # are really evaluated, keyless on the Claude subscription, like the agent.
+  llmJudge:
+    ref:
+      type: builtin.claude-code
   taskSets:
     - glob: ../*/task.yaml
       assertions:

--- a/evals/tasks/kubevirt/openai-agent/eval.yaml
+++ b/evals/tasks/kubevirt/openai-agent/eval.yaml
@@ -4,11 +4,11 @@ metadata:
 config:
   agent:
     type: "builtin.llm-agent"
-    model: "google:gemini-2.0-flash"
+    model: "openai:gpt-5"
   mcpConfigFile: ../../../mcp-config.yaml
   extensions:
     kubernetes:
-      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   taskSets:
     - glob: ../*/task.yaml
       assertions:


### PR DESCRIPTION
## What

Makes the local `mcpchecker` eval workflow reproducible from the docs alone and
**fully keyless** for the Claude Code agent. The docs and Makefile defaults had
drifted since the ACP migration (#839) and the `kubernetes` -> `core` suite rename
(#1081), and a local run still needed an OpenAI key for the LLM judge. Docs +
Makefile + eval-config only, no Go/server code touched.

Incorporates the useful parts of #995 and supersedes #947 (the `claude-agent-acp`
install target).

## Highlights

### Keyless local runs with the Claude Code agent

`evals/claude-code/eval.yaml` now judges with `builtin.claude-code` instead of
`openai:gpt-5`, so with `AGENT=claude-code` both the agent and the LLM judge run on
your Claude subscription. Every suite runs with no OpenAI key, and judge-backed
tasks are really evaluated rather than skipped. (The legacy `verify: contains:`
short form is semantic LLM judging, not a literal string match, so those tasks need
the judge.) The `kubevirt/claude-code` per-suite config gets the same judge. CI is
unaffected: it runs `evals/openai-agent/eval.yaml`, which keeps the independent
`openai:gpt-5` judge.

### Install + run targets

- New `make claude-agent-acp` target installs the adapter the claude-code agent
  needs (supersedes #947). Idempotent, and version-pinnable via
  `CLAUDE_AGENT_ACP_VERSION` (next to `MCPCHECKER_VERSION`). CI never installs the
  adapter, so this knob is purely for local reproducibility.
- New `SUITE` / `AGENT` / `MODEL` knobs on `make run-evals`, e.g.
  `make run-evals SUITE=kubevirt AGENT=claude-code MODEL=sonnet`. Selects the eval
  config, sets the suite label selector, and exports `ANTHROPIC_MODEL` (which drives
  both agent and judge). `run-evals` pulls in `claude-agent-acp` as a conditional
  prereq for the claude-code agent.

### Drift / latent-bug fixes

- `EVAL_LABEL_SELECTOR` default `suite=kubernetes` selected zero tasks after the
  rename -> now `suite=core`.
- `make run-server` readiness probe hit `/health` (a 404 that `curl -s` swallowed,
  degrading to a port-open check) -> now `curl -fsS .../healthz`.
- Aligned every eval config on `kubernetes-extension@v0.0.4`: the 15
  `core-eval-testing/**` configs and the `kubevirt/openai-agent` config were stale
  at `v0.0.3`. Also fixed that config's model from `google:gemini-2.0-flash` to
  `openai:gpt-5` so the `openai-agent` directory actually uses an OpenAI model.

### Docs

`evals/README.md` rewritten for the ACP agent: the `claude-agent-acp` prerequisite
(it bridges to the `claude` CLI, which runs on your subscription), `ANTHROPIC_MODEL`
model selection, a keyless single-suite quickstart, top-level vs per-suite configs,
the version knobs, and removal of the dead `examples/...` paths, the nonexistent
`agent` binary reference, the old `commands:`/`claude --print` block, and the
"OpenAI ACP" mislabel. `evals/tasks/README.md` updated for the rename
(`kubernetes/` -> `core/`, added `config`/`helm`/`tekton` families, noted the
shared-helper dirs).

## Verified locally

Ran the suites end to end (Kind + the MCP server + claude-code on Sonnet, **no
OpenAI key**):

- `helm` 3/3 pass.
- `core` 23/29 keyless: the 19 deterministic tasks pass, and all 4 judge-backed
  tasks (`ahoy`, `debug-app-logs`, `list-images-for-pods`, `nodes-top`) now pass
  with the claude-code judge giving real semantic verdicts. They had failed only
  because the OpenAI judge had no key, not because the agent was wrong. The
  remaining 6 are genuine (1 setup-script break, 5 `verify.sh` misses), unrelated
  to this change.
- `make run-server`'s new `/healthz` probe confirmed against a live server.

## CI safety

The mcpchecker CI pipeline is untouched: it drives the eval through
`mcpchecker-action` with `evals/openai-agent/eval.yaml` (judge unchanged) and never
calls `make run-evals`. The only CI-shared target changed is `make run-server`,
whose `/healthz` probe is verified (the endpoint returns 200 and is auth-exempt).

## Not done (follow-ups)

- A lighter eval-oriented Kind cluster target (issue point `#5`); the minimal manual
  path is documented in the quickstart instead.
- `make diff-evals` baseline naming for per-suite eval configs.

Closes #1234
