### PR TITLE
feat(kiali): update tool schemas for Gateway API and Inference API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,25 +462,25 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 - **kiali_get_mesh_status** - Retrieves the high-level health, topology, and environment details of the Istio service mesh. Returns multi-cluster control plane status (istiod), data plane namespace health (including ambient mesh status), observability stack health (Prometheus, Grafana...), and component connectivity. Use this tool as the first step to diagnose mesh-wide issues, verify Istio/Kiali versions, or check overall health before drilling into specific workloads.
 
-- **kiali_manage_istio_config_read** - Read Istio config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names. 'get' returns full YAML. For writes use manage_istio_config.
+- **kiali_manage_istio_config_read** - Read Istio, Gateway API, and Inference API config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names; omit group/kind to retrieve ALL config types in a single call. Supports Istio (networking.istio.io, security.istio.io), Gateway API (gateway.networking.k8s.io), and Inference API (inference.networking.k8s.io) when installed. 'get' returns full YAML. For writes use manage_istio_config.
   - `action` (`string`) **(required)** - Action to perform (read-only)
   - `clusterName` (`string`) - Optional cluster name. Defaults to the cluster name in the Kiali configuration.
-  - `group` (`string`) - API group of the Istio object. Required for 'get' action.
-  - `kind` (`string`) - Kind of the Istio object. Required for 'get' action.
+  - `group` (`string`) - API group of the Istio object. Required ONLY for 'get' action. For 'list', OMIT group and kind to retrieve ALL config types in a single call. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.
+  - `kind` (`string`) - Kind of the Istio object. Required ONLY for 'get' action. For 'list', OMIT to return all kinds at once — do NOT call separately for each kind.
   - `namespace` (`string`) - Namespace containing the Istio object. For 'list', if not provided, returns objects across all namespaces. For 'get', required.
   - `object` (`string`) - Name of the Istio object. Required for 'get' action.
   - `serviceName` (`string`) - Filter Istio configurations (VirtualServices, DestinationRules, and their referenced Gateways) that affect a specific service. Only applicable for 'list' action
-  - `version` (`string`) - API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action.
+  - `version` (`string`) - API version. Use 'v1' for all resource types. Required for 'get' action.
 
-- **kiali_manage_istio_config** - Create, patch, or delete Istio config. For list and get (read-only) use manage_istio_config_read.
+- **kiali_manage_istio_config** - Create, patch, or delete Istio, Gateway API, and Inference API config. Supports Istio resources (networking.istio.io, security.istio.io), Gateway API resources (gateway.networking.k8s.io), and Inference API resources (inference.networking.k8s.io) when installed on the cluster. For list and get (read-only) use manage_istio_config_read.
   - `action` (`string`) **(required)** - Action to perform (write)
   - `clusterName` (`string`) - Optional cluster name. Defaults to the cluster name in the Kiali configuration.
-  - `data` (`string`) - Complete JSON or YAML data to apply or create the object. Required for create and patch actions. You MUST provide a COMPLETE and VALID manifest with ALL required fields for the resource type. Arrays (like servers, http, etc.) are REPLACED entirely, so you must include ALL required fields within each array element.
-  - `group` (`string`) **(required)** - API group of the Istio object
+  - `data` (`string`) - JSON or YAML data for the resource. Required for create and patch actions. For create, you can provide partial content (e.g. only spec) and it will be merged onto a valid template with defaults. Arrays (like servers, http, etc.) are REPLACED entirely, so include ALL elements you want.
+  - `group` (`string`) **(required)** - API group of the Istio object. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.
   - `kind` (`string`) **(required)** - Kind of the Istio object (e.g., 'VirtualService', 'DestinationRule').
-  - `namespace` (`string`) **(required)** - Namespace containing the Istio object
-  - `object` (`string`) **(required)** - Name of the Istio object
-  - `version` (`string`) **(required)** - API version. Use 'v1' for VirtualService, DestinationRule, and Gateway.
+  - `namespace` (`string`) **(required)** - Namespace containing the Istio object.
+  - `object` (`string`) **(required)** - Name of the Istio object.
+  - `version` (`string`) **(required)** - API version. Use 'v1' for all resource types.
 
 - **kiali_get_resource_details** - Fetches a list of resources OR retrieves detailed data for a specific resource. If 'resourceName' is omitted, it returns a list. If 'resourceName' is provided, it returns details for that specific resource.
   - `clusterName` (`string`) - Optional. Name of the cluster to get resources from. If not provided, will use the default cluster name in the Kiali KubeConfig

