### PR TITLE
feat!(mcp): add 2026-07-28 spec support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/google/gnostic-models v0.7.1
 	github.com/google/jsonschema-go v0.4.3
 	github.com/google/uuid v1.6.0
-	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/prometheus/client_golang v1.24.1
-	github.com/spf13/afero v1.15.0
+	github.com/spf13/afero v1.12.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y
 github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -276,8 +276,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
-github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
+github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
+github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/internal/test/mcp.go
+++ b/internal/test/mcp.go
@@ -351,8 +351,8 @@ func (m *McpClient) GetPrompt(name string, arguments map[string]string) (*mcp.Ge
 }
 
 // SetLoggingLevel sets the logging level on the server
-func (m *McpClient) SetLoggingLevel(level mcp.LoggingLevel) error {
-	return m.Session.SetLoggingLevel(m.ctx, &mcp.SetLoggingLevelParams{
+func (m *McpClient) SetLoggingLevel(level mcp.LoggingLevel) error { //nolint:staticcheck // MCP logging deprecated (SEP-2577)
+	return m.Session.SetLoggingLevel(m.ctx, &mcp.SetLoggingLevelParams{ //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 		Level: level,
 	})
 }
@@ -437,7 +437,7 @@ func parseLogNotification(notification *CapturedNotification) *LogNotification {
 	}
 
 	// The Params field should be *mcp.LoggingMessageParams
-	if params, ok := notification.Params.(*mcp.LoggingMessageParams); ok {
+	if params, ok := notification.Params.(*mcp.LoggingMessageParams); ok { //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 		// Convert Data to string
 		var dataStr string
 		switch v := params.Data.(type) {

--- a/pkg/kubernetes/confirmation_validator.go
+++ b/pkg/kubernetes/confirmation_validator.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/confirmation"
-	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
+	"github.com/containers/kubernetes-mcp-server/pkg/mcplog" //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/pkg/kubernetes/windows_eula_validator.go
+++ b/pkg/kubernetes/windows_eula_validator.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
-	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
+	"github.com/containers/kubernetes-mcp-server/pkg/mcplog" //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"sigs.k8s.io/yaml"

--- a/pkg/kubernetes/windows_eula_validator_test.go
+++ b/pkg/kubernetes/windows_eula_validator_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
-	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
+	"github.com/containers/kubernetes-mcp-server/pkg/mcplog" //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/mcp/common_test.go
+++ b/pkg/mcp/common_test.go
@@ -149,7 +149,7 @@ func (s *BaseMcpSuite) InitMcpClient(options ...test.McpClientOption) {
 // This method sets the logging level to debug to ensure all log messages are received.
 func (s *BaseMcpSuite) StartCapturingLogNotifications() *test.NotificationCapture {
 	// Set logging level to debug to receive all log messages
-	err := s.SetLoggingLevel(mcp.LoggingLevel("debug"))
+	err := s.SetLoggingLevel(mcp.LoggingLevel("debug")) //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 	s.Require().NoError(err, "failed to set logging level")
 
 	return s.StartCapturingNotifications()

--- a/pkg/mcp/elicit.go
+++ b/pkg/mcp/elicit.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
-	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
+	"github.com/containers/kubernetes-mcp-server/pkg/mcplog" //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -136,7 +136,7 @@ func NewServer(ctx context.Context, configuration Configuration, targetProvider 
 					Resources: &mcp.ResourceCapabilities{ListChanged: !configuration.Stateless},
 					Prompts:   &mcp.PromptCapabilities{ListChanged: !configuration.Stateless},
 					Tools:     &mcp.ToolCapabilities{ListChanged: !configuration.Stateless},
-					Logging:   &mcp.LoggingCapabilities{},
+					Logging:   &mcp.LoggingCapabilities{}, //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 				},
 				Instructions: configuration.ServerInstructions,
 				Logger:       sdkLogger,

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
-	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
+	"github.com/containers/kubernetes-mcp-server/pkg/mcplog" //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 	"github.com/containers/kubernetes-mcp-server/pkg/telemetry"
 )
 

--- a/pkg/mcp/testdata/toolsets-config-tools.json
+++ b/pkg/mcp/testdata/toolsets-config-tools.json
@@ -2,6 +2,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Configuration: View"

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -2,6 +2,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Events: List"
@@ -27,6 +28,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Namespaces: List"
@@ -48,6 +50,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Node: Log"
@@ -82,6 +85,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Node: Stats Summary"
@@ -133,6 +137,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Delete"
     },
     "description": "Delete a Kubernetes Pod in the current or provided namespace with the provided name",
@@ -158,7 +163,9 @@
   {
     "annotations": {
       "destructiveHint": true,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Exec"
     },
     "description": "Execute a command in a Kubernetes Pod (shell access, run commands in container) in the current or provided namespace with the provided name and command",
@@ -196,6 +203,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: Get"
@@ -223,6 +231,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: List"
@@ -249,6 +258,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: List in Namespace"
@@ -282,6 +292,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: Log"
@@ -323,7 +334,9 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Run"
     },
     "description": "Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name",
@@ -392,6 +405,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Projects: List"
@@ -409,6 +423,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Create or Update"
     },
     "description": "Create or update a Kubernetes resource via Server-Side Apply. The manifest is the complete desired state: any field this tool previously set and the new manifest omits is removed. To edit an existing resource, fetch it with resources_get, modify it, then re-apply the full resource.\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
@@ -432,6 +447,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Delete"
     },
     "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
@@ -471,6 +487,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Resources: Get"
@@ -508,6 +525,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Resources: List"
@@ -552,6 +570,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Scale"
     },
     "description": "Get or update the scale of a Kubernetes resource in the current cluster by providing its apiVersion, kind, name, and optionally the namespace. If the scale is set in the tool call, the scale will be updated to that value. Always returns the current scale of the resource",

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -18,6 +18,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Configuration: View"
@@ -38,6 +39,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Events: List"
@@ -67,6 +69,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Namespaces: List"
@@ -92,6 +95,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Node: Log"
@@ -130,6 +134,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Node: Stats Summary"
@@ -189,6 +194,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Delete"
     },
     "description": "Delete a Kubernetes Pod in the current or provided namespace with the provided name",
@@ -218,7 +224,9 @@
   {
     "annotations": {
       "destructiveHint": true,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Exec"
     },
     "description": "Execute a command in a Kubernetes Pod (shell access, run commands in container) in the current or provided namespace with the provided name and command",
@@ -260,6 +268,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: Get"
@@ -291,6 +300,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: List"
@@ -321,6 +331,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: List in Namespace"
@@ -358,6 +369,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: Log"
@@ -403,7 +415,9 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Run"
     },
     "description": "Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name",
@@ -480,6 +494,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Projects: List"
@@ -502,6 +517,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Create or Update"
     },
     "description": "Create or update a Kubernetes resource via Server-Side Apply. The manifest is the complete desired state: any field this tool previously set and the new manifest omits is removed. To edit an existing resource, fetch it with resources_get, modify it, then re-apply the full resource.\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
@@ -529,6 +545,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Delete"
     },
     "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
