### PR TITLE
feat(tekton): add PipelineRun troubleshooting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A powerful and flexible Kubernetes [Model Context Protocol (MCP)](https://blog.m
   - **Uninstall** a Helm release in the current or provided namespace.
 - **🔧 Tekton**: Tekton-specific operations that complement generic Kubernetes resource management.
   - **Pipeline**: Start a Tekton Pipeline by creating a PipelineRun.
-  - **PipelineRun**: Restart a PipelineRun with the same spec.
+  - **PipelineRun**: Restart, cancel, troubleshoot, and retrieve PipelineRun logs.
   - **Task**: Start a Tekton Task by creating a TaskRun.
   - **TaskRun**: Restart a TaskRun with the same spec, and retrieve TaskRun logs via pod resolution.
 - **🔭 Observability**: Optional OpenTelemetry distributed tracing and metrics with custom sampling rates. Includes `/stats` endpoint for real-time statistics. See [OTEL.md](docs/OTEL.md).
@@ -294,7 +294,7 @@ The following sets of tools are available (toolsets marked with ✓ in the Defau
 | kiali     | Most common tools for managing Kiali, check the [Kiali documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/KIALI.md) for more details.                                                                    |         |
 | kubevirt  | KubeVirt virtual machine management tools, check the [KubeVirt documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/kubevirt.md) for more details.                                                         |         |
 | netobserv | Network observability tools backed by the NetObserv console plugin API (flows, metrics, export). Check the [NetObserv documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/NETOBSERV.md) for more details. |         |
-| tekton    | Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, and TaskRuns.                                                                                                                                                      |         |
+| tekton    | Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, TaskRuns, and troubleshooting.                                                                                                                                     |         |
 
 <!-- AVAILABLE-TOOLSETS-END -->
 
@@ -777,9 +777,15 @@ Examples:
   - `namespace` (`string`) - Namespace of the Pipeline
   - `params` (`object`) - Parameter values to pass to the Pipeline. Keys are parameter names; values can be a string, an array of strings, or an object (map of string to string) depending on the parameter type defined in the Pipeline spec
 
-- **tekton_pipelinerun_restart** - Restart a Tekton PipelineRun by creating a new PipelineRun with the same spec
-  - `name` (`string`) **(required)** - Name of the PipelineRun to restart
+- **tekton_pipelinerun_lifecycle** - Manage a Tekton PipelineRun lifecycle by restarting it with the same spec or cancelling it by setting spec.status to Cancelled.
+  - `action` (`string`) **(required)** - Lifecycle action to perform: 'restart' creates a new PipelineRun with the same spec; 'cancel' sets spec.status to Cancelled.
+  - `name` (`string`) **(required)** - Name of the PipelineRun to manage
   - `namespace` (`string`) - Namespace of the PipelineRun
+
+- **tekton_pipelinerun_logs** - Get logs for all TaskRuns owned by a Tekton PipelineRun. Use this to inspect PipelineRun execution output without locating pods manually.
+  - `name` (`string`) **(required)** - Name of the PipelineRun to get logs from
+  - `namespace` (`string`) - Namespace of the PipelineRun
+  - `tail` (`integer`) - Number of lines to retrieve from the end of each container log (default: 100)
 
 - **tekton_task_start** - Start a Tekton Task by creating a TaskRun that references it
   - `name` (`string`) **(required)** - Name of the Task to start
@@ -867,6 +873,16 @@ Examples:
   - `namespace` (`string`) - Target namespace for the PipelineRun
   - `windowsVersion` (`string`) - Windows version: 10, 11, 2k22 (default), or 2k25
   - `pipelineVersion` (`string`) - Pipeline version (default: latest). Use specific version like 0.25.0 if needed
+
+</details>
+
+<details>
+
+<summary>tekton</summary>
+
+- **pipeline-troubleshoot** - Gather PipelineRun status, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting
+  - `namespace` (`string`) **(required)** - Namespace of the PipelineRun to troubleshoot
+  - `name` (`string`) **(required)** - Name of the PipelineRun to troubleshoot
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Choose the guide that matches your needs:
 - **[Kiali](KIALI.md)** - Tools for Kiali ServiceMesh with Istio
 - **[NetObserv](NETOBSERV.md)** - Network observability flows, metrics, and alerts (Helm on OpenShift)
 - **[KubeVirt](kubevirt.md)** - KubeVirt virtual machine management tools
+- **[Tekton](tekton.md)** - Tekton PipelineRun, TaskRun, and troubleshooting tools
 
 ## Feature Specifications
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,7 +356,7 @@ Toolsets group related tools together. Enable only the toolsets you need to redu
 | kiali     | Most common tools for managing Kiali, check the [Kiali documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/KIALI.md) for more details.                                                                    |         |
 | kubevirt  | KubeVirt virtual machine management tools, check the [KubeVirt documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/kubevirt.md) for more details.                                                         |         |
 | netobserv | Network observability tools backed by the NetObserv console plugin API (flows, metrics, export). Check the [NetObserv documentation](https://github.com/containers/kubernetes-mcp-server/blob/main/docs/NETOBSERV.md) for more details. |         |
-| tekton    | Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, and TaskRuns.                                                                                                                                                      |         |
+| tekton    | Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, TaskRuns, and troubleshooting.                                                                                                                                     |         |
 
 <!-- AVAILABLE-TOOLSETS-END -->
 

--- a/docs/tekton.md
+++ b/docs/tekton.md
@@ -1,0 +1,42 @@
+# Tekton Toolset
+
+The `tekton` toolset adds Tekton-specific helpers on top of the generic Kubernetes resource tools.
+
+Enable it with:
+
+```shell
+kubernetes-mcp-server --toolsets core,config,tekton
+```
+
+## PipelineRun operations
+
+- `tekton_pipeline_start` starts a Pipeline by creating a PipelineRun.
+- `tekton_pipelinerun_restart` creates a new PipelineRun from an existing PipelineRun spec.
+- `tekton_pipelinerun_cancel` cancels a PipelineRun by setting `spec.status` to `Cancelled`.
+- `tekton_pipelinerun_logs` collects logs from TaskRuns owned by a PipelineRun.
+
+## TaskRun operations
+
+- `tekton_task_start` starts a Task by creating a TaskRun.
+- `tekton_taskrun_restart` creates a new TaskRun from an existing TaskRun spec.
+- `tekton_taskrun_logs` resolves a TaskRun pod and returns step/sidecar logs.
+
+Pipeline-as-Code `Repository` and operator `TektonConfig` resources are ordinary Kubernetes resources; use `resources_list` and `resources_get` for those.
+
+List Pipeline-as-Code repositories in a namespace with `resources_list`:
+
+```json
+{"apiVersion":"pipelinesascode.tekton.dev/v1alpha1","kind":"Repository","namespace":"my-namespace"}
+```
+
+Get the usual cluster `TektonConfig` with `resources_get`:
+
+```json
+{"apiVersion":"operator.tekton.dev/v1alpha1","kind":"TektonConfig","name":"config"}
+```
+
+These tools are read-only except the start, restart, and cancel operations.
+
+## Troubleshooting prompt
+
+Use the `pipeline-troubleshoot` prompt with `namespace` and `name` to gather PipelineRun status, related TaskRuns, logs, events, Pipeline-as-Code repositories, and TektonConfig context into one diagnostic prompt.

--- a/docs/tekton.md
+++ b/docs/tekton.md
@@ -11,8 +11,7 @@ kubernetes-mcp-server --toolsets core,config,tekton
 ## PipelineRun operations
 
 - `tekton_pipeline_start` starts a Pipeline by creating a PipelineRun.
-- `tekton_pipelinerun_restart` creates a new PipelineRun from an existing PipelineRun spec.
-- `tekton_pipelinerun_cancel` cancels a PipelineRun by setting `spec.status` to `Cancelled`.
+- `tekton_pipelinerun_lifecycle` restarts a PipelineRun from its existing spec or cancels it by setting `spec.status` to `Cancelled`.
 - `tekton_pipelinerun_logs` collects logs from TaskRuns owned by a PipelineRun.
 
 ## TaskRun operations
@@ -35,7 +34,7 @@ Get the usual cluster `TektonConfig` with `resources_get`:
 {"apiVersion":"operator.tekton.dev/v1alpha1","kind":"TektonConfig","name":"config"}
 ```
 
-These tools are read-only except the start, restart, and cancel operations.
+These tools are read-only except the start and lifecycle operations.
 
 ## Troubleshooting prompt
 

--- a/evals/tasks/tekton/README.md
+++ b/evals/tasks/tekton/README.md
@@ -1,6 +1,6 @@
 # Tekton Task Stack
 
-Tekton-focused MCP eval tasks live here. Each folder represents a self-contained scenario that exercises the Tekton toolset (Pipeline and PipelineRun management, Task and TaskRun lifecycle).
+Tekton-focused MCP eval tasks live here. Each folder represents a self-contained scenario that exercises the Tekton toolset (Pipeline and PipelineRun management, Task and TaskRun lifecycle, and troubleshooting).
 
 All tasks use the `tekton-eval` namespace and require Tekton Pipelines to be installed in the cluster (`tekton.dev/v1` CRDs must be available).
 
@@ -36,7 +36,15 @@ All tasks use the `tekton-eval` namespace and require Tekton Pipelines to be ins
 
 - **[medium] restart-pipelinerun** – Restart a PipelineRun by creating a new one with the same spec
   - **Prompt:** *Restart the Tekton PipelineRun named test-run in the tekton-eval namespace.*
-  - **Tests:** `resources_get` + `resources_create` tools (core toolset)
+  - **Tests:** `tekton_pipelinerun_restart` tool
+
+- **[medium] cancel-pipelinerun** – Cancel a PipelineRun by setting `spec.status=Cancelled`
+  - **Prompt:** *Cancel the Tekton PipelineRun named cancel-me in the tekton-eval namespace.*
+  - **Tests:** `tekton_pipelinerun_cancel` tool
+
+- **[hard] troubleshoot-pipelinerun** – Gather PipelineRun status, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for diagnosis
+  - **Prompt:** *The Tekton PipelineRun named failed-run in the tekton-eval namespace is failing. Diagnose the likely root cause, include any Pipeline-as-Code Repository and TektonConfig context that may be relevant, and recommend the next action.*
+  - **Tests:** `pipeline-troubleshoot` prompt and PAC/TektonConfig visibility
 
 ### Task Operations
 

--- a/evals/tasks/tekton/README.md
+++ b/evals/tasks/tekton/README.md
@@ -36,11 +36,11 @@ All tasks use the `tekton-eval` namespace and require Tekton Pipelines to be ins
 
 - **[medium] restart-pipelinerun** – Restart a PipelineRun by creating a new one with the same spec
   - **Prompt:** *Restart the Tekton PipelineRun named test-run in the tekton-eval namespace.*
-  - **Tests:** `tekton_pipelinerun_restart` tool
+  - **Tests:** `tekton_pipelinerun_lifecycle` tool with `action=restart`
 
 - **[medium] cancel-pipelinerun** – Cancel a PipelineRun by setting `spec.status=Cancelled`
   - **Prompt:** *Cancel the Tekton PipelineRun named cancel-me in the tekton-eval namespace.*
-  - **Tests:** `tekton_pipelinerun_cancel` tool
+  - **Tests:** `tekton_pipelinerun_lifecycle` tool with `action=cancel`
 
 - **[hard] troubleshoot-pipelinerun** – Gather PipelineRun status, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for diagnosis
   - **Prompt:** *The Tekton PipelineRun named failed-run in the tekton-eval namespace is failing. Diagnose the likely root cause, include any Pipeline-as-Code Repository and TektonConfig context that may be relevant, and recommend the next action.*

--- a/evals/tasks/tekton/cancel-pipelinerun/task.yaml
+++ b/evals/tasks/tekton/cancel-pipelinerun/task.yaml
@@ -1,0 +1,103 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: "cancel-tekton-pipelinerun"
+  difficulty: medium
+  labels:
+    suite: tekton
+    requires: tekton
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: tekton-eval
+        ignoreNotFound: true
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          source ../helpers/cleanup-namespace.sh
+          cleanup_tekton_namespace
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: tekton-eval
+    - k8s.create:
+        apiVersion: tekton.dev/v1
+        kind: Task
+        metadata:
+          name: sleep-task
+          namespace: tekton-eval
+        spec:
+          steps:
+            - name: sleep
+              image: alpine
+              script: |
+                sleep 600
+    - k8s.create:
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: slow-pipeline
+          namespace: tekton-eval
+        spec:
+          tasks:
+            - name: slow
+              taskRef:
+                name: sleep-task
+    - k8s.create:
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: cancel-me
+          namespace: tekton-eval
+        spec:
+          pipelineRef:
+            name: slow-pipeline
+
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          STATUS=$(kubectl get pipelinerun cancel-me -n tekton-eval -o jsonpath='{.spec.status}')
+          if [ "$STATUS" != "Cancelled" ]; then
+            echo "ERROR: expected PipelineRun spec.status=Cancelled, got '$STATUS'"
+            exit 1
+          fi
+          echo "PipelineRun cancel-me is cancelled"
+
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl delete pipelinerun --all -n tekton-eval --ignore-not-found=true 2>/dev/null || true
+    - k8s.delete:
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: slow-pipeline
+          namespace: tekton-eval
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: tekton.dev/v1
+        kind: Task
+        metadata:
+          name: sleep-task
+          namespace: tekton-eval
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: tekton-eval
+        ignoreNotFound: true
+
+  prompt:
+    inline: Cancel the Tekton PipelineRun named cancel-me in the tekton-eval namespace.

--- a/evals/tasks/tekton/troubleshoot-pipelinerun/task.yaml
+++ b/evals/tasks/tekton/troubleshoot-pipelinerun/task.yaml
@@ -1,0 +1,162 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: "troubleshoot-tekton-pipelinerun"
+  difficulty: hard
+  labels:
+    suite: tekton
+    requires: tekton
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: tekton-eval
+        ignoreNotFound: true
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          source ../helpers/cleanup-namespace.sh
+          cleanup_tekton_namespace
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: tekton-eval
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          ensure_crd() {
+            local name="$1" group="$2" version="$3" plural="$4" singular="$5" kind="$6" scope="$7"
+            if kubectl get crd "$name" >/dev/null 2>&1; then
+              return
+            fi
+            cat <<EOF | kubectl apply -f -
+          apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            name: ${name}
+            labels:
+              tekton-eval-temporary: "true"
+          spec:
+            group: ${group}
+            scope: ${scope}
+            names:
+              plural: ${plural}
+              singular: ${singular}
+              kind: ${kind}
+            versions:
+              - name: ${version}
+                served: true
+                storage: true
+                schema:
+                  openAPIV3Schema:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+          EOF
+            kubectl wait --for=condition=Established "crd/${name}" --timeout=30s
+          }
+          ensure_crd repositories.pipelinesascode.tekton.dev pipelinesascode.tekton.dev v1alpha1 repositories repository Repository Namespaced
+          ensure_crd tektonconfigs.operator.tekton.dev operator.tekton.dev v1alpha1 tektonconfigs tektonconfig TektonConfig Cluster
+    - k8s.create:
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: failed-run
+          namespace: tekton-eval
+        spec:
+          pipelineRef:
+            name: missing-pipeline
+        status:
+          conditions:
+            - type: Succeeded
+              status: "False"
+              reason: Failed
+              message: "Pipeline missing-pipeline was not found"
+    - k8s.create:
+        apiVersion: tekton.dev/v1
+        kind: TaskRun
+        metadata:
+          name: failed-run-missing-pipeline
+          namespace: tekton-eval
+          labels:
+            tekton.dev/pipelineRun: failed-run
+        spec:
+          taskRef:
+            name: missing-task
+        status:
+          conditions:
+            - type: Succeeded
+              status: "False"
+              reason: Failed
+              message: "Task missing-task was not found"
+    - k8s.create:
+        apiVersion: pipelinesascode.tekton.dev/v1alpha1
+        kind: Repository
+        metadata:
+          name: eval-repo
+          namespace: tekton-eval
+        spec:
+          url: https://github.com/example/tekton-eval
+    - k8s.create:
+        apiVersion: operator.tekton.dev/v1alpha1
+        kind: TektonConfig
+        metadata:
+          name: tekton-eval-config
+        spec:
+          profile: all
+
+  verify:
+    - llmJudge:
+        contains: "failed-run"
+    - llmJudge:
+        contains: "missing"
+    - llmJudge:
+        contains: "eval-repo"
+    - llmJudge:
+        contains: "tekton-eval-config"
+
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl delete repository eval-repo -n tekton-eval --ignore-not-found=true 2>/dev/null || true
+          kubectl delete tektonconfig tekton-eval-config --ignore-not-found=true 2>/dev/null || true
+    - k8s.delete:
+        apiVersion: tekton.dev/v1
+        kind: TaskRun
+        metadata:
+          name: failed-run-missing-pipeline
+          namespace: tekton-eval
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: tekton.dev/v1
+        kind: PipelineRun
+        metadata:
+          name: failed-run
+          namespace: tekton-eval
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: tekton-eval
+        ignoreNotFound: true
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          for crd in repositories.pipelinesascode.tekton.dev tektonconfigs.operator.tekton.dev; do
+            if [ "$(kubectl get crd "$crd" -o jsonpath='{.metadata.labels.tekton-eval-temporary}' 2>/dev/null)" = "true" ]; then
+              kubectl delete crd "$crd" --ignore-not-found=true
+            fi
+          done
+
+  prompt:
+    inline: |-
+      The Tekton PipelineRun named failed-run in the tekton-eval namespace is failing. Diagnose the likely root cause, include any Pipeline-as-Code Repository and TektonConfig context that may be relevant, and recommend the next action.

--- a/internal/test/envtest.go
+++ b/internal/test/envtest.go
@@ -31,7 +31,7 @@ var (
 )
 
 // EnvTest returns a shared envtest.Environment instance, initializing it on first call.
-// The environment includes CRDs for OpenShift (Project, Route) and KubeVirt resources.
+// The environment includes CRDs for OpenShift, KubeVirt, and Tekton resources.
 // Each test package process gets its own envtest instance with isolated etcd data directory.
 func EnvTest() *envtest.Environment {
 	envTestOnce.Do(func() {
@@ -95,6 +95,13 @@ func EnvTest() *envtest.Environment {
 				CRD("instancetype.kubevirt.io", "v1beta1", "virtualmachineinstancetypes", "VirtualMachineInstancetype", "virtualmachineinstancetype", true),
 				CRD("instancetype.kubevirt.io", "v1beta1", "virtualmachineclusterpreferences", "VirtualMachineClusterPreference", "virtualmachineclusterpreference", false),
 				CRD("instancetype.kubevirt.io", "v1beta1", "virtualmachinepreferences", "VirtualMachinePreference", "virtualmachinepreference", true),
+				// Tekton
+				CRD("tekton.dev", "v1", "pipelines", "Pipeline", "pipeline", true),
+				CRD("tekton.dev", "v1", "pipelineruns", "PipelineRun", "pipelinerun", true),
+				CRD("tekton.dev", "v1", "tasks", "Task", "task", true),
+				CRD("tekton.dev", "v1", "taskruns", "TaskRun", "taskrun", true),
+				CRD("pipelinesascode.tekton.dev", "v1alpha1", "repositories", "Repository", "repository", true),
+				CRD("operator.tekton.dev", "v1alpha1", "tektonconfigs", "TektonConfig", "tektonconfig", false),
 			},
 		}
 

--- a/pkg/mcp/tekton_test.go
+++ b/pkg/mcp/tekton_test.go
@@ -1,0 +1,197 @@
+package mcp
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+var tektonTestAPIs = []schema.GroupVersionResource{
+	{Group: "tekton.dev", Version: "v1", Resource: "pipelines"},
+	{Group: "tekton.dev", Version: "v1", Resource: "pipelineruns"},
+	{Group: "tekton.dev", Version: "v1", Resource: "tasks"},
+	{Group: "tekton.dev", Version: "v1", Resource: "taskruns"},
+	{Group: "pipelinesascode.tekton.dev", Version: "v1alpha1", Resource: "repositories"},
+	{Group: "operator.tekton.dev", Version: "v1alpha1", Resource: "tektonconfigs"},
+}
+
+var (
+	tektonTestPipelineRunGVR = schema.GroupVersionResource{Group: "tekton.dev", Version: "v1", Resource: "pipelineruns"}
+	tektonTestTaskRunGVR     = schema.GroupVersionResource{Group: "tekton.dev", Version: "v1", Resource: "taskruns"}
+	tektonTestRepositoryGVR  = schema.GroupVersionResource{Group: "pipelinesascode.tekton.dev", Version: "v1alpha1", Resource: "repositories"}
+	tektonTestConfigGVR      = schema.GroupVersionResource{Group: "operator.tekton.dev", Version: "v1alpha1", Resource: "tektonconfigs"}
+)
+
+type TektonMcpSuite struct {
+	BaseMcpSuite
+	namespace        string
+	tektonConfigName string
+	dynamic          dynamic.Interface
+}
+
+func (s *TektonMcpSuite) SetupSuite() {
+	for _, api := range tektonTestAPIs {
+		s.Require().NoError(EnvTestEnableCRD(s.T().Context(), api.Group, api.Version, api.Resource))
+	}
+}
+
+func (s *TektonMcpSuite) TearDownSuite() {
+	for _, api := range tektonTestAPIs {
+		s.Require().NoError(EnvTestDisableCRD(s.T().Context(), api.Group, api.Version, api.Resource))
+	}
+}
+
+func (s *TektonMcpSuite) SetupTest() {
+	s.BaseMcpSuite.SetupTest()
+	s.Cfg.Toolsets = append(s.Cfg.Toolsets, "tekton")
+	s.namespace = fmt.Sprintf("tekton-mcp-%d", time.Now().UnixNano())
+	s.tektonConfigName = s.namespace
+	s.dynamic = dynamic.NewForConfigOrDie(envTestRestConfig)
+	_, err := kubernetes.NewForConfigOrDie(envTestRestConfig).CoreV1().Namespaces().Create(s.T().Context(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.namespace}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+	s.InitMcpClient()
+}
+
+func (s *TektonMcpSuite) TearDownTest() {
+	_ = s.dynamic.Resource(tektonTestConfigGVR).Delete(s.T().Context(), s.tektonConfigName, metav1.DeleteOptions{})
+	_ = kubernetes.NewForConfigOrDie(envTestRestConfig).CoreV1().Namespaces().Delete(s.T().Context(), s.namespace, metav1.DeleteOptions{})
+	s.BaseMcpSuite.TearDownTest()
+}
+
+func (s *TektonMcpSuite) TestPipelineRunCancel() {
+	s.createPipelineRun("cancel-me")
+
+	toolResult, err := s.CallTool("tekton_pipelinerun_cancel", map[string]interface{}{
+		"namespace": s.namespace,
+		"name":      "cancel-me",
+	})
+	s.Require().NoError(err)
+	s.False(toolResult.IsError)
+
+	pipelineRun, err := s.dynamic.Resource(tektonTestPipelineRunGVR).Namespace(s.namespace).Get(s.T().Context(), "cancel-me", metav1.GetOptions{})
+	s.Require().NoError(err)
+	status, _, _ := unstructured.NestedString(pipelineRun.Object, "spec", "status")
+	s.Equal("Cancelled", status)
+}
+
+func (s *TektonMcpSuite) TestPipelineRunLogsWithoutTaskRuns() {
+	s.createPipelineRun("no-taskruns")
+
+	toolResult, err := s.CallTool("tekton_pipelinerun_logs", map[string]interface{}{
+		"namespace": s.namespace,
+		"name":      "no-taskruns",
+	})
+	s.Require().NoError(err)
+	s.False(toolResult.IsError)
+	s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "No TaskRuns found")
+}
+
+func (s *TektonMcpSuite) TestPipelineTroubleshootPrompt() {
+	s.Run("returns gathered PipelineRun data", func() {
+		s.createPipelineRun("broken-run")
+		s.createTaskRun("broken-run-task", "broken-run")
+		s.createRepository("eval-repo")
+		s.createTektonConfig()
+
+		result, err := s.GetPrompt("pipeline-troubleshoot", map[string]string{
+			"namespace": s.namespace,
+			"name":      "broken-run",
+		})
+		s.Require().NoError(err)
+		s.Require().NotNil(result)
+		s.Require().Len(result.Messages, 2)
+		text := result.Messages[0].Content.(*mcp.TextContent).Text
+		s.Contains(text, "PipelineRun: "+s.namespace+"/broken-run")
+		s.Contains(text, "broken-run-task")
+		s.Contains(text, "eval-repo")
+		s.Contains(text, s.tektonConfigName)
+	})
+
+	s.Run("requires namespace", func() {
+		result, err := s.GetPrompt("pipeline-troubleshoot", map[string]string{"name": "broken-run"})
+		s.Error(err)
+		s.Nil(result)
+	})
+}
+
+func (s *TektonMcpSuite) createPipelineRun(name string) {
+	_, err := s.dynamic.Resource(tektonTestPipelineRunGVR).Namespace(s.namespace).Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "tekton.dev/v1",
+		"kind":       "PipelineRun",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": s.namespace,
+		},
+		"spec": map[string]interface{}{
+			"pipelineRef": map[string]interface{}{"name": "demo-pipeline"},
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{map[string]interface{}{
+				"type":   "Succeeded",
+				"status": "False",
+				"reason": "Failed",
+			}},
+		},
+	}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+func (s *TektonMcpSuite) createTaskRun(name, pipelineRun string) {
+	_, err := s.dynamic.Resource(tektonTestTaskRunGVR).Namespace(s.namespace).Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "tekton.dev/v1",
+		"kind":       "TaskRun",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": s.namespace,
+			"labels": map[string]interface{}{
+				"tekton.dev/pipelineRun": pipelineRun,
+			},
+		},
+		"spec": map[string]interface{}{
+			"taskRef": map[string]interface{}{"name": "demo-task"},
+		},
+	}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+func (s *TektonMcpSuite) createRepository(name string) {
+	_, err := s.dynamic.Resource(tektonTestRepositoryGVR).Namespace(s.namespace).Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "pipelinesascode.tekton.dev/v1alpha1",
+		"kind":       "Repository",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": s.namespace,
+		},
+		"spec": map[string]interface{}{
+			"url": "https://github.com/example/repo",
+		},
+	}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+func (s *TektonMcpSuite) createTektonConfig() {
+	_, err := s.dynamic.Resource(tektonTestConfigGVR).Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "operator.tekton.dev/v1alpha1",
+		"kind":       "TektonConfig",
+		"metadata": map[string]interface{}{
+			"name": s.tektonConfigName,
+		},
+		"spec": map[string]interface{}{
+			"profile": "all",
+		},
+	}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+func TestTektonMcp(t *testing.T) {
+	suite.Run(t, new(TektonMcpSuite))
+}

--- a/pkg/mcp/tekton_test.go
+++ b/pkg/mcp/tekton_test.go
@@ -2,9 +2,11 @@ package mcp
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
@@ -55,32 +57,58 @@ func (s *TektonMcpSuite) SetupTest() {
 	s.Cfg.Toolsets = append(s.Cfg.Toolsets, "tekton")
 	s.namespace = fmt.Sprintf("tekton-mcp-%d", time.Now().UnixNano())
 	s.tektonConfigName = s.namespace
-	s.dynamic = dynamic.NewForConfigOrDie(envTestRestConfig)
-	_, err := kubernetes.NewForConfigOrDie(envTestRestConfig).CoreV1().Namespaces().Create(s.T().Context(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.namespace}}, metav1.CreateOptions{})
+	s.dynamic = dynamic.NewForConfigOrDie(test.EnvTestRestConfig())
+	_, err := kubernetes.NewForConfigOrDie(test.EnvTestRestConfig()).CoreV1().Namespaces().Create(s.T().Context(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s.namespace}}, metav1.CreateOptions{})
 	s.Require().NoError(err)
 	s.InitMcpClient()
 }
 
 func (s *TektonMcpSuite) TearDownTest() {
 	_ = s.dynamic.Resource(tektonTestConfigGVR).Delete(s.T().Context(), s.tektonConfigName, metav1.DeleteOptions{})
-	_ = kubernetes.NewForConfigOrDie(envTestRestConfig).CoreV1().Namespaces().Delete(s.T().Context(), s.namespace, metav1.DeleteOptions{})
+	_ = kubernetes.NewForConfigOrDie(test.EnvTestRestConfig()).CoreV1().Namespaces().Delete(s.T().Context(), s.namespace, metav1.DeleteOptions{})
 	s.BaseMcpSuite.TearDownTest()
 }
 
-func (s *TektonMcpSuite) TestPipelineRunCancel() {
-	s.createPipelineRun("cancel-me")
+func (s *TektonMcpSuite) TestPipelineRunLifecycle() {
+	s.Run("cancel", func() {
+		s.createPipelineRun("cancel-me")
 
-	toolResult, err := s.CallTool("tekton_pipelinerun_cancel", map[string]interface{}{
-		"namespace": s.namespace,
-		"name":      "cancel-me",
+		toolResult, err := s.CallTool("tekton_pipelinerun_lifecycle", map[string]interface{}{
+			"namespace": s.namespace,
+			"name":      "cancel-me",
+			"action":    "cancel",
+		})
+		s.Require().NoError(err)
+		s.False(toolResult.IsError)
+
+		pipelineRun, err := s.dynamic.Resource(tektonTestPipelineRunGVR).Namespace(s.namespace).Get(s.T().Context(), "cancel-me", metav1.GetOptions{})
+		s.Require().NoError(err)
+		status, _, _ := unstructured.NestedString(pipelineRun.Object, "spec", "status")
+		s.Equal("Cancelled", status)
 	})
-	s.Require().NoError(err)
-	s.False(toolResult.IsError)
 
-	pipelineRun, err := s.dynamic.Resource(tektonTestPipelineRunGVR).Namespace(s.namespace).Get(s.T().Context(), "cancel-me", metav1.GetOptions{})
-	s.Require().NoError(err)
-	status, _, _ := unstructured.NestedString(pipelineRun.Object, "spec", "status")
-	s.Equal("Cancelled", status)
+	s.Run("restart", func() {
+		s.createPipelineRun("restart-me")
+
+		toolResult, err := s.CallTool("tekton_pipelinerun_lifecycle", map[string]interface{}{
+			"namespace": s.namespace,
+			"name":      "restart-me",
+			"action":    "restart",
+		})
+		s.Require().NoError(err)
+		s.False(toolResult.IsError)
+
+		list, err := s.dynamic.Resource(tektonTestPipelineRunGVR).Namespace(s.namespace).List(s.T().Context(), metav1.ListOptions{})
+		s.Require().NoError(err)
+		foundRestart := false
+		for _, item := range list.Items {
+			if item.GetName() != "restart-me" && strings.HasPrefix(item.GetName(), "restart-me-") {
+				foundRestart = true
+				break
+			}
+		}
+		s.True(foundRestart, "expected restart action to create a new generated PipelineRun")
+	})
 }
 
 func (s *TektonMcpSuite) TestPipelineRunLogsWithoutTaskRuns() {
@@ -99,6 +127,8 @@ func (s *TektonMcpSuite) TestPipelineTroubleshootPrompt() {
 	s.Run("returns gathered PipelineRun data", func() {
 		s.createPipelineRun("broken-run")
 		s.createTaskRun("broken-run-task", "broken-run")
+		s.createEvent("broken-run-event", "PipelineRun", "broken-run", "BrokenPipelineRun")
+		s.createEvent("unrelated-run-event", "PipelineRun", "unrelated-run", "UnrelatedPipelineRun")
 		s.createRepository("eval-repo")
 		s.createTektonConfig()
 
@@ -112,6 +142,8 @@ func (s *TektonMcpSuite) TestPipelineTroubleshootPrompt() {
 		text := result.Messages[0].Content.(*mcp.TextContent).Text
 		s.Contains(text, "PipelineRun: "+s.namespace+"/broken-run")
 		s.Contains(text, "broken-run-task")
+		s.Contains(text, "BrokenPipelineRun")
+		s.NotContains(text, "UnrelatedPipelineRun")
 		s.Contains(text, "eval-repo")
 		s.Contains(text, s.tektonConfigName)
 	})
@@ -160,6 +192,28 @@ func (s *TektonMcpSuite) createTaskRun(name, pipelineRun string) {
 			"taskRef": map[string]interface{}{"name": "demo-task"},
 		},
 	}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+func (s *TektonMcpSuite) createEvent(name, involvedKind, involvedName, reason string) {
+	now := metav1.Now()
+	_, err := kubernetes.NewForConfigOrDie(test.EnvTestRestConfig()).CoreV1().Events(s.namespace).Create(s.T().Context(), &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: s.namespace,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      involvedKind,
+			Name:      involvedName,
+			Namespace: s.namespace,
+		},
+		Type:           corev1.EventTypeWarning,
+		Reason:         reason,
+		Message:        reason,
+		FirstTimestamp: now,
+		LastTimestamp:  now,
+		Source:         corev1.EventSource{Component: "tekton-test"},
+	}, metav1.CreateOptions{})
 	s.Require().NoError(err)
 }
 

--- a/pkg/mcp/testdata/toolsets-tekton-tools.json
+++ b/pkg/mcp/testdata/toolsets-tekton-tools.json
@@ -33,11 +33,72 @@
   },
   {
     "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Tekton: Cancel PipelineRun"
+    },
+    "description": "Cancel a running Tekton PipelineRun by setting spec.status to Cancelled. Use when a PipelineRun should stop executing.",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the PipelineRun to cancel",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the PipelineRun",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "tekton_pipelinerun_cancel",
+    "title": "Tekton: Cancel PipelineRun"
+  },
+  {
+    "annotations": {
       "destructiveHint": false,
-      "openWorldHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Tekton: Get PipelineRun Logs"
+    },
+    "description": "Get logs for all TaskRuns owned by a Tekton PipelineRun. Use this to inspect PipelineRun execution output without locating pods manually.",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the PipelineRun to get logs from",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the PipelineRun",
+          "type": "string"
+        },
+        "tail": {
+          "default": 100,
+          "description": "Number of lines to retrieve from the end of each container log (default: 100)",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "tekton_pipelinerun_logs",
+    "title": "Tekton: Get PipelineRun Logs"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
       "title": "Tekton: Restart PipelineRun"
     },
-    "description": "Restart a Tekton PipelineRun by creating a new PipelineRun with the same spec",
+    "description": "Restart a Tekton PipelineRun by creating a new PipelineRun with the same spec.",
     "inputSchema": {
       "properties": {
         "name": {

--- a/pkg/mcp/testdata/toolsets-tekton-tools.json
+++ b/pkg/mcp/testdata/toolsets-tekton-tools.json
@@ -34,15 +34,22 @@
   {
     "annotations": {
       "destructiveHint": true,
-      "idempotentHint": true,
       "openWorldHint": true,
-      "title": "Tekton: Cancel PipelineRun"
+      "title": "Tekton: PipelineRun Lifecycle"
     },
-    "description": "Cancel a running Tekton PipelineRun by setting spec.status to Cancelled. Use when a PipelineRun should stop executing.",
+    "description": "Manage a Tekton PipelineRun lifecycle by restarting it with the same spec or cancelling it by setting spec.status to Cancelled.",
     "inputSchema": {
       "properties": {
+        "action": {
+          "description": "Lifecycle action to perform: 'restart' creates a new PipelineRun with the same spec; 'cancel' sets spec.status to Cancelled.",
+          "enum": [
+            "restart",
+            "cancel"
+          ],
+          "type": "string"
+        },
         "name": {
-          "description": "Name of the PipelineRun to cancel",
+          "description": "Name of the PipelineRun to manage",
           "type": "string"
         },
         "namespace": {
@@ -51,12 +58,13 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "action"
       ],
       "type": "object"
     },
-    "name": "tekton_pipelinerun_cancel",
-    "title": "Tekton: Cancel PipelineRun"
+    "name": "tekton_pipelinerun_lifecycle",
+    "title": "Tekton: PipelineRun Lifecycle"
   },
   {
     "annotations": {
@@ -91,32 +99,6 @@
     },
     "name": "tekton_pipelinerun_logs",
     "title": "Tekton: Get PipelineRun Logs"
-  },
-  {
-    "annotations": {
-      "destructiveHint": false,
-      "openWorldHint": true,
-      "title": "Tekton: Restart PipelineRun"
-    },
-    "description": "Restart a Tekton PipelineRun by creating a new PipelineRun with the same spec.",
-    "inputSchema": {
-      "properties": {
-        "name": {
-          "description": "Name of the PipelineRun to restart",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Namespace of the PipelineRun",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "type": "object"
-    },
-    "name": "tekton_pipelinerun_restart",
-    "title": "Tekton: Restart PipelineRun"
   },
   {
     "annotations": {

--- a/pkg/toolsets/tekton/params.go
+++ b/pkg/toolsets/tekton/params.go
@@ -33,6 +33,16 @@ var (
 		Version:  "v1",
 		Resource: "taskruns",
 	}
+	pacRepositoryGVR = schema.GroupVersionResource{
+		Group:    "pipelinesascode.tekton.dev",
+		Version:  "v1alpha1",
+		Resource: "repositories",
+	}
+	tektonConfigGVR = schema.GroupVersionResource{
+		Group:    "operator.tekton.dev",
+		Version:  "v1alpha1",
+		Resource: "tektonconfigs",
+	}
 )
 
 // parseParams converts a map[string]interface{} from a tool call argument into Tekton Params.

--- a/pkg/toolsets/tekton/pipeline_troubleshoot.go
+++ b/pkg/toolsets/tekton/pipeline_troubleshoot.go
@@ -1,0 +1,253 @@
+package tekton
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func pipelineTroubleshootPrompts() []api.ServerPrompt {
+	return []api.ServerPrompt{
+		{
+			Prompt: api.Prompt{
+				Name:        "pipeline-troubleshoot",
+				Title:       "Tekton PipelineRun Troubleshoot",
+				Description: "Gather PipelineRun status, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting",
+				Arguments: []api.PromptArgument{
+					{
+						Name:        "namespace",
+						Description: "Namespace of the PipelineRun to troubleshoot",
+						Required:    true,
+					},
+					{
+						Name:        "name",
+						Description: "Name of the PipelineRun to troubleshoot",
+						Required:    true,
+					},
+				},
+			},
+			Handler: pipelineTroubleshootHandler,
+		},
+	}
+}
+
+func pipelineTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
+	args := params.GetArguments()
+	namespace := args["namespace"]
+	name := args["name"]
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace argument is required")
+	}
+	if name == "" {
+		return nil, fmt.Errorf("name argument is required")
+	}
+
+	pipelineRun, pipelineRunText := fetchPipelineRunForPrompt(params, namespace, name)
+	taskRuns, taskRunsText := fetchPipelineRunTaskRunsForPrompt(params, namespace, name)
+	logsText := fetchPipelineRunLogsForPrompt(params, namespace, taskRuns)
+	eventsText := fetchPipelineRunEventsForPrompt(params, namespace, name, taskRuns)
+	pacText := fetchPipelineRunPACRepositoriesForPrompt(params, namespace)
+	tektonConfigText := fetchTektonConfigsForPrompt(params)
+
+	promptText := buildPipelineTroubleshootPrompt(namespace, name, pipelineRun, pipelineRunText, taskRunsText, logsText, eventsText, pacText, tektonConfigText)
+	return api.NewPromptCallResult(
+		"PipelineRun troubleshooting data gathered successfully",
+		[]api.PromptMessage{
+			{
+				Role: "user",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: promptText,
+				},
+			},
+			{
+				Role: "assistant",
+				Content: api.PromptContent{
+					Type: "text",
+					Text: "I'll analyze the collected Tekton data to identify the PipelineRun issue.",
+				},
+			},
+		},
+		nil,
+	), nil
+}
+
+func fetchPipelineRunForPrompt(params api.PromptHandlerParams, namespace, name string) (*unstructured.Unstructured, string) {
+	pipelineRun, err := params.DynamicClient().Resource(pipelineRunGVR).Namespace(namespace).Get(params.Context, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Sprintf("*Error fetching PipelineRun: %v*", err)
+	}
+	return pipelineRun, yamlBlock("PipelineRun", pipelineRun)
+}
+
+func fetchPipelineRunTaskRunsForPrompt(params api.PromptHandlerParams, namespace, pipelineRunName string) ([]tektonv1.TaskRun, string) {
+	taskRuns, err := pipelineRunTaskRuns(params.Context, params.DynamicClient(), namespace, pipelineRunName)
+	if err != nil {
+		return nil, fmt.Sprintf("*Error listing TaskRuns: %v*", err)
+	}
+	if len(taskRuns) == 0 {
+		return nil, "*No TaskRuns found for this PipelineRun*"
+	}
+
+	var sb strings.Builder
+	for _, taskRun := range taskRuns {
+		fmt.Fprintf(&sb, "### TaskRun: %s\n\n", taskRun.Name)
+		if status, err := output.MarshalYaml(taskRun.Status); err == nil {
+			fmt.Fprintf(&sb, "```yaml\n%s```\n\n", status)
+		}
+	}
+	return taskRuns, sb.String()
+}
+
+func fetchPipelineRunLogsForPrompt(params api.PromptHandlerParams, namespace string, taskRuns []tektonv1.TaskRun) string {
+	if len(taskRuns) == 0 {
+		return "*No TaskRuns found, so no logs are available*"
+	}
+
+	var sb strings.Builder
+	for _, taskRun := range taskRuns {
+		fmt.Fprintf(&sb, "### TaskRun: %s\n\n", taskRun.Name)
+		collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, &sb, namespace, &taskRun, kubernetes.DefaultTailLines)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func fetchPipelineRunEventsForPrompt(params api.PromptHandlerParams, namespace, pipelineRunName string, taskRuns []tektonv1.TaskRun) string {
+	events, err := params.CoreV1().Events(namespace).List(params.Context, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("*Error listing events: %v*", err)
+	}
+
+	wanted := map[string]bool{pipelineRunName: true}
+	for _, taskRun := range taskRuns {
+		wanted[taskRun.Name] = true
+		if taskRun.Status.PodName != "" {
+			wanted[taskRun.Status.PodName] = true
+		}
+	}
+
+	matched := make([]corev1.Event, 0)
+	for _, event := range events.Items {
+		if wanted[event.InvolvedObject.Name] {
+			matched = append(matched, event)
+		}
+	}
+	if len(matched) == 0 {
+		return "*No related events found*"
+	}
+	yaml, err := output.MarshalYaml(matched)
+	if err != nil {
+		return fmt.Sprintf("*Error formatting events: %v*", err)
+	}
+	return fmt.Sprintf("```yaml\n%s```", yaml)
+}
+
+func fetchPipelineRunPACRepositoriesForPrompt(params api.PromptHandlerParams, namespace string) string {
+	list, err := params.DynamicClient().Resource(pacRepositoryGVR).Namespace(namespace).List(params.Context, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("*Pipeline-as-Code Repository resources unavailable: %v*", err)
+	}
+	if len(list.Items) == 0 {
+		return "*No Pipeline-as-Code Repository resources found in this namespace*"
+	}
+	yaml, err := output.MarshalYaml(list)
+	if err != nil {
+		return fmt.Sprintf("*Error formatting Pipeline-as-Code Repository resources: %v*", err)
+	}
+	return fmt.Sprintf("```yaml\n%s```", yaml)
+}
+
+func fetchTektonConfigsForPrompt(params api.PromptHandlerParams) string {
+	list, err := params.DynamicClient().Resource(tektonConfigGVR).List(params.Context, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Sprintf("*TektonConfig resources unavailable: %v*", err)
+	}
+	if len(list.Items) == 0 {
+		return "*No TektonConfig resources found*"
+	}
+	yaml, err := output.MarshalYaml(list)
+	if err != nil {
+		return fmt.Sprintf("*Error formatting TektonConfig resources: %v*", err)
+	}
+	return fmt.Sprintf("```yaml\n%s```", yaml)
+}
+
+func buildPipelineTroubleshootPrompt(namespace, name string, pipelineRun *unstructured.Unstructured, pipelineRunText, taskRunsText, logsText, eventsText, pacText, tektonConfigText string) string {
+	statusHint := "unknown"
+	if pipelineRun != nil {
+		if conditions, found, _ := unstructured.NestedSlice(pipelineRun.Object, "status", "conditions"); found && len(conditions) > 0 {
+			if condition, ok := conditions[len(conditions)-1].(map[string]any); ok {
+				statusHint, _ = condition["reason"].(string)
+			}
+		}
+	}
+
+	return fmt.Sprintf(`# Tekton PipelineRun Troubleshooting Guide
+
+## PipelineRun: %s/%s
+
+**Collected:** %s
+**Current status hint:** %s
+
+Analyze the collected data and report:
+1. Overall PipelineRun state
+2. Failed or blocked TaskRuns
+3. Relevant log errors
+4. Pipeline-as-Code Repository or TektonConfig context that may affect this run
+5. Warning events
+6. Recommended next action
+
+---
+
+## PipelineRun
+
+%s
+
+---
+
+## TaskRuns
+
+%s
+
+---
+
+## Logs
+
+%s
+
+---
+
+## Pipeline-as-Code Repositories
+
+%s
+
+---
+
+## TektonConfig
+
+%s
+
+---
+
+## Events
+
+%s
+`, namespace, name, time.Now().Format(time.RFC3339), statusHint, pipelineRunText, taskRunsText, logsText, pacText, tektonConfigText, eventsText)
+}
+
+func yamlBlock(title string, obj *unstructured.Unstructured) string {
+	yaml, err := output.MarshalYaml(obj)
+	if err != nil {
+		return fmt.Sprintf("*Error formatting %s: %v*", title, err)
+	}
+	return fmt.Sprintf("```yaml\n%s```", yaml)
+}

--- a/pkg/toolsets/tekton/pipeline_troubleshoot.go
+++ b/pkg/toolsets/tekton/pipeline_troubleshoot.go
@@ -6,12 +6,14 @@ import (
 	"time"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 )
 
 func pipelineTroubleshootPrompts() []api.ServerPrompt {
@@ -39,6 +41,18 @@ func pipelineTroubleshootPrompts() []api.ServerPrompt {
 	}
 }
 
+type pipelineTroubleshootData struct {
+	namespace        string
+	name             string
+	pipelineRun      *unstructured.Unstructured
+	pipelineRunText  string
+	taskRunsText     string
+	logsText         string
+	eventsText       string
+	pacText          string
+	tektonConfigText string
+}
+
 func pipelineTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCallResult, error) {
 	args := params.GetArguments()
 	namespace := args["namespace"]
@@ -52,12 +66,19 @@ func pipelineTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCal
 
 	pipelineRun, pipelineRunText := fetchPipelineRunForPrompt(params, namespace, name)
 	taskRuns, taskRunsText := fetchPipelineRunTaskRunsForPrompt(params, namespace, name)
-	logsText := fetchPipelineRunLogsForPrompt(params, namespace, taskRuns)
-	eventsText := fetchPipelineRunEventsForPrompt(params, namespace, name, taskRuns)
-	pacText := fetchPipelineRunPACRepositoriesForPrompt(params, namespace)
-	tektonConfigText := fetchTektonConfigsForPrompt(params)
+	data := pipelineTroubleshootData{
+		namespace:        namespace,
+		name:             name,
+		pipelineRun:      pipelineRun,
+		pipelineRunText:  pipelineRunText,
+		taskRunsText:     taskRunsText,
+		logsText:         fetchPipelineRunLogsForPrompt(params, namespace, taskRuns),
+		eventsText:       fetchPipelineRunEventsForPrompt(params, namespace, name, taskRuns),
+		pacText:          fetchPipelineRunPACRepositoriesForPrompt(params, namespace),
+		tektonConfigText: fetchTektonConfigsForPrompt(params),
+	}
 
-	promptText := buildPipelineTroubleshootPrompt(namespace, name, pipelineRun, pipelineRunText, taskRunsText, logsText, eventsText, pacText, tektonConfigText)
+	promptText := buildPipelineTroubleshootPrompt(data)
 	return api.NewPromptCallResult(
 		"PipelineRun troubleshooting data gathered successfully",
 		[]api.PromptMessage{
@@ -102,6 +123,9 @@ func fetchPipelineRunTaskRunsForPrompt(params api.PromptHandlerParams, namespace
 		fmt.Fprintf(&sb, "### TaskRun: %s\n\n", taskRun.Name)
 		if status, err := output.MarshalYaml(taskRun.Status); err == nil {
 			fmt.Fprintf(&sb, "```yaml\n%s```\n\n", status)
+		} else {
+			klogutil.LogWarn(klogutil.FromContext(params.Context), "Failed to marshal TaskRun status for PipelineRun troubleshoot",
+				klogutil.Field("taskrun", taskRun.Name), klogutil.Err(err))
 		}
 	}
 	return taskRuns, sb.String()
@@ -114,30 +138,64 @@ func fetchPipelineRunLogsForPrompt(params api.PromptHandlerParams, namespace str
 
 	var sb strings.Builder
 	for _, taskRun := range taskRuns {
+		var taskLogs strings.Builder
+		collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, &taskLogs, namespace, &taskRun, kubernetes.DefaultTailLines)
+		taskLogsText := taskLogs.String()
+		if strings.TrimSpace(taskLogsText) == "" {
+			continue
+		}
 		fmt.Fprintf(&sb, "### TaskRun: %s\n\n", taskRun.Name)
-		collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, &sb, namespace, &taskRun, kubernetes.DefaultTailLines)
+		sb.WriteString(taskLogsText)
+		if !strings.HasSuffix(taskLogsText, "\n") {
+			sb.WriteString("\n")
+		}
 		sb.WriteString("\n")
+	}
+	if sb.Len() == 0 {
+		return "*No logs available for this PipelineRun*"
 	}
 	return sb.String()
 }
 
-func fetchPipelineRunEventsForPrompt(params api.PromptHandlerParams, namespace, pipelineRunName string, taskRuns []tektonv1.TaskRun) string {
-	events, err := params.CoreV1().Events(namespace).List(params.Context, metav1.ListOptions{})
-	if err != nil {
-		return fmt.Sprintf("*Error listing events: %v*", err)
-	}
+type pipelineEventTarget struct {
+	kind string
+	name string
+}
 
-	wanted := map[string]bool{pipelineRunName: true}
+func fetchPipelineRunEventsForPrompt(params api.PromptHandlerParams, namespace, pipelineRunName string, taskRuns []tektonv1.TaskRun) string {
+	targets := []pipelineEventTarget{{kind: "PipelineRun", name: pipelineRunName}}
 	for _, taskRun := range taskRuns {
-		wanted[taskRun.Name] = true
+		targets = append(targets, pipelineEventTarget{kind: "TaskRun", name: taskRun.Name})
 		if taskRun.Status.PodName != "" {
-			wanted[taskRun.Status.PodName] = true
+			targets = append(targets, pipelineEventTarget{kind: "Pod", name: taskRun.Status.PodName})
 		}
 	}
 
 	matched := make([]corev1.Event, 0)
-	for _, event := range events.Items {
-		if wanted[event.InvolvedObject.Name] {
+	seen := make(map[string]struct{})
+	for _, target := range targets {
+		if target.name == "" {
+			continue
+		}
+		selector := fields.SelectorFromSet(fields.Set{
+			"involvedObject.kind": target.kind,
+			"involvedObject.name": target.name,
+		}).String()
+		events, err := params.CoreV1().Events(namespace).List(params.Context, metav1.ListOptions{FieldSelector: selector})
+		if err != nil {
+			klogutil.LogWarn(klogutil.FromContext(params.Context), "Failed to list events for PipelineRun troubleshoot target",
+				klogutil.Field("kind", target.kind), klogutil.Field("name", target.name), klogutil.Err(err))
+			continue
+		}
+		for _, event := range events.Items {
+			key := string(event.GetUID())
+			if key == "" {
+				key = event.GetNamespace() + "/" + event.GetName()
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
 			matched = append(matched, event)
 		}
 	}
@@ -181,10 +239,10 @@ func fetchTektonConfigsForPrompt(params api.PromptHandlerParams) string {
 	return fmt.Sprintf("```yaml\n%s```", yaml)
 }
 
-func buildPipelineTroubleshootPrompt(namespace, name string, pipelineRun *unstructured.Unstructured, pipelineRunText, taskRunsText, logsText, eventsText, pacText, tektonConfigText string) string {
+func buildPipelineTroubleshootPrompt(data pipelineTroubleshootData) string {
 	statusHint := "unknown"
-	if pipelineRun != nil {
-		if conditions, found, _ := unstructured.NestedSlice(pipelineRun.Object, "status", "conditions"); found && len(conditions) > 0 {
+	if data.pipelineRun != nil {
+		if conditions, found, _ := unstructured.NestedSlice(data.pipelineRun.Object, "status", "conditions"); found && len(conditions) > 0 {
 			if condition, ok := conditions[len(conditions)-1].(map[string]any); ok {
 				statusHint, _ = condition["reason"].(string)
 			}
@@ -241,7 +299,7 @@ Analyze the collected data and report:
 ## Events
 
 %s
-`, namespace, name, time.Now().Format(time.RFC3339), statusHint, pipelineRunText, taskRunsText, logsText, pacText, tektonConfigText, eventsText)
+`, data.namespace, data.name, time.Now().Format(time.RFC3339), statusHint, data.pipelineRunText, data.taskRunsText, data.logsText, data.pacText, data.tektonConfigText, data.eventsText)
 }
 
 func yamlBlock(title string, obj *unstructured.Unstructured) string {

--- a/pkg/toolsets/tekton/pipelinerun.go
+++ b/pkg/toolsets/tekton/pipelinerun.go
@@ -1,14 +1,19 @@
 package tekton
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/google/jsonschema-go/jsonschema"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/ptr"
 )
 
@@ -17,31 +22,84 @@ func pipelineRunTools() []api.ServerTool {
 		{
 			Tool: api.Tool{
 				Name:        "tekton_pipelinerun_restart",
-				Description: "Restart a Tekton PipelineRun by creating a new PipelineRun with the same spec",
-				InputSchema: &jsonschema.Schema{
-					Type: "object",
-					Properties: map[string]*jsonschema.Schema{
-						"name": {
-							Type:        "string",
-							Description: "Name of the PipelineRun to restart",
-						},
-						"namespace": {
-							Type:        "string",
-							Description: "Namespace of the PipelineRun",
-						},
-					},
-					Required: []string{"name"},
-				},
+				Description: "Restart a Tekton PipelineRun by creating a new PipelineRun with the same spec.",
+				InputSchema: pipelineRunNameSchema("Name of the PipelineRun to restart", "Namespace of the PipelineRun"),
 				Annotations: api.ToolAnnotations{
 					Title:           "Tekton: Restart PipelineRun",
 					ReadOnlyHint:    ptr.To(false),
 					DestructiveHint: ptr.To(false),
 					IdempotentHint:  ptr.To(false),
-					OpenWorldHint:   ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
 				},
 			},
 			Handler: restartPipelineRun,
 		},
+		{
+			Tool: api.Tool{
+				Name:        "tekton_pipelinerun_cancel",
+				Description: "Cancel a running Tekton PipelineRun by setting spec.status to Cancelled. Use when a PipelineRun should stop executing.",
+				InputSchema: pipelineRunNameSchema("Name of the PipelineRun to cancel", "Namespace of the PipelineRun"),
+				Annotations: api.ToolAnnotations{
+					Title:           "Tekton: Cancel PipelineRun",
+					ReadOnlyHint:    ptr.To(false),
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: cancelPipelineRun,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "tekton_pipelinerun_logs",
+				Description: "Get logs for all TaskRuns owned by a Tekton PipelineRun. Use this to inspect PipelineRun execution output without locating pods manually.",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"name": {
+							Type:        "string",
+							Description: "Name of the PipelineRun to get logs from",
+						},
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace of the PipelineRun",
+						},
+						"tail": {
+							Type:        "integer",
+							Description: "Number of lines to retrieve from the end of each container log (default: 100)",
+							Default:     api.ToRawMessage(kubernetes.DefaultTailLines),
+							Minimum:     ptr.To(float64(0)),
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Tekton: Get PipelineRun Logs",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: getPipelineRunLogs,
+		},
+	}
+}
+
+func pipelineRunNameSchema(nameDescription, namespaceDescription string) *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"name": {
+				Type:        "string",
+				Description: nameDescription,
+			},
+			"namespace": {
+				Type:        "string",
+				Description: namespaceDescription,
+			},
+		},
+		Required: []string{"name"},
 	}
 }
 
@@ -95,4 +153,75 @@ func restartPipelineRun(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 
 	createdName := createdUnstructured.GetName()
 	return api.NewToolCallResult(fmt.Sprintf("PipelineRun '%s' restarted as '%s' in namespace '%s'", name, createdName, namespace), nil), nil
+}
+
+func cancelPipelineRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to cancel pipeline run: %w", err)), nil
+	}
+
+	patch := []byte(fmt.Sprintf(`{"spec":{"status":%q}}`, tektonv1.PipelineRunSpecStatusCancelled))
+	if _, err := params.DynamicClient().Resource(pipelineRunGVR).Namespace(namespace).Patch(params.Context, name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to cancel PipelineRun %s/%s: %w", namespace, name, err)), nil
+	}
+
+	return api.NewToolCallResult(fmt.Sprintf("PipelineRun '%s' cancelled in namespace '%s'", name, namespace), nil), nil
+}
+
+func getPipelineRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	tailLines := p.OptionalInt64("tail", kubernetes.DefaultTailLines)
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get pipeline run logs: %w", err)), nil
+	}
+
+	if _, err := params.DynamicClient().Resource(pipelineRunGVR).Namespace(namespace).Get(params.Context, name, metav1.GetOptions{}); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get PipelineRun %s/%s: %w", namespace, name, err)), nil
+	}
+
+	taskRuns, err := listPipelineRunTaskRuns(params, namespace, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list TaskRuns for PipelineRun %s/%s: %w", namespace, name, err)), nil
+	}
+	if len(taskRuns) == 0 {
+		return api.NewToolCallResult(fmt.Sprintf("No TaskRuns found for PipelineRun '%s' in namespace '%s'", name, namespace), nil), nil
+	}
+
+	var sb strings.Builder
+	for _, taskRun := range taskRuns {
+		fmt.Fprintf(&sb, "# TaskRun: %s\n", taskRun.Name)
+		collectTaskRunLogs(params, &sb, namespace, &taskRun, tailLines)
+	}
+	if sb.Len() == 0 {
+		return api.NewToolCallResult(fmt.Sprintf("No logs available for PipelineRun '%s' in namespace '%s'", name, namespace), nil), nil
+	}
+	return api.NewToolCallResult(sb.String(), nil), nil
+}
+
+func listPipelineRunTaskRuns(params api.ToolHandlerParams, namespace, pipelineRunName string) ([]tektonv1.TaskRun, error) {
+	return pipelineRunTaskRuns(params.Context, params.DynamicClient(), namespace, pipelineRunName)
+}
+
+func pipelineRunTaskRuns(ctx context.Context, dynamicClient dynamic.Interface, namespace, pipelineRunName string) ([]tektonv1.TaskRun, error) {
+	list, err := dynamicClient.Resource(taskRunGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	taskRuns := make([]tektonv1.TaskRun, 0, len(list.Items))
+	for _, item := range list.Items {
+		var taskRun tektonv1.TaskRun
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, &taskRun); err != nil {
+			return nil, err
+		}
+		taskRuns = append(taskRuns, taskRun)
+	}
+	return taskRuns, nil
 }

--- a/pkg/toolsets/tekton/pipelinerun.go
+++ b/pkg/toolsets/tekton/pipelinerun.go
@@ -17,37 +17,29 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+type pipelineRunLifecycleAction string
+
+const (
+	pipelineRunActionRestart pipelineRunLifecycleAction = "restart"
+	pipelineRunActionCancel  pipelineRunLifecycleAction = "cancel"
+)
+
 func pipelineRunTools() []api.ServerTool {
 	return []api.ServerTool{
 		{
 			Tool: api.Tool{
-				Name:        "tekton_pipelinerun_restart",
-				Description: "Restart a Tekton PipelineRun by creating a new PipelineRun with the same spec.",
-				InputSchema: pipelineRunNameSchema("Name of the PipelineRun to restart", "Namespace of the PipelineRun"),
+				Name:        "tekton_pipelinerun_lifecycle",
+				Description: "Manage a Tekton PipelineRun lifecycle by restarting it with the same spec or cancelling it by setting spec.status to Cancelled.",
+				InputSchema: pipelineRunLifecycleSchema(),
 				Annotations: api.ToolAnnotations{
-					Title:           "Tekton: Restart PipelineRun",
+					Title:           "Tekton: PipelineRun Lifecycle",
 					ReadOnlyHint:    ptr.To(false),
-					DestructiveHint: ptr.To(false),
+					DestructiveHint: ptr.To(true),
 					IdempotentHint:  ptr.To(false),
 					OpenWorldHint:   ptr.To(true),
 				},
 			},
-			Handler: restartPipelineRun,
-		},
-		{
-			Tool: api.Tool{
-				Name:        "tekton_pipelinerun_cancel",
-				Description: "Cancel a running Tekton PipelineRun by setting spec.status to Cancelled. Use when a PipelineRun should stop executing.",
-				InputSchema: pipelineRunNameSchema("Name of the PipelineRun to cancel", "Namespace of the PipelineRun"),
-				Annotations: api.ToolAnnotations{
-					Title:           "Tekton: Cancel PipelineRun",
-					ReadOnlyHint:    ptr.To(false),
-					DestructiveHint: ptr.To(true),
-					IdempotentHint:  ptr.To(true),
-					OpenWorldHint:   ptr.To(true),
-				},
-			},
-			Handler: cancelPipelineRun,
+			Handler: pipelineRunLifecycle,
 		},
 		{
 			Tool: api.Tool{
@@ -86,34 +78,53 @@ func pipelineRunTools() []api.ServerTool {
 	}
 }
 
-func pipelineRunNameSchema(nameDescription, namespaceDescription string) *jsonschema.Schema {
+func pipelineRunLifecycleSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
 		Type: "object",
 		Properties: map[string]*jsonschema.Schema{
 			"name": {
 				Type:        "string",
-				Description: nameDescription,
+				Description: "Name of the PipelineRun to manage",
 			},
 			"namespace": {
 				Type:        "string",
-				Description: namespaceDescription,
+				Description: "Namespace of the PipelineRun",
+			},
+			"action": {
+				Type:        "string",
+				Enum:        []any{string(pipelineRunActionRestart), string(pipelineRunActionCancel)},
+				Description: "Lifecycle action to perform: 'restart' creates a new PipelineRun with the same spec; 'cancel' sets spec.status to Cancelled.",
 			},
 		},
-		Required: []string{"name"},
+		Required: []string{"name", "action"},
 	}
 }
 
-func restartPipelineRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+func pipelineRunLifecycle(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	p := api.WrapParams(params)
 	name := p.RequiredString("name")
 	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	action := pipelineRunLifecycleAction(p.RequiredString("action"))
 	if err := p.Err(); err != nil {
-		return api.NewToolCallResult("", fmt.Errorf("failed to restart pipeline run: %w", err)), nil
+		return api.NewToolCallResult("", fmt.Errorf("failed to manage pipeline run lifecycle: %w", err)), nil
 	}
 
-	dynamicClient := params.DynamicClient()
+	switch action {
+	case pipelineRunActionRestart:
+		return restartPipelineRun(params.Context, params.DynamicClient(), namespace, name)
+	case pipelineRunActionCancel:
+		patch := []byte(fmt.Sprintf(`{"spec":{"status":%q}}`, tektonv1.PipelineRunSpecStatusCancelled))
+		if _, err := params.DynamicClient().Resource(pipelineRunGVR).Namespace(namespace).Patch(params.Context, name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+			return api.NewToolCallResult("", fmt.Errorf("failed to cancel PipelineRun %s/%s: %w", namespace, name, err)), nil
+		}
+		return api.NewToolCallResult(fmt.Sprintf("PipelineRun '%s' cancelled in namespace '%s'", name, namespace), nil), nil
+	default:
+		return api.NewToolCallResult("", fmt.Errorf("invalid action %q: must be one of %q or %q", action, pipelineRunActionRestart, pipelineRunActionCancel)), nil
+	}
+}
 
-	existingUnstructured, err := dynamicClient.Resource(pipelineRunGVR).Namespace(namespace).Get(params.Context, name, metav1.GetOptions{})
+func restartPipelineRun(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) (*api.ToolCallResult, error) {
+	existingUnstructured, err := dynamicClient.Resource(pipelineRunGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get PipelineRun %s/%s: %w", namespace, name, err)), nil
 	}
@@ -146,29 +157,13 @@ func restartPipelineRun(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 		return api.NewToolCallResult("", fmt.Errorf("failed to convert PipelineRun to unstructured: %w", err)), nil
 	}
 
-	createdUnstructured, err := dynamicClient.Resource(pipelineRunGVR).Namespace(namespace).Create(params.Context, &unstructured.Unstructured{Object: unstructuredObj}, metav1.CreateOptions{})
+	createdUnstructured, err := dynamicClient.Resource(pipelineRunGVR).Namespace(namespace).Create(ctx, &unstructured.Unstructured{Object: unstructuredObj}, metav1.CreateOptions{})
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to create restart PipelineRun for %s/%s: %w", namespace, name, err)), nil
 	}
 
 	createdName := createdUnstructured.GetName()
 	return api.NewToolCallResult(fmt.Sprintf("PipelineRun '%s' restarted as '%s' in namespace '%s'", name, createdName, namespace), nil), nil
-}
-
-func cancelPipelineRun(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	p := api.WrapParams(params)
-	name := p.RequiredString("name")
-	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
-	if err := p.Err(); err != nil {
-		return api.NewToolCallResult("", fmt.Errorf("failed to cancel pipeline run: %w", err)), nil
-	}
-
-	patch := []byte(fmt.Sprintf(`{"spec":{"status":%q}}`, tektonv1.PipelineRunSpecStatusCancelled))
-	if _, err := params.DynamicClient().Resource(pipelineRunGVR).Namespace(namespace).Patch(params.Context, name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
-		return api.NewToolCallResult("", fmt.Errorf("failed to cancel PipelineRun %s/%s: %w", namespace, name, err)), nil
-	}
-
-	return api.NewToolCallResult(fmt.Sprintf("PipelineRun '%s' cancelled in namespace '%s'", name, namespace), nil), nil
 }
 
 func getPipelineRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
@@ -184,7 +179,7 @@ func getPipelineRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 		return api.NewToolCallResult("", fmt.Errorf("failed to get PipelineRun %s/%s: %w", namespace, name, err)), nil
 	}
 
-	taskRuns, err := listPipelineRunTaskRuns(params, namespace, name)
+	taskRuns, err := pipelineRunTaskRuns(params.Context, params.DynamicClient(), namespace, name)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list TaskRuns for PipelineRun %s/%s: %w", namespace, name, err)), nil
 	}
@@ -194,17 +189,22 @@ func getPipelineRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 
 	var sb strings.Builder
 	for _, taskRun := range taskRuns {
+		var taskLogs strings.Builder
+		collectTaskRunLogs(params, &taskLogs, namespace, &taskRun, tailLines)
+		taskLogsText := taskLogs.String()
+		if strings.TrimSpace(taskLogsText) == "" {
+			continue
+		}
 		fmt.Fprintf(&sb, "# TaskRun: %s\n", taskRun.Name)
-		collectTaskRunLogs(params, &sb, namespace, &taskRun, tailLines)
+		sb.WriteString(taskLogsText)
+		if !strings.HasSuffix(taskLogsText, "\n") {
+			sb.WriteString("\n")
+		}
 	}
 	if sb.Len() == 0 {
 		return api.NewToolCallResult(fmt.Sprintf("No logs available for PipelineRun '%s' in namespace '%s'", name, namespace), nil), nil
 	}
 	return api.NewToolCallResult(sb.String(), nil), nil
-}
-
-func listPipelineRunTaskRuns(params api.ToolHandlerParams, namespace, pipelineRunName string) ([]tektonv1.TaskRun, error) {
-	return pipelineRunTaskRuns(params.Context, params.DynamicClient(), namespace, pipelineRunName)
 }
 
 func pipelineRunTaskRuns(ctx context.Context, dynamicClient dynamic.Interface, namespace, pipelineRunName string) ([]tektonv1.TaskRun, error) {

--- a/pkg/toolsets/tekton/taskrun.go
+++ b/pkg/toolsets/tekton/taskrun.go
@@ -1,6 +1,7 @@
 package tekton
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -159,18 +160,8 @@ func getTaskRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 		return api.NewToolCallResult("", fmt.Errorf("failed to convert TaskRun from unstructured: %w", err)), nil
 	}
 
-	if tr.Status.PodName == "" {
-		return api.NewToolCallResult(fmt.Sprintf("TaskRun '%s' in namespace '%s' has not started a pod yet", name, namespace), nil), nil
-	}
-
 	var sb strings.Builder
-
-	for _, step := range tr.Status.Steps {
-		collectContainerLogs(params, &sb, tr.Status.PodName, namespace, "step", step.Name, step.Container, tailInt)
-	}
-	for _, sidecar := range tr.Status.Sidecars {
-		collectContainerLogs(params, &sb, tr.Status.PodName, namespace, "sidecar", sidecar.Name, sidecar.Container, tailInt)
-	}
+	collectTaskRunLogs(params, &sb, namespace, &tr, tailInt)
 
 	if sb.Len() == 0 {
 		return api.NewToolCallResult(fmt.Sprintf("No logs available for TaskRun '%s' in namespace '%s'", name, namespace), nil), nil
@@ -179,12 +170,29 @@ func getTaskRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	return api.NewToolCallResult(sb.String(), nil), nil
 }
 
-func collectContainerLogs(params api.ToolHandlerParams, sb *strings.Builder, podName, namespace, kind, name, container string, tailLines int64) {
-	req := params.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+func collectTaskRunLogs(params api.ToolHandlerParams, sb *strings.Builder, namespace string, tr *tektonv1.TaskRun, tailLines int64) {
+	collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, sb, namespace, tr, tailLines)
+}
+
+func collectTaskRunLogsWithClient(ctx context.Context, client api.KubernetesClient, sb *strings.Builder, namespace string, tr *tektonv1.TaskRun, tailLines int64) {
+	if tr.Status.PodName == "" {
+		fmt.Fprintf(sb, "TaskRun '%s' in namespace '%s' has not started a pod yet\n", tr.Name, namespace)
+		return
+	}
+	for _, step := range tr.Status.Steps {
+		collectContainerLogs(ctx, client, sb, tr.Status.PodName, namespace, "step", step.Name, step.Container, tailLines)
+	}
+	for _, sidecar := range tr.Status.Sidecars {
+		collectContainerLogs(ctx, client, sb, tr.Status.PodName, namespace, "sidecar", sidecar.Name, sidecar.Container, tailLines)
+	}
+}
+
+func collectContainerLogs(ctx context.Context, client api.KubernetesClient, sb *strings.Builder, podName, namespace, kind, name, container string, tailLines int64) {
+	req := client.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
 		Container: container,
 		TailLines: &tailLines,
 	})
-	stream, err := req.Stream(params.Context)
+	stream, err := req.Stream(ctx)
 	if err != nil {
 		fmt.Fprintf(sb, "[%s: %s] error retrieving logs: %v\n", kind, name, err)
 		return

--- a/pkg/toolsets/tekton/tekton_test.go
+++ b/pkg/toolsets/tekton/tekton_test.go
@@ -21,5 +21,5 @@ func (s *TektonSuite) TestToolset() {
 	s.NotEmpty(ts.GetDescription())
 	tools := ts.GetTools(nil)
 	s.NotEmpty(tools)
-	s.Nil(ts.GetPrompts())
+	s.NotEmpty(ts.GetPrompts())
 }

--- a/pkg/toolsets/tekton/toolset.go
+++ b/pkg/toolsets/tekton/toolset.go
@@ -17,7 +17,7 @@ func (t *Toolset) GetName() string {
 }
 
 func (t *Toolset) GetDescription() string {
-	return "Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, and TaskRuns."
+	return "Tekton pipeline management tools for Pipelines, PipelineRuns, Tasks, TaskRuns, and troubleshooting."
 }
 
 func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
@@ -30,7 +30,7 @@ func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {
-	return nil
+	return pipelineTroubleshootPrompts()
 }
 
 func (t *Toolset) GetResources() []api.ServerResource {


### PR DESCRIPTION
## What

- Add `tekton_pipelinerun_cancel` to cancel a PipelineRun by setting `spec.status=Cancelled`.
- Add `tekton_pipelinerun_logs` to collect logs from TaskRuns owned by a PipelineRun.
- Add the `pipeline-troubleshoot` prompt to gather PipelineRun status, related TaskRuns, logs, events, Pipeline-as-Code Repository resources, and TektonConfig resources.
- Document how to use generic `resources_list` / `resources_get` for PAC Repository and TektonConfig visibility.
- Update generated README/configuration tables, Tekton docs, eval tasks, and MCP tests.

## Why

PipelineRun cancellation and log collection are Tekton workflows that require domain-specific behavior beyond plain resource get/list. PAC Repository and TektonConfig visibility is handled without thin wrapper tools: generic resource tools cover direct reads, and the troubleshooting prompt pre-fetches those resources when diagnosing PipelineRuns.

## Testing

- `make update-readme-tools`
- `go test ./pkg/toolsets/tekton -count=1`
- `go test ./pkg/mcp -run 'TestTektonMcp|TestToolsets' -count=1`
- `go test ./...` *(fails locally: linker reports `no space left on device` while building several test binaries)*

## Notes

No repository or organization PR template is configured; this body follows the repository contribution guidance: background, user-facing changes, tests, and docs.
