### PR TITLE
fix(evals): correct core task-definition bugs

### DIFF
--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -179,6 +179,12 @@ jobs:
       - name: Setup Kind cluster
         run: make kind-create-cluster KIND_CLUSTER_NAME="$KIND_CLUSTER_NAME"
 
+      # Only the core suite needs a resize-capable StorageClass (for resize-pvc).
+      # Runs for suite=core and for the "all" run (empty label-selector).
+      - name: Install CSI hostPath driver (resize-capable StorageClass)
+        if: needs.check-trigger.outputs.label-selector == 'suite=core' || needs.check-trigger.outputs.label-selector == ''
+        run: make csi-hostpath-install
+
       - name: Install Istio/Kiali and bookinfo demo
         if: contains(needs.check-trigger.outputs.toolsets, 'kiali')
         run: make setup-kiali

--- a/build/storage.mk
+++ b/build/storage.mk
@@ -1,0 +1,41 @@
+# CSI hostPath driver installation (resize-capable StorageClass for evals)
+#
+# Provides the `csi-hostpath-sc` StorageClass with allowVolumeExpansion: true so
+# the core `resize-pvc` eval task can run. kind's default `standard` StorageClass
+# (rancher.io/local-path) does not support volume expansion.
+
+# Reference-only: the upstream release the vendored manifest was trimmed from
+# (kubernetes-csi/csi-driver-host-path). Used only in the log line below; the
+# actual image tags are pinned inside the manifest, so bumping this alone changes
+# nothing — update dev/config/csi-hostpath/csi-hostpath-driver.yaml to upgrade.
+CSI_HOSTPATH_VERSION ?= v1.17.1
+CSI_HOSTPATH_MANIFEST = dev/config/csi-hostpath/csi-hostpath-driver.yaml
+
+##@ Storage
+
+.PHONY: csi-hostpath-install
+csi-hostpath-install: ## Install a resize-capable hostPath CSI StorageClass (csi-hostpath-sc)
+	@echo "========================================="
+	@echo "Installing hostPath CSI driver (trimmed from $(CSI_HOSTPATH_VERSION))"
+	@echo "========================================="
+	@echo ""
+	@echo "Applying CSI hostPath driver manifest..."
+	@kubectl apply -f $(CSI_HOSTPATH_MANIFEST)
+	@echo ""
+	@echo "Waiting for the CSI hostPath plugin to be ready..."
+	@kubectl rollout status statefulset/csi-hostpathplugin -n csi-driver --timeout=5m
+	@echo "✅ CSI hostPath driver ready (StorageClass: csi-hostpath-sc)"
+
+.PHONY: csi-hostpath-uninstall
+csi-hostpath-uninstall: ## Uninstall the hostPath CSI driver
+	@echo "Uninstalling hostPath CSI driver..."
+	@kubectl delete -f $(CSI_HOSTPATH_MANIFEST) --ignore-not-found
+	@echo "✅ CSI hostPath driver uninstalled"
+
+.PHONY: csi-hostpath-status
+csi-hostpath-status: ## Show hostPath CSI driver status
+	@echo "CSI hostPath pods:"
+	@kubectl get pods -n csi-driver 2>/dev/null || echo "CSI hostPath driver not installed"
+	@echo ""
+	@echo "StorageClasses:"
+	@kubectl get storageclass 2>/dev/null || true