--- a/build/kiali.mk
+++ b/build/kiali.mk
@@ -25,6 +25,11 @@ istioctl:
 		rm -rf $$TMPDIR ;\
 	}
 
+# Install Gateway API CRDs required for Gateway API eval tasks and Kiali AI tools
+.PHONY: install-gateway-api-crds
+install-gateway-api-crds:
+	@evals/tasks/kiali/scripts/ensure_gateway_api_crds.sh
+
 # Install Istio (demo profile) and enable sidecar injection in default namespace
 .PHONY: install-istio
 install-istio: istioctl
@@ -76,4 +81,4 @@ expose-kiali:
 	echo "Kiali is being exposed on http://localhost:20001"
 
 .PHONY: setup-kiali
-setup-kiali: install-istio update-kiali-version install-bookinfo-demo expose-kiali expose-bookinfo-demo ## Setup Kiali
+setup-kiali: install-istio install-gateway-api-crds update-kiali-version install-bookinfo-demo expose-kiali expose-bookinfo-demo ## Setup Kiali

--- a/evals/tasks/kiali/README.md
+++ b/evals/tasks/kiali/README.md
@@ -21,10 +21,16 @@ The `update_tasks` target runs `scripts/update_tasks.sh`, which parses every sce
 ## Tasks defined
 <!-- TASKS-START -->
 - Configuration Management
+  - [easy] gateway-api-list-httproutes (List Gateway API HTTPRoutes)
+        **Prompt:** *|*
+  - [easy] inference-api-list-pools (List Inference API Pools)
+        **Prompt:** *|*
   - [easy] istio-list (List and Validate VirtualServices)
         **Prompt:** *|*
   - [easy] istio-list-destination-rules (List and Validate DestinationRules)
         **Prompt:** *"List all DestinationRules in the 'bookinfo' namespace and report if any of them have validation errors."*
+  - [medium] gateway-api-create-httproute (Create Gateway API HTTPRoute)
+        **Prompt:** *|*
   - [medium] istio-create (Create Istio Gateway)
         **Prompt:** *"Create a new Istio Gateway named 'my-gateway' in the 'istio-system' namespace."*
   - [medium] istio-delete (Remove Fault Injection)

--- a/evals/tasks/kiali/gateway-api-create-httproute/cleanup.sh
+++ b/evals/tasks/kiali/gateway-api-create-httproute/cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kubectl delete httproute eval-create-route -n bookinfo --ignore-not-found
+kubectl delete gateway eval-gateway -n bookinfo --ignore-not-found

--- a/evals/tasks/kiali/gateway-api-create-httproute/gateway-api-create-httproute.yaml
+++ b/evals/tasks/kiali/gateway-api-create-httproute/gateway-api-create-httproute.yaml
@@ -1,0 +1,30 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kiali
+  name: "Create Gateway API HTTPRoute"
+  category: "Configuration Management"
+  description: "Creates a Kubernetes Gateway API HTTPRoute in bookinfo using manage_istio_config."
+  difficulty: medium
+spec:
+  requires:
+  - extension: kubernetes
+    as: k8s
+  setup:
+  - script:
+      file: ./setup.sh
+      timeout: 180s
+  verify:
+  - script:
+      file: ./verify.sh
+      timeout: 30s
+  cleanup:
+  - script:
+      file: ./cleanup.sh
+      timeout: 60s
+  prompt:
+    inline: |
+      Create a Kubernetes Gateway API HTTPRoute named 'eval-create-route' in the 'bookinfo' namespace.
+      This is an HTTPRoute in the gateway.networking.k8s.io API group (not an Istio VirtualService).
+      Route traffic to the 'productpage' service on port 9080 using parent gateway 'eval-gateway'.

--- a/evals/tasks/kiali/gateway-api-create-httproute/setup.sh
+++ b/evals/tasks/kiali/gateway-api-create-httproute/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/../scripts/ensure_gateway_api_crds.sh"
+
+cat <<'EOF' | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: eval-gateway
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+EOF

