### PR TITLE
chore(evals): switch anthropic/google evals to ref-based

### DIFF
--- a/evals/core-eval-testing/builtin-anthropic/eval-config.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-config.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: builtin.llm-agent
+      model: "anthropic:claude-sonnet-4-6"
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-anthropic/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-core.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: builtin.llm-agent
+      model: "anthropic:claude-sonnet-4-6"
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-anthropic/eval-helm.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-helm.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: builtin.llm-agent
+      model: "anthropic:claude-sonnet-4-6"
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-google/eval-config.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-config.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: builtin.llm-agent
+      model: "google:gemini-3.1-pro-preview"
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-google/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-core.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: builtin.llm-agent
+      model: "google:gemini-3.1-pro-preview"
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-google/eval-helm.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-helm.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.3
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: builtin.llm-agent
+      model: "google:gemini-3.1-pro-preview"
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:


### PR DESCRIPTION
switch eval config for the llmJudge from env-based to ref-based approach to respect existing credential pipelines. 
For anthropic, sets to `claude-sonnet-4-6`. 
For gemini, sets to `gemini-3.1-pro-preview`. 