--- a/dev/config/csi-hostpath/csi-hostpath-driver.yaml
+++ b/dev/config/csi-hostpath/csi-hostpath-driver.yaml
@@ -1,0 +1,307 @@
+# Minimal hostPath CSI driver for the eval cluster.
+#
+# Purpose: give the eval cluster a StorageClass that supports volume expansion
+# (allowVolumeExpansion: true) so the core `resize-pvc` task can run. kind's
+# default `standard` StorageClass is rancher.io/local-path, which does not allow
+# expansion, so resize-pvc times out on a plain kind cluster.
+#
+# Trimmed from kubernetes-csi/csi-driver-host-path v1.17.1
+# (deploy/kubernetes-1.30/hostpath). Only the pieces needed to dynamically
+# provision and EXPAND a PersistentVolume are kept:
+#   - hostpath plugin + node-driver-registrar
+#   - external-provisioner (create/delete volumes)
+#   - external-resizer     (expand volumes)
+# The attacher, snapshotter and health-monitor sidecars are intentionally
+# omitted, along with their VolumeSnapshot CRDs and snapshot-controller, which
+# resize-pvc does not need. CSIDriver.attachRequired: false removes the need for
+# the attacher. All image tags are copied verbatim from the upstream v1.17.1
+# deploy bundle; note the plugin image (hostpathplugin:v1.16.1) is versioned
+# independently and intentionally lags the release tag — do not "bump" it to
+# v1.17.1 (no such image tag exists). To refresh, re-copy the tags from that bundle.
+#
+# Installed by `make csi-hostpath-install` (build/storage.mk).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: csi-driver
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-hostpathplugin-sa
+  namespace: csi-driver
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-resizer-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-hostpathplugin-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: csi-driver
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-hostpathplugin-resizer-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: csi-driver
+roleRef:
+  kind: ClusterRole
+  name: external-resizer-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: external-provisioner-cfg
+  namespace: csi-driver
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-hostpathplugin-provisioner-role-cfg
+  namespace: csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: csi-driver
+roleRef:
+  kind: Role
+  name: external-provisioner-cfg
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: external-resizer-cfg
+  namespace: csi-driver
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-hostpathplugin-resizer-role-cfg
+  namespace: csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: csi-hostpathplugin-sa
+    namespace: csi-driver
+roleRef:
+  kind: Role
+  name: external-resizer-cfg
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: hostpath.csi.k8s.io
+spec:
+  # No attacher sidecar is deployed, so volumes must not require attachment.
+  attachRequired: false
+  podInfoOnMount: true
+  fsGroupPolicy: File
+  volumeLifecycleModes:
+    - Persistent
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: csi-hostpathplugin
+  namespace: csi-driver
+  labels:
+    app.kubernetes.io/name: csi-hostpathplugin
+spec:
+  serviceName: "csi-hostpathplugin"
+  # hostPath driver only works with a single replica on a single node.
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: csi-hostpathplugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: csi-hostpathplugin
+    spec:
+      serviceAccountName: csi-hostpathplugin-sa
+      containers:
+        - name: hostpath
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.16.1
+          args:
+            - "--drivername=hostpath.csi.k8s.io"
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          # No livenessProbe: upstream's probe on :9898 is served by the separate
+          # `liveness-probe` sidecar, which is trimmed out here. The hostpathplugin
+          # binary does not serve HTTP health itself, so a probe would connection-
+          # refuse and kubelet would restart the container in a loop. Liveness is not
+          # needed for a throwaway eval driver.
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+            - mountPath: /var/lib/kubelet/plugins
+              mountPropagation: Bidirectional
+              name: plugins-dir
+            - mountPath: /csi-data-dir
+              name: csi-data-dir
+            - mountPath: /dev
+              name: dev-dir
+        - name: node-driver-registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath/csi.sock
+          securityContext:
+            privileged: true
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /registration
+              name: registration-dir
+            - mountPath: /csi-data-dir
+              name: csi-data-dir
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+            - --feature-gates=Topology=true
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+          args:
+            - -v=5
+            - -csi-address=/csi/csi.sock
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-hostpath
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins
+            type: Directory
+          name: plugins-dir
+        - hostPath:
+            # Where PV data is persisted on the host node.
+            path: /var/lib/csi-hostpath-data/
+            type: DirectoryOrCreate
+          name: csi-data-dir
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: dev-dir
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-hostpath-sc
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/evals/tasks/core/filter-events-by-type/filter-events-by-type.yaml
+++ b/evals/tasks/core/filter-events-by-type/filter-events-by-type.yaml
@@ -14,9 +14,15 @@ spec:
       env:
         AGENTS_OUTPUT: "{agent.output}"
       inline: |-