--- a/evals/tasks/kiali/gateway-api-create-httproute/verify.sh
+++ b/evals/tasks/kiali/gateway-api-create-httproute/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS="bookinfo"
+NAME="eval-create-route"
+
+if kubectl get httproute "$NAME" -n "$NS" >/dev/null 2>&1; then
+  echo "Verified: HTTPRoute '$NAME' exists in namespace '$NS'."
+else
+  echo "HTTPRoute '$NAME' not found in namespace '$NS'."
+  exit 1
+fi

--- a/evals/tasks/kiali/gateway-api-list-httproutes/cleanup.sh
+++ b/evals/tasks/kiali/gateway-api-list-httproutes/cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kubectl delete httproute eval-list-route -n bookinfo --ignore-not-found
+kubectl delete gateway eval-gateway -n bookinfo --ignore-not-found

--- a/evals/tasks/kiali/gateway-api-list-httproutes/gateway-api-list-httproutes.yaml
+++ b/evals/tasks/kiali/gateway-api-list-httproutes/gateway-api-list-httproutes.yaml
@@ -1,0 +1,29 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kiali
+  name: "List Gateway API HTTPRoutes"
+  category: "Configuration Management"
+  description: "Lists Kubernetes Gateway API HTTPRoute resources in a namespace using manage_istio_config_read."
+  difficulty: easy
+spec:
+  requires:
+  - extension: kubernetes
+    as: k8s
+  setup:
+  - script:
+      file: ./setup.sh
+      timeout: 180s
+  verify:
+  - llmJudge:
+      contains: "eval-list-route"
+  cleanup:
+  - script:
+      file: ./cleanup.sh
+      timeout: 60s
+  prompt:
+    inline: |
+      List all Kubernetes Gateway API HTTPRoute resources in the 'bookinfo' namespace.
+      These are HTTPRoute objects in the gateway.networking.k8s.io API group (not Istio VirtualServices).
+      Summarize the HTTPRoute names you found and mention eval-list-route if it appears.

--- a/evals/tasks/kiali/gateway-api-list-httproutes/setup.sh
+++ b/evals/tasks/kiali/gateway-api-list-httproutes/setup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/../scripts/ensure_gateway_api_crds.sh"
+
+cat <<'EOF' | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: eval-gateway
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: eval-list-route
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  parentRefs:
+  - name: eval-gateway
+    namespace: bookinfo
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: productpage
+      port: 9080
+EOF

--- a/evals/tasks/kiali/inference-api-list-pools/cleanup.sh
+++ b/evals/tasks/kiali/inference-api-list-pools/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kubectl delete inferencepool eval-list-pool -n bookinfo --ignore-not-found

--- a/evals/tasks/kiali/inference-api-list-pools/inference-api-list-pools.yaml
+++ b/evals/tasks/kiali/inference-api-list-pools/inference-api-list-pools.yaml
@@ -1,0 +1,29 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kiali
+  name: "List Inference API Pools"
+  category: "Configuration Management"
+  description: "Lists InferencePool resources in a namespace using manage_istio_config_read."
+  difficulty: easy
+spec:
+  requires:
+  - extension: kubernetes
+    as: k8s
+  setup:
+  - script:
+      file: ./setup.sh
+      timeout: 180s
+  verify:
+  - llmJudge:
+      contains: "eval-list-pool"
+  cleanup:
+  - script:
+      file: ./cleanup.sh
+      timeout: 60s
+  prompt:
+    inline: |
+      List all InferencePool resources in the 'bookinfo' namespace.
+      These are InferencePool objects in the inference.networking.k8s.io API group.
+      Summarize the InferencePool names you found and mention eval-list-pool if it appears.

--- a/evals/tasks/kiali/inference-api-list-pools/setup.sh
+++ b/evals/tasks/kiali/inference-api-list-pools/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/../scripts/ensure_inference_api_crds.sh"
+
+cat <<'EOF' | kubectl apply -f -
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: eval-list-pool
+  namespace: bookinfo
+  labels:
+    gevals.kiali.io/test: gevals-testing
+spec:
+  targetPorts:
+  - number: 8000
+  selector:
+    matchLabels:
+      app: example-model
+  endpointPickerRef:
+    group: ""
+    kind: Service
+    name: example-epp
+    port:
+      number: 9002
+    failureMode: FailClose
+EOF

--- a/evals/tasks/kiali/scripts/ensure_gateway_api_crds.sh
+++ b/evals/tasks/kiali/scripts/ensure_gateway_api_crds.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.5.0}"
+
+if kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; then
+  echo "Gateway API CRDs already installed"
+  exit 0
+fi
+
+echo "Installing Gateway API CRDs ${GATEWAY_API_VERSION}..."
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}" | kubectl apply -f -