@@ -572,6 +589,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Resources: Get"
@@ -613,6 +631,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Resources: List"
@@ -661,6 +680,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Scale"
     },
     "description": "Get or update the scale of a Kubernetes resource in the current cluster by providing its apiVersion, kind, name, and optionally the namespace. If the scale is set in the tool call, the scale will be updated to that value. Always returns the current scale of the resource",

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -2,6 +2,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Configuration: View"
@@ -22,6 +23,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Events: List"
@@ -47,6 +49,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Namespaces: List"
@@ -68,6 +71,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Node: Log"
@@ -102,6 +106,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Node: Stats Summary"
@@ -153,6 +158,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Delete"
     },
     "description": "Delete a Kubernetes Pod in the current or provided namespace with the provided name",
@@ -178,7 +184,9 @@
   {
     "annotations": {
       "destructiveHint": true,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Exec"
     },
     "description": "Execute a command in a Kubernetes Pod (shell access, run commands in container) in the current or provided namespace with the provided name and command",
@@ -216,6 +224,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: Get"
@@ -243,6 +252,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: List"
@@ -269,6 +279,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: List in Namespace"
@@ -302,6 +313,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: Log"
@@ -343,7 +355,9 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Run"
     },
     "description": "Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name",
@@ -412,6 +426,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Projects: List"
@@ -429,6 +444,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Create or Update"
     },
     "description": "Create or update a Kubernetes resource via Server-Side Apply. The manifest is the complete desired state: any field this tool previously set and the new manifest omits is removed. To edit an existing resource, fetch it with resources_get, modify it, then re-apply the full resource.\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