-        bad=$(echo "$AGENTS_OUTPUT" | grep 'Warning events' | grep 'bad-pod' | grep '.events-filter-test. namespace')
-        good=$(echo "$AGENTS_OUTPUT" | grep "good-pod")
-        if [ -n "$bad" ] && [ -z "$good" ]; then
+        # bad-pod's only events are Warning image-pull failures for the bogus image
+        # quay.io/this-image-does-not-exist (see setup.sh). A correct answer surfaces
+        # that content (kubelet's verbatim ErrImagePull / ImagePullBackOff / "Failed to
+        # pull image" messages) and must exclude the healthy good-pod, whose events are
+        # all Normal. Anchor on the event content, not the agent's surrounding prose,
+        # which varies in wording and word order between models (some correct answers
+        # never write the words "Warning" or "bad-pod" at all).
+        if echo "$AGENTS_OUTPUT" | grep -qiE 'ErrImagePull|ImagePullBackOff|Failed to pull image|this-image-does-not-exist' \
+          && ! echo "$AGENTS_OUTPUT" | grep -q 'good-pod'; then
           exit 0
         else
           exit 1

--- a/evals/tasks/core/filter-namespace-by-name/filter-namespace-by-name.yaml
+++ b/evals/tasks/core/filter-namespace-by-name/filter-namespace-by-name.yaml
@@ -14,7 +14,16 @@ spec:
       env:
         AGENTS_OUTPUT: "{agent.output}"
       inline: |-
-        [ X"$(echo "$AGENTS_OUTPUT" | grep -v 'ns-beta')" = X"" ] && exit 0 || exit 1
+        # The task asks for ONLY ns-beta via a field selector; ns-alpha and ns-gamma
+        # must be excluded. Check that ns-beta is present and the other two are absent,
+        # regardless of any surrounding prose (the old every-line grep rejected correct
+        # answers that included a heading or listed the namespace field-by-field).
+        if echo "$AGENTS_OUTPUT" | grep -q 'ns-beta' \
+          && ! echo "$AGENTS_OUTPUT" | grep -qE 'ns-(alpha|gamma)'; then
+          exit 0
+        else
+          exit 1
+        fi
   cleanup:
   - script:
       file: cleanup.sh

--- a/evals/tasks/core/multi-container-pod-communication/cleanup.sh
+++ b/evals/tasks/core/multi-container-pod-communication/cleanup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-kubectl delete pod communication-pod -n multi-container-test --ignore-not-found
-kubectl delete configmap shared-data -n multi-container-test --ignore-not-found
-kubectl delete namespace multi-container-test --ignore-not-found
+kubectl delete pod communication-pod -n multi-container-logging --ignore-not-found
+kubectl delete configmap shared-data -n multi-container-logging --ignore-not-found
+kubectl delete namespace multi-container-logging --ignore-not-found

--- a/evals/tasks/core/multi-container-pod-communication/setup.sh
+++ b/evals/tasks/core/multi-container-pod-communication/setup.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-kubectl delete namespace multi-container-test --ignore-not-found
-kubectl create namespace multi-container-test
+kubectl delete namespace multi-container-logging --ignore-not-found
+kubectl create namespace multi-container-logging

--- a/evals/tasks/core/multi-container-pod-communication/verify.sh
+++ b/evals/tasks/core/multi-container-pod-communication/verify.sh
@@ -31,8 +31,10 @@ if [[ ! "$VOLUMES" == *"logs-volume"* ]]; then
 fi
 
 # is web server accessible
+# nginx-unprivileged listens on 8080 (it cannot bind :80 as a non-root user), so
+# probe 8080 rather than 80 — curl to :80 exits 7 (connection refused).
 echo "Testing web server access..."
