### PR TITLE
ci(mcpchecker): reference workflow event inputs via env vars

### DIFF
--- a/.github/workflows/mcpchecker-report.yaml
+++ b/.github/workflows/mcpchecker-report.yaml
@@ -19,8 +19,10 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
-          JOB_CONCLUSION=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs" \
+          JOB_CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/jobs" \
             --jq '.jobs[] | select(.name == "Run MCP Evaluation") | .conclusion')
 
           if [[ -n "$JOB_CONCLUSION" && "$JOB_CONCLUSION" != "skipped" ]]; then
@@ -43,6 +45,9 @@ jobs:
         if: steps.check.outputs.should-report == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           PR_NUMBER=$(jq -r '.pr_number' eval-context/context.json)
           PR_SHA=$(jq -r '.pr_sha' eval-context/context.json)
@@ -56,7 +61,7 @@ jobs:
 
           PASS_RATE=$(awk "BEGIN {printf \"%.1f\", $TASK_PASS_RATE * 100}")
 
-          if [[ "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
+          if [[ "$RUN_CONCLUSION" != "success" ]]; then
             OVERALL="⚠️ Workflow failed"
           elif [[ "$PASSED" == "true" ]]; then
             OVERALL="✅ Passed"
@@ -82,7 +87,7 @@ jobs:
           )
           fi
 
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$(cat <<EOF
+          gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "$(cat <<EOF
           ## mcpchecker MCP Evaluation Results
 
           **Commit:** \`${PR_SHA:0:7}\`
@@ -95,6 +100,6 @@ jobs:
           | Overall | ${OVERALL} |
           ${DIFF_SECTION}
 
-          [View full results](https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }})
+          [View full results](https://github.com/${REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID})
           EOF
           )"

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -74,42 +74,51 @@ jobs:
     steps:
       - name: Check trigger conditions
         id: check
+        # All event-derived values are passed through `env` and referenced as shell
+        # variables. They are never interpolated directly into the `run` script, so
+        # untrusted input (e.g. a comment body) cannot alter the script that executes.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          HEAD_SHA: ${{ github.sha }}
+          INPUT_SUITE: ${{ github.event.inputs.suite }}
         run: |
-          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
-            # Check if commenter has write access
-            PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission" --jq '.permission')
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            # Only repository collaborators with admin/write access may trigger a run.
+            PERMISSION=$(gh api "repos/${REPOSITORY}/collaborators/${COMMENTER}/permission" --jq '.permission')
 
-            if [[ "$PERMISSION" == "admin" || "$PERMISSION" == "write" ]]; then
-              echo "should-run=true" >> $GITHUB_OUTPUT
-              echo "is-pr=true" >> $GITHUB_OUTPUT
-              PR_NUMBER="${{ github.event.issue.number }}"
-              echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
-
-              # Capture SHA at trigger time to prevent TOCTOU race condition
-              # This ensures we run the exact code the maintainer reviewed
-              PR_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')
-              echo "pr-sha=$PR_SHA" >> $GITHUB_OUTPUT
-              echo "Pinned to SHA: $PR_SHA"
-            else
-              echo "should-run=false" >> $GITHUB_OUTPUT
-              echo "User ${{ github.event.comment.user.login }} does not have permission to trigger evaluations"
+            if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+              echo "should-run=false" >> "$GITHUB_OUTPUT"
+              echo "User ${COMMENTER} does not have permission to trigger evaluations"
+              exit 0
             fi
+
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "is-pr=true" >> "$GITHUB_OUTPUT"
+            echo "pr-number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+
+            # Capture SHA at trigger time to prevent TOCTOU race condition
+            # This ensures we run the exact code the maintainer reviewed
+            PR_SHA=$(gh pr view "$ISSUE_NUMBER" --repo "$REPOSITORY" --json headRefOid --jq '.headRefOid')
+            echo "pr-sha=$PR_SHA" >> "$GITHUB_OUTPUT"
+            echo "Pinned to SHA: $PR_SHA"
           else
-            echo "should-run=true" >> $GITHUB_OUTPUT
-            echo "is-pr=false" >> $GITHUB_OUTPUT
-            echo "pr-sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "is-pr=false" >> "$GITHUB_OUTPUT"
+            echo "pr-sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
           fi
 
           # Suite selection: defaults to 'core', can be overridden by workflow_dispatch input or PR comment
-          SUITE="${{ github.event.inputs.suite || 'core' }}"
+          SUITE="${INPUT_SUITE:-core}"
 
-          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
             # Parse /run-mcpchecker [suite] from PR comment
-            COMMENT_BODY="${{ github.event.comment.body }}"
-            COMMENT_BODY="${COMMENT_BODY//[[:space:]]/ }"
-            read -r _ FIRST_WORD _ <<< "$COMMENT_BODY"
+            BODY="${COMMENT_BODY//[[:space:]]/ }"
+            read -r _ FIRST_WORD _ <<< "$BODY"
             case "${FIRST_WORD,,}" in
               core|helm|kubevirt|kiali|tekton|all)
                 SUITE="${FIRST_WORD,,}"

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -130,29 +130,29 @@ jobs:
           # All suites use the same eval.yaml file; suite controls label-selector + infra.
           case "$SUITE" in
             helm)
-              echo "label-selector=suite=helm" >> $GITHUB_OUTPUT
-              echo "toolsets=core,config,helm" >> $GITHUB_OUTPUT
+              echo "label-selector=suite=helm" >> "$GITHUB_OUTPUT"
+              echo "toolsets=core,config,helm" >> "$GITHUB_OUTPUT"
               ;;
             kubevirt)
-              echo "label-selector=suite=kubevirt" >> $GITHUB_OUTPUT
-              echo "toolsets=core,config,kubevirt,tekton" >> $GITHUB_OUTPUT
+              echo "label-selector=suite=kubevirt" >> "$GITHUB_OUTPUT"
+              echo "toolsets=core,config,kubevirt,tekton" >> "$GITHUB_OUTPUT"
               ;;
             kiali)
-              echo "label-selector=suite=kiali" >> $GITHUB_OUTPUT
-              echo "toolsets=core,config,kiali" >> $GITHUB_OUTPUT
+              echo "label-selector=suite=kiali" >> "$GITHUB_OUTPUT"
+              echo "toolsets=core,config,kiali" >> "$GITHUB_OUTPUT"
               ;;
             tekton)
-              echo "label-selector=suite=tekton" >> $GITHUB_OUTPUT
-              echo "toolsets=core,tekton" >> $GITHUB_OUTPUT
+              echo "label-selector=suite=tekton" >> "$GITHUB_OUTPUT"
+              echo "toolsets=core,tekton" >> "$GITHUB_OUTPUT"
               ;;
             all)
-              echo "label-selector=" >> $GITHUB_OUTPUT  # No filter: run all taskSets
-              echo "toolsets=core,config,helm,kiali,kubevirt,tekton" >> $GITHUB_OUTPUT
+              echo "label-selector=" >> "$GITHUB_OUTPUT"  # No filter: run all taskSets
+              echo "toolsets=core,config,helm,kiali,kubevirt,tekton" >> "$GITHUB_OUTPUT"
               ;;
             *)
               # Default to core suite (matches 'core' or any unrecognized suite)
-              echo "label-selector=suite=core" >> $GITHUB_OUTPUT
-              echo "toolsets=core,config" >> $GITHUB_OUTPUT
+              echo "label-selector=suite=core" >> "$GITHUB_OUTPUT"
+              echo "toolsets=core,config" >> "$GITHUB_OUTPUT"
               ;;
           esac
 
@@ -177,7 +177,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup Kind cluster
-        run: make kind-create-cluster KIND_CLUSTER_NAME=${{ env.KIND_CLUSTER_NAME }}
+        run: make kind-create-cluster KIND_CLUSTER_NAME="$KIND_CLUSTER_NAME"
 
       - name: Install Istio/Kiali and bookinfo demo
         if: contains(needs.check-trigger.outputs.toolsets, 'kiali')
@@ -226,7 +226,7 @@ jobs:
         if: always()
         run: |
           make stop-server || true
-          make kind-delete-cluster KIND_CLUSTER_NAME=${{ env.KIND_CLUSTER_NAME }} || true
+          make kind-delete-cluster KIND_CLUSTER_NAME="$KIND_CLUSTER_NAME" || true
 
       # Compare PR results against baseline from main branch
       - name: Fetch baseline results from main
@@ -271,19 +271,28 @@ jobs:
         if: always() && needs.check-trigger.outputs.is-pr == 'true'
         env:
           DIFF_OUTPUT: ${{ steps.mcpchecker-diff.outputs.diff-output }}
+          PR_NUMBER: ${{ needs.check-trigger.outputs.pr-number }}
+          PR_SHA: ${{ needs.check-trigger.outputs.pr-sha }}
+          TASKS_PASSED: ${{ steps.mcpchecker.outputs.tasks-passed }}
+          TASKS_TOTAL: ${{ steps.mcpchecker.outputs.tasks-total }}
+          TASK_PASS_RATE: ${{ steps.mcpchecker.outputs.task-pass-rate }}
+          ASSERTIONS_PASSED: ${{ steps.mcpchecker.outputs.assertions-passed }}
+          ASSERTIONS_TOTAL: ${{ steps.mcpchecker.outputs.assertions-total }}
+          PASSED: ${{ steps.mcpchecker.outputs.passed }}
+          HAS_DIFF: ${{ steps.diff-check.outputs.has-diff || 'false' }}
         run: |
           mkdir -p eval-context
           cat > eval-context/context.json << EOF
           {
-            "pr_number": "${{ needs.check-trigger.outputs.pr-number }}",
-            "pr_sha": "${{ needs.check-trigger.outputs.pr-sha }}",
-            "tasks_passed": "${{ steps.mcpchecker.outputs.tasks-passed }}",
-            "tasks_total": "${{ steps.mcpchecker.outputs.tasks-total }}",
-            "task_pass_rate": "${{ steps.mcpchecker.outputs.task-pass-rate }}",
-            "assertions_passed": "${{ steps.mcpchecker.outputs.assertions-passed }}",
-            "assertions_total": "${{ steps.mcpchecker.outputs.assertions-total }}",
-            "passed": "${{ steps.mcpchecker.outputs.passed }}",
-            "has_diff": "${{ steps.diff-check.outputs.has-diff || 'false' }}"
+            "pr_number": "${PR_NUMBER}",
+            "pr_sha": "${PR_SHA}",
+            "tasks_passed": "${TASKS_PASSED}",
+            "tasks_total": "${TASKS_TOTAL}",
+            "task_pass_rate": "${TASK_PASS_RATE}",
+            "assertions_passed": "${ASSERTIONS_PASSED}",
+            "assertions_total": "${ASSERTIONS_TOTAL}",
+            "passed": "${PASSED}",
+            "has_diff": "${HAS_DIFF}"
           }
           EOF
           if [ -n "$DIFF_OUTPUT" ]; then


### PR DESCRIPTION
## Summary

Refactors the `mcpchecker` evaluation workflows to reference GitHub event
context (event name, repository, comment body, issue/PR number, workflow run
id, …) through each job's `env:` block and as shell variables, instead of
interpolating `${{ … }}` expressions directly inside `run:` scripts.

This follows the GitHub Actions recommendation for handling event inputs,
keeps shell quoting consistent across the steps, and improves readability.
The `check-trigger` permission check now also returns early when the
commenter is not a collaborator with admin/write access.

No behavior change for scheduled runs, `workflow_dispatch`, or authorized
`/run-mcpchecker` PR comments.

## Changes

- `mcpchecker.yaml`: route `check-trigger` event inputs through `env`; early
  return in the permission gate.
- `mcpchecker-report.yaml`: route `report` event inputs through `env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
