### PR TITLE
ci(release): scope publish workflows to first-party tag-push releases

### DIFF
--- a/.github/workflows/release-mcp-registry.yaml
+++ b/.github/workflows/release-mcp-registry.yaml
@@ -22,7 +22,13 @@ permissions:
 jobs:
   publish:
     name: Publish to MCP Registry
-    if: github.repository == 'containers/kubernetes-mcp-server' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+    # Only act on this repository's own tag-push releases (or a manual dispatch).
+    if: >-
+      github.repository == 'containers/kubernetes-mcp-server' &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-mcpb.yaml
+++ b/.github/workflows/release-mcpb.yaml
@@ -21,7 +21,13 @@ permissions:
 jobs:
   mcpb:
     name: Publish MCPB Bundles
-    if: github.repository == 'containers/kubernetes-mcp-server' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+    # Only act on this repository's own tag-push releases (or a manual dispatch).
+    if: >-
+      github.repository == 'containers/kubernetes-mcp-server' &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository))
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## What

The MCPB bundle (`release-mcpb.yaml`) and MCP Registry (`release-mcp-registry.yaml`) publish workflows trigger on `workflow_run` completions of the `Release` workflow. This scopes their job `if` conditions so they only run for this repository's own tag-push releases (or an explicit `workflow_dispatch`), rather than for any `Release` workflow completion.

## Why

Both jobs read `github.event.workflow_run.*`. Constraining the trigger to a `push` event originating from this repository keeps publishing deterministic and avoids acting on unrelated `Release` completions.

## Notes

No change to the normal release path — a `v*` tag push still produces the bundles and the registry entry exactly as before, and `workflow_dispatch` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