--- a/evals/tasks/kiali/scripts/ensure_inference_api_crds.sh
+++ b/evals/tasks/kiali/scripts/ensure_inference_api_crds.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INFERENCE_API_VERSION="${INFERENCE_API_VERSION:-v1.5.0}"
+
+if kubectl get crd inferencepools.inference.networking.k8s.io >/dev/null 2>&1; then
+  echo "Inference API CRDs already installed"
+  exit 0
+fi
+
+echo "Installing Inference API CRDs ${INFERENCE_API_VERSION}..."
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${INFERENCE_API_VERSION}" | kubectl apply -f -

--- a/pkg/mcp/testdata/toolsets-kiali-tools.json
+++ b/pkg/mcp/testdata/toolsets-kiali-tools.json
@@ -364,9 +364,9 @@
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
-      "title": "Manage Istio Config: Create, Patch, Delete"
+      "title": "Manage Istio, Gateway API, and Inference API Config: Create, Patch, Delete"
     },
-    "description": "Create, patch, or delete Istio config. For list and get (read-only) use manage_istio_config_read.",
+    "description": "Create, patch, or delete Istio, Gateway API, and Inference API config. Supports Istio resources (networking.istio.io, security.istio.io), Gateway API resources (gateway.networking.k8s.io), and Inference API resources (inference.networking.k8s.io) when installed on the cluster. For list and get (read-only) use manage_istio_config_read.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -383,14 +383,16 @@
           "type": "string"
         },
         "data": {
-          "description": "Complete JSON or YAML data to apply or create the object. Required for create and patch actions. You MUST provide a COMPLETE and VALID manifest with ALL required fields for the resource type. Arrays (like servers, http, etc.) are REPLACED entirely, so you must include ALL required fields within each array element.",
+          "description": "JSON or YAML data for the resource. Required for create and patch actions. For create, you can provide partial content (e.g. only spec) and it will be merged onto a valid template with defaults. Arrays (like servers, http, etc.) are REPLACED entirely, so include ALL elements you want.",
           "type": "string"
         },
         "group": {
-          "description": "API group of the Istio object",
+          "description": "API group of the Istio object. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.",
           "enum": [
             "networking.istio.io",
-            "security.istio.io"
+            "security.istio.io",
+            "gateway.networking.k8s.io",
+            "inference.networking.k8s.io"
           ],
           "type": "string"
         },
@@ -407,20 +409,26 @@
             "EnvoyFilter",
             "AuthorizationPolicy",
             "PeerAuthentication",
-            "RequestAuthentication"
+            "RequestAuthentication",
+            "HTTPRoute",
+            "GRPCRoute",
+            "ReferenceGrant",
+            "TCPRoute",
+            "TLSRoute",
+            "InferencePool"
           ],
           "type": "string"
         },
         "namespace": {
-          "description": "Namespace containing the Istio object",
+          "description": "Namespace containing the Istio object.",
           "type": "string"
         },
         "object": {
-          "description": "Name of the Istio object",
+          "description": "Name of the Istio object.",
           "type": "string"
         },
         "version": {
-          "description": "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway.",
+          "description": "API version. Use 'v1' for all resource types.",
           "type": "string"
         }
       },
@@ -435,7 +443,7 @@
       "type": "object"
     },
     "name": "kiali_manage_istio_config",
