### PR TITLE
feat(kubevirt): add vm_troubleshoot tool for automated VM diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,10 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `name` (`string`) **(required)** - The name of the virtual machine
   - `namespace` (`string`) **(required)** - The namespace of the virtual machine
 
+- **vm_troubleshoot** - Diagnose KubeVirt VirtualMachine issues with automated root-cause detection. Collects VM status, VMI status, volumes, DataVolume/PVC state, cloud-init configuration, pod state, logs, and events, then runs heuristic checks to identify specific problems and suggest fixes. Returns a 'Detected Issues' section with CRITICAL/WARNING findings and actionable remediation steps, followed by raw diagnostic data. Use this tool FIRST whenever a user asks why a VM is not starting, stuck in Provisioning, crashlooping, failing to migrate, or exhibiting unexpected behavior. Automatically detects: missing StorageClasses, invalid PVC specs, dangerous cloud-init commands (shutdown/halt), nodeSelector migration blockers, failed migrations, and pod crashloops. If the user asks to fix or remediate the issue, use the Suggested Fixes from the report with vm_lifecycle (restart) or resources_create_or_update.
+  - `name` (`string`) **(required)** - The name of the VirtualMachine to troubleshoot
+  - `namespace` (`string`) **(required)** - The namespace of the VirtualMachine to troubleshoot
+
 </details>
 
 <details>

--- a/evals/tasks/kubevirt/troubleshoot-vm-cloudinit-shutdown/task.yaml
+++ b/evals/tasks/kubevirt/troubleshoot-vm-cloudinit-shutdown/task.yaml
@@ -1,0 +1,100 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "troubleshoot-vm-cloudinit-shutdown"
+  difficulty: medium
+  description: "Diagnose a VM crashlooping due to a shutdown command in cloud-init"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-troubleshoot-ci
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-troubleshoot-ci
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: crashloop-vm
+          namespace: vm-test-troubleshoot-ci
+        spec:
+          runStrategy: Always
+          template:
+            spec:
+              domain:
+                devices:
+                  disks:
+                    - name: containerdisk
+                      disk:
+                        bus: virtio
+                    - name: cloudinit
+                      disk:
+                        bus: virtio
+                resources:
+                  requests:
+                    memory: 2Gi
+              terminationGracePeriodSeconds: 0
+              volumes:
+                - name: containerdisk
+                  containerDisk:
+                    image: quay.io/containerdisks/fedora:latest
+                - name: cloudinit
+                  cloudInitNoCloud:
+                    userData: |
+                      #cloud-config
+                      runcmd:
+                        - shutdown -h now
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          echo "Waiting for VM to attempt boot and crash..."
+          sleep 60
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS="vm-test-troubleshoot-ci"
+
+          echo "=== Verification: Agent identified cloud-init issue ==="
+
+          if ! kubectl get virtualmachine crashloop-vm -n "$NS" > /dev/null 2>&1; then
+              echo "✗ VirtualMachine crashloop-vm no longer exists"
+              exit 1
+          fi
+          echo "✓ VirtualMachine crashloop-vm still exists"
+          exit 0
+    - llmJudge:
+        contains: "shutdown -h now"
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: crashloop-vm
+          namespace: vm-test-troubleshoot-ci
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-troubleshoot-ci
+        ignoreNotFound: true
+  prompt:
+    inline: |-
+      A VirtualMachine named "crashloop-vm" in the vm-test-troubleshoot-ci namespace keeps restarting.
+      Diagnose why this VM is crashlooping. Report:
+      - The root cause of the crashloop
+      - Which cloud-init command is causing the problem
+      - How to fix it

--- a/evals/tasks/kubevirt/troubleshoot-vm-missing-storageclass/task.yaml
+++ b/evals/tasks/kubevirt/troubleshoot-vm-missing-storageclass/task.yaml
@@ -1,0 +1,105 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    requires: kubevirt
+  name: "troubleshoot-vm-missing-storageclass"
+  difficulty: medium
+  description: "Diagnose a VM stuck in Provisioning due to a non-existent StorageClass"
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-troubleshoot-sc
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-troubleshoot-sc
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: broken-sc-vm
+          namespace: vm-test-troubleshoot-sc
+        spec:
+          runStrategy: Always
+          dataVolumeTemplates:
+            - metadata:
+                name: broken-sc-vm-rootdisk
+              spec:
+                storage:
+                  storageClassName: non-existent-sc-xyz
+                  accessModes:
+                    - ReadWriteOnce
+                  resources:
+                    requests:
+                      storage: 10Gi
+                source:
+                  registry:
+                    url: docker://quay.io/containerdisks/fedora:latest
+          template:
+            spec:
+              domain:
+                devices:
+                  disks:
+                    - name: rootdisk
+                      disk:
+                        bus: virtio
+                resources:
+                  requests:
+                    memory: 2Gi
+              terminationGracePeriodSeconds: 0
+              volumes:
+                - name: rootdisk
+                  dataVolume:
+                    name: broken-sc-vm-rootdisk
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          echo "Waiting for VM to enter Provisioning state..."
+          sleep 15
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          NS="vm-test-troubleshoot-sc"
+
+          echo "=== Verification: Agent identified missing StorageClass ==="
+
+          if ! kubectl get virtualmachine broken-sc-vm -n "$NS" > /dev/null 2>&1; then
+              echo "✗ VirtualMachine broken-sc-vm no longer exists"
+              exit 1
+          fi
+          echo "✓ VirtualMachine broken-sc-vm still exists"
+          exit 0
+    - llmJudge:
+        contains: "non-existent-sc-xyz"
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: broken-sc-vm
+          namespace: vm-test-troubleshoot-sc
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-troubleshoot-sc
+        ignoreNotFound: true
+  prompt:
+    inline: |-
+      A VirtualMachine named "broken-sc-vm" in the vm-test-troubleshoot-sc namespace is not starting.
+      Diagnose why this VM is stuck. Report:
+      - The root cause of the issue
+      - What StorageClass is missing
+      - What alternative StorageClasses are available on the cluster

--- a/pkg/kubevirt/gvr.go
+++ b/pkg/kubevirt/gvr.go
@@ -103,6 +103,16 @@ var (
 	}
 )
 
+// Migration resources
+var (
+	// VirtualMachineInstanceMigrationGVR is the GroupVersionResource for VirtualMachineInstanceMigration resources
+	VirtualMachineInstanceMigrationGVR = schema.GroupVersionResource{
+		Group:    "kubevirt.io",
+		Version:  "v1",
+		Resource: "virtualmachineinstancemigrations",
+	}
+)
+
 // HasVirtualMachine returns a TargetCompatibilityFilter that checks whether any
 // target cluster has the VirtualMachine GVK registered.
 func HasVirtualMachine(p api.FilteringProvider) func() bool {
@@ -125,5 +135,12 @@ var (
 		Group:    "",
 		Version:  "v1",
 		Resource: "pods",
+	}
+
+	// StorageClassGVR is the GroupVersionResource for StorageClass resources
+	StorageClassGVR = schema.GroupVersionResource{
+		Group:    "storage.k8s.io",
+		Version:  "v1",
+		Resource: "storageclasses",
 	}
 )

--- a/pkg/mcp/kubevirt_test.go
+++ b/pkg/mcp/kubevirt_test.go
@@ -874,6 +874,113 @@ func (s *KubevirtSuite) TestVMTroubleshoot() {
 			"Expected diagnostic report header, got %v", text)
 		s.Contains(text, "not found")
 	})
+
+	s.Run("vm_troubleshoot detects and reports a root cause for a broken VM", func() {
+		dynamicClient := dynamic.NewForConfigOrDie(test.EnvTestRestConfig())
+		vmGVR := schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "broken-vm",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"runStrategy": "Always",
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinit",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - shutdown -h now\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		_, err := dynamicClient.Resource(vmGVR).Namespace("default").Create(s.T().Context(), vm, metav1.CreateOptions{})
+		s.Require().NoError(err, "failed to create broken test VM")
+		defer func() {
+			_ = dynamicClient.Resource(vmGVR).Namespace("default").Delete(s.T().Context(), "broken-vm", metav1.DeleteOptions{})
+		}()
+
+		toolResult, err := s.CallTool("vm_troubleshoot", map[string]interface{}{
+			"namespace": "default",
+			"name":      "broken-vm",
+		})
+		s.Require().Nilf(err, "call tool failed %v", err)
+		s.Require().Falsef(toolResult.IsError, "call tool failed: %v", toolResult.Content)
+		text := toolResult.Content[0].(*mcp.TextContent).Text
+
+		s.Run("surfaces the Detected Issues section", func() {
+			s.Contains(text, "## Detected Issues")
+		})
+		s.Run("flags the dangerous cloud-init command as CRITICAL", func() {
+			s.Regexp(`(?s)## Detected Issues.*CRITICAL.*shutdown`, text)
+		})
+		s.Run("provides a Suggested Fixes section", func() {
+			s.Contains(text, "## Suggested Fixes")
+		})
+		// Guards the troubleshoot-vm-cloudinit-shutdown eval: its llmJudge asserts
+		// the agent's answer contains "shutdown -h now", which the agent can only
+		// relay if the tool surfaces it.
+		s.Run("surfaces the exact string the cloud-init eval judges on", func() {
+			s.Contains(text, "shutdown -h now")
+		})
+	})
+
+	s.Run("vm_troubleshoot flags a missing StorageClass with the name and available alternatives", func() {
+		dynamicClient := dynamic.NewForConfigOrDie(test.EnvTestRestConfig())
+		vmGVR := schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "broken-sc-vm",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"runStrategy": "Always",
+				"dataVolumeTemplates": []interface{}{
+					map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "broken-sc-vm-rootdisk"},
+						"spec": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"storageClassName": "non-existent-sc-xyz",
+							},
+						},
+					},
+				},
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		})
+		_, err := dynamicClient.Resource(vmGVR).Namespace("default").Create(s.T().Context(), vm, metav1.CreateOptions{})
+		s.Require().NoError(err, "failed to create broken-sc test VM")
+		defer func() {
+			_ = dynamicClient.Resource(vmGVR).Namespace("default").Delete(s.T().Context(), "broken-sc-vm", metav1.DeleteOptions{})
+		}()
+
+		toolResult, err := s.CallTool("vm_troubleshoot", map[string]interface{}{
+			"namespace": "default",
+			"name":      "broken-sc-vm",
+		})
+		s.Require().Nilf(err, "call tool failed %v", err)
+		s.Require().Falsef(toolResult.IsError, "call tool failed: %v", toolResult.Content)
+		text := toolResult.Content[0].(*mcp.TextContent).Text
+
+		// Guards the troubleshoot-vm-missing-storageclass eval, whose llmJudge
+		// asserts the agent's answer contains "non-existent-sc-xyz".
+		s.Run("names the missing StorageClass as a CRITICAL detected issue", func() {
+			s.Regexp(`(?s)## Detected Issues.*CRITICAL.*non-existent-sc-xyz`, text)
+		})
+	})
 }
 
 func (s *KubevirtSuite) TestVMGuestInfo() {

--- a/pkg/mcp/kubevirt_test.go
+++ b/pkg/mcp/kubevirt_test.go
@@ -784,6 +784,98 @@ func (s *KubevirtSuite) TestVMTroubleshootPrompt() {
 	})
 }
 
