### PR TITLE
docs: add SECURITY.md policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Before reporting an issue, check our backlog of [open issues](https://github.com
 
 If you find a new bug or have a feature request, we'd love to hear about it! For bug reports, the most important aspect is that they include enough information for us to reproduce the problem. Please include as much detail as possible and try to remove extra details that don't relate to the issue itself. The easier it is for us to reproduce it, the faster it'll be fixed! For feature requests, please describe the use case and why the feature would be valuable.
 
-Please don't include any private or sensitive information in your issue. Security issues should **NOT** be reported via GitHub issues. Please report security vulnerabilities responsibly through [GitHub's security advisory feature](https://github.com/containers/kubernetes-mcp-server/security/advisories).
+Please don't include any private or sensitive information in your issue. Security issues should **NOT** be reported via GitHub issues. Please report security vulnerabilities responsibly by following our [security policy](SECURITY.md).
 
 ## Contributing Code
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+The Kubernetes MCP Server maintainers and community take the security of the project seriously.
+We appreciate your efforts to responsibly disclose your findings and will work with you to resolve them.
+
+## Supported Versions
+
+Security fixes are applied to the **latest released version** of `kubernetes-mcp-server`.
+We do not maintain long-term support or backport branches, so we strongly encourage everyone to stay on the most recent release.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.**
+
+Instead, report them privately through GitHub's built-in private vulnerability reporting:
+
+1. Go to the repository's [**Report a vulnerability**](https://github.com/containers/kubernetes-mcp-server/security/advisories/new) page, also reachable from the repository's [**Security** tab](https://github.com/containers/kubernetes-mcp-server/security).
+2. Fill in the advisory form and submit it.
+
+This creates a private advisory visible only to the project maintainers.
+
+To help us triage and prioritize the report, please include as much of the following as you can:
+
+- The type of issue (e.g. credential exposure, privilege escalation, command injection, SSRF).
+- The affected version(s) of `kubernetes-mcp-server`, and the relevant configuration (e.g. enabled toolsets, transport, read-only mode).
+- Step-by-step instructions to reproduce the issue.
+- Proof-of-concept or exploit code, if available.
+- The impact of the issue, including how an attacker might exploit it.
+
+Reports written in English are preferred.
+
+## What to Expect
+
+- We will acknowledge your report as soon as possible and keep you informed as we triage it and work toward a fix.
+- The repository maintainers triage incoming reports.
+  Issues that also affect downstream distributions are additionally handled through Red Hat's internal product security process.
+- We will work with you privately to understand and resolve the issue before any public disclosure, and we are happy to credit you in the resulting advisory unless you prefer to remain anonymous.
+
+## Disclosure and Announcements
+
+Once a fix is available, we publish the details as a [GitHub Security Advisory](https://github.com/containers/kubernetes-mcp-server/security/advisories) and include them in the corresponding [release notes](https://github.com/containers/kubernetes-mcp-server/releases).
+We recommend watching the repository's releases to stay informed about security updates.


### PR DESCRIPTION
## Summary

Adds a root-level `SECURITY.md` security policy (resolves #1132). The repo had no
security policy, so the GitHub **Security** tab / "Report a vulnerability" link were
empty, and `CONTRIBUTING.md` pointed reporters at the bare advisories listing page.

The policy reflects the direction agreed in the issue:

- **Reporting channel:** GitHub's built-in private vulnerability reporting (no mailing
  list / email alias). Explicitly directs reporters away from public issues, PRs, and
  discussions.
- **Supported versions:** security fixes target the latest released version (no
  LTS/backport branches).
- **Triage:** repo maintainers; downstream-affecting issues additionally handled
  through Red Hat product security.
- **Acknowledgement:** best-effort (no committed SLA).
- **Disclosure & announcements:** coordinated handling; published via GitHub Security
  Advisories and release notes (no fixed embargo clock).

`CONTRIBUTING.md` now links to the new policy. Content is modeled on comparable
Kubernetes/CNCF projects using the same reporting channel (e.g. Argo CD, Crossplane)
and the GitHub-recommended "don't report via public channels" wording.

## Notes

- Docs-only change; no Go code affected.
- `SECURITY.md` uses semantic line breaks (one sentence per line) for clean diffs.