-    "title": "Manage Istio Config: Create, Patch, Delete"
+    "title": "Manage Istio, Gateway API, and Inference API Config: Create, Patch, Delete"
   },
   {
     "annotations": {
@@ -443,9 +451,9 @@
       "idempotentHint": true,
       "openWorldHint": true,
       "readOnlyHint": true,
-      "title": "Manage Istio Config: List or Get"
+      "title": "Manage Istio, Gateway API, and Inference API Config: List or Get"
     },
-    "description": "Read Istio config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names. 'get' returns full YAML. For writes use manage_istio_config.",
+    "description": "Read Istio, Gateway API, and Inference API config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names; omit group/kind to retrieve ALL config types in a single call. Supports Istio (networking.istio.io, security.istio.io), Gateway API (gateway.networking.k8s.io), and Inference API (inference.networking.k8s.io) when installed. 'get' returns full YAML. For writes use manage_istio_config.",
     "inputSchema": {
       "dependentRequired": {
         "object": [
@@ -469,15 +477,17 @@
           "type": "string"
         },
         "group": {
-          "description": "API group of the Istio object. Required for 'get' action.",
+          "description": "API group of the Istio object. Required ONLY for 'get' action. For 'list', OMIT group and kind to retrieve ALL config types in a single call. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.",
           "enum": [
             "networking.istio.io",
-            "security.istio.io"
+            "security.istio.io",
+            "gateway.networking.k8s.io",
+            "inference.networking.k8s.io"
           ],
           "type": "string"
         },
         "kind": {
-          "description": "Kind of the Istio object. Required for 'get' action.",
+          "description": "Kind of the Istio object. Required ONLY for 'get' action. For 'list', OMIT to return all kinds at once — do NOT call separately for each kind.",
           "enum": [
             "VirtualService",
             "DestinationRule",
@@ -489,7 +499,13 @@
             "EnvoyFilter",
             "AuthorizationPolicy",
             "PeerAuthentication",
-            "RequestAuthentication"
+            "RequestAuthentication",
+            "HTTPRoute",
+            "GRPCRoute",
+            "ReferenceGrant",
+            "TCPRoute",
+            "TLSRoute",
+            "InferencePool"
           ],
           "type": "string"
         },
@@ -506,7 +522,7 @@
           "type": "string"
         },
         "version": {
-          "description": "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action.",
+          "description": "API version. Use 'v1' for all resource types. Required for 'get' action.",
           "type": "string"
         }
       },
@@ -516,6 +532,6 @@
       "type": "object"
     },
     "name": "kiali_manage_istio_config_read",
-    "title": "Manage Istio Config: List or Get"
+    "title": "Manage Istio, Gateway API, and Inference API Config: List or Get"
   }
 ]