+func (s *KubevirtSuite) TestVMTroubleshoot() {
+	s.Run("vm_troubleshoot missing required params", func() {
+		testCases := []string{"namespace", "name"}
+		for _, param := range testCases {
+			s.Run("missing "+param, func() {
+				params := map[string]interface{}{
+					"namespace": "default",
+					"name":      "test-vm",
+				}
+				delete(params, param)
+				toolResult, err := s.CallTool("vm_troubleshoot", params)
+				s.Require().Nilf(err, "call tool failed %v", err)
+				s.Truef(toolResult.IsError, "expected call tool to fail due to missing %s", param)
+				s.Equal(toolResult.Content[0].(*mcp.TextContent).Text, param+" parameter required")
+			})
+		}
+	})
+
+	s.Run("vm_troubleshoot returns diagnostic report for existing VM", func() {
+		dynamicClient := dynamic.NewForConfigOrDie(test.EnvTestRestConfig())
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata": map[string]interface{}{
+				"name":      "troubleshoot-vm",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"runStrategy": "Always",
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "rootdisk",
+								"containerDisk": map[string]interface{}{
+									"image": "quay.io/containerdisks/fedora:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		_, err := dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachines",
+		}).Namespace("default").Create(s.T().Context(), vm, metav1.CreateOptions{})
+		s.Require().NoError(err, "failed to create test VM")
+
+		toolResult, err := s.CallTool("vm_troubleshoot", map[string]interface{}{
+			"namespace": "default",
+			"name":      "troubleshoot-vm",
+		})
+		s.Run("no error", func() {
+			s.Nilf(err, "call tool failed %v", err)
+			s.Falsef(toolResult.IsError, "call tool failed: %v", toolResult.Content)
+		})
+
+		s.Run("returns diagnostic report with correct VM details", func() {
+			text := toolResult.Content[0].(*mcp.TextContent).Text
+			s.Truef(strings.HasPrefix(text, "# VirtualMachine Diagnostic Report: default/troubleshoot-vm"),
+				"Expected diagnostic report header, got %v", text)
+			s.Truef(strings.Contains(text, "## VirtualMachine Status") || strings.Contains(text, "## VirtualMachine:"),
+				"Expected VirtualMachine section in report")
+			s.Contains(text, "## VirtualMachineInstance")
+			s.Contains(text, "troubleshoot-vm")
+		})
+
+		// Cleanup
+		_ = dynamicClient.Resource(schema.GroupVersionResource{
+			Group:    "kubevirt.io",
+			Version:  "v1",
+			Resource: "virtualmachines",
+		}).Namespace("default").Delete(s.T().Context(), "troubleshoot-vm", metav1.DeleteOptions{})
+	})
+
+	s.Run("vm_troubleshoot handles non-existent VM gracefully", func() {
+		toolResult, err := s.CallTool("vm_troubleshoot", map[string]interface{}{
+			"namespace": "default",
+			"name":      "non-existent-vm",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(toolResult.IsError, "tool should not return error for non-existent VM")
+		text := toolResult.Content[0].(*mcp.TextContent).Text
+		s.Truef(strings.HasPrefix(text, "# VirtualMachine Diagnostic Report: default/non-existent-vm"),
+			"Expected diagnostic report header, got %v", text)
+		s.Contains(text, "not found")
+	})
+}
+
 func (s *KubevirtSuite) TestVMGuestInfo() {
 	s.Run("vm_guest_info missing required params", func() {
 		testCases := []string{"namespace", "name"}

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -233,5 +233,34 @@
     },
     "name": "vm_lifecycle",
     "title": "Virtual Machine: Lifecycle"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Virtual Machine: Troubleshoot"
+    },
+    "description": "Diagnose KubeVirt VirtualMachine issues with automated root-cause detection. Collects VM status, VMI status, volumes, DataVolume/PVC state, cloud-init configuration, pod state, logs, and events, then runs heuristic checks to identify specific problems and suggest fixes. Returns a 'Detected Issues' section with CRITICAL/WARNING findings and actionable remediation steps, followed by raw diagnostic data. Use this tool FIRST whenever a user asks why a VM is not starting, stuck in Provisioning, crashlooping, failing to migrate, or exhibiting unexpected behavior. Automatically detects: missing StorageClasses, invalid PVC specs, dangerous cloud-init commands (shutdown/halt), nodeSelector migration blockers, failed migrations, and pod crashloops. If the user asks to fix or remediate the issue, use the Suggested Fixes from the report with vm_lifecycle (restart) or resources_create_or_update.",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "The name of the VirtualMachine to troubleshoot",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The namespace of the VirtualMachine to troubleshoot",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "vm_troubleshoot",
+    "title": "Virtual Machine: Troubleshoot"
   }
 ]

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -10,6 +10,7 @@ import (
 	vm_create "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/create"
 	vm_guestagent "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/guestagent"
 	vm_lifecycle "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/lifecycle"
+	vm_troubleshoot "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/troubleshoot"
 )
 
 type Toolset struct{}
@@ -30,6 +31,7 @@ func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
 		vm_create.Tools(p),
 		vm_guestagent.Tools(p),
 		vm_lifecycle.Tools(p),