@@ -452,6 +468,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Delete"
     },
     "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
@@ -491,6 +508,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Resources: Get"
@@ -528,6 +546,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Resources: List"
@@ -572,6 +591,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Scale"
     },
     "description": "Get or update the scale of a Kubernetes resource in the current cluster by providing its apiVersion, kind, name, and optionally the namespace. If the scale is set in the tool call, the scale will be updated to that value. Always returns the current scale of the resource",

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -2,6 +2,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Configuration: View"
@@ -22,6 +23,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Events: List"
@@ -47,6 +49,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Namespaces: List"
@@ -68,6 +71,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Node: Log"
@@ -102,6 +106,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Node: Stats Summary"
@@ -153,6 +158,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Delete"
     },
     "description": "Delete a Kubernetes Pod in the current or provided namespace with the provided name",
@@ -178,7 +184,9 @@
   {
     "annotations": {
       "destructiveHint": true,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Exec"
     },
     "description": "Execute a command in a Kubernetes Pod (shell access, run commands in container) in the current or provided namespace with the provided name and command",
@@ -216,6 +224,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: Get"
@@ -243,6 +252,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: List"
@@ -269,6 +279,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: List in Namespace"
@@ -302,6 +313,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Pods: Log"
@@ -343,7 +355,9 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Pods: Run"
     },
     "description": "Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name",
@@ -412,6 +426,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Projects: List"
@@ -429,6 +444,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Create or Update"
     },
     "description": "Create or update a Kubernetes resource via Server-Side Apply. The manifest is the complete desired state: any field this tool previously set and the new manifest omits is removed. To edit an existing resource, fetch it with resources_get, modify it, then re-apply the full resource.\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
@@ -452,6 +468,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Delete"
     },
     "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
@@ -491,6 +508,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Resources: Get"
@@ -528,6 +546,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Resources: List"
@@ -572,6 +591,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Resources: Scale"
     },
     "description": "Get or update the scale of a Kubernetes resource in the current cluster by providing its apiVersion, kind, name, and optionally the namespace. If the scale is set in the tool call, the scale will be updated to that value. Always returns the current scale of the resource",

--- a/pkg/mcp/testdata/toolsets-helm-tools.json
+++ b/pkg/mcp/testdata/toolsets-helm-tools.json
@@ -2,7 +2,9 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Helm: Install"
     },
     "description": "Install (deploy) a Helm chart to create a release in the current or provided namespace",
@@ -37,6 +39,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Helm: List"
@@ -63,6 +66,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Helm: Uninstall"
     },
     "description": "Uninstall a Helm release in the current or provided namespace",

--- a/pkg/mcp/testdata/toolsets-kiali-tools.json
+++ b/pkg/mcp/testdata/toolsets-kiali-tools.json
@@ -2,6 +2,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Workload: Logs"
@@ -64,6 +65,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Get Mesh Status"
@@ -79,6 +81,7 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
       "title": "Get Mesh Traffic Graph"