--- a/pkg/toolsets/kiali/tools/manage_istio_config.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config.go
@@ -17,7 +17,7 @@ func InitManageIstioConfig() []api.ServerTool {
 	ret = append(ret, api.ServerTool{
 		Tool: api.Tool{
 			Name:        name,
-			Description: "Create, patch, or delete Istio config. For list and get (read-only) use manage_istio_config_read.",
+			Description: "Create, patch, or delete Istio, Gateway API, and Inference API config. Supports Istio resources (networking.istio.io, security.istio.io), Gateway API resources (gateway.networking.k8s.io), and Inference API resources (inference.networking.k8s.io) when installed on the cluster. For list and get (read-only) use manage_istio_config_read.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -28,29 +28,29 @@ func InitManageIstioConfig() []api.ServerTool {
 					},
 					"namespace": {
 						Type:        "string",
-						Description: "Namespace containing the Istio object",
+						Description: "Namespace containing the Istio object.",
 					},
 					"group": {
 						Type:        "string",
-						Description: "API group of the Istio object",
-						Enum:        []any{"networking.istio.io", "security.istio.io"},
+						Description: "API group of the Istio object. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.",
+						Enum:        []any{"networking.istio.io", "security.istio.io", "gateway.networking.k8s.io", "inference.networking.k8s.io"},
 					},
 					"version": {
 						Type:        "string",
-						Description: "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway.",
+						Description: "API version. Use 'v1' for all resource types.",
 					},
 					"kind": {
 						Type:        "string",
 						Description: "Kind of the Istio object (e.g., 'VirtualService', 'DestinationRule').",
-						Enum:        []any{"VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication"},
+						Enum:        []any{"VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication", "HTTPRoute", "GRPCRoute", "ReferenceGrant", "TCPRoute", "TLSRoute", "InferencePool"},
 					},
 					"object": {
 						Type:        "string",
-						Description: "Name of the Istio object",
+						Description: "Name of the Istio object.",
 					},
 					"data": {
 						Type:        "string",
-						Description: "Complete JSON or YAML data to apply or create the object. Required for create and patch actions. You MUST provide a COMPLETE and VALID manifest with ALL required fields for the resource type. Arrays (like servers, http, etc.) are REPLACED entirely, so you must include ALL required fields within each array element.",
+						Description: "JSON or YAML data for the resource. Required for create and patch actions. For create, you can provide partial content (e.g. only spec) and it will be merged onto a valid template with defaults. Arrays (like servers, http, etc.) are REPLACED entirely, so include ALL elements you want.",
 					},
 					"clusterName": {
 						Type:        "string",
@@ -60,7 +60,7 @@ func InitManageIstioConfig() []api.ServerTool {
 				Required: []string{"action", "namespace", "group", "version", "kind", "object"},
 			},
 			Annotations: api.ToolAnnotations{
-				Title:           "Manage Istio Config: Create, Patch, Delete",
+				Title:           "Manage Istio, Gateway API, and Inference API Config: Create, Patch, Delete",
 				ReadOnlyHint:    ptr.To(false),
 				DestructiveHint: ptr.To(true),
 				IdempotentHint:  ptr.To(true),

--- a/pkg/toolsets/kiali/tools/manage_istio_config_read.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config_read.go
@@ -17,8 +17,10 @@ func InitManageIstioConfigRead() []api.ServerTool {
 	ret = append(ret, api.ServerTool{
 		Tool: api.Tool{
 			Name: name,
-			Description: "Read Istio config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} " +
-				"where valid/invalid arrays contain resource names. 'get' returns full YAML. For writes use manage_istio_config.",
+			Description: "Read Istio, Gateway API, and Inference API config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} " +
+				"where valid/invalid arrays contain resource names; omit group/kind to retrieve ALL config types in a single call. " +
+				"Supports Istio (networking.istio.io, security.istio.io), Gateway API (gateway.networking.k8s.io), and Inference API (inference.networking.k8s.io) when installed. " +
+				"'get' returns full YAML. For writes use manage_istio_config.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -33,17 +35,17 @@ func InitManageIstioConfigRead() []api.ServerTool {
 					},
 					"group": {
 						Type:        "string",
-						Description: "API group of the Istio object. Required for 'get' action.",
-						Enum:        []any{"networking.istio.io", "security.istio.io"},
+						Description: "API group of the Istio object. Required ONLY for 'get' action. For 'list', OMIT group and kind to retrieve ALL config types in a single call. Use 'gateway.networking.k8s.io' for Gateway API resources. Use 'inference.networking.k8s.io' for Inference API resources.",
+						Enum:        []any{"networking.istio.io", "security.istio.io", "gateway.networking.k8s.io", "inference.networking.k8s.io"},
 					},
 					"version": {
 						Type:        "string",
-						Description: "API version. Use 'v1' for VirtualService, DestinationRule, and Gateway. Required for 'get' action.",
+						Description: "API version. Use 'v1' for all resource types. Required for 'get' action.",
 					},
 					"kind": {
 						Type:        "string",
-						Description: "Kind of the Istio object. Required for 'get' action.",
-						Enum:        []any{"VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication"},
+						Description: "Kind of the Istio object. Required ONLY for 'get' action. For 'list', OMIT to return all kinds at once \u2014 do NOT call separately for each kind.",
+						Enum:        []any{"VirtualService", "DestinationRule", "Gateway", "ServiceEntry", "Sidecar", "WorkloadEntry", "WorkloadGroup", "EnvoyFilter", "AuthorizationPolicy", "PeerAuthentication", "RequestAuthentication", "HTTPRoute", "GRPCRoute", "ReferenceGrant", "TCPRoute", "TLSRoute", "InferencePool"},
 					},
 					"object": {
 						Type:        "string",
@@ -64,7 +66,7 @@ func InitManageIstioConfigRead() []api.ServerTool {
 				},
 			},
 			Annotations: api.ToolAnnotations{
-				Title:           "Manage Istio Config: List or Get",
+				Title:           "Manage Istio, Gateway API, and Inference API Config: List or Get",
 				ReadOnlyHint:    ptr.To(true),
 				DestructiveHint: ptr.To(false),
 				IdempotentHint:  ptr.To(true),


### PR DESCRIPTION
## Summary

Companion PR for https://github.com/kiali/kiali/pull/9988

- Update `manage_istio_config` and `manage_istio_config_read` tool schema descriptions to support Gateway API and Inference API resources
- Clarify that `group`/`kind` are optional for list actions (omitting returns all types in one call)
- Correct version guidance: use `v1` for all resource types
- Update `data` description to reflect partial-create merge semantics
- Regenerate golden test snapshot

## Test plan

- [x] `go test ./pkg/mcp/ -run TestToolsets` passes
- [x] Golden snapshot updated and verified


Made with [Cursor](https://cursor.com)