### PR TITLE
fix(pods): propagate Kubernetes API error message in pods_log

### DIFF
--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -8,6 +8,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	labelutil "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -143,14 +144,38 @@ func (c *Core) PodsLog(ctx context.Context, namespace, name, container string, p
 
 	req := pods.GetLogs(name, logOptions)
 	res := req.Do(ctx)
-	if res.Error() != nil {
-		return "", res.Error()
+	if err := res.Error(); err != nil {
+		return "", extractKubernetesError(err)
 	}
 	rawData, err := res.Raw()
 	if err != nil {
 		return "", err
 	}
 	return string(rawData), nil
+}
+
+// extractKubernetesError ensures the returned error carries the actual message
+// from the Kubernetes API server. client-go's StatusError.Error() returns only
+// ErrStatus.Message, which some error paths leave empty (e.g., HTTP 400 from
+// the pod log endpoint when a container has been terminated). In those cases
+// the real server message is preserved in StatusDetails.Causes — extract it
+// so callers receive an actionable error instead of an empty string.
+func extractKubernetesError(err error) error {
+	var statusErr *apierrors.StatusError
+	if !errors.As(err, &statusErr) {
+		return err
+	}
+	if statusErr.ErrStatus.Message != "" {
+		return err
+	}
+	if details := statusErr.ErrStatus.Details; details != nil {
+		for _, cause := range details.Causes {
+			if cause.Message != "" {
+				return fmt.Errorf("%s: %s", statusErr.ErrStatus.Reason, cause.Message)
+			}
+		}
+	}
+	return fmt.Errorf("%s (HTTP %d)", statusErr.ErrStatus.Reason, statusErr.ErrStatus.Code)
 }
 
 func (c *Core) PodsRun(ctx context.Context, namespace, name, image string, port int32) ([]*unstructured.Unstructured, error) {

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	labelutil "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/kubernetes/pods_test.go
+++ b/pkg/kubernetes/pods_test.go
@@ -1,10 +1,12 @@
 package kubernetes
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -105,4 +107,92 @@ func (s *ResolveContainerSuite) TestResolveContainer() {
 
 func TestResolveContainer(t *testing.T) {
 	suite.Run(t, new(ResolveContainerSuite))
+}
+
+type ExtractKubernetesErrorSuite struct {
+	suite.Suite
+}
+
+func (s *ExtractKubernetesErrorSuite) TestExtractKubernetesError() {
+	s.Run("non-StatusError is returned as-is", func() {
+		original := fmt.Errorf("some network error")
+		s.Equal(original, extractKubernetesError(original))
+	})
+	s.Run("wrapped non-StatusError is returned as-is", func() {
+		inner := fmt.Errorf("connection refused")
+		wrapped := fmt.Errorf("request failed: %w", inner)
+		s.Equal(wrapped, extractKubernetesError(wrapped))
+	})
+	s.Run("StatusError with non-empty message is returned as-is", func() {
+		err := &apierrors.StatusError{ErrStatus: metav1.Status{
+			Message: "pods \"my-pod\" not found",
+			Reason:  metav1.StatusReasonNotFound,
+			Code:    404,
+		}}
+		s.Equal(err, extractKubernetesError(err))
+	})
+	s.Run("StatusError with empty message extracts cause", func() {
+		err := &apierrors.StatusError{ErrStatus: metav1.Status{
+			Reason: metav1.StatusReasonBadRequest,
+			Code:   400,
+			Details: &metav1.StatusDetails{
+				Causes: []metav1.StatusCause{
+					{Message: `container "buggy-app" in pod "buggy-app-abc123" not found`},
+				},
+			},
+		}}
+		result := extractKubernetesError(err)
+		s.Contains(result.Error(), "BadRequest")
+		s.Contains(result.Error(), `container "buggy-app" in pod "buggy-app-abc123" not found`)
+	})
+	s.Run("StatusError with empty message and multiple causes uses first non-empty", func() {
+		err := &apierrors.StatusError{ErrStatus: metav1.Status{
+			Reason: metav1.StatusReasonBadRequest,
+			Code:   400,
+			Details: &metav1.StatusDetails{
+				Causes: []metav1.StatusCause{
+					{Message: ""},
+					{Message: "the real error message"},
+				},
+			},
+		}}
+		result := extractKubernetesError(err)
+		s.Contains(result.Error(), "the real error message")
+	})
+	s.Run("StatusError with empty message and no details falls back to reason and code", func() {
+		err := &apierrors.StatusError{ErrStatus: metav1.Status{
+			Reason: metav1.StatusReasonBadRequest,
+			Code:   400,
+		}}
+		s.Equal("BadRequest (HTTP 400)", extractKubernetesError(err).Error())
+	})
+	s.Run("StatusError with empty message and empty causes falls back to reason and code", func() {
+		err := &apierrors.StatusError{ErrStatus: metav1.Status{
+			Reason: metav1.StatusReasonBadRequest,
+			Code:   400,
+			Details: &metav1.StatusDetails{
+				Causes: []metav1.StatusCause{},
+			},
+		}}
+		s.Equal("BadRequest (HTTP 400)", extractKubernetesError(err).Error())
+	})
+	s.Run("wrapped StatusError with empty message extracts cause", func() {
+		inner := &apierrors.StatusError{ErrStatus: metav1.Status{
+			Reason: metav1.StatusReasonBadRequest,
+			Code:   400,
+			Details: &metav1.StatusDetails{
+				Causes: []metav1.StatusCause{
+					{Message: "container not found"},
+				},
+			},
+		}}
+		wrapped := fmt.Errorf("log retrieval failed: %w", inner)
+		result := extractKubernetesError(wrapped)
+		s.NotEqual(wrapped, result)
+		s.Contains(result.Error(), "container not found")
+	})
+}
+
+func TestExtractKubernetesError(t *testing.T) {
+	suite.Run(t, new(ExtractKubernetesErrorSuite))
 }


### PR DESCRIPTION
# Bug/Improvement: Kubernetes MCP `pods_log` returns opaque error for terminated containers

**Component:** kubernetes-mcp-server
**Severity:** Low (non-blocking — the agent continues with available data)
**Type:** Bug + Improvement

## Description

When the AI agent calls `pods_log` on a pod whose container has terminated and been cleaned up by the container runtime, the Kubernetes MCP server returns a generic `Error (code 1): None`. The actual Kubernetes API error — `container "buggy-demo-app" in pod "buggy-demo-app-58964dc486-k8s44" not found` — is swallowed and not propagated through the MCP error response.

This has two consequences:

1. **For the agent:** it receives no actionable information about why the log retrieval failed, so it cannot reason about the failure or adjust its strategy (e.g., skip to other data sources, look for a replacement pod).
2. **For the operator:** the warning log `Tool call failed: Kubernetes MCP → pods_log: Error (code 1): None` provides no diagnostic value without cross-referencing the Kubernetes API directly.

## Steps to Reproduce

1. Deploy the `buggy-demo-app` in the `demo-app` namespace.
2. Wait for (or cause) the pod's container to terminate — e.g., the container exits with code 143 (SIGTERM) and is not restarted, leaving the pod in a terminated state.
3. Open the OCP Troubleshooter UI and submit a prompt such as:
   > "Troubleshoot the application buggy-demo-app in the demo-app namespace. Check pod health, look at Prometheus metrics for error rates and latency, retrieve logs, and give me a full diagnosis."
4. The agent will call `pods_list_in_namespace`, discover the pod, then call `pods_log` on it.
5. Observe in the `ocp-troubleshooter` container logs:
   ```
   [WARNING] agent — Tool call failed: OpenShift MCP → pods_log: Error (code 1): None
   ```
6. The OGX sidecar logs (in the stored response object) contain the actual Kubernetes error:
   ```
   container "buggy-demo-app" in pod "buggy-demo-app-58964dc486-k8s44" not found
   ```
   This message is captured by the MCP server but not included in the MCP error response sent back to the agent.

## Observed Behaviour

| Timestamp (UTC)     | Tool Call        | Result |
|----------------------|------------------|--------|
| 2026-06-15 15:43:41 | `pods_log`       | `Error (code 1): None` |
| 2026-06-15 16:27:44 | `pods_log`       | `Error (code 1): None` |
| 2026-06-15 16:32:14 | `pods_log`       | `Error (code 1): None` |
| 2026-06-15 16:56:51 | `pods_log`       | Success (different pod: `working-demo-app`) |
| 2026-06-15 17:02:54 | `pods_log`       | Success (same pod, different invocation context) |
| 2026-06-15 17:41:14 | `pods_log`       | `Error (code 1): None` |
| 2026-06-15 17:42:27 | `pods_log`       | Success |

**Root cause:** Pod `buggy-demo-app-58964dc486-k8s44` had its container terminated since 2026-06-10 (exit code 143 / SIGTERM). The container runtime no longer exposes logs for it, so the Kubernetes API returns a "container not found" error.
