### PR TITLE
cleanup(logs): more contextual logging in kubevirt and mcp

### DIFF
--- a/pkg/kubevirt/resources.go
+++ b/pkg/kubevirt/resources.go
@@ -3,12 +3,14 @@ package kubevirt
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 )
 
 const (
@@ -72,7 +74,7 @@ func collectDataSources(ctx context.Context, dynamicClient dynamic.Interface) ma
 	for _, ns := range wellKnownNamespaces {
 		list, err := dynamicClient.Resource(DataSourceGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			slog.Debug("failed to list DataSources in well-known namespace", "namespace", ns, "error", err)
+			klogutil.LogInfo(klog.FromContext(ctx).V(4), "failed to list DataSources in well-known namespace", klogutil.Field("kubernetes.namespace.name", ns), klogutil.Err(err))
 		} else {
 			items = append(items, list.Items...)
 		}
@@ -81,7 +83,7 @@ func collectDataSources(ctx context.Context, dynamicClient dynamic.Interface) ma
 	// List DataSources from all namespaces
 	list, err := dynamicClient.Resource(DataSourceGVR).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		slog.Debug("failed to list DataSources cluster-wide", "error", err)
+		klogutil.LogInfo(klog.FromContext(ctx).V(4), "failed to list DataSources cluster-wide", klogutil.Err(err))
 	} else {
 		items = append(items, list.Items...)
 	}
@@ -133,7 +135,7 @@ func SearchPreferences(ctx context.Context, dynamicClient dynamic.Interface, nam
 	var results []PreferenceInfo
 	clusterList, err := dynamicClient.Resource(VirtualMachineClusterPreferenceGVR).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		slog.Debug("failed to list cluster-scoped VirtualMachineClusterPreferences", "error", err)
+		klogutil.LogInfo(klog.FromContext(ctx).V(4), "failed to list cluster-scoped VirtualMachineClusterPreferences", klogutil.Err(err))
 	} else {
 		for _, item := range clusterList.Items {
 			results = append(results, PreferenceInfo{
@@ -146,7 +148,7 @@ func SearchPreferences(ctx context.Context, dynamicClient dynamic.Interface, nam
 	// Search for namespaced VirtualMachinePreferences
 	namespacedList, err := dynamicClient.Resource(VirtualMachinePreferenceGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		slog.Debug("failed to list namespaced VirtualMachinePreferences", "namespace", namespace, "error", err)
+		klogutil.LogInfo(klog.FromContext(ctx).V(4), "failed to list namespaced VirtualMachinePreferences", klogutil.Field("kubernetes.namespace.name", namespace), klogutil.Err(err))
 	} else {
 		for _, item := range namespacedList.Items {
 			results = append(results, PreferenceInfo{
@@ -178,7 +180,7 @@ func SearchInstancetypes(ctx context.Context, dynamicClient dynamic.Interface, n
 	var results []InstancetypeInfo
 	clusterList, err := dynamicClient.Resource(VirtualMachineClusterInstancetypeGVR).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		slog.Debug("failed to list cluster-scoped VirtualMachineClusterInstancetypes", "error", err)
+		klogutil.LogInfo(klog.FromContext(ctx).V(4), "failed to list cluster-scoped VirtualMachineClusterInstancetypes", klogutil.Err(err))
 	} else {
 		for _, item := range clusterList.Items {
 			results = append(results, InstancetypeInfo{
@@ -192,7 +194,7 @@ func SearchInstancetypes(ctx context.Context, dynamicClient dynamic.Interface, n
 	// Search for namespaced VirtualMachineInstancetypes
 	namespacedList, err := dynamicClient.Resource(VirtualMachineInstancetypeGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		slog.Debug("failed to list namespaced VirtualMachineInstancetypes", "namespace", namespace, "error", err)
+		klogutil.LogInfo(klog.FromContext(ctx).V(4), "failed to list namespaced VirtualMachineInstancetypes", klogutil.Field("kubernetes.namespace.name", namespace), klogutil.Err(err))
 	} else {
 		for _, item := range namespacedList.Items {
 			results = append(results, InstancetypeInfo{

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -114,7 +114,7 @@ type Server struct {
 func NewServer(ctx context.Context, configuration Configuration, targetProvider internalk8s.Provider) (*Server, error) {
 	sdkLogger := configuration.SDKLogger
 	if sdkLogger == nil {
-		sdkLogger = slog.New(logr.ToSlogHandler(klog.Background()))
+		sdkLogger = slog.New(logr.ToSlogHandler(klog.FromContext(ctx)))
 	}
 	s := &Server{
 		server: mcp.NewServer(


### PR DESCRIPTION
Follow-up to #1240, cleaning up the last couple of spots that weren't going through the contextual logging framework.

## Changes

**`pkg/kubevirt/resources.go`** — the resource discovery helpers logged their "failed to list" branches through Go's global `slog` default logger (the DataSource lines live in the unexported `collectDataSources` helper that backs `SearchDataSources`; the preference and instancetype lines in `SearchPreferences` and `SearchInstancetypes`). Nothing wires that logger to klog, so those lines bypassed the log sink entirely (no `-v` verbosity, no file output, no secret redaction, no OTEL), and since slog's default minimum level is `Info` the `Debug` lines were silently dropped at runtime anyway. All six now go through `klog.FromContext(ctx)` at `V(4)` using the `klogutil` helpers, with `kubernetes.namespace.name` / `exception.message` keys to match the rest of the codebase.

**`pkg/mcp/mcp.go`** — the SDK logger fallback in `NewServer` now derives from `klog.FromContext(ctx)` instead of `klog.Background()`, so it honors the contextual logger when no `SDKLogger` is supplied (the normal path already passes one from the logging sink).

## Testing

- `go build ./...`, `go vet`, `gofmt` all clean
- `go test ./pkg/kubevirt/...` passes
- `make lint` reports 0 issues