-kubectl exec "$POD_NAME" -n "$NAMESPACE" -c web-server -- curl -s -o /dev/null -w "%{http_code}" localhost:80 | grep -q 200
+kubectl exec "$POD_NAME" -n "$NAMESPACE" -c web-server -- curl -s -o /dev/null -w "%{http_code}" localhost:8080 | grep -q 200
 
 # logger container can see the access logs
 echo "Verifying logger container can access nginx logs..."

--- a/evals/tasks/core/resize-pvc/artifacts/storage-pvc.yaml
+++ b/evals/tasks/core/resize-pvc/artifacts/storage-pvc.yaml
@@ -4,6 +4,10 @@ metadata:
   name: storage-pvc
   namespace: resize-pv
 spec:
+  # csi-hostpath-sc allows volume expansion (allowVolumeExpansion: true); kind's
+  # default `standard` StorageClass (rancher.io/local-path) does not, so the
+  # resize would never take effect. Installed via `make csi-hostpath-install`.
+  storageClassName: csi-hostpath-sc
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
## What

Fixes agent-independent bugs in several `core` mcpchecker eval task
definitions (reported in #1238). These tasks failed for every agent
because the task scripts and checks were wrong, not because of agent
capability.

## Changes

**multi-container-pod-communication**
- `verify.sh` curled the nginx-unprivileged container on `localhost:80`,
  but that image only listens on `8080` (it cannot bind `:80` as a
  non-root user), so curl exited 7 and the task never passed. Now probes
  `:8080`.
- `setup.sh` and `cleanup.sh` used the namespace `multi-container-test`
  while the prompt and `verify.sh` use `multi-container-logging`.
  Everything now uses `multi-container-logging`.

**filter-events-by-type and filter-namespace-by-name**
- Both verifies grep'd the agent's prose for a specific wording and word
  order, so correct answers failed depending on how the model phrased
  them. Checked against six weekly gpt-5 runs from the results history,
  two of which never write the words "Warning" or "bad-pod" at all.
- filter-events-by-type now anchors on the event content itself
  (kubelet's verbatim `ErrImagePull` / `ImagePullBackOff` / `Failed to
  pull image` / the bogus image name) and still excludes `good-pod`.
- filter-namespace-by-name now checks that `ns-beta` is present and
  `ns-alpha` / `ns-gamma` are absent, regardless of surrounding prose.

**resize-pvc**
- kind's default `standard` StorageClass (`rancher.io/local-path`) has
  `allowVolumeExpansion: false`, so the resize never took effect and
  verify timed out.
- Adds a trimmed hostPath CSI driver (`dev/config/csi-hostpath/`,
  installed via `make csi-hostpath-install`) that provides a
  `csi-hostpath-sc` StorageClass with `allowVolumeExpansion: true`. The
  manifest is trimmed from csi-driver-host-path v1.17.1 to just the
  plugin, node-driver-registrar, external-provisioner, and
  external-resizer (no attacher, snapshotter, or health-monitor).
- CI installs it for the core suite (and the `all` run) before starting
  the server, and the task PVC points at the new StorageClass.

## Not included

Per the issue, `ssa-field-preservation` (needs an upstream
mcpchecker/kubernetes-extension change) and the `fix-probes`
`maxToolCalls` assertion are left for follow-ups. `fix-service-routing`
and `deployment-traffic-switch` are working as intended and are not
touched.

## Verification

- Ran the two rewritten verifies against six real gpt-5 runs per task
  (mined from the weekly results history) plus synthetic wrong answers:
  all correct answers pass, all wrong answers fail. The old checks failed
  5/6 and 6/6 of the real correct answers.
- Stood up a kind cluster (k8s v1.34) and ran the real `setup.sh` /
  `verify.sh` end to end: `resize-pvc` reaches 3Gi and passes,
  `multi-container-pod-communication` passes on `:8080`, and the CSI
  plugin runs with zero restarts.

Refs #1238