@@ -380,6 +383,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Manage Istio, Gateway API, and Inference API Config: Create, Patch, Delete"
     },
     "description": "Create, patch, or delete Istio, Gateway API, and Inference API config. Supports Istio resources (networking.istio.io, security.istio.io), Gateway API resources (gateway.networking.k8s.io), and Inference API resources (inference.networking.k8s.io) when installed on the cluster. For list and get (read-only) use manage_istio_config_read.",

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -4,6 +4,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false,
+      "readOnlyHint": false,
       "title": "Virtual Machine: Clone"
     },
     "description": "Clone a VirtualMachine on KubeVirt by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the KubeVirt Clone API",
@@ -37,6 +38,7 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false,
+      "readOnlyHint": false,
       "title": "Virtual Machine: Create"
     },
     "description": "Create a VirtualMachine on KubeVirt with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.",
@@ -200,7 +202,9 @@
   {
     "annotations": {
       "destructiveHint": true,
+      "idempotentHint": false,
       "openWorldHint": false,
+      "readOnlyHint": false,
       "title": "Virtual Machine: Lifecycle"
     },
     "description": "Manage KubeVirt VirtualMachine lifecycle: start, stop, or restart a VM",

--- a/pkg/mcp/testdata/toolsets-tekton-tools.json
+++ b/pkg/mcp/testdata/toolsets-tekton-tools.json
@@ -2,7 +2,9 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": false,
+      "readOnlyHint": false,
       "title": "Tekton: Start Pipeline"
     },
     "description": "Start a Tekton Pipeline by creating a PipelineRun that references it",
@@ -34,7 +36,9 @@
   {
     "annotations": {
       "destructiveHint": true,
+      "idempotentHint": false,
       "openWorldHint": true,
+      "readOnlyHint": false,
       "title": "Tekton: PipelineRun Lifecycle"
     },
     "description": "Manage a Tekton PipelineRun lifecycle by restarting it with the same spec or cancelling it by setting spec.status to Cancelled.",
@@ -103,7 +107,9 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": false,
+      "readOnlyHint": false,
       "title": "Tekton: Start Task"
     },
     "description": "Start a Tekton Task by creating a TaskRun that references it",
@@ -169,7 +175,9 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": false,
       "openWorldHint": false,
+      "readOnlyHint": false,
       "title": "Tekton: Restart TaskRun"
     },
     "description": "Restart a Tekton TaskRun by creating a new TaskRun with the same spec",

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/confirmation"
-	"github.com/containers/kubernetes-mcp-server/pkg/mcplog"
+	"github.com/containers/kubernetes-mcp-server/pkg/mcplog" //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"k8s.io/utils/ptr"

--- a/pkg/mcplog/log.go
+++ b/pkg/mcplog/log.go
@@ -1,3 +1,8 @@
+// Package mcplog sends log notifications to MCP clients via the MCP logging capability.
+//
+// Deprecated: The MCP logging feature is deprecated as of protocol version 2026-07-28 (SEP-2577).
+// Migrate to consuming stderr output (for STDIO servers) or OpenTelemetry.
+// See https://modelcontextprotocol.io/seps/2577-deprecate-roots-sampling-and-logging.
 package mcplog
 
 import (
@@ -166,8 +171,8 @@ func SendMCPLog(ctx context.Context, level Level, message string) {
 
 	message = Sanitize(message)
 
-	if err := session.Log(ctx, &mcp.LoggingMessageParams{
-		Level:  mcp.LoggingLevel(level.String()),
+	if err := session.Log(ctx, &mcp.LoggingMessageParams{ //nolint:staticcheck // MCP logging deprecated (SEP-2577)
+		Level:  mcp.LoggingLevel(level.String()), //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 		Logger: "kubernetes-mcp-server",
 		Data:   message,
 	}); err != nil {


### PR DESCRIPTION
This PR bumps to the first RC for the 1.7.0 MCP SDK, which includes support for the new spec version and some deprecations. We mostly seem to be affected by logging so far.

If you test this out with a client and see any issues, please leave comments here so we can investigate and fix/report upstream.