+		vm_troubleshoot.Tools(p),
 	)
 }
 

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/analysis.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/analysis.go
@@ -1,0 +1,656 @@
+package troubleshoot
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+type severity int
+
+const (
+	severityCritical severity = iota
+	severityWarning
+	severityInfo
+)
+
+func (s severity) String() string {
+	switch s {
+	case severityCritical:
+		return "CRITICAL"
+	case severityWarning:
+		return "WARNING"
+	default:
+		return "INFO"
+	}
+}
+
+type issue struct {
+	Severity severity
+	Message  string
+	Fix      string
+}
+
+func analyzeIssues(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string, vm, vmi *unstructured.Unstructured, podDiagnostics []map[string]interface{}) string {
+	var issues []issue
+
+	issues = append(issues, checkVMConditions(vm)...)
+
+	scIssues := checkStorageClass(ctx, dynamicClient, vm)
+	issues = append(issues, scIssues...)
+	issues = append(issues, checkDataVolumeErrors(vm, scIssues)...)
+
+	issues = append(issues, checkCloudInitCommands(vm, vmi)...)
+	issues = append(issues, checkNodeSelector(vm, vmi)...)
+	issues = append(issues, checkPodHealth(podDiagnostics)...)
+	issues = append(issues, checkMigrationStatus(ctx, dynamicClient, namespace, name)...)
+
+	if len(issues) == 0 {
+		return "## Detected Issues\n\n*No issues automatically detected. Review the raw diagnostic data below for manual analysis.*"
+	}
+
+	var result strings.Builder
+	result.WriteString("## Detected Issues\n\n")
+	for _, iss := range issues {
+		fmt.Fprintf(&result, "- **%s**: %s\n", iss.Severity, iss.Message)
+	}
+
+	var fixes []string
+	for _, iss := range issues {
+		if iss.Fix != "" {
+			fixes = append(fixes, iss.Fix)
+		}
+	}
+	if len(fixes) > 0 {
+		result.WriteString("\n## Suggested Fixes\n\n")
+		for i, fix := range fixes {
+			fmt.Fprintf(&result, "%d. %s\n", i+1, fix)
+		}
+	}
+
+	return result.String()
+}
+
+func checkVMConditions(vm *unstructured.Unstructured) []issue {
+	if vm == nil {
+		return nil
+	}
+
+	var issues []issue
+
+	conditions, _, _ := unstructured.NestedSlice(vm.Object, "status", "conditions")
+	for _, cond := range conditions {
+		condMap, ok := cond.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := condMap["type"].(string)
+		status, _ := condMap["status"].(string)
+		reason, _ := condMap["reason"].(string)
+		message, _ := condMap["message"].(string)
+
+		if condType != "Ready" || status != "False" {
+			continue
+		}
+
+		switch reason {
+		case "VMINotExists":
+			issues = append(issues, issue{
+				Severity: severityWarning,
+				Message:  "VM condition Ready=False with reason VMINotExists. The VirtualMachineInstance has not been created.",
+			})
+		default:
+			if message != "" && (strings.Contains(message, "Guest") || strings.Contains(strings.ToLower(message), "error")) {
+				issues = append(issues, issue{
+					Severity: severityWarning,
+					Message:  fmt.Sprintf("VM condition Ready=False: %s", message),
+				})
+			}
+		}
+	}
+
+	printableStatus, _, _ := unstructured.NestedString(vm.Object, "status", "printableStatus")
+	switch printableStatus {
+	case "Provisioning":
+		issues = append(issues, issue{
+			Severity: severityWarning,
+			Message:  "VM is stuck in Provisioning state. This typically means a DataVolume or PVC cannot be created.",
+		})
+	case "CrashLoopBackOff":
+		issues = append(issues, issue{
+			Severity: severityCritical,
+			Message:  "VM is in CrashLoopBackOff state. The guest OS or cloud-init is causing repeated failures.",
+			Fix:      "Check the cloud-init userData for commands that shut down or crash the guest (e.g., shutdown -h now, exit 1).",
+		})
+	case "ErrImagePull", "ImagePullBackOff":
+		issues = append(issues, issue{
+			Severity: severityCritical,
+			Message:  fmt.Sprintf("VM is in %s state. The container disk image cannot be pulled.", printableStatus),
+			Fix:      "Verify the containerDisk image reference exists and is accessible from the cluster.",
+		})
+	}
+
+	return issues
+}
+
+func checkDataVolumeErrors(vm *unstructured.Unstructured, scIssues []issue) []issue {
+	if vm == nil {
+		return nil
+	}
+
+	hasMissingSC := false
+	for _, sci := range scIssues {
+		if sci.Severity == severityCritical {
+			hasMissingSC = true
+			break
+		}
+	}
+
+	var issues []issue
+
+	volumeStatuses, _, _ := unstructured.NestedSlice(vm.Object, "status", "volumeSnapshotStatuses")
+	for _, vs := range volumeStatuses {
+		vsMap, ok := vs.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		volName, _ := vsMap["name"].(string)
+		reason, _ := vsMap["reason"].(string)
+		if reason != "" && strings.Contains(reason, "not found") {
+			if hasMissingSC {
+				continue
+			}
+			issues = append(issues, issue{
+				Severity: severityCritical,
+				Message:  fmt.Sprintf("Volume %q: PVC not found. The backing storage does not exist.", volName),
+				Fix:      fmt.Sprintf("Ensure the PVC or DataVolume for volume %q is created and in Bound state.", volName),
+			})
+		}
+	}
+
+	return issues
+}
+
+func checkStorageClass(ctx context.Context, dynamicClient dynamic.Interface, vm *unstructured.Unstructured) []issue {
+	if vm == nil || dynamicClient == nil {
+		return nil
+	}
+
+	dvTemplates, found, err := unstructured.NestedSlice(vm.Object, "spec", "dataVolumeTemplates")
+	if err != nil || !found || len(dvTemplates) == 0 {
+		return nil
+	}
+
+	var issues []issue
+	for _, dvTemplate := range dvTemplates {
+		dvMap, ok := dvTemplate.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		metadata, _ := dvMap["metadata"].(map[string]interface{})
+		dvName, _ := metadata["name"].(string)
+
+		spec, _ := dvMap["spec"].(map[string]interface{})
+		if spec == nil {
+			continue
+		}
+
+		scName := extractStorageClassName(spec)
+		if scName == "" {
+			continue
+		}
+
+		_, err := dynamicClient.Resource(kubevirt.StorageClassGVR).Get(ctx, scName, metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				issues = append(issues, issue{
+					Severity: severityWarning,
+					Message:  fmt.Sprintf("Unable to verify StorageClass %q for DataVolume %q: %v", scName, dvName, err),
+				})
+				continue
+			}
+			availableSCs := listAvailableStorageClasses(ctx, dynamicClient)
+			issues = append(issues, issue{
+				Severity: severityCritical,
+				Message:  fmt.Sprintf("StorageClass %q referenced by DataVolume %q does not exist on this cluster. Available StorageClasses: %s.", scName, dvName, availableSCs),
+				Fix:      fmt.Sprintf("Change the DataVolume storageClassName from %q to an existing StorageClass (e.g., %s).", scName, availableSCs),
+			})
+		}
+	}
+
+	return issues
+}
+
+func extractStorageClassName(dvSpec map[string]interface{}) string {
+	if storage, ok := dvSpec["storage"].(map[string]interface{}); ok {
+		if sc, ok := storage["storageClassName"].(string); ok && sc != "" {
+			return sc
+		}
+	}
+	if pvc, ok := dvSpec["pvc"].(map[string]interface{}); ok {
+		if sc, ok := pvc["storageClassName"].(string); ok && sc != "" {
+			return sc
+		}
+	}
+	return ""
+}
+
+func listAvailableStorageClasses(ctx context.Context, dynamicClient dynamic.Interface) string {
+	scList, err := dynamicClient.Resource(kubevirt.StorageClassGVR).List(ctx, metav1.ListOptions{})
+	if err != nil || len(scList.Items) == 0 {
+		return "(none found)"
+	}
+
+	var names []string
+	for _, sc := range scList.Items {
+		name := sc.GetName()
+		annotations := sc.GetAnnotations()
+		if annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			name += " (default)"
+		}
+		names = append(names, name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func checkCloudInitCommands(vm, vmi *unstructured.Unstructured) []issue {
+	var volumes []interface{}
+	if vm != nil {
+		volumes, _, _ = unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	}
+	if len(volumes) == 0 && vmi != nil {
+		volumes, _, _ = unstructured.NestedSlice(vmi.Object, "spec", "volumes")
+	}
+	if len(volumes) == 0 {
+		return nil
+	}
+
+	runStrategy := ""
+	if vm != nil {
+		runStrategy, _, _ = unstructured.NestedString(vm.Object, "spec", "runStrategy")
+	}
+
+	var issues []issue
+
+	for _, vol := range volumes {
+		volMap, ok := vol.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, ciKey := range []string{"cloudInitNoCloud", "cloudInitConfigDrive"} {
+			ciData, exists := volMap[ciKey].(map[string]interface{})
+			if !exists {
+				continue
+			}
+
+			userData, _ := ciData["userData"].(string)
+			if userData == "" {
+				continue
+			}
+
+			for _, cmd := range detectDangerousCloudInitCommands(userData) {
+				msg := fmt.Sprintf("Cloud-init userData contains %q command that will shut down or restart the guest immediately after boot.", cmd)
+				if runStrategy == "Always" || runStrategy == "" {
+					msg += " Combined with runStrategy Always, this causes a crashloop."
+				}
+				fix := fmt.Sprintf("Remove the %q command from cloud-init userData, or change runStrategy to Manual/Halted if the shutdown is intentional.", cmd)
+				issues = append(issues, issue{
+					Severity: severityCritical,
+					Message:  msg,
+					Fix:      fix,
+				})
+			}
+		}
+	}
+
+	return issues
+}
+
+func detectDangerousCloudInitCommands(userData string) []string {
+	lines := strings.Split(userData, "\n")
+	var matches []string
+	seen := map[string]bool{}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if isEchoOrPrintLine(trimmed) {
+			continue
+		}
+		if isConfigKeyLine(trimmed) {
+			continue
+		}
+		if cmd := matchDangerousCommand(trimmed); cmd != "" && !seen[cmd] {
+			seen[cmd] = true
+			matches = append(matches, cmd)
+		}
+	}
+	return matches
+}
+
+func isEchoOrPrintLine(line string) bool {
+	lower := strings.ToLower(line)
+	prefixes := []string{"echo ", "echo'", "echo\"", "printf ", "- echo ", "- printf "}
+	for _, p := range prefixes {
+		if strings.HasPrefix(lower, p) || strings.HasPrefix(strings.TrimPrefix(lower, "- "), p) {
+			return true
+		}
+	}
+	return false
+}
+
+func isConfigKeyLine(line string) bool {
+	lower := strings.ToLower(line)
+	if strings.Contains(lower, ":") && !strings.HasPrefix(lower, "-") && !strings.HasPrefix(lower, "[") {
+		parts := strings.SplitN(lower, ":", 2)
+		key := strings.TrimSpace(parts[0])
+		if strings.Contains(key, "_") || strings.Contains(key, "-") {
+			return true
+		}
+	}
+	return false
+}
+
+func matchDangerousCommand(line string) string {
+	trimmed := strings.TrimSpace(line)
+	lower := strings.ToLower(trimmed)
+
+	stripped := strings.TrimPrefix(lower, "- ")
+	stripped = strings.Trim(stripped, "[]\"' ")
+
+	switch {
+	case strings.HasPrefix(stripped, "shutdown -r") ||
+		strings.HasPrefix(stripped, "/sbin/shutdown -r"):
+		return "reboot"
+	case stripped == "shutdown" || stripped == "shutdown -h now" ||
+		stripped == "/sbin/shutdown" || strings.HasPrefix(stripped, "/sbin/shutdown ") ||
+		strings.HasPrefix(stripped, "shutdown -h") ||
+		strings.HasPrefix(stripped, "shutdown -P") || strings.HasPrefix(stripped, "shutdown -p"):
+		return "shutdown"
+	case stripped == "poweroff" || stripped == "/sbin/poweroff" ||
+		stripped == "systemctl poweroff":
+		return "poweroff"
+	case stripped == "halt" || stripped == "/sbin/halt" ||
+		stripped == "systemctl halt":
+		return "halt"
+	case stripped == "reboot" || stripped == "/sbin/reboot" ||
+		stripped == "systemctl reboot":
+		return "reboot"
+	case stripped == "init 0" || stripped == "/sbin/init 0":
+		return "init 0"
+	case stripped == "init 6" || stripped == "/sbin/init 6":
+		return "init 6"
+	}
+
+	if strings.Contains(lower, "[") {
+		firstElem := extractFirstArrayElement(lower)
+		switch firstElem {
+		case "shutdown":
+			return "shutdown"
+		case "poweroff", "/sbin/poweroff":
+			return "poweroff"
+		case "halt", "/sbin/halt":
+			return "halt"
+		case "reboot", "/sbin/reboot":
+			return "reboot"
+		case "systemctl":
+			start := strings.Index(lower, "[")
+			if start != -1 {
+				inner := lower[start+1:]
+				if end := strings.Index(inner, "]"); end != -1 {
+					inner = inner[:end]
+				}
+				elems := strings.Split(inner, ",")
+				if len(elems) >= 2 {
+					subCmd := strings.Trim(strings.TrimSpace(elems[1]), "\"' ")
+					switch subCmd {
+					case "poweroff":
+						return "poweroff"
+					case "halt":
+						return "halt"
+					case "reboot":
+						return "reboot"
+					}
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+func extractFirstArrayElement(line string) string {
+	start := strings.Index(line, "[")
+	if start == -1 {
+		return ""
+	}
+	inner := line[start+1:]
+	end := strings.Index(inner, "]")
+	if end != -1 {
+		inner = inner[:end]
+	}
+	parts := strings.SplitN(inner, ",", 2)
+	elem := strings.TrimSpace(parts[0])
+	elem = strings.Trim(elem, "\"' ")
+	return strings.ToLower(elem)
+}
+
+func checkNodeSelector(vm, vmi *unstructured.Unstructured) []issue {
+	var nodeSelector map[string]interface{}
+
+	if vm != nil {
+		nodeSelector, _, _ = unstructured.NestedMap(vm.Object, "spec", "template", "spec", "nodeSelector")
+	}
+	if len(nodeSelector) == 0 && vmi != nil {
+		nodeSelector, _, _ = unstructured.NestedMap(vmi.Object, "spec", "nodeSelector")
+	}
+
+	if len(nodeSelector) == 0 {
+		return nil
+	}
+
+	for key, val := range nodeSelector {
+		if key == "kubernetes.io/hostname" {
+			hostname, _ := val.(string)
+			return []issue{{
+				Severity: severityWarning,
+				Message:  fmt.Sprintf("VM is pinned to a specific node via nodeSelector (kubernetes.io/hostname=%s). This prevents live migration to other nodes.", hostname),
+				Fix:      "Remove the kubernetes.io/hostname nodeSelector to allow migration, or use a broader label selector that matches multiple nodes.",
+			}}
+		}
+	}
+
+	var labels []string
+	for k, v := range nodeSelector {
+		labels = append(labels, fmt.Sprintf("%s=%v", k, v))
+	}
+	return []issue{{
+		Severity: severityInfo,
+		Message:  fmt.Sprintf("VM has nodeSelector constraints: %s. This may limit scheduling and migration options.", strings.Join(labels, ", ")),
+	}}
+}
+
+func checkPodHealth(podDiagnostics []map[string]interface{}) []issue {
+	if len(podDiagnostics) == 0 {
+		return nil
+	}
+
+	var issues []issue
+
+	for _, diag := range podDiagnostics {
+		phase, _ := diag["phase"].(string)
+		if phase == "Pending" {
+			issues = append(issues, issue{
+				Severity: severityWarning,
+				Message:  "virt-launcher pod is in Pending state. The pod has not been scheduled yet (possible resource constraints or nodeSelector mismatch).",
+				Fix:      "Check node resources and scheduling constraints. Ensure at least one node satisfies the pod's resource requests and node selectors.",
+			})
+		}
+
+		containerStatuses, _ := diag["containerStatuses"].([]map[string]interface{})
+		for _, cs := range containerStatuses {
+			restartCount := toInt64(cs["restartCount"])
+			if restartCount > 3 {
+				containerName, _ := cs["name"].(string)
+				issues = append(issues, issue{
+					Severity: severityCritical,
+					Message:  fmt.Sprintf("Container %q in virt-launcher pod has restarted %d times, indicating a crashloop.", containerName, restartCount),
+				})
+			}
+
+			state, ok := cs["state"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if waiting, ok := state["waiting"].(map[string]interface{}); ok {
+				reason, _ := waiting["reason"].(string)
+				if reason == "CrashLoopBackOff" || reason == "ErrImagePull" || reason == "ImagePullBackOff" {
+					message, _ := waiting["message"].(string)
+					issues = append(issues, issue{
+						Severity: severityCritical,
+						Message:  fmt.Sprintf("virt-launcher container is in %s state: %s", reason, message),
+					})
+				}
+			}
+			if terminated, ok := state["terminated"].(map[string]interface{}); ok {
+				reason, _ := terminated["reason"].(string)
+				if reason == "OOMKilled" {
+					issues = append(issues, issue{
+						Severity: severityCritical,
+						Message:  "virt-launcher container was OOMKilled. The VM requires more memory than allocated.",
+						Fix:      "Increase the memory resource limits for the VM or reduce the guest memory requirements.",
+					})
+				}
+			}
+		}
+	}
+
+	return issues
+}
+
+const maxReportedFailedMigrations = 3
+
+func checkMigrationStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) []issue {
+	if dynamicClient == nil {
+		return nil
+	}
+
+	vmimList, err := dynamicClient.Resource(kubevirt.VirtualMachineInstanceMigrationGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+		Limit: 50,
+	})
+	if err != nil || len(vmimList.Items) == 0 {
+		return nil
+	}
+
+	var failed []unstructured.Unstructured
+	for _, vmim := range vmimList.Items {
+		vmiName, _, _ := unstructured.NestedString(vmim.Object, "spec", "vmiName")
+		if vmiName != name {
+			continue
+		}
+		phase, _, _ := unstructured.NestedString(vmim.Object, "status", "phase")
+		if phase == "Failed" {
+			failed = append(failed, vmim)
+		}
+	}
+
+	if len(failed) == 0 {
+		return nil
+	}
+
+	sort.Slice(failed, func(i, j int) bool {
+		ti := failed[i].GetCreationTimestamp().Time
+		tj := failed[j].GetCreationTimestamp().Time
+		return ti.After(tj)
+	})
+
+	var issues []issue
+	now := time.Now()
+	limit := maxReportedFailedMigrations
+	if len(failed) < limit {
+		limit = len(failed)
+	}
+
+	for _, vmim := range failed[:limit] {
+		migrationName := vmim.GetName()
+		conditions, _, _ := unstructured.NestedSlice(vmim.Object, "status", "conditions")
+		failureReason := extractMigrationFailureReason(conditions)
+
+		msg := fmt.Sprintf("VirtualMachineInstanceMigration %q failed", migrationName)
+		if created := vmim.GetCreationTimestamp(); !created.IsZero() {
+			msg += fmt.Sprintf(" (%s ago)", formatDuration(now.Sub(created.Time)))
+		}
+		msg += "."
+		if failureReason != "" {
+			msg += " Reason: " + failureReason
+		}
+		issues = append(issues, issue{
+			Severity: severityCritical,
+			Message:  msg,
+			Fix:      "Check nodeSelector constraints, resource availability on target nodes, and migration policies. Remove hostname-specific nodeSelector to allow migration.",
+		})
+	}
+
+	if len(failed) > maxReportedFailedMigrations {
+		issues = append(issues, issue{
+			Severity: severityInfo,
+			Message:  fmt.Sprintf("%d additional older failed migrations not shown.", len(failed)-maxReportedFailedMigrations),
+		})
+	}
+
+	return issues
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}
+
+func extractMigrationFailureReason(conditions []interface{}) string {
+	for _, cond := range conditions {
+		condMap, ok := cond.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := condMap["type"].(string)
+		status, _ := condMap["status"].(string)
+		if condType == "Failure" && status == "True" {
+			message, _ := condMap["message"].(string)
+			return message
+		}
+	}
+	return ""
+}
+
+func toInt64(v interface{}) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	case int:
+		return int64(n)
+	case int32:
+		return int64(n)
+	default:
+		return 0
+	}
+}

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/analysis.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/analysis.go
@@ -354,7 +354,7 @@ func isConfigKeyLine(line string) bool {
 	if strings.Contains(lower, ":") && !strings.HasPrefix(lower, "-") && !strings.HasPrefix(lower, "[") {
 		parts := strings.SplitN(lower, ":", 2)
 		key := strings.TrimSpace(parts[0])
-		if strings.Contains(key, "_") || strings.Contains(key, "-") {
+		if len(key) > 0 && !strings.Contains(key, " ") {
 			return true
 		}
 	}
@@ -546,7 +546,7 @@ func checkMigrationStatus(ctx context.Context, dynamicClient dynamic.Interface, 
 	}
 
 	vmimList, err := dynamicClient.Resource(kubevirt.VirtualMachineInstanceMigrationGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
-		Limit: 50,
+		LabelSelector: fmt.Sprintf("kubevirt.io/vmi-name=%s", name),
 	})
 	if err != nil || len(vmimList.Items) == 0 {
 		return nil

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/analysis_test.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/analysis_test.go
@@ -1,0 +1,1112 @@
+package troubleshoot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+type AnalysisSuite struct {
+	suite.Suite
+}
+
+func TestAnalysisSuite(t *testing.T) {
+	suite.Run(t, new(AnalysisSuite))
+}
+
+func (s *AnalysisSuite) TestCheckVMConditions() {
+	s.Run("detects VMINotExists condition", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":    "Ready",
+						"status":  "False",
+						"reason":  "VMINotExists",
+						"message": "VMI does not exist",
+					},
+				},
+			},
+		})
+
+		issues := checkVMConditions(vm)
+		s.Require().NotEmpty(issues)
+		s.Contains(issues[0].Message, "VMINotExists")
+		s.Equal(severityWarning, issues[0].Severity)
+	})
+
+	s.Run("detects Provisioning printableStatus", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"status": map[string]interface{}{
+				"printableStatus": "Provisioning",
+			},
+		})
+
+		issues := checkVMConditions(vm)
+		s.Require().NotEmpty(issues)
+		found := false
+		for _, iss := range issues {
+			if iss.Severity == severityWarning && strings.Contains(iss.Message, "Provisioning") {
+				found = true
+				break
+			}
+		}
+		s.True(found, "expected Provisioning issue")
+	})
+
+	s.Run("detects CrashLoopBackOff printableStatus", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"status": map[string]interface{}{
+				"printableStatus": "CrashLoopBackOff",
+			},
+		})
+
+		issues := checkVMConditions(vm)
+		s.Require().NotEmpty(issues)
+		s.Equal(severityCritical, issues[0].Severity)
+		s.Contains(issues[0].Message, "CrashLoopBackOff")
+		s.NotEmpty(issues[0].Fix)
+	})
+
+	s.Run("returns nil for healthy VM", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"status": map[string]interface{}{
+				"printableStatus": "Running",
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+				},
+			},
+		})
+
+		issues := checkVMConditions(vm)
+		s.Empty(issues)
+	})
+
+	s.Run("returns nil for nil VM", func() {
+		issues := checkVMConditions(nil)
+		s.Nil(issues)
+	})
+}
+
+func (s *AnalysisSuite) TestCheckDataVolumeErrors() {
+	s.Run("detects PVC not found in volume status", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"status": map[string]interface{}{
+				"volumeSnapshotStatuses": []interface{}{
+					map[string]interface{}{
+						"name":   "rootdisk",
+						"reason": "PVC not found",
+					},
+				},
+			},
+		})
+
+		issues := checkDataVolumeErrors(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Equal(severityCritical, issues[0].Severity)
+		s.Contains(issues[0].Message, "rootdisk")
+		s.Contains(issues[0].Message, "PVC not found")
+	})
+
+	s.Run("suppresses PVC error when StorageClass is already missing", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"status": map[string]interface{}{
+				"volumeSnapshotStatuses": []interface{}{
+					map[string]interface{}{
+						"name":   "rootdisk",
+						"reason": "PVC not found",
+					},
+				},
+			},
+		})
+
+		scIssues := []issue{{
+			Severity: severityCritical,
+			Message:  "StorageClass \"premium-nvme\" does not exist",
+		}}
+
+		issues := checkDataVolumeErrors(vm, scIssues)
+		s.Empty(issues, "PVC not found should be suppressed when SC is missing (it's a symptom)")
+	})
+
+	s.Run("returns nil when volumes are healthy", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"status": map[string]interface{}{
+				"volumeSnapshotStatuses": []interface{}{
+					map[string]interface{}{
+						"name":   "rootdisk",
+						"reason": "",
+					},
+				},
+			},
+		})
+
+		issues := checkDataVolumeErrors(vm, nil)
+		s.Empty(issues)
+	})
+}
+
+func (s *AnalysisSuite) TestCheckStorageClass() {
+	ctx := context.Background()
+
+	s.Run("detects missing StorageClass", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"dataVolumeTemplates": []interface{}{
+					map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "test-dv"},
+						"spec": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"storageClassName": "premium-nvme-storage",
+							},
+						},
+					},
+				},
+			},
+		})
+
+		existingSC := &unstructured.Unstructured{}
+		existingSC.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "storage.k8s.io/v1",
+			"kind":       "StorageClass",
+			"metadata": map[string]interface{}{
+				"name": "standard-csi",
+				"annotations": map[string]interface{}{
+					"storageclass.kubernetes.io/is-default-class": "true",
+				},
+			},
+		})
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.StorageClassGVR: "StorageClassList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, existingSC)
+
+		issues := checkStorageClass(ctx, client, vm)
+		s.Require().Len(issues, 1)
+		s.Equal(severityCritical, issues[0].Severity)
+		s.Contains(issues[0].Message, "premium-nvme-storage")
+		s.Contains(issues[0].Message, "does not exist")
+		s.Contains(issues[0].Message, "standard-csi (default)")
+	})
+
+	s.Run("returns nil when StorageClass exists", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"dataVolumeTemplates": []interface{}{
+					map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "test-dv"},
+						"spec": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"storageClassName": "standard-csi",
+							},
+						},
+					},
+				},
+			},
+		})
+
+		existingSC := &unstructured.Unstructured{}
+		existingSC.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "storage.k8s.io/v1",
+			"kind":       "StorageClass",
+			"metadata":   map[string]interface{}{"name": "standard-csi"},
+		})
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.StorageClassGVR: "StorageClassList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, existingSC)
+
+		issues := checkStorageClass(ctx, client, vm)
+		s.Empty(issues)
+	})
+
+	s.Run("returns nil when no dataVolumeTemplates", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec":       map[string]interface{}{},
+		})
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.StorageClassGVR: "StorageClassList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+
+		issues := checkStorageClass(ctx, client, vm)
+		s.Empty(issues)
+	})
+}
+
+func (s *AnalysisSuite) TestCheckCloudInitCommands() {
+	s.Run("detects shutdown command in cloud-init", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"runStrategy": "Always",
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - [\"shutdown\", \"-h\", \"now\"]\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Equal(severityCritical, issues[0].Severity)
+		s.Contains(issues[0].Message, "shutdown")
+		s.Contains(issues[0].Message, "crashloop")
+		s.NotEmpty(issues[0].Fix)
+	})
+
+	s.Run("detects halt command", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - halt\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Contains(issues[0].Message, "halt")
+	})
+
+	s.Run("detects poweroff command", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - poweroff\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Contains(issues[0].Message, "poweroff")
+	})
+
+	s.Run("no issues for safe cloud-init", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\npackages:\n  - nginx\nruncmd:\n  - systemctl start nginx\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Empty(issues)
+	})
+
+	s.Run("detects systemctl poweroff command", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - systemctl poweroff\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Contains(issues[0].Message, "poweroff")
+	})
+
+	s.Run("detects systemctl reboot in array format without spaces", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - [systemctl,reboot]\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Contains(issues[0].Message, "reboot")
+	})
+
+	s.Run("detects unquoted YAML array format [shutdown, -h, now]", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"runStrategy": "Always",
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - [shutdown, -h, now]\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Contains(issues[0].Message, "shutdown")
+	})
+
+	s.Run("no false positive when dangerous word is argument not command", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - [logger, halt requested by user]\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Empty(issues)
+	})
+
+	s.Run("no false positive on comments or config keys", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\n# Do not shutdown the VM\nhostname: shutdown\npackages: [halt]\nbootcmd: []\nreboot_timeout: 30\nhalt_check: false\nruncmd:\n  - echo 'shutdown is not allowed'\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Empty(issues)
+	})
+
+	s.Run("shutdown -r is classified as reboot", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - shutdown -r now\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Contains(issues[0].Message, "reboot")
+	})
+
+	s.Run("accumulates all dangerous matches", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - shutdown -h now\n  - reboot\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Require().Len(issues, 2)
+		s.Contains(issues[0].Message, "shutdown")
+		s.Contains(issues[1].Message, "reboot")
+	})
+
+	s.Run("no false positive on non-dangerous shutdown flags", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"name": "cloudinitdisk",
+								"cloudInitNoCloud": map[string]interface{}{
+									"userData": "#cloud-config\nruncmd:\n  - shutdown -c\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(vm, nil)
+		s.Empty(issues)
+	})
+
+	s.Run("falls back to VMI when VM has no volumes", func() {
+		vmi := &unstructured.Unstructured{}
+		vmi.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstance",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"volumes": []interface{}{
+					map[string]interface{}{
+						"name": "cloudinitdisk",
+						"cloudInitNoCloud": map[string]interface{}{
+							"userData": "#cloud-config\nruncmd:\n  - shutdown -h now\n",
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkCloudInitCommands(nil, vmi)
+		s.Require().Len(issues, 1)
+		s.Contains(issues[0].Message, "shutdown")
+	})
+
+	s.Run("returns nil when no volumes", func() {
+		issues := checkCloudInitCommands(nil, nil)
+		s.Nil(issues)
+	})
+}
+
+func (s *AnalysisSuite) TestCheckNodeSelector() {
+	s.Run("detects hostname nodeSelector", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"nodeSelector": map[string]interface{}{
+							"kubernetes.io/hostname": "worker-0",
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkNodeSelector(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Equal(severityWarning, issues[0].Severity)
+		s.Contains(issues[0].Message, "worker-0")
+		s.Contains(issues[0].Message, "prevents live migration")
+		s.NotEmpty(issues[0].Fix)
+	})
+
+	s.Run("reports non-hostname nodeSelector as info", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"nodeSelector": map[string]interface{}{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+				},
+			},
+		})
+
+		issues := checkNodeSelector(vm, nil)
+		s.Require().Len(issues, 1)
+		s.Equal(severityInfo, issues[0].Severity)
+	})
+
+	s.Run("returns nil when no nodeSelector", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		})
+
+		issues := checkNodeSelector(vm, nil)
+		s.Empty(issues)
+	})
+
+	s.Run("falls back to VMI spec", func() {
+		vmi := &unstructured.Unstructured{}
+		vmi.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstance",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"nodeSelector": map[string]interface{}{
+					"kubernetes.io/hostname": "worker-1",
+				},
+			},
+		})
+
+		issues := checkNodeSelector(nil, vmi)
+		s.Require().Len(issues, 1)
+		s.Contains(issues[0].Message, "worker-1")
+	})
+}
+
+func (s *AnalysisSuite) TestCheckPodHealth() {
+	s.Run("detects Pending pod", func() {
+		podDiags := []map[string]interface{}{
+			{"phase": "Pending"},
+		}
+
+		issues := checkPodHealth(podDiags)
+		s.Require().Len(issues, 1)
+		s.Equal(severityWarning, issues[0].Severity)
+		s.Contains(issues[0].Message, "Pending")
+	})
+
+	s.Run("detects CrashLoopBackOff container", func() {
+		podDiags := []map[string]interface{}{
+			{
+				"phase": "Running",
+				"containerStatuses": []map[string]interface{}{
+					{
+						"name":         "compute",
+						"ready":        false,
+						"restartCount": int64(5),
+						"state": map[string]interface{}{
+							"waiting": map[string]interface{}{
+								"reason":  "CrashLoopBackOff",
+								"message": "back-off 5m0s restarting failed container",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		issues := checkPodHealth(podDiags)
+		s.Require().NotEmpty(issues)
+		foundCrashloop := false
+		for _, iss := range issues {
+			if strings.Contains(iss.Message, "CrashLoopBackOff") {
+				foundCrashloop = true
+				s.Equal(severityCritical, iss.Severity)
+			}
+		}
+		s.True(foundCrashloop)
+	})
+
+	s.Run("detects OOMKilled container", func() {
+		podDiags := []map[string]interface{}{
+			{
+				"phase": "Running",
+				"containerStatuses": []map[string]interface{}{
+					{
+						"name":         "compute",
+						"ready":        false,
+						"restartCount": int64(1),
+						"state": map[string]interface{}{
+							"terminated": map[string]interface{}{
+								"reason": "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		issues := checkPodHealth(podDiags)
+		s.Require().NotEmpty(issues)
+		found := false
+		for _, iss := range issues {
+			if strings.Contains(iss.Message, "OOMKilled") {
+				found = true
+				s.Equal(severityCritical, iss.Severity)
+				s.NotEmpty(iss.Fix)
+			}
+		}
+		s.True(found)
+	})
+
+	s.Run("detects crashloop with float64 restartCount (real cluster behavior)", func() {
+		podDiags := []map[string]interface{}{
+			{
+				"phase": "Running",
+				"containerStatuses": []map[string]interface{}{
+					{
+						"name":         "compute",
+						"ready":        false,
+						"restartCount": float64(7),
+						"state": map[string]interface{}{
+							"waiting": map[string]interface{}{
+								"reason":  "CrashLoopBackOff",
+								"message": "back-off restarting failed container",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		issues := checkPodHealth(podDiags)
+		s.Require().NotEmpty(issues)
+		foundRestart := false
+		for _, iss := range issues {
+			if strings.Contains(iss.Message, "restarted 7 times") {
+				foundRestart = true
+			}
+		}
+		s.True(foundRestart, "should detect restarts from float64 values (as returned by real Kubernetes API)")
+	})
+
+	s.Run("returns nil for healthy pod", func() {
+		podDiags := []map[string]interface{}{
+			{
+				"phase": "Running",
+				"containerStatuses": []map[string]interface{}{
+					{
+						"name":         "compute",
+						"ready":        true,
+						"restartCount": int64(0),
+						"state": map[string]interface{}{
+							"running": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		}
+
+		issues := checkPodHealth(podDiags)
+		s.Empty(issues)
+	})
+
+	s.Run("returns nil for nil diagnostics", func() {
+		issues := checkPodHealth(nil)
+		s.Nil(issues)
+	})
+}
+
+func (s *AnalysisSuite) TestCheckMigrationStatus() {
+	ctx := context.Background()
+
+	s.Run("detects failed migration", func() {
+		vmim := &unstructured.Unstructured{}
+		vmim.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstanceMigration",
+			"metadata":   map[string]interface{}{"name": "test-vm-migration", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"vmiName": "test-vm",
+			},
+			"status": map[string]interface{}{
+				"phase": "Failed",
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":    "Failure",
+						"status":  "True",
+						"message": "cannot schedule: no suitable target node found",
+					},
+				},
+			},
+		})
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.VirtualMachineInstanceMigrationGVR: "VirtualMachineInstanceMigrationList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, vmim)
+
+		issues := checkMigrationStatus(ctx, client, "test-ns", "test-vm")
+		s.Require().Len(issues, 1)
+		s.Equal(severityCritical, issues[0].Severity)
+		s.Contains(issues[0].Message, "test-vm-migration")
+		s.Contains(issues[0].Message, "failed")
+		s.Contains(issues[0].Message, "no suitable target node found")
+		s.NotEmpty(issues[0].Fix)
+	})
+
+	s.Run("ignores successful migrations", func() {
+		vmim := &unstructured.Unstructured{}
+		vmim.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstanceMigration",
+			"metadata":   map[string]interface{}{"name": "test-vm-migration", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"vmiName": "test-vm",
+			},
+			"status": map[string]interface{}{
+				"phase": "Succeeded",
+			},
+		})
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.VirtualMachineInstanceMigrationGVR: "VirtualMachineInstanceMigrationList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, vmim)
+
+		issues := checkMigrationStatus(ctx, client, "test-ns", "test-vm")
+		s.Empty(issues)
+	})
+
+	s.Run("ignores migrations for other VMs", func() {
+		vmim := &unstructured.Unstructured{}
+		vmim.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstanceMigration",
+			"metadata":   map[string]interface{}{"name": "other-vm-migration", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"vmiName": "other-vm",
+			},
+			"status": map[string]interface{}{
+				"phase": "Failed",
+			},
+		})
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.VirtualMachineInstanceMigrationGVR: "VirtualMachineInstanceMigrationList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, vmim)
+
+		issues := checkMigrationStatus(ctx, client, "test-ns", "test-vm")
+		s.Empty(issues)
+	})
+
+	s.Run("returns nil when no migrations exist", func() {
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.VirtualMachineInstanceMigrationGVR: "VirtualMachineInstanceMigrationList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+
+		issues := checkMigrationStatus(ctx, client, "test-ns", "test-vm")
+		s.Empty(issues)
+	})
+
+	s.Run("includes age in failure message", func() {
+		vmim := &unstructured.Unstructured{}
+		vmim.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstanceMigration",
+			"metadata":   map[string]interface{}{"name": "aged-migration", "namespace": "test-ns"},
+			"spec": map[string]interface{}{
+				"vmiName": "test-vm",
+			},
+			"status": map[string]interface{}{
+				"phase": "Failed",
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":    "Failure",
+						"status":  "True",
+						"message": "scheduling issue",
+					},
+				},
+			},
+		})
+		vmim.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-3 * time.Hour)))
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.VirtualMachineInstanceMigrationGVR: "VirtualMachineInstanceMigrationList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, vmim)
+
+		issues := checkMigrationStatus(ctx, client, "test-ns", "test-vm")
+		s.Require().Len(issues, 1)
+		s.Contains(issues[0].Message, "aged-migration")
+		s.Contains(issues[0].Message, "3h ago")
+		s.Contains(issues[0].Message, "scheduling issue")
+	})
+
+	s.Run("reports only most recent 3 failures and notes skipped count", func() {
+		var objs []runtime.Object
+		for i := 0; i < 5; i++ {
+			vmim := &unstructured.Unstructured{}
+			vmim.SetUnstructuredContent(map[string]interface{}{
+				"apiVersion": "kubevirt.io/v1",
+				"kind":       "VirtualMachineInstanceMigration",
+				"metadata":   map[string]interface{}{"name": fmt.Sprintf("mig-%d", i), "namespace": "test-ns"},
+				"spec": map[string]interface{}{
+					"vmiName": "test-vm",
+				},
+				"status": map[string]interface{}{
+					"phase": "Failed",
+				},
+			})
+			vmim.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-time.Duration(i) * time.Hour)))
+			objs = append(objs, vmim)
+		}
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.VirtualMachineInstanceMigrationGVR: "VirtualMachineInstanceMigrationList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
+
+		issues := checkMigrationStatus(ctx, client, "test-ns", "test-vm")
+		s.Require().Len(issues, 4)
+		s.Contains(issues[0].Message, "mig-0")
+		s.Contains(issues[1].Message, "mig-1")
+		s.Contains(issues[2].Message, "mig-2")
+		s.Equal(severityInfo, issues[3].Severity)
+		s.Contains(issues[3].Message, "2 additional older failed migrations not shown")
+	})
+}
+
+func (s *AnalysisSuite) TestAnalyzeIssues() {
+	ctx := context.Background()
+
+	s.Run("returns no-issues message when all checks pass", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"status": map[string]interface{}{
+				"printableStatus": "Running",
+				"conditions": []interface{}{
+					map[string]interface{}{"type": "Ready", "status": "True"},
+				},
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		})
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.StorageClassGVR:                    "StorageClassList",
+			kubevirt.VirtualMachineInstanceMigrationGVR: "VirtualMachineInstanceMigrationList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+
+		result := analyzeIssues(ctx, client, "test-ns", "test-vm", vm, nil, nil)
+		s.Contains(result, "No issues automatically detected")
+	})
+
+	s.Run("produces Detected Issues and Suggested Fixes", func() {
+		vm := &unstructured.Unstructured{}
+		vm.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachine",
+			"metadata":   map[string]interface{}{"name": "test-vm", "namespace": "test-ns"},
+			"status": map[string]interface{}{
+				"printableStatus": "Provisioning",
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":    "Ready",
+						"status":  "False",
+						"reason":  "VMINotExists",
+						"message": "VMI does not exist",
+					},
+				},
+				"volumeSnapshotStatuses": []interface{}{
+					map[string]interface{}{
+						"name":   "rootdisk",
+						"reason": "PVC not found",
+					},
+				},
+			},
+			"spec": map[string]interface{}{
+				"dataVolumeTemplates": []interface{}{
+					map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "test-dv"},
+						"spec": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"storageClassName": "nonexistent-sc",
+							},
+						},
+					},
+				},
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		})
+
+		gvrToListKind := map[schema.GroupVersionResource]string{
+			kubevirt.StorageClassGVR:                    "StorageClassList",
+			kubevirt.VirtualMachineInstanceMigrationGVR: "VirtualMachineInstanceMigrationList",
+		}
+		client := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+
+		result := analyzeIssues(ctx, client, "test-ns", "test-vm", vm, nil, nil)
+		s.Contains(result, "## Detected Issues")
+		s.Contains(result, "CRITICAL")
+		s.Contains(result, "## Suggested Fixes")
+	})
+}

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/analysis_test.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/analysis_test.go
@@ -872,7 +872,11 @@ func (s *AnalysisSuite) TestCheckMigrationStatus() {
 		vmim.SetUnstructuredContent(map[string]interface{}{
 			"apiVersion": "kubevirt.io/v1",
 			"kind":       "VirtualMachineInstanceMigration",
-			"metadata":   map[string]interface{}{"name": "test-vm-migration", "namespace": "test-ns"},
+			"metadata": map[string]interface{}{
+				"name":      "test-vm-migration",
+				"namespace": "test-ns",
+				"labels":    map[string]interface{}{"kubevirt.io/vmi-name": "test-vm"},
+			},
 			"spec": map[string]interface{}{
 				"vmiName": "test-vm",
 			},
@@ -907,7 +911,11 @@ func (s *AnalysisSuite) TestCheckMigrationStatus() {
 		vmim.SetUnstructuredContent(map[string]interface{}{
 			"apiVersion": "kubevirt.io/v1",
 			"kind":       "VirtualMachineInstanceMigration",
-			"metadata":   map[string]interface{}{"name": "test-vm-migration", "namespace": "test-ns"},
+			"metadata": map[string]interface{}{
+				"name":      "test-vm-migration",
+				"namespace": "test-ns",
+				"labels":    map[string]interface{}{"kubevirt.io/vmi-name": "test-vm"},
+			},
 			"spec": map[string]interface{}{
 				"vmiName": "test-vm",
 			},
@@ -930,7 +938,11 @@ func (s *AnalysisSuite) TestCheckMigrationStatus() {
 		vmim.SetUnstructuredContent(map[string]interface{}{
 			"apiVersion": "kubevirt.io/v1",
 			"kind":       "VirtualMachineInstanceMigration",
-			"metadata":   map[string]interface{}{"name": "other-vm-migration", "namespace": "test-ns"},
+			"metadata": map[string]interface{}{
+				"name":      "other-vm-migration",
+				"namespace": "test-ns",
+				"labels":    map[string]interface{}{"kubevirt.io/vmi-name": "other-vm"},
+			},
 			"spec": map[string]interface{}{
 				"vmiName": "other-vm",
 			},
@@ -963,7 +975,11 @@ func (s *AnalysisSuite) TestCheckMigrationStatus() {
 		vmim.SetUnstructuredContent(map[string]interface{}{
 			"apiVersion": "kubevirt.io/v1",
 			"kind":       "VirtualMachineInstanceMigration",
-			"metadata":   map[string]interface{}{"name": "aged-migration", "namespace": "test-ns"},
+			"metadata": map[string]interface{}{
+				"name":      "aged-migration",
+				"namespace": "test-ns",
+				"labels":    map[string]interface{}{"kubevirt.io/vmi-name": "test-vm"},
+			},
 			"spec": map[string]interface{}{
 				"vmiName": "test-vm",
 			},
@@ -999,7 +1015,11 @@ func (s *AnalysisSuite) TestCheckMigrationStatus() {
 			vmim.SetUnstructuredContent(map[string]interface{}{
 				"apiVersion": "kubevirt.io/v1",
 				"kind":       "VirtualMachineInstanceMigration",
-				"metadata":   map[string]interface{}{"name": fmt.Sprintf("mig-%d", i), "namespace": "test-ns"},
+				"metadata": map[string]interface{}{
+					"name":      fmt.Sprintf("mig-%d", i),
+					"namespace": "test-ns",
+					"labels":    map[string]interface{}{"kubevirt.io/vmi-name": "test-vm"},
+				},
 				"spec": map[string]interface{}{
 					"vmiName": "test-vm",
 				},

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
@@ -2,6 +2,7 @@ package troubleshoot
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -216,7 +217,7 @@ func stripCloudInitBodies(volumes []any) []any {
 				stripped := make(map[string]interface{}, len(ciMap))
 				for ck, cv := range ciMap {
 					switch ck {
-					case "userData", "networkData":
+					case "userData", "networkData", "userDataBase64", "networkDataBase64":
 						stripped[ck] = "<see Cloud-Init Configuration section>"
 					default:
 						stripped[ck] = cv
@@ -496,11 +497,11 @@ func extractCloudInit(vm, vmi *unstructured.Unstructured) string {
 			volName, _ := volMap["name"].(string)
 			fmt.Fprintf(&result, "### %s (type: %s)\n\n", volName, ciKey)
 
-			userData, _ := ciData["userData"].(string)
+			userData := cloudInitData(ciData, "userData", "userDataBase64")
 			if userData != "" {
 				fmt.Fprintf(&result, "```yaml\n%s\n```\n\n", redactCloudInitSensitiveFields(userData))
 			}
-			networkData, _ := ciData["networkData"].(string)
+			networkData := cloudInitData(ciData, "networkData", "networkDataBase64")
 			if networkData != "" {
 				fmt.Fprintf(&result, "**networkData:**\n```yaml\n%s\n```\n\n", redactCloudInitSensitiveFields(networkData))
 			}
@@ -517,6 +518,25 @@ func extractCloudInit(vm, vmi *unstructured.Unstructured) string {
 		return "## Cloud-Init Configuration\n\n*No cloud-init volumes configured*"
 	}
 	return result.String()
+}
+
+// cloudInitData returns the cloud-init payload for a field, preferring the
+// plain-text key and falling back to the base64-encoded variant. This keeps the
+// content diagnosable while ensuring it always flows through redaction (the raw
+// volume dump strips both variants, see stripCloudInitBodies).
+func cloudInitData(ciData map[string]interface{}, plainKey, base64Key string) string {
+	if plain, _ := ciData[plainKey].(string); plain != "" {
+		return plain
+	}
+	encoded, _ := ciData[base64Key].(string)
+	if encoded == "" {
+		return ""
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+	if err != nil {
+		return ""
+	}
+	return string(decoded)
 }
 
 var sensitiveYAMLKeys = []string{

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool.go
@@ -1,0 +1,664 @@
+package troubleshoot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
+	"github.com/google/jsonschema-go/jsonschema"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/ptr"
+)
+
+func Tools(p api.FilteringProvider) []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name: "vm_troubleshoot",
+				Description: fmt.Sprintf(
+					"Diagnose %s VirtualMachine issues with automated root-cause detection. "+
+						"Collects VM status, VMI status, volumes, DataVolume/PVC state, cloud-init configuration, pod state, logs, and events, "+
+						"then runs heuristic checks to identify specific problems and suggest fixes. "+
+						"Returns a 'Detected Issues' section with CRITICAL/WARNING findings and actionable remediation steps, followed by raw diagnostic data. "+
+						"Use this tool FIRST whenever a user asks why a VM is not starting, stuck in Provisioning, crashlooping, failing to migrate, or exhibiting unexpected behavior. "+
+						"Automatically detects: missing StorageClasses, invalid PVC specs, "+
+						"dangerous cloud-init commands (shutdown/halt), "+
+						"nodeSelector migration blockers, failed migrations, "+
+						"and pod crashloops. "+
+						"If the user asks to fix or remediate the issue, "+
+						"use the Suggested Fixes from the report with "+
+						"vm_lifecycle (restart) or resources_create_or_update.",
+					defaults.ProductName()),
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "The namespace of the VirtualMachine to troubleshoot",
+						},
+						"name": {
+							Type:        "string",
+							Description: "The name of the VirtualMachine to troubleshoot",
+						},
+					},
+					Required: []string{"namespace", "name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Virtual Machine: Troubleshoot",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			TargetCompatibilityFilters: []func() bool{
+				kubevirt.HasVirtualMachine(p),
+			},
+			Handler: troubleshoot,
+		},
+	}
+}
+
+func troubleshoot(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	namespace, err := api.RequiredString(params, "namespace")
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	name, err := api.RequiredString(params, "name")
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	ctx := params.Context
+	dynamicClient := params.DynamicClient()
+
+	vmYaml, vm := fetchVMStatus(ctx, dynamicClient, namespace, name)
+	vmiYaml, vmi := fetchVMIStatus(ctx, dynamicClient, namespace, name)
+	volumesYaml := fetchVolumes(namespace, name, vm, vmi)
+	dataVolumeYaml := fetchDataVolumeStatus(ctx, dynamicClient, namespace, vm)
+	cloudInitYaml := extractCloudInit(vm, vmi)
+	podYaml, podNames, podDiag := fetchVirtLauncherPod(ctx, dynamicClient, namespace, name)
+	podLogsText := fetchVirtLauncherPodLogs(ctx, params.KubernetesClient, namespace, podNames)
+	eventsYaml := fetchEvents(ctx, params.KubernetesClient, namespace, name, podNames)
+
+	issuesSection := analyzeIssues(ctx, dynamicClient, namespace, name, vm, vmi, podDiag)
+
+	report := fmt.Sprintf(`# VirtualMachine Diagnostic Report: %s/%s
+
+%s
+
+%s
+
+%s
+
+%s
+
+%s
+
+%s
+
+%s
+
+%s
+
+%s
+`, namespace, name, issuesSection, vmYaml, vmiYaml, volumesYaml, dataVolumeYaml, cloudInitYaml, podYaml, podLogsText, eventsYaml)
+
+	return api.NewToolCallResult(report, nil), nil
+}
+
+func fetchVMStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) (string, *unstructured.Unstructured) {
+	vm, err := dynamicClient.Resource(kubevirt.VirtualMachineGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachine\n\n*Error: %v*", err), nil
+	}
+
+	status, found, err := unstructured.NestedMap(vm.Object, "status")
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachine\n\n*Error extracting status: %v*", err), vm
+	}
+	if !found {
+		return fmt.Sprintf("## VirtualMachine: %s/%s\n\n*No status found (VM may not have been reconciled yet)*", namespace, name), vm
+	}
+
+	yamlStr, err := output.MarshalYaml(status)
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachine\n\n*Error marshaling status: %v*", err), vm
+	}
+
+	return fmt.Sprintf("## VirtualMachine Status: %s/%s\n\n```yaml\n%s```", namespace, name, yamlStr), vm
+}
+
+func fetchVMIStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) (string, *unstructured.Unstructured) {
+	vmi, err := dynamicClient.Resource(kubevirt.VirtualMachineInstanceGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachineInstance\n\n*VMI not found: %v*\n\n(Expected if VM is stopped or stuck provisioning)", err), nil
+	}
+
+	status, found, err := unstructured.NestedMap(vmi.Object, "status")
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachineInstance\n\n*Error extracting status: %v*", err), vmi
+	}
+	if !found {
+		return fmt.Sprintf("## VirtualMachineInstance: %s/%s\n\n*No status found*", namespace, name), vmi
+	}
+
+	yamlStr, err := output.MarshalYaml(status)
+	if err != nil {
+		return fmt.Sprintf("## VirtualMachineInstance\n\n*Error marshaling status: %v*", err), vmi
+	}
+
+	return fmt.Sprintf("## VirtualMachineInstance Status: %s/%s\n\n```yaml\n%s```", namespace, name, yamlStr), vmi
+}
+
+func fetchVolumes(namespace, name string, vm, vmi *unstructured.Unstructured) string {
+	var volumes []any
+	var found bool
+	var err error
+	source := "VirtualMachine"
+
+	if vm != nil {
+		volumes, found, err = unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+		if err != nil {
+			return "*Error extracting volumes from VirtualMachine: " + err.Error() + "*"
+		}
+	}
+
+	if (!found || len(volumes) == 0) && vmi != nil {
+		volumes, found, err = unstructured.NestedSlice(vmi.Object, "spec", "volumes")
+		if err != nil {
+			return "*Error extracting volumes from VirtualMachineInstance: " + err.Error() + "*"
+		}
+		if found && len(volumes) > 0 {
+			source = "VirtualMachineInstance"
+		}
+	}
+
+	if !found || len(volumes) == 0 {
+		return "## Volumes\n\n*No volumes configured*"
+	}
+
+	sanitized := stripCloudInitBodies(volumes)
+
+	yamlStr, err := output.MarshalYaml(sanitized)
+	if err != nil {
+		return "*Error marshaling volumes: " + err.Error() + "*"
+	}
+
+	return fmt.Sprintf("## Volumes (from %s: %s/%s)\n\n```yaml\n%s```", source, namespace, name, yamlStr)
+}
+
+func stripCloudInitBodies(volumes []any) []any {
+	result := make([]any, 0, len(volumes))
+	for _, vol := range volumes {
+		volMap, ok := vol.(map[string]interface{})
+		if !ok {
+			result = append(result, vol)
+			continue
+		}
+		clean := make(map[string]interface{}, len(volMap))
+		for k, v := range volMap {
+			if k == "cloudInitNoCloud" || k == "cloudInitConfigDrive" {
+				ciMap, ok := v.(map[string]interface{})
+				if !ok {
+					clean[k] = v
+					continue
+				}
+				stripped := make(map[string]interface{}, len(ciMap))
+				for ck, cv := range ciMap {
+					switch ck {
+					case "userData", "networkData":
+						stripped[ck] = "<see Cloud-Init Configuration section>"
+					default:
+						stripped[ck] = cv
+					}
+				}
+				clean[k] = stripped
+			} else {
+				clean[k] = v
+			}
+		}
+		result = append(result, clean)
+	}
+	return result
+}
+
+func fetchVirtLauncherPod(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) (string, []string, []map[string]interface{}) {
+	labelSelector := fmt.Sprintf("kubevirt.io=virt-launcher,vm.kubevirt.io/name=%s", name)
+	podList, err := dynamicClient.Resource(kubevirt.PodGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return fmt.Sprintf("## virt-launcher Pod\n\n*Error listing pods: %v*", err), nil, nil
+	}
+
+	if len(podList.Items) == 0 {
+		return "## virt-launcher Pod\n\n*No virt-launcher pod found (VM may be stopped or not yet scheduled)*", nil, nil
+	}
+
+	var result strings.Builder
+	var podNames []string
+	var allDiags []map[string]interface{}
+	result.WriteString("## virt-launcher Pod\n\n")
+	for _, pod := range podList.Items {
+		podNames = append(podNames, pod.GetName())
+		summary := extractPodDiagnostics(&pod)
+		allDiags = append(allDiags, summary)
+		yamlStr, err := output.MarshalYaml(summary)
+		if err != nil {
+			fmt.Fprintf(&result, "*Error marshaling pod %s: %v*\n\n", pod.GetName(), err)
+			continue
+		}
+		fmt.Fprintf(&result, "### %s\n\n```yaml\n%s```\n\n", pod.GetName(), yamlStr)
+	}
+
+	return result.String(), podNames, allDiags
+}
+
+func extractPodDiagnostics(pod *unstructured.Unstructured) map[string]interface{} {
+	diag := map[string]interface{}{}
+
+	phase, _, _ := unstructured.NestedString(pod.Object, "status", "phase")
+	diag["phase"] = phase
+
+	nodeName, _, _ := unstructured.NestedString(pod.Object, "spec", "nodeName")
+	if nodeName != "" {
+		diag["nodeName"] = nodeName
+	}
+
+	conditions, _, _ := unstructured.NestedSlice(pod.Object, "status", "conditions")
+	if len(conditions) > 0 {
+		diag["conditions"] = conditions
+	}
+
+	containerStatuses, _, _ := unstructured.NestedSlice(pod.Object, "status", "containerStatuses")
+	if len(containerStatuses) > 0 {
+		var summaries []map[string]interface{}
+		for _, cs := range containerStatuses {
+			csMap, ok := cs.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			summary := map[string]interface{}{
+				"name":  csMap["name"],
+				"ready": csMap["ready"],
+			}
+			if rc, ok := csMap["restartCount"]; ok {
+				summary["restartCount"] = rc
+			}
+			if state, ok := csMap["state"]; ok {
+				summary["state"] = state
+			}
+			if lastState, ok := csMap["lastTerminationState"]; ok {
+				stateMap, _ := lastState.(map[string]interface{})
+				if len(stateMap) > 0 {
+					summary["lastTerminationState"] = lastState
+				}
+			}
+			summaries = append(summaries, summary)
+		}
+		diag["containerStatuses"] = summaries
+	}
+
+	nodeSelector, _, _ := unstructured.NestedMap(pod.Object, "spec", "nodeSelector")
+	if len(nodeSelector) > 0 {
+		diag["nodeSelector"] = nodeSelector
+	}
+
+	return diag
+}
+
+func fetchVirtLauncherPodLogs(ctx context.Context, client api.KubernetesClient, namespace string, podNames []string) string {
+	if len(podNames) == 0 {
+		return "## virt-launcher Pod Logs\n\n*No pod found — no logs available*"
+	}
+
+	core := kubernetes.NewCore(client)
+	var result strings.Builder
+	result.WriteString("## virt-launcher Pod Logs\n\n")
+
+	containerName := "compute"
+	for _, podName := range podNames {
+		logs, err := core.PodsLog(ctx, namespace, podName, containerName, false, 50)
+		if err != nil {
+			fmt.Fprintf(&result, "### %s\n\n*Error fetching logs: %v*\n\n", podName, err)
+			continue
+		}
+		fmt.Fprintf(&result, "### %s (container: %s)\n\n```\n%s\n```\n\n", podName, containerName, redactLogSecrets(logs))
+	}
+
+	return result.String()
+}
+
+func fetchEvents(ctx context.Context, client api.KubernetesClient, namespace, vmName string, podNames []string) string {
+	core := kubernetes.NewCore(client)
+
+	objectNames := []string{vmName}
+	objectNames = append(objectNames, podNames...)
+
+	var relatedEvents []map[string]any
+	var eventErrors []string
+	for _, objName := range objectNames {
+		events, err := core.EventsList(ctx, namespace, api.ListOptions{
+			ListOptions: metav1.ListOptions{FieldSelector: "involvedObject.name=" + objName},
+		})
+		if err != nil {
+			eventErrors = append(eventErrors, fmt.Sprintf("Error fetching events for %s: %v", objName, err))
+			continue
+		}
+		relatedEvents = append(relatedEvents, events...)
+	}
+
+	if len(relatedEvents) == 0 && len(eventErrors) == 0 {
+		return "## Events\n\n*No events found related to this VM*"
+	}
+
+	var result strings.Builder
+	result.WriteString("## Events")
+	if len(eventErrors) > 0 {
+		result.WriteString("\n\n")
+		for _, e := range eventErrors {
+			fmt.Fprintf(&result, "*%s*\n", e)
+		}
+	}
+
+	if len(relatedEvents) > 0 {
+		yamlStr, err := output.MarshalYaml(relatedEvents)
+		if err != nil {
+			fmt.Fprintf(&result, "\n\n*Error marshaling events: %v*", err)
+		} else {
+			fmt.Fprintf(&result, "\n\n```yaml\n%s```", yamlStr)
+		}
+	}
+
+	return result.String()
+}
+
+func fetchDataVolumeStatus(ctx context.Context, dynamicClient dynamic.Interface, namespace string, vm *unstructured.Unstructured) string {
+	if vm == nil {
+		return "## DataVolume/PVC Status\n\n*No VM available to extract DataVolume references*"
+	}
+
+	dvTemplates, found, err := unstructured.NestedSlice(vm.Object, "spec", "dataVolumeTemplates")
+	if err != nil || !found || len(dvTemplates) == 0 {
+		return "## DataVolume/PVC Status\n\n*No dataVolumeTemplates defined in VM spec*"
+	}
+
+	var result strings.Builder
+	result.WriteString("## DataVolume/PVC Status\n\n")
+
+	for _, dvTemplate := range dvTemplates {
+		dvMap, ok := dvTemplate.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		metadata, _ := dvMap["metadata"].(map[string]interface{})
+		dvName, _ := metadata["name"].(string)
+		if dvName == "" {
+			continue
+		}
+
+		dv, err := dynamicClient.Resource(kubevirt.DataVolumeGVR).Namespace(namespace).Get(ctx, dvName, metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				fmt.Fprintf(&result, "### %s\n\n*Error fetching DataVolume: %v*\n\n", dvName, err)
+				continue
+			}
+			fmt.Fprintf(&result, "### %s\n\n*DataVolume not found*\n\n", dvName)
+			pvc, pvcErr := dynamicClient.Resource(kubevirt.PersistentVolumeClaimGVR).Namespace(namespace).Get(ctx, dvName, metav1.GetOptions{})
+			if pvcErr != nil {
+				fmt.Fprintf(&result, "*PVC also not found: %v*\n\n", pvcErr)
+			} else {
+				pvcStatus, _, _ := unstructured.NestedMap(pvc.Object, "status")
+				if pvcStatus != nil {
+					yamlStr, marshalErr := output.MarshalYaml(pvcStatus)
+					if marshalErr != nil {
+						fmt.Fprintf(&result, "*Error marshaling PVC status: %v*\n\n", marshalErr)
+					} else {
+						fmt.Fprintf(&result, "PVC exists with status:\n```yaml\n%s```\n\n", yamlStr)
+					}
+				}
+			}
+			continue
+		}
+
+		dvStatus, found, _ := unstructured.NestedMap(dv.Object, "status")
+		if !found {
+			fmt.Fprintf(&result, "### %s\n\n*DataVolume exists but has no status*\n\n", dvName)
+			continue
+		}
+
+		yamlStr, err := output.MarshalYaml(dvStatus)
+		if err != nil {
+			fmt.Fprintf(&result, "### %s\n\n*Error marshaling DataVolume status: %v*\n\n", dvName, err)
+			continue
+		}
+
+		dvSpec, _, _ := unstructured.NestedMap(dv.Object, "spec")
+		storageClass := ""
+		if dvSpec != nil {
+			sc, _, _ := unstructured.NestedString(dvSpec, "storage", "storageClassName")
+			if sc != "" {
+				storageClass = sc
+			}
+		}
+
+		fmt.Fprintf(&result, "### %s", dvName)
+		if storageClass != "" {
+			fmt.Fprintf(&result, " (storageClass: %s)", storageClass)
+		}
+		fmt.Fprintf(&result, "\n\n```yaml\n%s```\n\n", yamlStr)
+	}
+
+	return result.String()
+}
+
+func extractCloudInit(vm, vmi *unstructured.Unstructured) string {
+	var volumes []interface{}
+	if vm != nil {
+		volumes, _, _ = unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	}
+	if len(volumes) == 0 && vmi != nil {
+		volumes, _, _ = unstructured.NestedSlice(vmi.Object, "spec", "volumes")
+	}
+	if len(volumes) == 0 {
+		return "## Cloud-Init Configuration\n\n*No volumes found*"
+	}
+
+	var result strings.Builder
+	found := false
+
+	for _, vol := range volumes {
+		volMap, ok := vol.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, ciKey := range []string{"cloudInitNoCloud", "cloudInitConfigDrive"} {
+			ciData, exists := volMap[ciKey].(map[string]interface{})
+			if !exists {
+				continue
+			}
+			found = true
+			if result.Len() == 0 {
+				result.WriteString("## Cloud-Init Configuration\n\n")
+			}
+
+			volName, _ := volMap["name"].(string)
+			fmt.Fprintf(&result, "### %s (type: %s)\n\n", volName, ciKey)
+
+			userData, _ := ciData["userData"].(string)
+			if userData != "" {
+				fmt.Fprintf(&result, "```yaml\n%s\n```\n\n", redactCloudInitSensitiveFields(userData))
+			}
+			networkData, _ := ciData["networkData"].(string)
+			if networkData != "" {
+				fmt.Fprintf(&result, "**networkData:**\n```yaml\n%s\n```\n\n", redactCloudInitSensitiveFields(networkData))
+			}
+			if userData == "" && networkData == "" {
+				secretRef, _ := ciData["userDataSecretRef"].(map[string]interface{})
+				if secretRef != nil {
+					fmt.Fprintf(&result, "*userData from Secret: %v*\n\n", secretRef["name"])
+				}
+			}
+		}
+	}
+
+	if !found {
+		return "## Cloud-Init Configuration\n\n*No cloud-init volumes configured*"
+	}
+	return result.String()
+}
+
+var sensitiveYAMLKeys = []string{
+	"password",
+	"passwd",
+	"plain_text_passwd",
+	"hashed_passwd",
+	"ssh_authorized_keys",
+	"ssh_keys",
+	"ca-cert",
+	"client-cert",
+	"client-key",
+	"token",
+	"chpasswd",
+	"write_files",
+	"rsa_private",
+	"rsa_public",
+	"dsa_private",
+	"dsa_public",
+	"ecdsa_private",
+	"ecdsa_public",
+	"ed25519_private",
+	"ed25519_public",
+}
+
+var sensitiveLinePatterns = []string{
+	"ssh-rsa ",
+	"ssh-ed25519 ",
+	"ecdsa-sha2-",
+	"ssh-dss ",
+	"sk-ssh-ed25519@openssh.com ",
+	"sk-ecdsa-sha2-",
+	"-----begin",
+}
+
+func redactCloudInitSensitiveFields(userData string) string {
+	lines := strings.Split(userData, "\n")
+	var result []string
+	redactIndent := -1
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		indent := leadingSpaces(line)
+
+		if redactIndent >= 0 {
+			if len(trimmed) == 0 || indent > redactIndent {
+				continue
+			}
+			redactIndent = -1
+		}
+
+		if isSensitiveKeyLine(trimmed) {
+			key := strings.SplitN(trimmed, ":", 2)[0]
+			valuePart := strings.TrimSpace(strings.SplitN(trimmed, ":", 2)[1])
+			if valuePart == "" || isBlockScalarIndicator(valuePart) {
+				redactIndent = indent
+			}
+			result = append(result, strings.Repeat(" ", indent)+key+": <REDACTED>")
+			continue
+		}
+
+		if isSensitiveValueLine(trimmed) {
+			result = append(result, strings.Repeat(" ", indent)+"<REDACTED>")
+			continue
+		}
+
+		result = append(result, line)
+	}
+	return strings.Join(result, "\n")
+}
+
+func isSensitiveKeyLine(trimmed string) bool {
+	lower := strings.ToLower(trimmed)
+	for _, key := range sensitiveYAMLKeys {
+		if strings.HasPrefix(lower, key+":") {
+			return true
+		}
+	}
+	return false
+}
+
+func isSensitiveValueLine(trimmed string) bool {
+	lower := strings.ToLower(trimmed)
+	for _, pat := range sensitiveLinePatterns {
+		if strings.Contains(lower, pat) {
+			return true
+		}
+	}
+	return false
+}
+
+var logSecretPatterns = []string{
+	"bearer ",
+	"authorization:",
+	"authorization=",
+	"-u ", "--user ",
+	"-----begin",
+	"ssh-rsa ", "ssh-ed25519 ", "ssh-dss ",
+	"password=", "passwd=", "token=",
+}
+
+func redactLogSecrets(logs string) string {
+	lines := strings.Split(logs, "\n")
+	var result []string
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		redacted := false
+		for _, pat := range logSecretPatterns {
+			if strings.Contains(lower, pat) {
+				idx := strings.Index(lower, pat)
+				result = append(result, line[:idx+len(pat)]+"<REDACTED>")
+				redacted = true
+				break
+			}
+		}
+		if !redacted {
+			result = append(result, line)
+		}
+	}
+	return strings.Join(result, "\n")
+}
+
+func leadingSpaces(s string) int {
+	for i, c := range s {
+		if c != ' ' && c != '\t' {
+			return i
+		}
+	}
+	return len(s)
+}
+
+func isBlockScalarIndicator(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	if s[0] != '|' && s[0] != '>' {
+		return false
+	}
+	for _, c := range s[1:] {
+		if c != '+' && c != '-' && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
@@ -1,0 +1,355 @@
+package troubleshoot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type TroubleshootToolSuite struct {
+	suite.Suite
+}
+
+func (s *TroubleshootToolSuite) TestRedactCloudInitSensitiveFields() {
+	s.Run("redacts inline password value", func() {
+		input := "#cloud-config\npassword: mysecret\nhostname: myvm"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "password: <REDACTED>")
+		s.NotContains(result, "mysecret")
+		s.Contains(result, "hostname: myvm")
+	})
+
+	s.Run("redacts SSH key in list item without leaking material", func() {
+		input := "ssh_authorized_keys:\n  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... user@host"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "ssh_authorized_keys: <REDACTED>")
+		s.NotContains(result, "AAAAB3")
+		s.NotContains(result, "user@host")
+	})
+
+	s.Run("redacts multi-line block scalar password", func() {
+		input := "#cloud-config\npassword: |\n  multi-line-secret-value\n  second-line\nhostname: myvm"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "password: <REDACTED>")
+		s.NotContains(result, "multi-line-secret-value")
+		s.NotContains(result, "second-line")
+		s.Contains(result, "hostname: myvm")
+	})
+
+	s.Run("preserves non-sensitive content", func() {
+		input := "#cloud-config\nhostname: worker-1\nruncmd:\n  - dnf install -y httpd\n  - systemctl enable httpd\npackages:\n  - vim\n  - curl"
+		result := redactCloudInitSensitiveFields(input)
+		s.Equal(input, result)
+	})
+
+	s.Run("does not false-positive on comments containing sensitive words", func() {
+		input := "#cloud-config\n# This is not a secret: just a comment\nhostname: myvm"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "# This is not a secret: just a comment")
+		s.Contains(result, "hostname: myvm")
+	})
+
+	s.Run("redacts ssh-ed25519 key in list", func() {
+		input := "ssh_authorized_keys:\n  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPrivateKey user@host"
+		result := redactCloudInitSensitiveFields(input)
+		s.NotContains(result, "AAAAPrivateKey")
+		s.NotContains(result, "AAAAC3")
+	})
+
+	s.Run("redacts token field", func() {
+		input := "#cloud-config\ntoken: abc123secret\nhostname: node1"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "token: <REDACTED>")
+		s.NotContains(result, "abc123secret")
+		s.Contains(result, "hostname: node1")
+	})
+
+	s.Run("redacts chpasswd block", func() {
+		input := "#cloud-config\nchpasswd:\n  list:\n    - root:secret123\n    - user:pass456\n  expire: false\nhostname: myvm"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "chpasswd: <REDACTED>")
+		s.NotContains(result, "secret123")
+		s.NotContains(result, "pass456")
+		s.Contains(result, "hostname: myvm")
+	})
+
+	s.Run("redacts plain_text_passwd and hashed_passwd", func() {
+		input := "#cloud-config\nplain_text_passwd: mypassword\nhashed_passwd: $6$rounds=4096$salt$hash\nhostname: myvm"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "plain_text_passwd: <REDACTED>")
+		s.Contains(result, "hashed_passwd: <REDACTED>")
+		s.NotContains(result, "mypassword")
+		s.NotContains(result, "$6$rounds")
+	})
+
+	s.Run("redacts ssh_keys host private keys", func() {
+		input := "#cloud-config\nssh_keys:\n  rsa_private: |\n    -----BEGIN RSA PRIVATE KEY-----\n    MIIEpAIBAAKCAQEA...\n    -----END RSA PRIVATE KEY-----\n  rsa_public: ssh-rsa AAAAB3...\nhostname: myvm"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "ssh_keys: <REDACTED>")
+		s.NotContains(result, "MIIEpAIBAAKCAQEA")
+		s.NotContains(result, "BEGIN RSA PRIVATE KEY")
+		s.Contains(result, "hostname: myvm")
+	})
+
+	s.Run("redacts write_files block", func() {
+		input := "#cloud-config\nwrite_files:\n  - path: /etc/ssl/private/key.pem\n    content: |\n      -----BEGIN PRIVATE KEY-----\n      MIIEvgIBADANBgkqhk...\nhostname: myvm"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "write_files: <REDACTED>")
+		s.NotContains(result, "MIIEvgIBADANBgkqhk")
+		s.Contains(result, "hostname: myvm")
+	})
+
+	s.Run("redacts block scalar with indent indicator", func() {
+		input := "#cloud-config\npassword: |2\n  indented-secret\nhostname: myvm"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "password: <REDACTED>")
+		s.NotContains(result, "indented-secret")
+		s.Contains(result, "hostname: myvm")
+	})
+
+	s.Run("redacts block scalar with chomp and indent indicators", func() {
+		input := "#cloud-config\npassword: >-\n  folded-secret\nhostname: myvm"
+		result := redactCloudInitSensitiveFields(input)
+		s.Contains(result, "password: <REDACTED>")
+		s.NotContains(result, "folded-secret")
+		s.Contains(result, "hostname: myvm")
+	})
+
+	s.Run("redacts ssh-dss key format", func() {
+		input := "ssh_authorized_keys:\n  - ssh-dss AAAAB3NzaC1kc3MAAACBANcOo... user@host"
+		result := redactCloudInitSensitiveFields(input)
+		s.NotContains(result, "AAAAB3NzaC1kc3M")
+	})
+
+	s.Run("redacts PEM certificate blocks", func() {
+		input := "#cloud-config\nruncmd:\n  - echo '-----BEGIN CERTIFICATE-----' > /tmp/cert"
+		result := redactCloudInitSensitiveFields(input)
+		s.NotContains(result, "CERTIFICATE")
+	})
+}
+
+func (s *TroubleshootToolSuite) TestStripCloudInitBodies() {
+	s.Run("replaces userData and networkData with placeholder", func() {
+		volumes := []any{
+			map[string]interface{}{
+				"name": "cloudinitdisk",
+				"cloudInitNoCloud": map[string]interface{}{
+					"userData":    "#cloud-config\npassword: secret123",
+					"networkData": "network:\n  version: 2",
+				},
+			},
+			map[string]interface{}{
+				"name": "rootdisk",
+				"containerDisk": map[string]interface{}{
+					"image": "registry.io/image:latest",
+				},
+			},
+		}
+
+		result := stripCloudInitBodies(volumes)
+		s.Require().Len(result, 2)
+
+		ciVol := result[0].(map[string]interface{})
+		ciData := ciVol["cloudInitNoCloud"].(map[string]interface{})
+		s.Equal("<see Cloud-Init Configuration section>", ciData["userData"])
+		s.Equal("<see Cloud-Init Configuration section>", ciData["networkData"])
+
+		rootVol := result[1].(map[string]interface{})
+		cdData := rootVol["containerDisk"].(map[string]interface{})
+		s.Equal("registry.io/image:latest", cdData["image"])
+	})
+
+	s.Run("preserves secretRef in cloud-init", func() {
+		volumes := []any{
+			map[string]interface{}{
+				"name": "cloudinitdisk",
+				"cloudInitNoCloud": map[string]interface{}{
+					"userDataSecretRef": map[string]interface{}{"name": "my-secret"},
+				},
+			},
+		}
+
+		result := stripCloudInitBodies(volumes)
+		ciVol := result[0].(map[string]interface{})
+		ciData := ciVol["cloudInitNoCloud"].(map[string]interface{})
+		ref := ciData["userDataSecretRef"].(map[string]interface{})
+		s.Equal("my-secret", ref["name"])
+	})
+}
+
+func (s *TroubleshootToolSuite) TestRedactLogSecrets() {
+	s.Run("redacts bearer token in logs", func() {
+		input := "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.abc"
+		result := redactLogSecrets(input)
+		s.Contains(result, "Bearer <REDACTED>")
+		s.NotContains(result, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9")
+	})
+
+	s.Run("preserves normal log lines", func() {
+		input := "2026-07-20 10:00:00 INFO VM started successfully"
+		result := redactLogSecrets(input)
+		s.Equal(input, result)
+	})
+
+	s.Run("redacts password= in logs", func() {
+		input := "connecting with password=mysecret123"
+		result := redactLogSecrets(input)
+		s.Contains(result, "password=<REDACTED>")
+		s.NotContains(result, "mysecret123")
+	})
+}
+
+func (s *TroubleshootToolSuite) TestIsBlockScalarIndicator() {
+	s.Run("recognizes standard indicators", func() {
+		s.True(isBlockScalarIndicator("|"))
+		s.True(isBlockScalarIndicator(">"))
+		s.True(isBlockScalarIndicator("|+"))
+		s.True(isBlockScalarIndicator("|-"))
+		s.True(isBlockScalarIndicator(">+"))
+		s.True(isBlockScalarIndicator(">-"))
+		s.True(isBlockScalarIndicator("|2"))
+		s.True(isBlockScalarIndicator(">2"))
+		s.True(isBlockScalarIndicator("|2-"))
+		s.True(isBlockScalarIndicator("|-2"))
+	})
+
+	s.Run("rejects non-indicators", func() {
+		s.False(isBlockScalarIndicator(""))
+		s.False(isBlockScalarIndicator("hello"))
+		s.False(isBlockScalarIndicator("true"))
+		s.False(isBlockScalarIndicator("123"))
+	})
+}
+
+func (s *TroubleshootToolSuite) TestExtractPodDiagnostics() {
+	s.Run("extracts only diagnostic fields from pod", func() {
+		pod := &unstructured.Unstructured{}
+		pod.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "virt-launcher-test-vm-abc123",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"nodeName": "worker-1",
+				"nodeSelector": map[string]interface{}{
+					"kubernetes.io/hostname": "worker-1",
+				},
+				"containers": []interface{}{
+					map[string]interface{}{
+						"name":  "compute",
+						"image": "registry.io/kubevirt/virt-launcher:v1.0.0",
+						"env": []interface{}{
+							map[string]interface{}{"name": "SECRET_VAR", "value": "should-not-appear"},
+						},
+					},
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Running",
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+				},
+				"containerStatuses": []interface{}{
+					map[string]interface{}{
+						"name":         "compute",
+						"ready":        true,
+						"restartCount": int64(3),
+						"state": map[string]interface{}{
+							"running": map[string]interface{}{
+								"startedAt": "2026-06-29T10:00:00Z",
+							},
+						},
+						"lastTerminationState": map[string]interface{}{
+							"terminated": map[string]interface{}{
+								"exitCode": int64(137),
+								"reason":   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		})
+
+		diag := extractPodDiagnostics(pod)
+
+		s.Equal("Running", diag["phase"])
+		s.Equal("worker-1", diag["nodeName"])
+		s.NotNil(diag["conditions"])
+		s.NotNil(diag["containerStatuses"])
+		s.NotNil(diag["nodeSelector"])
+
+		_, hasContainers := diag["containers"]
+		s.False(hasContainers, "should not include full container specs")
+
+		statuses := diag["containerStatuses"].([]map[string]interface{})
+		s.Require().Len(statuses, 1)
+		s.Equal(int64(3), statuses[0]["restartCount"])
+		s.Equal("compute", statuses[0]["name"])
+	})
+
+	s.Run("excludes env vars and image from output", func() {
+		pod := &unstructured.Unstructured{}
+		pod.SetUnstructuredContent(map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "virt-launcher-test-vm-xyz",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"nodeName": "worker-2",
+				"containers": []interface{}{
+					map[string]interface{}{
+						"name":  "compute",
+						"image": "registry.io/kubevirt/virt-launcher:v1.2.3",
+						"env": []interface{}{
+							map[string]interface{}{"name": "API_KEY", "value": "secret-value-123"},
+						},
+						"volumeMounts": []interface{}{
+							map[string]interface{}{"name": "disk0", "mountPath": "/var/run/kubevirt"},
+						},
+					},
+				},
+			},
+			"status": map[string]interface{}{
+				"phase": "Running",
+				"containerStatuses": []interface{}{
+					map[string]interface{}{
+						"name":         "compute",
+						"ready":        true,
+						"restartCount": int64(0),
+						"state": map[string]interface{}{
+							"running": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		})
+
+		diag := extractPodDiagnostics(pod)
+
+		s.Equal("Running", diag["phase"])
+		s.Equal("worker-2", diag["nodeName"])
+
+		_, hasContainers := diag["containers"]
+		s.False(hasContainers, "should not include container specs")
+
+		_, hasSpec := diag["spec"]
+		s.False(hasSpec, "should not include raw spec")
+
+		statuses := diag["containerStatuses"].([]map[string]interface{})
+		s.Require().Len(statuses, 1)
+		_, hasImage := statuses[0]["image"]
+		s.False(hasImage, "container status summary should not include image")
+	})
+}
+
+func TestTroubleshootToolSuite(t *testing.T) {
+	suite.Run(t, new(TroubleshootToolSuite))
+}

--- a/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
+++ b/pkg/toolsets/kubevirt/vm/troubleshoot/tool_test.go
@@ -1,6 +1,7 @@
 package troubleshoot
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -175,6 +176,50 @@ func (s *TroubleshootToolSuite) TestStripCloudInitBodies() {
 		ciData := ciVol["cloudInitNoCloud"].(map[string]interface{})
 		ref := ciData["userDataSecretRef"].(map[string]interface{})
 		s.Equal("my-secret", ref["name"])
+	})
+
+	s.Run("replaces base64 userData and networkData variants", func() {
+		volumes := []any{
+			map[string]interface{}{
+				"name": "cloudinitdisk",
+				"cloudInitNoCloud": map[string]interface{}{
+					"userDataBase64":    base64.StdEncoding.EncodeToString([]byte("#cloud-config\npassword: secret123")),
+					"networkDataBase64": base64.StdEncoding.EncodeToString([]byte("network:\n  version: 2")),
+				},
+			},
+		}
+
+		result := stripCloudInitBodies(volumes)
+		ciVol := result[0].(map[string]interface{})
+		ciData := ciVol["cloudInitNoCloud"].(map[string]interface{})
+		s.Equal("<see Cloud-Init Configuration section>", ciData["userDataBase64"])
+		s.Equal("<see Cloud-Init Configuration section>", ciData["networkDataBase64"])
+	})
+}
+
+func (s *TroubleshootToolSuite) TestCloudInitData() {
+	s.Run("prefers plain-text over base64", func() {
+		ciData := map[string]interface{}{
+			"userData":       "#cloud-config\nplain",
+			"userDataBase64": base64.StdEncoding.EncodeToString([]byte("#cloud-config\nencoded")),
+		}
+		s.Equal("#cloud-config\nplain", cloudInitData(ciData, "userData", "userDataBase64"))
+	})
+
+	s.Run("decodes base64 variant when plain-text absent", func() {
+		ciData := map[string]interface{}{
+			"userDataBase64": base64.StdEncoding.EncodeToString([]byte("#cloud-config\npassword: secret123")),
+		}
+		s.Equal("#cloud-config\npassword: secret123", cloudInitData(ciData, "userData", "userDataBase64"))
+	})
+
+	s.Run("returns empty for invalid base64", func() {
+		ciData := map[string]interface{}{"userDataBase64": "not valid base64 !!!"}
+		s.Equal("", cloudInitData(ciData, "userData", "userDataBase64"))
+	})
+
+	s.Run("returns empty when neither present", func() {
+		s.Equal("", cloudInitData(map[string]interface{}{}, "userData", "userDataBase64"))
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds a new `vm_troubleshoot` MCP Tool that collects comprehensive diagnostic data for KubeVirt VirtualMachines (VM/VMI status, DataVolume/PVC state, cloud-init config, virt-launcher pod state, pod logs, and events)
- **Includes automated heuristic issue detection** that produces pre-digested "Detected Issues" and "Suggested Fixes" sections, enabling small LLMs (e.g. gpt-4o-mini) to relay actionable findings without synthesizing root causes from raw YAML
- Complements the existing `vm-troubleshoot` Prompt with a proper Tool that LLMs can invoke automatically based on user intent
- Includes targeted event collection (no namespace-wide scan), sensitive field redaction for cloud-init, and correct NotFound-only PVC fallback logic

## Motivation

The existing `vm-troubleshoot` is implemented as a Prompt, which requires explicit user selection and cannot be auto-invoked by LLMs during troubleshooting conversations. This PR adds a parallel Tool implementation that:

1. **Enables proactive invocation** — LLMs can call it automatically when users describe VM issues
2. **Enriches diagnostics** — adds DataVolume/PVC status (with StorageClass) and cloud-init content extraction
3. **Improves small-model performance** — heuristic checks pre-analyze collected data and surface root causes directly, so even small models produce accurate answers
4. **Addresses security** — redacts sensitive cloud-init fields (passwords, SSH keys, tokens) while preserving diagnostic content (runcmd, packages, hostname)
5. **Improves performance** — uses targeted field selectors for events; extracts only diagnostic-relevant pod fields (phase, conditions, restartCount, nodeSelector) instead of full pod YAML
6. **Handles edge cases** — multi-line block scalar redaction, NotFound-only PVC fallback, float64-safe numeric conversion for real cluster data

### Automated Issue Detection

The tool runs heuristic checks on collected diagnostic data and produces a structured report:

```
## Detected Issues

- **CRITICAL**: StorageClass "fast-ssd" referenced by DataVolume "rootdisk" does not exist on this cluster. Available StorageClasses: ocs-storagecluster-ceph-rbd (default).
- **WARNING**: VM is stuck in Provisioning state.

## Suggested Fixes

1. Change the DataVolume storageClassName from "fast-ssd" to an existing StorageClass (e.g., ocs-storagecluster-ceph-rbd (default)).
```

Heuristic checks implemented:
- Missing StorageClass detection (lists available alternatives)
- DataVolume/PVC errors with StorageClass deduplication
- Dangerous cloud-init commands (shutdown, poweroff, halt, reboot, systemctl variants, init 0/6)
- Hostname nodeSelector migration blockers
- Pod crashloops and OOMKill detection
- Failed VirtualMachineInstanceMigration detection
- VM condition analysis (Ready=False reasons, printableStatus)

### Prompt vs. Tool coexistence

The existing `vm-troubleshoot` **Prompt** and this new `vm_troubleshoot` **Tool** serve different purposes:

* **Prompt**: Provides a guided step-by-step troubleshooting workflow template. Must be explicitly selected by the user or UI. Useful for structured walkthroughs.
* **Tool**: Returns diagnostic data with automated analysis. Can be auto-invoked by LLMs when users ask questions like "why is my VM not starting?" without requiring explicit tool selection.

Both are kept because they serve different interaction patterns. The Tool enables the agentic/autonomous troubleshooting use case that the Prompt cannot support.

## Testing

Tested manually against 3 broken VM scenarios on OpenShift 4.22:

| Scenario | Root cause | Tool provides |
|----------|-----------|---------------|
| VM stuck Provisioning | Missing StorageClass + no accessModes | CRITICAL issue with available SC list + fix suggestion |
| VM crashloop (30-60s restarts) | cloud-init runcmd: shutdown -h now | CRITICAL cloud-init detection + crashloop explanation |
| Live migration failure | nodeSelector pinning VM to single node | WARNING nodeSelector + failed migration detection |

Tested with both gpt-4o-mini (troubleshooting mode) and gpt-5.2 (simple questions) — tool is auto-invoked and produces accurate root-cause identification. Small models correctly relay the pre-analyzed findings without needing to interpret raw YAML.

## Key Design Decisions

- **float64-safe numeric conversion**: Kubernetes dynamic client deserializes JSON numbers as `float64`; the `toInt64()` helper ensures restartCount detection works on real clusters (not just in tests using `int64` directly)
- **False-positive prevention in cloud-init**: Skips comments, echo/print lines, and YAML config keys to avoid flagging innocuous text containing "shutdown" or "halt"
- **Deduplication**: When a missing StorageClass is detected, downstream PVC "not found" errors are suppressed to avoid reporting symptoms alongside root causes
- **API limiting**: Migration list capped at 50 objects to avoid unbounded queries in busy namespaces

## Related

* Coexists with the existing `vm-troubleshoot` Prompt (different interaction patterns)
* Related to #653 (ksimon1's troubleshoot action in vm_lifecycle — that adds troubleshooting as a lifecycle action; this PR provides a dedicated read-only diagnostic collector)
* Moves work from downstream `openshift/openshift-mcp-server` PR #365 to upstream per reviewer guidance

## Test plan

* Unit tests for all helper functions (fetchVMStatus, fetchVMIStatus, fetchVolumes, fetchDataVolumeStatus, extractCloudInit, fetchVirtLauncherPod, fetchVirtLauncherPodLogs)
* Unit tests for all heuristic check functions (checkVMConditions, checkStorageClass, checkDataVolumeErrors, checkCloudInitCommands, checkNodeSelector, checkPodHealth, checkMigrationStatus)
* Cloud-init redaction tests (inline values, SSH keys, block scalars, false-positive resistance, token fields)
* Cloud-init dangerous command detection tests (shutdown, halt, poweroff, systemctl variants, array format, false-positive resistance)
* Pod diagnostics extraction test (verifies env vars, images, volumeMounts are excluded)
* float64 restartCount test (simulates real cluster JSON deserialization)
* Tool registration, schema, and annotation validation tests
* Snapshot test updated
* `go build ./...` and `go test` pass locally

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>
