### PR TITLE
Feature: bootstrap oauth UI for safer use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@ _output/
 node_modules/
 
 .npmrc
+
+# Local secrets — the bootstrap OAuth signing key (MCP_AUTH_SECRET) lives here.
+# Never commit it: it can decrypt/forge every client registration and access token.
+.env
+.env.*
+!.env.example
+
 kubernetes-mcp-server
 !charts/kubernetes-mcp-server
 !cmd/kubernetes-mcp-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:latest AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
@@ -12,7 +12,13 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL io.modelcontextprotocol.server.name="io.github.containers/kubernetes-mcp-server"
 WORKDIR /app
 COPY --from=builder /app/kubernetes-mcp-server /app/kubernetes-mcp-server
+
+# Provide a writable HOME for the non-root user (required for kubeconfig bootstrap).
+ENV HOME=/home/nonroot
+RUN mkdir -p "${HOME}/.kube" && chown -R 65532:65532 "${HOME}"
+
 USER 65532:65532
+ENV KUBECONFIG="${HOME}/.kube/config"
 ENTRYPOINT ["/app/kubernetes-mcp-server"]
 CMD ["--port", "8080"]
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 .DEFAULT_GOAL := help
 
 PACKAGE = $(shell go list -m)
-GIT_COMMIT_HASH = $(shell git rev-parse HEAD)
-GIT_VERSION = $(shell git describe --tags --always --dirty)
+GIT_COMMIT_HASH = $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
+GIT_VERSION = $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
 BUILD_TIME = $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 BINARY_NAME = kubernetes-mcp-server
 WEBSITE_URL = https://github.com/containers/kubernetes-mcp-server

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ For direct binary usage:
 kubernetes-mcp-server --port 9890 --bootstrap-ui --cluster-provider kubeconfig --kubeconfig ~/.kube/config
 ```
 
-Set `MCP_AUTH_SECRET` to a stable 32-byte base64url value if issued OAuth tokens must survive server restarts. If it is unset, the server uses an ephemeral key for the current process.
+Set `MCP_AUTH_SECRET` to a stable 32-byte base64url value so issued OAuth tokens and client registrations survive server restarts. If it is unset, the server generates a new ephemeral key on every start, which invalidates all previously registered clients — they will be shown a "Reconnect required" page. Use a **unique** secret per server, keep it out of version control (e.g. in a gitignored `.env`), and note that **rotating it forces every connected client to re-authenticate once**. See [Signing key persistence and rotation](docs/configuration.md#signing-key-mcp_auth_secret--persistence-and-rotation) for details.
 
 ## 📊 MCP Logging <a id="mcp-logging"></a>
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ uvx kubernetes-mcp-server@latest --help
 | `--read-only`             | If set, the MCP server will run in read-only mode, meaning it will not allow any write operations (create, update, delete) on the Kubernetes cluster. This is useful for debugging or inspecting the cluster without making changes.                                                          |
 | `--disable-destructive`   | If set, the MCP server will disable all destructive operations (delete, update, etc.) on the Kubernetes cluster. This is useful for debugging or inspecting the cluster without accidentally making changes. This option has no effect when `--read-only` is used.                            |
 | `--stateless`             | If set, the MCP server will run in stateless mode, disabling tool and prompt change notifications. This is useful for container deployments, load balancing, and serverless environments where maintaining client state is not desired.                                                       |
+| `--bootstrap-ui`          | Enables local HTTP bootstrap mode. The server protects `/mcp` with internal OAuth, serves `/kube/login`, and waits for a validated kubeconfig before connecting to Kubernetes. Requires `--port`.                                                                                              |
 | `--toolsets`              | Comma-separated list of toolsets to enable. Check the [🛠️ Tools and Functionalities](#tools-and-functionalities) section for more information.                                                                                                                                                |
 | `--disable-multi-cluster` | If set, the MCP server will disable multi-cluster support and will only use the current context from the kubeconfig file. This is useful if you want to restrict the MCP server to a single cluster.                                                                                          |
 | `--cluster-provider`      | Cluster provider strategy to use (one of: kubeconfig, in-cluster, kcp, disabled). If not set, the server will auto-detect based on the environment.                                                                                                                                           |
@@ -243,6 +244,24 @@ For comprehensive TOML configuration documentation, including:
 - OAuth/OIDC authentication for HTTP mode ([Keycloak](docs/KEYCLOAK_OIDC_SETUP.md), [Microsoft Entra ID](docs/ENTRA_ID_SETUP.md))
 
 See the **[Configuration Reference](docs/configuration.md)**.
+
+### Bootstrap UI mode
+
+Bootstrap UI mode is useful for containerized local runs where the server should not connect to Kubernetes until a user supplies a kubeconfig in the browser:
+
+```shell
+docker compose up --build
+```
+
+Then open `http://localhost:9890/kube/login`, choose or paste a kubeconfig, and let the server validate it before MCP clients use `http://localhost:9890/mcp`.
+
+For direct binary usage:
+
+```shell
+kubernetes-mcp-server --port 9890 --bootstrap-ui --cluster-provider kubeconfig --kubeconfig ~/.kube/config
+```
+
+Set `MCP_AUTH_SECRET` to a stable 32-byte base64url value if issued OAuth tokens must survive server restarts. If it is unset, the server uses an ephemeral key for the current process.
 
 ## 📊 MCP Logging <a id="mcp-logging"></a>
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,10 +10,14 @@
 ####   docker compose up --build
 ####
 #### Then open:
-####   http://localhost:9890/kube/login
+####   http://localhost:9790/kube/login
 ####
 #### MCP client URL:
-####   http://localhost:9890/mcp
+####   http://localhost:9790/mcp
+####
+#### Optional: set MCP_AUTH_SECRET in a .env file to keep bearer tokens valid across restarts.
+####   If unset, the server generates one at startup and logs it at INFO — copy it to .env to reuse.
+####   Generate with: openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
 ####
 services:
   kubernetes-mcp-server:
@@ -37,6 +41,14 @@ services:
       - "9790:8080"
 
     restart: unless-stopped
+
+    environment:
+      # OAuth signing key (32 bytes, base64url). Optional — if unset, the server generates
+      # one at startup and logs it at INFO. Set it to keep bearer tokens valid across restarts.
+      MCP_AUTH_SECRET: ${MCP_AUTH_SECRET:-}
+
+      # Access token lifetime. Default: 10h. Override to shorten or extend.
+      MCP_AUTH_ACCESS_TTL: ${MCP_AUTH_ACCESS_TTL:-10h}
 
     volumes:
       - kubeconfig:/home/nonroot/.kube

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,45 @@
+####
+#### Kubernetes MCP Server — local bootstrap via Docker Compose (HTTP + SSE)
+####
+#### This compose file runs the server in "bootstrap UI" mode:
+####   - /mcp is protected by internal OAuth (PKCE)
+####   - the server does NOT connect to Kubernetes until you validate a kubeconfig in the browser
+####   - kubeconfig is persisted in a named volume mounted at /home/nonroot/.kube
+####
+#### Quickstart:
+####   docker compose up --build
+####
+#### Then open:
+####   http://localhost:9890/kube/login
+####
+#### MCP client URL:
+####   http://localhost:9890/mcp
+####
+services:
+  kubernetes-mcp-server:
+    image: kubernetes-mcp-server:local
+
+    build:
+      context: .
+
+    command:
+      - --port
+      - "8080"
+      - --bootstrap-ui
+      - --cluster-provider
+      - kubeconfig
+      - --kubeconfig
+      - /home/nonroot/.kube/config
+
+    ports:
+      # Map a unique host port, matching the local remote-MCP convention used
+      # by the Viasat MCP servers.
+      - "9790:8080"
+
+    restart: unless-stopped
+
+    volumes:
+      - kubeconfig:/home/nonroot/.kube
+
+volumes:
+  kubeconfig:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -480,6 +480,7 @@ Configure OAuth/OIDC authentication for HTTP mode deployments.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `bootstrap_ui` | boolean | `false` | When `true`, enables local browser bootstrap mode. The server acts as its own OAuth 2.1 authorization server, protects `/mcp` with sealed bearer tokens, serves `/kube/login`, and does not connect to Kubernetes until a kubeconfig is validated. Requires HTTP mode (`port`) and `cluster_auth_mode = "kubeconfig"`. |
 | `require_oauth` | boolean | `false` | When `true`, requires OAuth authentication for all requests. This **DOES NOT** determine validation strategy, which is done separately by `authorization_url` and `skip_jwt_verification` |
 | `oauth_audience` | string | `""` | Valid audience for OAuth tokens (for offline JWT claim validation). |
 | `authorization_url` | string | `""` | URL of the OIDC authorization server for token validation and STS exchange. |
@@ -498,6 +499,29 @@ Configure OAuth/OIDC authentication for HTTP mode deployments.
 | `cluster_auth_mode` | string | `""` | Cluster auth mode: `passthrough` (forward Authorization header when present, fall back to kubeconfig when absent) or `kubeconfig` (always use kubeconfig credentials). Defaults to `passthrough`. |
 | `certificate_authority` | string | `""` | Path to CA certificate for validating authorization server connections. |
 | `server_url` | string | `""` | Public URL of the MCP server (used for OAuth metadata). |
+
+#### Bootstrap UI mode
+
+Bootstrap UI mode is separate from the external OAuth/OIDC `require_oauth` flow. In this mode, keep `require_oauth = false`; the server provides internal OAuth discovery, dynamic client registration, PKCE authorization, and sealed access tokens for MCP clients. Kubernetes access always uses the kubeconfig selected through `/kube/login`.
+
+**Example:**
+```toml
+port = "8080"
+bootstrap_ui = true
+cluster_auth_mode = "kubeconfig"
+cluster_provider_strategy = "kubeconfig"
+kubeconfig = "/home/nonroot/.kube/config"
+```
+
+`bootstrap_ui` is not compatible with `require_oauth`, `oauth_audience`, `authorization_url`, `skip_jwt_verification`, or `certificate_authority`. `server_url` may still be set when the server is behind a proxy so OAuth metadata advertises the correct public URL.
+
+Set `MCP_AUTH_SECRET` to a stable 32-byte base64url-encoded value when tokens should survive process restarts:
+
+```shell
+MCP_AUTH_SECRET="$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=')"
+```
+
+If `MCP_AUTH_SECRET` is not set, the server generates an ephemeral key for the current process.
 
 **Example (with client secret):**
 ```toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -515,13 +515,51 @@ kubeconfig = "/home/nonroot/.kube/config"
 
 `bootstrap_ui` is not compatible with `require_oauth`, `oauth_audience`, `authorization_url`, `skip_jwt_verification`, or `certificate_authority`. `server_url` may still be set when the server is behind a proxy so OAuth metadata advertises the correct public URL.
 
-Set `MCP_AUTH_SECRET` to a stable 32-byte base64url-encoded value when tokens should survive process restarts:
+##### Signing key (`MCP_AUTH_SECRET`) — persistence and rotation
 
-```shell
-MCP_AUTH_SECRET="$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=')"
-```
+In bootstrap UI mode the server is **stateless**: it keeps no database or session
+store. Every OAuth artifact — the dynamic client registration (`client_id`), the
+authorization request, the authorization code, and the access token — is sealed
+(AES-256-GCM) into the token itself using `MCP_AUTH_SECRET`. Validating any of
+them means unsealing it with that same key.
 
-If `MCP_AUTH_SECRET` is not set, the server generates an ephemeral key for the current process.
+Consequences of this design:
+
+- **Set a stable secret in production.** If `MCP_AUTH_SECRET` is unset, the server
+  generates a **new ephemeral key on every process start** and logs it at `INFO`.
+  Any client that registered under the previous key can no longer be validated —
+  its `/authorize` request fails and the user is shown a *"Reconnect required"*
+  page. Persist a stable value so registrations and tokens survive restarts:
+
+  ```shell
+  MCP_AUTH_SECRET="$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=')"
+  ```
+
+  With Docker Compose, put it in a `.env` file next to `docker-compose.yaml`
+  (the compose file reads `MCP_AUTH_SECRET: ${MCP_AUTH_SECRET:-}`). **Never commit
+  `.env`** — the secret can decrypt and forge every token this server issues.
+
+- **Use a unique secret per server.** Do **not** share one `MCP_AUTH_SECRET`
+  across multiple MCP servers. Servers never validate each other's tokens, so a
+  shared key buys nothing and widens blast radius: one leaked secret would let an
+  attacker forge tokens against every server that shares it. One stable, unique
+  key per server.
+
+- **Rotating the secret forces every client to re-authenticate.** Rotation is the
+  intended way to invalidate all outstanding tokens (for example after a suspected
+  leak or an operator handover). After you change `MCP_AUTH_SECRET` and restart,
+  all connected MCP clients hit the *"Reconnect required"* page **once** and must
+  reconnect. Communicate rotations to users; the reconnect procedure is:
+
+  1. In the MCP client, remove/disconnect this server so it drops the stale saved
+     credential (in Claude Code: `/mcp` → select the server → disconnect, or
+     re-run `claude mcp add`).
+  2. Reconnect / re-add the server. The client registers again automatically and
+     reopens `/kube/login`.
+  3. Complete the kubeconfig login; access is restored once validation succeeds.
+
+Access-token lifetime is controlled separately by `MCP_AUTH_ACCESS_TTL`
+(default `10h`).
 
 **Example (with client secret):**
 ```toml

--- a/pkg/bootstrap/kubeconfig.go
+++ b/pkg/bootstrap/kubeconfig.go
@@ -1,0 +1,298 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"net/url"
+	"os"
+	"sort"
+	"time"
+
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type ClusterFacts struct {
+	APIServerURL   string
+	APIHost        string
+	ContextName    string
+	UserName       string
+	AuthMethod     string
+	ClusterVersion string
+	RedirectURL    template.URL
+
+	Namespaces      []string
+	Nodes           []string
+	ServiceAccounts []string
+	CRDs            []string
+	Tools           []string
+
+	NamespaceCount      int
+	NodeCount           int
+	ServiceAccountCount int
+	CRDCount            int
+
+	InventoryWarnings []string
+}
+
+func ValidateKubeconfig(ctx context.Context, kubeconfigPath string, maxItems int) (*ClusterFacts, error) {
+	b, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read kubeconfig: %w", err)
+	}
+	cfg, err := clientcmd.Load(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+
+	contextName, err := resolveContextName(cfg)
+	if err != nil {
+		return nil, err
+	}
+	ctxEntry := cfg.Contexts[contextName]
+	if ctxEntry == nil {
+		return nil, fmt.Errorf("kubeconfig context %q not found", contextName)
+	}
+
+	clusterName := ctxEntry.Cluster
+	userName := ctxEntry.AuthInfo
+
+	cluster := cfg.Clusters[clusterName]
+	if cluster == nil {
+		return nil, fmt.Errorf("kubeconfig cluster %q not found", clusterName)
+	}
+	apiServerURL := cluster.Server
+
+	authMethod := classifyAuthMethod(cfg, userName)
+
+	restCfg, err := restConfigForContext(kubeconfigPath, contextName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Defensive timeout in case the caller did not set one.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+	}
+
+	cs, err := clientset.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	nsList, err := cs.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespaces: %w", err)
+	}
+	nodeList, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	namespaces := make([]string, 0, len(nsList.Items))
+	for i := range nsList.Items {
+		namespaces = append(namespaces, nsList.Items[i].Name)
+	}
+	sort.Strings(namespaces)
+	namespaceCount := len(namespaces)
+
+	nodes := make([]string, 0, len(nodeList.Items))
+	for i := range nodeList.Items {
+		nodes = append(nodes, nodeList.Items[i].Name)
+	}
+	sort.Strings(nodes)
+	nodeCount := len(nodes)
+
+	warnings := make([]string, 0)
+	clusterVersion := ""
+	if version, err := cs.Discovery().ServerVersion(); err != nil {
+		warnings = append(warnings, fmt.Sprintf("Cluster version unavailable: %v", err))
+	} else if version != nil {
+		clusterVersion = version.GitVersion
+	}
+
+	serviceAccounts, serviceAccountCount, err := listServiceAccounts(ctx, cs, maxItems)
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("Service accounts unavailable: %v", err))
+	}
+
+	crds, crdCount, err := listCRDs(ctx, restCfg, maxItems)
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("CRDs unavailable: %v", err))
+	}
+
+	if maxItems > 0 {
+		namespaces = limit(namespaces, maxItems)
+		nodes = limit(nodes, maxItems)
+	}
+
+	return &ClusterFacts{
+		APIServerURL:        apiServerURL,
+		APIHost:             apiHost(apiServerURL),
+		ContextName:         contextName,
+		UserName:            userName,
+		AuthMethod:          authMethod,
+		ClusterVersion:      clusterVersion,
+		Namespaces:          namespaces,
+		Nodes:               nodes,
+		ServiceAccounts:     serviceAccounts,
+		CRDs:                crds,
+		NamespaceCount:      namespaceCount,
+		NodeCount:           nodeCount,
+		ServiceAccountCount: serviceAccountCount,
+		CRDCount:            crdCount,
+		InventoryWarnings:   warnings,
+	}, nil
+}
+
+func listServiceAccounts(ctx context.Context, cs *clientset.Clientset, maxItems int) ([]string, int, error) {
+	saList, err := cs.CoreV1().ServiceAccounts(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, 0, err
+	}
+	serviceAccounts := make([]string, 0, len(saList.Items))
+	for i := range saList.Items {
+		serviceAccounts = append(serviceAccounts, saList.Items[i].Namespace+"/"+saList.Items[i].Name)
+	}
+	sort.Strings(serviceAccounts)
+	count := len(serviceAccounts)
+	if maxItems > 0 {
+		serviceAccounts = limit(serviceAccounts, maxItems)
+	}
+	return serviceAccounts, count, nil
+}
+
+func listCRDs(ctx context.Context, restCfg *rest.Config, maxItems int) ([]string, int, error) {
+	cs, err := apiextensionsclientset.NewForConfig(restCfg)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create apiextensions client: %w", err)
+	}
+	crdList, err := cs.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, 0, err
+	}
+	crds := make([]string, 0, len(crdList.Items))
+	for i := range crdList.Items {
+		crds = append(crds, crdList.Items[i].Name)
+	}
+	sort.Strings(crds)
+	count := len(crds)
+	if maxItems > 0 {
+		crds = limit(crds, maxItems)
+	}
+	return crds, count, nil
+}
+
+func apiHost(apiServerURL string) string {
+	u, err := url.Parse(apiServerURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+func (f *ClusterFacts) normalize() {
+	if f == nil {
+		return
+	}
+	if f.APIHost == "" {
+		f.APIHost = apiHost(f.APIServerURL)
+	}
+	if f.NamespaceCount == 0 && len(f.Namespaces) > 0 {
+		f.NamespaceCount = len(f.Namespaces)
+	}
+	if f.NodeCount == 0 && len(f.Nodes) > 0 {
+		f.NodeCount = len(f.Nodes)
+	}
+	if f.ServiceAccountCount == 0 && len(f.ServiceAccounts) > 0 {
+		f.ServiceAccountCount = len(f.ServiceAccounts)
+	}
+	if f.CRDCount == 0 && len(f.CRDs) > 0 {
+		f.CRDCount = len(f.CRDs)
+	}
+}
+
+func resolveContextName(cfg *clientcmdapi.Config) (string, error) {
+	if cfg.CurrentContext != "" {
+		return cfg.CurrentContext, nil
+	}
+	if len(cfg.Contexts) == 1 {
+		for name := range cfg.Contexts {
+			return name, nil
+		}
+	}
+	if len(cfg.Contexts) == 0 {
+		return "", fmt.Errorf("kubeconfig has no contexts")
+	}
+	// Keep message actionable and consistent with Manager's behavior.
+	names := make([]string, 0, len(cfg.Contexts))
+	for name := range cfg.Contexts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return "", fmt.Errorf("kubeconfig current-context is not set and multiple contexts are available (%s); set one with 'kubectl config use-context <context-name>'", join(names))
+}
+
+func restConfigForContext(kubeconfigPath, contextName string) (*rest.Config, error) {
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath}
+	clientCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{CurrentContext: contextName},
+	)
+	restCfg, err := clientCfg.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rest config: %w", err)
+	}
+	// Apply a default timeout for all requests made via this rest.Config.
+	restCfg.Timeout = 10 * time.Second
+	return restCfg, nil
+}
+
+func classifyAuthMethod(cfg *clientcmdapi.Config, userName string) string {
+	auth := cfg.AuthInfos[userName]
+	if auth == nil {
+		return "unknown"
+	}
+	if auth.Exec != nil {
+		return "exec"
+	}
+	if auth.Token != "" || auth.TokenFile != "" {
+		return "token"
+	}
+	if len(auth.ClientCertificateData) > 0 || auth.ClientCertificate != "" {
+		return "client-cert"
+	}
+	if auth.Username != "" && auth.Password != "" {
+		return "basic"
+	}
+	return "unknown"
+}
+
+func limit(in []string, max int) []string {
+	if max <= 0 || len(in) <= max {
+		return in
+	}
+	out := make([]string, 0, max)
+	out = append(out, in[:max]...)
+	return out
+}
+
+func join(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	sep := ", "
+	// Manual join avoids pulling in strings for a single call site.
+	s := items[0]
+	for i := 1; i < len(items); i++ {
+		s += sep + items[i]
+	}
+	return s
+}

--- a/pkg/bootstrap/pkce.go
+++ b/pkg/bootstrap/pkce.go
@@ -1,0 +1,59 @@
+package bootstrap
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+)
+
+// VerifyPKCES256 checks that verifier matches the given S256 code challenge.
+func VerifyPKCES256(codeChallenge, codeVerifier string) error {
+	if codeChallenge == "" {
+		return errors.New("code_challenge is required")
+	}
+	if !isValidCodeVerifier(codeVerifier) {
+		return errors.New("invalid code_verifier")
+	}
+	sum := sha256.Sum256([]byte(codeVerifier))
+	expected := base64.RawURLEncoding.EncodeToString(sum[:])
+	if expected != codeChallenge {
+		return fmt.Errorf("pkce verification failed")
+	}
+	return nil
+}
+
+// S256Challenge computes the S256 code challenge for a verifier.
+func S256Challenge(codeVerifier string) (string, error) {
+	if !isValidCodeVerifier(codeVerifier) {
+		return "", errors.New("invalid code_verifier")
+	}
+	sum := sha256.Sum256([]byte(codeVerifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}
+
+// isValidCodeVerifier applies RFC 7636 character and length requirements.
+//
+// code_verifier MUST be between 43 and 128 characters, and contain only
+// unreserved characters: ALPHA / DIGIT / "-" / "." / "_" / "~".
+func isValidCodeVerifier(v string) bool {
+	if len(v) < 43 || len(v) > 128 {
+		return false
+	}
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+			continue
+		case c >= 'A' && c <= 'Z':
+			continue
+		case c >= '0' && c <= '9':
+			continue
+		case c == '-' || c == '.' || c == '_' || c == '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/bootstrap/preview.go
+++ b/pkg/bootstrap/preview.go
@@ -1,0 +1,354 @@
+package bootstrap
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/yaml"
+)
+
+type KubeconfigPreview struct {
+	Valid                  bool                       `json:"valid"`
+	Format                 string                     `json:"format"`
+	APIVersion             string                     `json:"apiVersion"`
+	Kind                   string                     `json:"kind"`
+	CurrentContext         string                     `json:"currentContext"`
+	DeclaredCurrentContext string                     `json:"declaredCurrentContext,omitempty"`
+	Clusters               []KubeconfigClusterPreview `json:"clusters"`
+	Users                  []KubeconfigUserPreview    `json:"users"`
+	Contexts               []KubeconfigContextPreview `json:"contexts"`
+}
+
+type KubeconfigClusterPreview struct {
+	Name                  string                       `json:"name"`
+	Server                string                       `json:"server"`
+	Host                  string                       `json:"host,omitempty"`
+	TLSServerName         string                       `json:"tlsServerName,omitempty"`
+	InsecureSkipTLSVerify bool                         `json:"insecureSkipTLSVerify,omitempty"`
+	Current               bool                         `json:"current"`
+	ContextNames          []string                     `json:"contextNames,omitempty"`
+	Certificate           KubeconfigCertificatePreview `json:"certificate"`
+}
+
+type KubeconfigCertificatePreview struct {
+	Present       bool     `json:"present"`
+	Source        string   `json:"source,omitempty"`
+	Summary       string   `json:"summary,omitempty"`
+	ExpiresAt     string   `json:"expiresAt,omitempty"`
+	ExpiresInDays int      `json:"expiresInDays,omitempty"`
+	Expired       bool     `json:"expired,omitempty"`
+	Subjects      []string `json:"subjects,omitempty"`
+	Issuers       []string `json:"issuers,omitempty"`
+	Error         string   `json:"error,omitempty"`
+}
+
+type KubeconfigUserPreview struct {
+	Name                 string `json:"name"`
+	AuthMethod           string `json:"authMethod"`
+	TokenPreview         string `json:"tokenPreview,omitempty"`
+	TokenFile            string `json:"tokenFile,omitempty"`
+	ExecCommand          string `json:"execCommand,omitempty"`
+	Username             string `json:"username,omitempty"`
+	HasClientCertificate bool   `json:"hasClientCertificate,omitempty"`
+	HasClientKey         bool   `json:"hasClientKey,omitempty"`
+}
+
+type KubeconfigContextPreview struct {
+	Name      string `json:"name"`
+	Cluster   string `json:"cluster"`
+	User      string `json:"user"`
+	Namespace string `json:"namespace,omitempty"`
+	Current   bool   `json:"current"`
+}
+
+type kubeconfigTypeMeta struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+}
+
+func PreviewKubeconfig(raw []byte) (*KubeconfigPreview, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("kubeconfig content is empty")
+	}
+
+	format := "yaml"
+	if json.Valid(raw) {
+		format = "json"
+	}
+
+	var meta kubeconfigTypeMeta
+	if err := yaml.Unmarshal(raw, &meta); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML/JSON metadata: %w", err)
+	}
+	if meta.APIVersion != "" && meta.APIVersion != "v1" {
+		return nil, fmt.Errorf("unsupported kubeconfig apiVersion %q (expected v1)", meta.APIVersion)
+	}
+	if meta.Kind != "" && meta.Kind != "Config" {
+		return nil, fmt.Errorf("unsupported kubeconfig kind %q (expected Config)", meta.Kind)
+	}
+
+	cfg, err := clientcmd.Load(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig YAML/JSON: %w", err)
+	}
+	currentContext, err := resolveContextName(cfg)
+	if err != nil {
+		return nil, err
+	}
+	currentCtx := cfg.Contexts[currentContext]
+	if currentCtx == nil {
+		return nil, fmt.Errorf("kubeconfig context %q not found", currentContext)
+	}
+	if currentCtx.Cluster == "" {
+		return nil, fmt.Errorf("kubeconfig context %q does not reference a cluster", currentContext)
+	}
+	if cfg.Clusters[currentCtx.Cluster] == nil {
+		return nil, fmt.Errorf("kubeconfig cluster %q not found", currentCtx.Cluster)
+	}
+
+	contextNamesByCluster := map[string][]string{}
+	for name, ctx := range cfg.Contexts {
+		if ctx == nil || ctx.Cluster == "" {
+			continue
+		}
+		contextNamesByCluster[ctx.Cluster] = append(contextNamesByCluster[ctx.Cluster], name)
+	}
+	for clusterName := range contextNamesByCluster {
+		sort.Strings(contextNamesByCluster[clusterName])
+	}
+
+	preview := &KubeconfigPreview{
+		Valid:                  true,
+		Format:                 format,
+		APIVersion:             valueOr(meta.APIVersion, "v1"),
+		Kind:                   valueOr(meta.Kind, "Config"),
+		CurrentContext:         currentContext,
+		DeclaredCurrentContext: cfg.CurrentContext,
+		Clusters:               previewClusters(cfg, currentCtx.Cluster, contextNamesByCluster),
+		Users:                  previewUsers(cfg),
+		Contexts:               previewContexts(cfg, currentContext),
+	}
+	return preview, nil
+}
+
+func previewClusters(cfg *clientcmdapi.Config, currentCluster string, contextNamesByCluster map[string][]string) []KubeconfigClusterPreview {
+	names := sortedClusterNames(cfg)
+	out := make([]KubeconfigClusterPreview, 0, len(names))
+	for _, name := range names {
+		cluster := cfg.Clusters[name]
+		if cluster == nil {
+			continue
+		}
+		out = append(out, KubeconfigClusterPreview{
+			Name:                  name,
+			Server:                cluster.Server,
+			Host:                  hostFromServer(cluster.Server),
+			TLSServerName:         cluster.TLSServerName,
+			InsecureSkipTLSVerify: cluster.InsecureSkipTLSVerify,
+			Current:               name == currentCluster,
+			ContextNames:          append([]string(nil), contextNamesByCluster[name]...),
+			Certificate:           previewCertificate(cluster, time.Now().UTC()),
+		})
+	}
+	return out
+}
+
+func previewUsers(cfg *clientcmdapi.Config) []KubeconfigUserPreview {
+	names := sortedAuthInfoNames(cfg)
+	out := make([]KubeconfigUserPreview, 0, len(names))
+	for _, name := range names {
+		auth := cfg.AuthInfos[name]
+		if auth == nil {
+			continue
+		}
+		user := KubeconfigUserPreview{
+			Name:                 name,
+			AuthMethod:           classifyAuthMethod(cfg, name),
+			TokenPreview:         redactSecret(auth.Token),
+			TokenFile:            auth.TokenFile,
+			Username:             auth.Username,
+			HasClientCertificate: len(auth.ClientCertificateData) > 0 || auth.ClientCertificate != "",
+			HasClientKey:         len(auth.ClientKeyData) > 0 || auth.ClientKey != "",
+		}
+		if auth.Exec != nil {
+			user.ExecCommand = auth.Exec.Command
+		}
+		out = append(out, user)
+	}
+	return out
+}
+
+func previewContexts(cfg *clientcmdapi.Config, currentContext string) []KubeconfigContextPreview {
+	names := sortedContextNames(cfg)
+	out := make([]KubeconfigContextPreview, 0, len(names))
+	for _, name := range names {
+		ctx := cfg.Contexts[name]
+		if ctx == nil {
+			continue
+		}
+		out = append(out, KubeconfigContextPreview{
+			Name:      name,
+			Cluster:   ctx.Cluster,
+			User:      ctx.AuthInfo,
+			Namespace: ctx.Namespace,
+			Current:   name == currentContext,
+		})
+	}
+	return out
+}
+
+func previewCertificate(cluster *clientcmdapi.Cluster, now time.Time) KubeconfigCertificatePreview {
+	if cluster == nil {
+		return KubeconfigCertificatePreview{}
+	}
+	if cluster.InsecureSkipTLSVerify {
+		return KubeconfigCertificatePreview{
+			Present: true,
+			Source:  "insecure-skip-tls-verify",
+			Summary: "TLS verification is disabled for this cluster",
+		}
+	}
+	if len(cluster.CertificateAuthorityData) == 0 {
+		if cluster.CertificateAuthority != "" {
+			return KubeconfigCertificatePreview{
+				Present: true,
+				Source:  "certificate-authority",
+				Summary: "CA certificate file reference (not inspected during preview): " + cluster.CertificateAuthority,
+			}
+		}
+		return KubeconfigCertificatePreview{
+			Present: false,
+			Summary: "No certificate authority data or file reference",
+		}
+	}
+
+	certs, err := parseCertificates(cluster.CertificateAuthorityData)
+	if err != nil {
+		return KubeconfigCertificatePreview{
+			Present: true,
+			Source:  "certificate-authority-data",
+			Summary: "CA data is present but could not be parsed as an X.509 certificate",
+			Error:   err.Error(),
+		}
+	}
+	soonest := certs[0]
+	for _, cert := range certs[1:] {
+		if cert.NotAfter.Before(soonest.NotAfter) {
+			soonest = cert
+		}
+	}
+
+	subjects := make([]string, 0, len(certs))
+	issuers := make([]string, 0, len(certs))
+	for _, cert := range certs {
+		subjects = append(subjects, cert.Subject.String())
+		issuers = append(issuers, cert.Issuer.String())
+	}
+
+	days := int(soonest.NotAfter.Sub(now).Hours() / 24)
+	return KubeconfigCertificatePreview{
+		Present:       true,
+		Source:        "certificate-authority-data",
+		Summary:       fmt.Sprintf("%d certificate(s), earliest expiry %s", len(certs), soonest.NotAfter.Format("2006-01-02")),
+		ExpiresAt:     soonest.NotAfter.Format(time.RFC3339),
+		ExpiresInDays: days,
+		Expired:       now.After(soonest.NotAfter),
+		Subjects:      subjects,
+		Issuers:       issuers,
+	}
+}
+
+func parseCertificates(data []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+	}
+	if len(certs) > 0 {
+		return certs, nil
+	}
+	cert, err := x509.ParseCertificate(data)
+	if err != nil {
+		return nil, err
+	}
+	return []*x509.Certificate{cert}, nil
+}
+
+func sortedClusterNames(cfg *clientcmdapi.Config) []string {
+	names := make([]string, 0, len(cfg.Clusters))
+	for name := range cfg.Clusters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedAuthInfoNames(cfg *clientcmdapi.Config) []string {
+	names := make([]string, 0, len(cfg.AuthInfos))
+	for name := range cfg.AuthInfos {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedContextNames(cfg *clientcmdapi.Config) []string {
+	names := make([]string, 0, len(cfg.Contexts))
+	for name := range cfg.Contexts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func hostFromServer(server string) string {
+	u, err := url.Parse(server)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+func redactSecret(secret string) string {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return ""
+	}
+	runes := []rune(secret)
+	if len(runes) <= 8 {
+		return strings.Repeat("•", len(runes))
+	}
+	if len(runes) <= 18 {
+		return string(runes[:3]) + "…" + string(runes[len(runes)-3:])
+	}
+	return string(runes[:8]) + "…" + string(runes[len(runes)-6:])
+}
+
+func valueOr(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}

--- a/pkg/bootstrap/preview_test.go
+++ b/pkg/bootstrap/preview_test.go
@@ -1,0 +1,118 @@
+package bootstrap
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPreviewKubeconfigSummarizesSanitizedConfig(t *testing.T) {
+	certDER := testCertificateDER(t)
+	caData := base64.StdEncoding.EncodeToString(certDER)
+	raw := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: az-eastus-seceng-devsecops-prod
+  cluster:
+    server: https://console.rancher.az.viasat.com/k8s/clusters/c-m-ssrsjmh2
+    certificate-authority-data: %q
+- name: az-eastus-seceng-devsecops-prod-fqdn
+  cluster:
+    server: https://az-eastus-seceng-devsecops-prod-api.rancher.az.viasat.com
+    certificate-authority-data: %q
+users:
+- name: az-eastus-seceng-devsecops-prod
+  user:
+    token: kubecoabcdefghijklmnopqrstuvwxyz85pgdqbc526rx
+contexts:
+- name: az-eastus-seceng-devsecops-prod
+  context:
+    user: az-eastus-seceng-devsecops-prod
+    cluster: az-eastus-seceng-devsecops-prod
+- name: az-eastus-seceng-devsecops-prod-fqdn
+  context:
+    user: az-eastus-seceng-devsecops-prod
+    cluster: az-eastus-seceng-devsecops-prod-fqdn
+current-context: az-eastus-seceng-devsecops-prod
+`, caData, caData)
+
+	preview, err := PreviewKubeconfig([]byte(raw))
+	if err != nil {
+		t.Fatalf("PreviewKubeconfig: %v", err)
+	}
+	if !preview.Valid {
+		t.Fatalf("expected preview to be valid")
+	}
+	if preview.APIVersion != "v1" || preview.Kind != "Config" {
+		t.Fatalf("unexpected type metadata: %s %s", preview.APIVersion, preview.Kind)
+	}
+	if preview.CurrentContext != "az-eastus-seceng-devsecops-prod" {
+		t.Fatalf("unexpected current context %q", preview.CurrentContext)
+	}
+	if len(preview.Clusters) != 2 {
+		t.Fatalf("expected 2 clusters, got %d", len(preview.Clusters))
+	}
+	if !preview.Clusters[0].Current {
+		t.Fatalf("expected first sorted cluster to be current")
+	}
+	if preview.Clusters[0].Server != "https://console.rancher.az.viasat.com/k8s/clusters/c-m-ssrsjmh2" {
+		t.Fatalf("unexpected server %q", preview.Clusters[0].Server)
+	}
+	if preview.Clusters[0].Host != "console.rancher.az.viasat.com" {
+		t.Fatalf("unexpected host %q", preview.Clusters[0].Host)
+	}
+	if !preview.Clusters[0].Certificate.Present || preview.Clusters[0].Certificate.ExpiresInDays <= 300 {
+		t.Fatalf("expected certificate expiration summary, got %#v", preview.Clusters[0].Certificate)
+	}
+	if len(preview.Users) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(preview.Users))
+	}
+	if preview.Users[0].AuthMethod != "token" {
+		t.Fatalf("expected token auth, got %q", preview.Users[0].AuthMethod)
+	}
+	if preview.Users[0].TokenPreview == "" || strings.Contains(preview.Users[0].TokenPreview, "abcdefghijklmnopqrstuvwxyz") {
+		t.Fatalf("expected redacted token preview, got %q", preview.Users[0].TokenPreview)
+	}
+	if len(preview.Contexts) != 2 || !preview.Contexts[0].Current {
+		t.Fatalf("expected sorted contexts with current flag, got %#v", preview.Contexts)
+	}
+}
+
+func TestPreviewKubeconfigRejectsMalformedConfig(t *testing.T) {
+	_, err := PreviewKubeconfig([]byte("apiVersion: v1\nkind: Config\nclusters:\n- nope"))
+	if err == nil {
+		t.Fatalf("expected malformed kubeconfig to fail")
+	}
+}
+
+func testCertificateDER(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	now := time.Now().UTC()
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "Viasat Test Root CA",
+		},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return der
+}

--- a/pkg/bootstrap/sealer.go
+++ b/pkg/bootstrap/sealer.go
@@ -1,0 +1,94 @@
+package bootstrap
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	// sealKeyBytes is the required key length for AES-256.
+	sealKeyBytes = 32
+	// nonceSize is the GCM nonce size. cipher.AEAD.NonceSize() is also 12 for GCM,
+	// but we keep this constant explicit since tokens embed the nonce.
+	nonceSize = 12
+)
+
+type Sealer struct {
+	gcm       cipher.AEAD
+	rand      io.Reader
+	aadPrefix string
+}
+
+func NewSealer(key []byte, aadPrefix string) (*Sealer, error) {
+	if len(key) != sealKeyBytes {
+		return nil, fmt.Errorf("invalid sealer key length %d (expected %d)", len(key), sealKeyBytes)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES-GCM: %w", err)
+	}
+	if gcm.NonceSize() != nonceSize {
+		return nil, fmt.Errorf("unexpected AES-GCM nonce size %d (expected %d)", gcm.NonceSize(), nonceSize)
+	}
+	return &Sealer{gcm: gcm, rand: rand.Reader, aadPrefix: aadPrefix}, nil
+}
+
+func (s *Sealer) aad(tokenType string) []byte {
+	// AAD binds the token to this server module and token type.
+	return []byte(s.aadPrefix + ":" + tokenType)
+}
+
+func (s *Sealer) Seal(tokenType string, v any) (string, error) {
+	plain, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal token payload: %w", err)
+	}
+	nonce := make([]byte, nonceSize)
+	if _, err := io.ReadFull(s.rand, nonce); err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+	ciphertext := s.gcm.Seal(nil, nonce, plain, s.aad(tokenType))
+	buf := append(nonce, ciphertext...)
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func (s *Sealer) Unseal(tokenType, token string, out any) error {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return fmt.Errorf("invalid token encoding: %w", err)
+	}
+	if len(raw) < nonceSize {
+		return errors.New("invalid token: too short")
+	}
+	nonce := raw[:nonceSize]
+	ciphertext := raw[nonceSize:]
+	plain, err := s.gcm.Open(nil, nonce, ciphertext, s.aad(tokenType))
+	if err != nil {
+		return fmt.Errorf("invalid token: %w", err)
+	}
+	if err := json.Unmarshal(plain, out); err != nil {
+		return fmt.Errorf("invalid token payload: %w", err)
+	}
+	return nil
+}
+
+func ParseSealerKeyBase64URL(key string) ([]byte, error) {
+	b, err := base64.RawURLEncoding.DecodeString(key)
+	if err != nil {
+		return nil, fmt.Errorf("invalid MCP_AUTH_SECRET encoding (expected base64url): %w", err)
+	}
+	if len(b) != sealKeyBytes {
+		return nil, fmt.Errorf("invalid MCP_AUTH_SECRET length %d (expected %d bytes)", len(b), sealKeyBytes)
+	}
+	return b, nil
+}

--- a/pkg/bootstrap/server.go
+++ b/pkg/bootstrap/server.go
@@ -1,0 +1,1606 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/mcp"
+)
+
+const (
+	tokenTypeClient      = "client"
+	tokenTypeAuthRequest = "auth_request"
+	tokenTypeAuthCode    = "auth_code"
+	tokenTypeAccess      = "access"
+
+	sealerAADPrefix = "kubernetes-mcp-server/bootstrap"
+)
+
+type Options struct {
+	CfgState        *config.StaticConfigState
+	McpServer       *mcp.Server
+	DynamicProvider *kubernetes.DynamicProvider
+	ProviderBuilder func(ctx context.Context) (kubernetes.Provider, error)
+	// Optional override used by tests.
+	KubeconfigValidator func(ctx context.Context, kubeconfigPath string) (*ClusterFacts, error)
+}
+
+type Server struct {
+	cfgState  *config.StaticConfigState
+	mcpServer *mcp.Server
+	dyn       *kubernetes.DynamicProvider
+	buildProv func(ctx context.Context) (kubernetes.Provider, error)
+	validate  func(ctx context.Context, kubeconfigPath string) (*ClusterFacts, error)
+	sealer    *Sealer
+	now       func() time.Time
+
+	configureMu sync.Mutex
+}
+
+func NewServer(opts Options) (*Server, error) {
+	if opts.CfgState == nil {
+		return nil, errors.New("CfgState is required")
+	}
+	if opts.McpServer == nil {
+		return nil, errors.New("McpServer is required")
+	}
+	if opts.DynamicProvider == nil {
+		return nil, errors.New("DynamicProvider is required")
+	}
+	if opts.ProviderBuilder == nil {
+		return nil, errors.New("ProviderBuilder is required")
+	}
+
+	key, err := sealerKeyFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	sealer, err := NewSealer(key, sealerAADPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	validate := opts.KubeconfigValidator
+	if validate == nil {
+		validate = func(ctx context.Context, kubeconfigPath string) (*ClusterFacts, error) {
+			return ValidateKubeconfig(ctx, kubeconfigPath, 25)
+		}
+	}
+
+	return &Server{
+		cfgState:  opts.CfgState,
+		mcpServer: opts.McpServer,
+		dyn:       opts.DynamicProvider,
+		buildProv: opts.ProviderBuilder,
+		validate:  validate,
+		sealer:    sealer,
+		now:       time.Now,
+	}, nil
+}
+
+func sealerKeyFromEnv() ([]byte, error) {
+	secret := strings.TrimSpace(os.Getenv("MCP_AUTH_SECRET"))
+	if secret != "" {
+		return ParseSealerKeyBase64URL(secret)
+	}
+	key := make([]byte, sealKeyBytes)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("failed to generate ephemeral auth key: %w", err)
+	}
+	return key, nil
+}
+
+// RegisterRoutes registers the internal OAuth and bootstrap UI endpoints.
+// Call this once during HTTP server initialization.
+func (s *Server) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/.well-known/oauth-authorization-server", s.handleAuthorizationServerMetadata)
+	mux.HandleFunc("/.well-known/oauth-protected-resource", s.handleProtectedResourceMetadata)
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", s.handleProtectedResourceMetadata)
+	mux.HandleFunc("/.well-known/mcp/server-card.json", s.handleServerCard)
+
+	mux.HandleFunc("/register", s.handleRegister)
+	mux.HandleFunc("/authorize", s.handleAuthorize)
+	mux.HandleFunc("/token", s.handleToken)
+	mux.HandleFunc("/kube/login", s.handleKubeLogin)
+	mux.HandleFunc("/kube/preview", s.handleKubePreview)
+}
+
+// Protect enforces sealed-token bearer auth for protected endpoints (e.g. /mcp).
+func (s *Server) Protect(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			withCORSHeaders(w)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		token, ok := bearerToken(r.Header.Get("Authorization"))
+		if !ok {
+			s.writeAuthChallenge(w, r, "missing_token")
+			return
+		}
+		claims := accessToken{}
+		if err := s.sealer.Unseal(tokenTypeAccess, token, &claims); err != nil {
+			s.writeAuthChallenge(w, r, "invalid_token")
+			return
+		}
+		if err := claims.validate(s.now()); err != nil {
+			s.writeAuthChallenge(w, r, "invalid_token")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) writeAuthChallenge(w http.ResponseWriter, r *http.Request, errorType string) {
+	metaURL := s.baseURL(r) + "/.well-known/oauth-protected-resource/mcp"
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Kubernetes MCP Server", resource_metadata="%s", error="%s"`, metaURL, errorType))
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte("Unauthorized"))
+}
+
+func bearerToken(header string) (string, bool) {
+	if header == "" || !strings.HasPrefix(header, "Bearer ") {
+		return "", false
+	}
+	t := strings.TrimSpace(strings.TrimPrefix(header, "Bearer "))
+	return t, t != ""
+}
+
+func (s *Server) baseURL(r *http.Request) string {
+	cfg := s.cfgState.Load()
+	if cfg.ServerURL != "" {
+		return strings.TrimSuffix(cfg.ServerURL, "/")
+	}
+	scheme := "https"
+	host := r.Host
+	if cfg.TrustProxyHeaders {
+		if r.TLS == nil && !strings.HasPrefix(r.Header.Get("X-Forwarded-Proto"), "https") {
+			scheme = "http"
+		}
+		if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
+			host = fwdHost
+		}
+	} else {
+		if r.TLS == nil {
+			scheme = "http"
+		}
+	}
+	return fmt.Sprintf("%s://%s", scheme, host)
+}
+
+func (s *Server) kubeconfigPath() string {
+	cfg := s.cfgState.Load()
+	if cfg.KubeConfig != "" {
+		return cfg.KubeConfig
+	}
+	h, err := os.UserHomeDir()
+	if err != nil || h == "" {
+		return filepath.Join("/", ".kube", "config")
+	}
+	return filepath.Join(h, ".kube", "config")
+}
+
+type tokenBase struct {
+	Iat int64 `json:"iat"`
+	Exp int64 `json:"exp"`
+}
+
+func newTokenBase(now time.Time, ttl time.Duration) tokenBase {
+	return tokenBase{Iat: now.Unix(), Exp: now.Add(ttl).Unix()}
+}
+
+func (b tokenBase) validate(now time.Time) error {
+	if now.Unix() > b.Exp {
+		return errors.New("token expired")
+	}
+	return nil
+}
+
+type clientRegistration struct {
+	tokenBase
+	RedirectURIs []string `json:"redirect_uris"`
+	ClientName   string   `json:"client_name,omitempty"`
+}
+
+type authRequest struct {
+	tokenBase
+
+	ClientID            string `json:"client_id"`
+	RedirectURI         string `json:"redirect_uri"`
+	State               string `json:"state,omitempty"`
+	Scope               string `json:"scope,omitempty"`
+	CodeChallenge       string `json:"code_challenge"`
+	CodeChallengeMethod string `json:"code_challenge_method"`
+}
+
+type authCode struct {
+	tokenBase
+
+	ClientID            string `json:"client_id"`
+	RedirectURI         string `json:"redirect_uri"`
+	Scope               string `json:"scope,omitempty"`
+	CodeChallenge       string `json:"code_challenge"`
+	CodeChallengeMethod string `json:"code_challenge_method"`
+}
+
+type accessToken struct {
+	tokenBase
+
+	ClientID string `json:"client_id"`
+	Scope    string `json:"scope,omitempty"`
+}
+
+func (s *Server) handleAuthorizationServerMetadata(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		withCORSHeaders(w)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cfg := s.cfgState.Load()
+	base := s.baseURL(r)
+
+	meta := map[string]any{
+		"issuer":                                base,
+		"authorization_endpoint":                base + "/authorize",
+		"token_endpoint":                        base + "/token",
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+	}
+	if len(cfg.OAuthScopes) > 0 {
+		meta["scopes_supported"] = cfg.OAuthScopes
+	}
+	if !cfg.DisableDynamicClientRegistration {
+		meta["registration_endpoint"] = base + "/register"
+	}
+
+	writeJSON(w, http.StatusOK, meta)
+}
+
+func (s *Server) handleProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		withCORSHeaders(w)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cfg := s.cfgState.Load()
+	base := s.baseURL(r)
+	meta := map[string]any{
+		"resource":                 base + "/mcp",
+		"authorization_servers":    []string{base},
+		"bearer_methods_supported": []string{"header"},
+	}
+	if len(cfg.OAuthScopes) > 0 {
+		meta["scopes_supported"] = cfg.OAuthScopes
+	}
+
+	writeJSON(w, http.StatusOK, meta)
+}
+
+func (s *Server) handleServerCard(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		withCORSHeaders(w)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	base := s.baseURL(r)
+	card := map[string]any{
+		"name":         "kubernetes-mcp-server",
+		"mcp_endpoint": base + "/mcp",
+		"sse_endpoint": base + "/sse",
+		"login_url":    base + "/kube/login",
+	}
+	writeJSON(w, http.StatusOK, card)
+}
+
+type registerRequest struct {
+	RedirectURIs []string `json:"redirect_uris"`
+	ClientName   string   `json:"client_name,omitempty"`
+}
+
+type registerResponse struct {
+	ClientID                string   `json:"client_id"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	ClientName              string   `json:"client_name,omitempty"`
+}
+
+func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		withCORSHeaders(w)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.cfgState.Load().DisableDynamicClientRegistration {
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if len(req.RedirectURIs) == 0 {
+		http.Error(w, "redirect_uris is required", http.StatusBadRequest)
+		return
+	}
+	for i := range req.RedirectURIs {
+		if err := validateRedirectURI(req.RedirectURIs[i]); err != nil {
+			http.Error(w, fmt.Sprintf("invalid redirect_uri: %v", err), http.StatusBadRequest)
+			return
+		}
+	}
+
+	reg := clientRegistration{
+		tokenBase:    newTokenBase(s.now(), 24*time.Hour),
+		RedirectURIs: append([]string(nil), req.RedirectURIs...),
+		ClientName:   req.ClientName,
+	}
+	clientID, err := s.sealer.Seal(tokenTypeClient, &reg)
+	if err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := registerResponse{
+		ClientID:                clientID,
+		RedirectURIs:            reg.RedirectURIs,
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+		ClientName:              reg.ClientName,
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+func validateRedirectURI(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return err
+	}
+	// MCP desktop clients commonly register private-use callback schemes
+	// (for example warp://...) instead of only http(s). Keep this aligned with
+	// the other Viasat MCP servers: require an absolute URI with scheme+host,
+	// then enforce exact redirect_uri matching during authorize/token exchange.
+	if u.Scheme == "" {
+		return errors.New("missing scheme")
+	}
+	if u.Host == "" {
+		return errors.New("missing host")
+	}
+	if u.Fragment != "" {
+		return errors.New("fragment not allowed")
+	}
+	return nil
+}
+
+func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	q := r.URL.Query()
+	if q.Get("response_type") != "code" {
+		http.Error(w, "response_type must be 'code'", http.StatusBadRequest)
+		return
+	}
+	clientID := q.Get("client_id")
+	redirectURI := q.Get("redirect_uri")
+	state := q.Get("state")
+	scope := q.Get("scope")
+	codeChallenge := q.Get("code_challenge")
+	codeChallengeMethod := q.Get("code_challenge_method")
+	if clientID == "" || redirectURI == "" {
+		http.Error(w, "client_id and redirect_uri are required", http.StatusBadRequest)
+		return
+	}
+	if codeChallenge == "" || codeChallengeMethod != "S256" {
+		http.Error(w, "PKCE code_challenge and code_challenge_method=S256 are required", http.StatusBadRequest)
+		return
+	}
+
+	reg, err := s.parseClientRegistration(clientID)
+	if err != nil {
+		http.Error(w, "invalid client_id", http.StatusBadRequest)
+		return
+	}
+	if !contains(reg.RedirectURIs, redirectURI) {
+		http.Error(w, "redirect_uri is not registered for client", http.StatusBadRequest)
+		return
+	}
+
+	areq := authRequest{
+		tokenBase:           newTokenBase(s.now(), 10*time.Minute),
+		ClientID:            clientID,
+		RedirectURI:         redirectURI,
+		State:               state,
+		Scope:               scope,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+	}
+	sealed, err := s.sealer.Seal(tokenTypeAuthRequest, &areq)
+	if err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+	loginURL := "/kube/login?request=" + url.QueryEscape(sealed)
+	http.Redirect(w, r, loginURL, http.StatusFound)
+}
+
+func redirectWithCode(redirectURI, code, state string) string {
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		return redirectURI
+	}
+	q := u.Query()
+	q.Set("code", code)
+	if state != "" {
+		q.Set("state", state)
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func (s *Server) parseClientRegistration(clientID string) (*clientRegistration, error) {
+	reg := clientRegistration{}
+	if err := s.sealer.Unseal(tokenTypeClient, clientID, &reg); err != nil {
+		return nil, err
+	}
+	if err := reg.validate(s.now()); err != nil {
+		return nil, err
+	}
+	if len(reg.RedirectURIs) == 0 {
+		return nil, errors.New("no redirect_uris")
+	}
+	return &reg, nil
+}
+
+func (s *Server) issueAuthCode(code authCode) (string, error) {
+	return s.sealer.Seal(tokenTypeAuthCode, &code)
+}
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int64  `json:"expires_in"`
+	Scope       string `json:"scope,omitempty"`
+}
+
+func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		withCORSHeaders(w)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Invalid form body", http.StatusBadRequest)
+		return
+	}
+	if r.PostForm.Get("grant_type") != "authorization_code" {
+		http.Error(w, "unsupported grant_type", http.StatusBadRequest)
+		return
+	}
+
+	clientID := r.PostForm.Get("client_id")
+	redirectURI := r.PostForm.Get("redirect_uri")
+	code := r.PostForm.Get("code")
+	verifier := r.PostForm.Get("code_verifier")
+	if clientID == "" || redirectURI == "" || code == "" || verifier == "" {
+		http.Error(w, "client_id, redirect_uri, code, and code_verifier are required", http.StatusBadRequest)
+		return
+	}
+
+	reg, err := s.parseClientRegistration(clientID)
+	if err != nil {
+		http.Error(w, "invalid client_id", http.StatusBadRequest)
+		return
+	}
+	if !contains(reg.RedirectURIs, redirectURI) {
+		http.Error(w, "redirect_uri is not registered for client", http.StatusBadRequest)
+		return
+	}
+
+	ac := authCode{}
+	if err := s.sealer.Unseal(tokenTypeAuthCode, code, &ac); err != nil {
+		http.Error(w, "invalid code", http.StatusBadRequest)
+		return
+	}
+	if err := ac.validate(s.now()); err != nil {
+		http.Error(w, "invalid code", http.StatusBadRequest)
+		return
+	}
+	if ac.ClientID != clientID || ac.RedirectURI != redirectURI {
+		http.Error(w, "invalid code", http.StatusBadRequest)
+		return
+	}
+	if ac.CodeChallengeMethod != "S256" {
+		http.Error(w, "invalid code", http.StatusBadRequest)
+		return
+	}
+	if err := VerifyPKCES256(ac.CodeChallenge, verifier); err != nil {
+		http.Error(w, "invalid code_verifier", http.StatusBadRequest)
+		return
+	}
+
+	at := accessToken{
+		tokenBase: newTokenBase(s.now(), 1*time.Hour),
+		ClientID:  clientID,
+		Scope:     ac.Scope,
+	}
+	access, err := s.sealer.Seal(tokenTypeAccess, &at)
+	if err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+	resp := tokenResponse{
+		AccessToken: access,
+		TokenType:   "Bearer",
+		ExpiresIn:   3600,
+		Scope:       ac.Scope,
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+type kubeLoginView struct {
+	HasExisting  bool
+	ExistingPath string
+	DefaultMode  string
+	RequestToken string
+	Error        string
+	Pasted       string
+}
+
+var kubeLoginTemplate = template.Must(template.New("kube-login").Parse(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kubernetes MCP Server — Bootstrap</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; background:#f5f5f5; margin:0; padding:0; }
+    .card { max-width:760px; margin:7vh auto; background:#fff; padding:24px; border-radius:12px; box-shadow:0 4px 20px rgba(0,0,0,0.08); }
+    h1 { margin:0 0 8px 0; font-size:20px; }
+    h2 { margin:0 0 10px 0; font-size:16px; }
+    h3 { margin:12px 0 8px 0; font-size:14px; }
+    p { margin:0 0 16px 0; color:#555; font-size:14px; line-height:1.4; }
+    label { display:block; font-weight:600; font-size:13px; margin:12px 0 6px; }
+    input, textarea { width:100%; padding:10px 12px; border:1px solid #ddd; border-radius:8px; font-size:14px; box-sizing:border-box; }
+    input[type="radio"] { width:auto; margin:0 8px 0 0; accent-color:#0052cc; }
+    textarea { min-height:220px; resize:vertical; font-family:ui-monospace, SFMono-Regular, Menlo, monospace; line-height:1.35; }
+    button { width:100%; margin-top:16px; padding:10px 12px; border:0; border-radius:8px; background:#0052cc; color:#fff; font-weight:700; font-size:14px; cursor:pointer; }
+    button:hover { background:#0043a8; }
+    .section { border:1px solid #e6e6e6; border-radius:10px; padding:14px; margin:12px 0; }
+    .err { background:#fdecea; border:1px solid #f5c6cb; color:#7a1c1c; padding:10px 12px; border-radius:8px; margin-bottom:12px; font-size:13px; white-space:pre-wrap; }
+    .success { background:#e7f7ed; border:1px solid #b7ebc6; color:#0f5132; padding:10px 12px; border-radius:8px; margin-bottom:12px; font-size:13px; }
+    .info { background:#eef4ff; border:1px solid #cfe0ff; color:#1f3b7a; padding:10px 12px; border-radius:8px; margin:0 0 12px 0; font-size:13px; }
+    .note { background:#fff8e1; border-left:4px solid #ff8f00; padding:10px 12px; border-radius:8px; margin-top:12px; font-size:13px; color:#555; }
+    .muted { color:#666; font-size:12px; }
+    .radio-row { display:flex; align-items:flex-start; gap:8px; margin:10px 0; }
+    .radio-row label { margin:0; display:inline; }
+    .dropzone { border:2px dashed #cfe0ff; border-radius:10px; padding:14px; margin:12px 0; background:#f8fbff; color:#1f3b7a; text-align:center; font-size:13px; }
+    .dropzone.dragging { border-color:#0052cc; background:#eef4ff; }
+    .invalid-input { border-color:#dc3545 !important; box-shadow:0 0 0 2px rgba(220,53,69,0.12); }
+    .preview { margin-top:12px; }
+    .hidden { display:none; }
+    .steps { display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px; margin:12px 0; }
+    .step { border:1px solid #e6e6e6; border-radius:10px; padding:10px 12px; background:#fff; color:#666; font-size:13px; font-weight:700; }
+    button.step { width:100%; margin:0; text-align:left; cursor:pointer; }
+    button.step:hover { border-color:#cfe0ff; background:#f8fbff; }
+    .step.active { border-color:#cfe0ff; background:#eef4ff; color:#1f3b7a; }
+    .step.done { border-color:#b7ebc6; background:#e7f7ed; color:#0f5132; }
+    .step.error { border-color:#f5c6cb; background:#fdecea; color:#7a1c1c; }
+    .step small { display:block; margin-top:2px; font-weight:500; font-size:11px; color:inherit; opacity:0.82; }
+    .step-content { margin-top:12px; }
+    .config-header { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; border:1px solid #e6e6e6; border-radius:10px; padding:14px; margin:12px 0; }
+    .chip { display:inline-block; padding:3px 8px; border-radius:999px; background:#eef4ff; color:#1f3b7a; font-size:12px; font-weight:700; white-space:nowrap; }
+    .chip.ok { background:#e7f7ed; color:#0f5132; }
+    .chip.warn { background:#fff8e1; color:#7a5200; }
+    .cluster-grid { display:grid; grid-template-columns:1fr; gap:12px; margin-top:12px; }
+    .cluster-card { border:1px solid #e6e6e6; border-radius:12px; padding:16px; background:#fff; }
+    .cluster-card.current { border-color:#7bd88f; background:linear-gradient(180deg, #fbfffc 0%, #ffffff 100%); box-shadow:0 0 0 3px rgba(15,81,50,0.08); }
+    .cluster-card h3 { margin:0 0 10px 0; font-size:16px; }
+    .cluster-heading { display:flex; justify-content:space-between; align-items:flex-start; gap:10px; margin-bottom:8px; }
+    .nested { border-top:1px solid #f0f0f0; margin-top:12px; padding-top:10px; }
+    .nested h4 { margin:0 0 8px 0; font-size:13px; color:#333; }
+    .actions { display:flex; gap:10px; margin-top:14px; }
+    .actions button { margin-top:0; }
+    .meta-row { font-size:13px; margin:6px 0; color:#333; overflow-wrap:anywhere; }
+    .meta-label { font-weight:600; margin-right:6px; }
+    .source-panel pre { max-height:360px; overflow:auto; padding:12px; border-radius:8px; background:#1f2937; color:#e5e7eb; font-size:12px; line-height:1.4; white-space:pre-wrap; }
+    button:disabled { background:#b8c2d6; cursor:not-allowed; }
+    button.loading { display:flex; align-items:center; justify-content:center; gap:8px; }
+    .spinner { display:inline-block; width:13px; height:13px; border:2px solid rgba(255,255,255,0.45); border-top-color:#fff; border-radius:50%; animation:spin .8s linear infinite; }
+    button.secondary { background:#f1f1f1; color:#333; border:1px solid #ddd; }
+    button.secondary:hover { background:#e6e6e6; }
+    code { background:#f1f1f1; padding:1px 4px; border-radius:4px; }
+    @keyframes spin { to { transform:rotate(360deg); } }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Kubernetes MCP Server</h1>
+    <p>Connect this MCP server by validating a kubeconfig. The server will not connect to Kubernetes until this step succeeds.</p>
+    <div class="info">
+      🔐 Bootstrap mode protects <code>/mcp</code> with internal OAuth and keeps all auth state sealed into short-lived tokens.
+    </div>
+    {{if .Error}}<div class="err">{{.Error}}</div>{{end}}
+    <form id="kubeForm" method="post" action="/kube/login" enctype="multipart/form-data" autocomplete="off">
+      <div class="steps">
+        <button id="stepSource" type="button" class="step active">🔎 1. Source validation<small>Paste, drop, upload, or use existing</small></button>
+        <button id="stepReview" type="button" class="step">⏳ 2. Review target<small>Confirm cluster URL and user</small></button>
+        <button id="stepCurrent" type="button" class="step">⏳ 3. Current state<small>Shown after confirmation</small></button>
+      </div>
+
+      <div id="sourceStepPanel" class="step-content">
+        <div id="sourceControls" class="section">
+          <h2>🔑 Kubeconfig source</h2>
+          <p class="muted">Choose an existing kubeconfig, paste YAML, or upload a file. Pasted/uploaded content is persisted with owner-only permissions only after you enable access.</p>
+          <div id="dropZone" class="dropzone">
+            🧲 Drag and drop a kubeconfig YAML/JSON file here, or paste it below.
+          </div>
+        {{if .HasExisting}}
+          <div class="radio-row">
+            <input id="mode_existing" type="radio" name="mode" value="existing" autocomplete="off" {{if eq .DefaultMode "existing"}}checked{{end}} />
+            <label for="mode_existing">📁 Use existing kubeconfig<br/><span class="muted"><code>{{.ExistingPath}}</code></span></label>
+          </div>
+        {{end}}
+          <div class="radio-row">
+            <input id="mode_paste" type="radio" name="mode" value="paste" autocomplete="off" {{if eq .DefaultMode "paste"}}checked{{end}} />
+            <label for="mode_paste">📋 Paste kubeconfig YAML</label>
+          </div>
+          <textarea id="kubeconfigPaste" name="kubeconfig_paste" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off" placeholder="apiVersion: v1&#10;clusters: ...">{{.Pasted}}</textarea>
+
+          <div class="radio-row">
+            <input id="mode_upload" type="radio" name="mode" value="upload" autocomplete="off" {{if eq .DefaultMode "upload"}}checked{{end}} />
+            <label for="mode_upload">📎 Upload kubeconfig file</label>
+          </div>
+          <input id="kubeconfigUpload" type="file" name="kubeconfig_upload" autocomplete="off" accept=".yaml,.yml,.json,.conf,.config,text/yaml,application/yaml,application/json" />
+        </div>
+        <div id="previewStatus" class="info">
+          🧪 Paste, drop, upload, or select an existing kubeconfig to preview it before enabling access.
+        </div>
+        <div id="sourcePanel" class="source-panel hidden">
+          <pre id="sourceCode"></pre>
+          <button id="backButton" type="button" class="secondary">⬅️ Back to target review</button>
+        </div>
+      </div>
+      <div id="reviewStepPanel" class="step-content hidden">
+        <div id="configHeader" class="config-header"></div>
+        <div id="clusterCards" class="cluster-grid"></div>
+        <div class="actions">
+          <button id="changeSourceButton" type="button" class="secondary">⬅️ Change kubeconfig</button>
+          <button id="detailsButton" type="button" class="secondary">📄 Show source details</button>
+        </div>
+        <input type="hidden" name="request" value="{{.RequestToken}}" />
+        <button id="enableButton" type="submit" disabled>🔒 Validate kubeconfig preview first</button>
+      </div>
+
+    </form>
+
+    <div class="note">
+      Treat kubeconfig contents as sensitive. Source details are shown only in this browser so you can inspect parse errors or confirm the file before enabling access.
+    </div>
+  </div>
+  <script>
+  (function () {
+    var form = document.getElementById('kubeForm');
+    var paste = document.getElementById('kubeconfigPaste');
+    var upload = document.getElementById('kubeconfigUpload');
+    var dropZone = document.getElementById('dropZone');
+    var previewStatus = document.getElementById('previewStatus');
+    var sourceStepPanel = document.getElementById('sourceStepPanel');
+    var reviewStepPanel = document.getElementById('reviewStepPanel');
+    var stepSource = document.getElementById('stepSource');
+    var stepReview = document.getElementById('stepReview');
+    var stepCurrent = document.getElementById('stepCurrent');
+    var sourceControls = document.getElementById('sourceControls');
+    var sourcePanel = document.getElementById('sourcePanel');
+    var sourceCode = document.getElementById('sourceCode');
+    var configHeader = document.getElementById('configHeader');
+    var clusterCards = document.getElementById('clusterCards');
+    var detailsButton = document.getElementById('detailsButton');
+    var backButton = document.getElementById('backButton');
+    var changeSourceButton = document.getElementById('changeSourceButton');
+    var enableButton = document.getElementById('enableButton');
+    var debounceTimer;
+    var lastSource = '';
+    var lastPreviewValid = false;
+    var lastPreview = null;
+
+    function escapeHtml(value) {
+      return String(value || '').replace(/[&<>"']/g, function (ch) {
+        return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch];
+      });
+    }
+
+    function selectedMode() {
+      var checked = form.querySelector('input[name="mode"]:checked');
+      return checked ? checked.value : 'paste';
+    }
+
+    function setMode(mode) {
+      var input = form.querySelector('input[name="mode"][value="' + mode + '"]');
+      if (input) {
+        input.checked = true;
+      }
+    }
+
+    function setUploadEnabled(enabled) {
+      upload.disabled = !enabled;
+    }
+    function setStepCard(el, state, icon, title, detail) {
+      el.className = state === 'pending' ? 'step' : 'step ' + state;
+      el.innerHTML = icon + ' ' + title + '<small>' + detail + '</small>';
+      el.setAttribute('aria-current', state === 'active' ? 'step' : 'false');
+    }
+
+    function setStep(step) {
+      if (step === 'review') {
+        sourceStepPanel.classList.add('hidden');
+        reviewStepPanel.classList.remove('hidden');
+        sourcePanel.classList.add('hidden');
+        sourceControls.classList.remove('hidden');
+        setUploadEnabled(false);
+        setStepCard(stepSource, 'done', '✅', '1. Source validation', 'Kubeconfig parsed');
+        setStepCard(stepReview, 'active', '👀', '2. Review target', 'Confirm cluster URL and user');
+        setStepCard(stepCurrent, 'pending', '⏳', '3. Current state', 'Shown after confirmation');
+      } else {
+        reviewStepPanel.classList.add('hidden');
+        sourceStepPanel.classList.remove('hidden');
+        setUploadEnabled(true);
+        setStepCard(stepSource, 'active', '🔎', '1. Source validation', 'Paste, drop, upload, or use existing');
+        setStepCard(stepReview, lastPreviewValid ? 'done' : 'pending', lastPreviewValid ? '✅' : '⏳', '2. Review target', lastPreviewValid ? 'Preview completed' : 'Confirm cluster URL and user');
+        setStepCard(stepCurrent, 'pending', '⏳', '3. Current state', 'Shown after confirmation');
+      }
+    }
+
+    function setEnable(valid) {
+      lastPreviewValid = !!valid;
+      enableButton.disabled = !lastPreviewValid;
+      enableButton.textContent = lastPreviewValid ? '🚀 Enable Kubernetes Access' : '🔒 Validate kubeconfig preview first';
+    }
+
+    function setStatus(kind, html) {
+      previewStatus.className = kind;
+      previewStatus.innerHTML = html;
+    }
+
+    function resetPreview(message) {
+      lastPreview = null;
+      setEnable(false);
+      setStep('source');
+      paste.classList.remove('invalid-input');
+      dropZone.classList.remove('invalid-input');
+      sourceControls.classList.remove('hidden');
+      configHeader.innerHTML = '';
+      clusterCards.innerHTML = '';
+      setStatus('info', message || '🧪 Paste, drop, upload, or select an existing kubeconfig to validate it before review.');
+    }
+
+    function showSource(show) {
+      if (show) {
+        setStep('source');
+        sourceControls.classList.add('hidden');
+        sourcePanel.classList.remove('hidden');
+        sourceCode.textContent = lastSource || 'Source is not displayed for the existing kubeconfig path.';
+      } else {
+        sourcePanel.classList.add('hidden');
+        sourceControls.classList.remove('hidden');
+        if (lastPreviewValid) {
+          setStep('review');
+        }
+      }
+    }
+
+    function renderError(message, revealSource) {
+      lastPreview = null;
+      setEnable(false);
+      setStep('source');
+      configHeader.innerHTML = '';
+      clusterCards.innerHTML = '';
+      paste.classList.add('invalid-input');
+      dropZone.classList.add('invalid-input');
+      sourceControls.classList.remove('hidden');
+      setStepCard(stepSource, 'error', '❌', '1. Source validation', 'Fix the source and validate again');
+      setStepCard(stepReview, 'pending', '⏳', '2. Review target', 'Confirm cluster URL and user');
+      setStepCard(stepCurrent, 'pending', '⏳', '3. Current state', 'Shown after confirmation');
+      setStatus('err', '❌ Kubeconfig source validation failed: ' + escapeHtml(message));
+      if (revealSource) {
+        sourcePanel.classList.remove('hidden');
+        sourceCode.textContent = lastSource || '';
+      } else {
+        sourcePanel.classList.add('hidden');
+      }
+    }
+
+    function certificateLine(cert) {
+      if (!cert) {
+        return '<span class="muted">No certificate info</span>';
+      }
+      var bits = [];
+      if (cert.summary) {
+        bits.push(escapeHtml(cert.summary));
+      }
+      if (cert.expired) {
+        bits.push('<span class="chip warn">expired</span>');
+      } else if (cert.expiresInDays) {
+        bits.push('<span class="chip">expires in ' + escapeHtml(cert.expiresInDays) + ' days</span>');
+      }
+      if (cert.subjects && cert.subjects.length) {
+        bits.push('<div class="muted">Subject: ' + escapeHtml(cert.subjects[0]) + '</div>');
+      }
+      if (cert.error) {
+        bits.push('<span class="chip warn">' + escapeHtml(cert.error) + '</span>');
+      }
+      return bits.join(' ');
+    }
+
+    function usersForCluster(preview, clusterName) {
+      var userNames = {};
+      (preview.contexts || []).forEach(function (ctx) {
+        if (ctx.cluster === clusterName && ctx.user) {
+          userNames[ctx.user] = true;
+        }
+      });
+      return (preview.users || []).filter(function (user) { return !!userNames[user.name]; });
+    }
+
+    function contextsForCluster(preview, clusterName) {
+      return (preview.contexts || []).filter(function (ctx) { return ctx.cluster === clusterName; });
+    }
+
+    function renderRelatedUsers(users) {
+      if (!users.length) {
+        return '<div class="muted">No user is referenced by this cluster context.</div>';
+      }
+      return users.map(function (user) {
+        var token = user.tokenPreview ? '<div class="meta-row"><span class="meta-label">Token</span><code>' + escapeHtml(user.tokenPreview) + '</code></div>' : '';
+        var exec = user.execCommand ? '<div class="meta-row"><span class="meta-label">Exec</span><code>' + escapeHtml(user.execCommand) + '</code></div>' : '';
+        var tokenFile = user.tokenFile ? '<div class="meta-row"><span class="meta-label">Token file</span><code>' + escapeHtml(user.tokenFile) + '</code></div>' : '';
+        var cert = user.hasClientCertificate ? '<span class="chip">client certificate</span> ' : '';
+        var key = user.hasClientKey ? '<span class="chip">client key</span>' : '';
+        return '<div class="meta-row"><span class="meta-label">👤 User</span><code>' + escapeHtml(user.name) + '</code> <span class="chip">' + escapeHtml(user.authMethod) + '</span></div>' + token + tokenFile + exec + '<div class="meta-row">' + cert + key + '</div>';
+      }).join('');
+    }
+
+    function renderRelatedContexts(contexts) {
+      if (!contexts.length) {
+        return '<div class="muted">No contexts reference this cluster.</div>';
+      }
+      return contexts.map(function (ctx) {
+        var current = ctx.current ? ' <span class="chip ok">✅ default</span>' : '';
+        var ns = ctx.namespace ? ' namespace <code>' + escapeHtml(ctx.namespace) + '</code>' : '';
+        return '<div class="meta-row"><span class="meta-label">🧭 Context</span><code>' + escapeHtml(ctx.name) + '</code>' + current + ns + '</div>';
+      }).join('');
+    }
+
+    function renderClusters(preview) {
+      var clusters = preview.clusters || [];
+      if (!clusters.length) {
+        clusterCards.innerHTML = '<div class="cluster-card"><h3>🖥️ No clusters</h3><div class="muted">No clusters were found in this kubeconfig.</div></div>';
+        return;
+      }
+      clusterCards.innerHTML = clusters.map(function (cluster) {
+        var current = cluster.current ? '<span class="chip ok">✅ current</span>' : '';
+        var contexts = contextsForCluster(preview, cluster.name);
+        var users = usersForCluster(preview, cluster.name);
+        return '<div class="cluster-card ' + (cluster.current ? 'current' : '') + '">' +
+          '<div class="cluster-heading"><h3>🖥️ ' + escapeHtml(cluster.name) + '</h3>' + current + '</div>' +
+          '<div class="meta-row"><span class="meta-label">URL</span><code>' + escapeHtml(cluster.server) + '</code></div>' +
+          '<div class="meta-row"><span class="meta-label">Host</span><code>' + escapeHtml(cluster.host || 'n/a') + '</code></div>' +
+          '<div class="meta-row"><span class="meta-label">Certificate</span>' + certificateLine(cluster.certificate) + '</div>' +
+          '<div class="nested"><h4>Related identity</h4>' + renderRelatedUsers(users) + '</div>' +
+          '<div class="nested"><h4>Context mapping</h4>' + renderRelatedContexts(contexts) + '</div>' +
+          '</div>';
+      }).join('');
+    }
+
+    function renderPreview(preview) {
+      lastPreview = preview;
+      paste.classList.remove('invalid-input');
+      dropZone.classList.remove('invalid-input');
+      setEnable(true);
+      setStatus('success', '✅ Source is valid ' + escapeHtml(preview.format || 'yaml') + '. Review the target cluster before connecting.');
+      configHeader.innerHTML =
+        '<div><strong>☸️ ' + escapeHtml(preview.kind || 'Config') + ' object</strong>' +
+        '<div class="meta-row"><span class="meta-label">apiVersion</span><code>' + escapeHtml(preview.apiVersion || 'v1') + '</code></div>' +
+        '<div class="meta-row"><span class="meta-label">current-context</span><code>' + escapeHtml(preview.currentContext || 'n/a') + '</code></div></div>' +
+        '<span class="chip ok">✅ valid</span>';
+      renderClusters(preview);
+      setStep('review');
+    }
+
+    async function preview(mode, source) {
+      try {
+        setEnable(false);
+        setStatus('info', '🔎 Validating kubeconfig source…');
+        var response = await fetch('/kube/preview', {
+          method: 'POST',
+          cache: 'no-store',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({mode: mode, kubeconfig: source || ''})
+        });
+        var result = await response.json();
+        if (!result.valid) {
+          renderError(result.error || 'invalid kubeconfig', mode !== 'existing');
+          return;
+        }
+        renderPreview(result);
+      } catch (err) {
+        renderError(err && err.message ? err.message : String(err), mode !== 'existing');
+      }
+    }
+
+    function previewCurrentInput() {
+      var mode = selectedMode();
+      if (mode === 'existing') {
+        lastSource = '';
+        preview('existing', '');
+        return;
+      }
+      lastSource = paste.value;
+      if (!lastSource.trim()) {
+        resetPreview('🧪 Paste, drop, or upload a kubeconfig YAML/JSON file to validate it.');
+        return;
+      }
+      preview(mode, lastSource);
+    }
+
+    function schedulePreview() {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(previewCurrentInput, 350);
+    }
+
+    function readFile(file) {
+      if (!file) {
+        return;
+      }
+      var reader = new FileReader();
+      reader.onload = function () {
+        setMode('paste');
+        paste.value = String(reader.result || '');
+        lastSource = paste.value;
+        preview('paste', lastSource);
+      };
+      reader.onerror = function () {
+        renderError('failed to read dropped/uploaded file', true);
+      };
+      reader.readAsText(file);
+    }
+
+    paste.addEventListener('input', function () {
+      setMode('paste');
+      schedulePreview();
+    });
+    paste.addEventListener('paste', function () {
+      setMode('paste');
+      setTimeout(previewCurrentInput, 0);
+    });
+    upload.addEventListener('change', function () {
+      readFile(upload.files && upload.files[0]);
+    });
+    form.querySelectorAll('input[name="mode"]').forEach(function (input) {
+      input.addEventListener('change', previewCurrentInput);
+    });
+    dropZone.addEventListener('dragover', function (event) {
+      event.preventDefault();
+      dropZone.classList.add('dragging');
+    });
+    dropZone.addEventListener('dragleave', function () {
+      dropZone.classList.remove('dragging');
+    });
+    dropZone.addEventListener('drop', function (event) {
+      event.preventDefault();
+      dropZone.classList.remove('dragging');
+      if (event.dataTransfer.files && event.dataTransfer.files.length > 0) {
+        readFile(event.dataTransfer.files[0]);
+        return;
+      }
+      var text = event.dataTransfer.getData('text/plain');
+      if (text) {
+        setMode('paste');
+        paste.value = text;
+        lastSource = text;
+        preview('paste', text);
+      }
+    });
+    detailsButton.addEventListener('click', function () {
+      showSource(true);
+    });
+    backButton.addEventListener('click', function () {
+      showSource(false);
+    });
+
+    stepSource.addEventListener('click', function () {
+      sourcePanel.classList.add('hidden');
+      sourceControls.classList.remove('hidden');
+      setStep('source');
+      setStatus(lastPreviewValid ? 'success' : 'info', lastPreviewValid ? '✅ Source is valid. You can edit it here or return to the review tab.' : '🧪 Paste, drop, upload, or select an existing kubeconfig to validate it before review.');
+    });
+
+    stepReview.addEventListener('click', function () {
+      if (lastPreviewValid) {
+        setStep('review');
+        setStatus('success', '✅ Source is valid. Review the target cluster before connecting.');
+        return;
+      }
+      setStep('source');
+      setStatus('info', '⏳ Review target unlocks after source validation succeeds.');
+    });
+
+    stepCurrent.addEventListener('click', function () {
+      if (lastPreviewValid) {
+        setStep('review');
+        setStatus('info', '⏳ Current state loads after you click Enable Kubernetes Access and the live cluster validation succeeds.');
+        return;
+      }
+      setStep('source');
+      setStatus('info', '⏳ Current state loads after source validation, target review, and confirmation.');
+    });
+    changeSourceButton.addEventListener('click', function () {
+      setStep('source');
+      sourcePanel.classList.add('hidden');
+      sourceControls.classList.remove('hidden');
+      setStatus(lastPreviewValid ? 'success' : 'info', lastPreviewValid ? '✅ Source is valid. Edit or replace it to re-validate.' : '🧪 Paste, drop, or upload a kubeconfig YAML/JSON file to validate it.');
+    });
+    form.addEventListener('submit', function (event) {
+      if (!lastPreviewValid) {
+        event.preventDefault();
+        renderError('Source validation must pass before Kubernetes access can be enabled.', selectedMode() !== 'existing');
+        return;
+      }
+      form.classList.add('submitting');
+      enableButton.disabled = true;
+      enableButton.classList.add('loading');
+      enableButton.innerHTML = '<span class="spinner" aria-hidden="true"></span> Enabling Kubernetes Access…';
+      setStatus('info', '⏳ Validating live cluster access and loading the current-state dashboard…');
+    });
+    function initializeFreshSourceState() {
+      paste.value = '';
+      upload.value = '';
+      lastSource = '';
+      lastPreviewValid = false;
+      lastPreview = null;
+      if (selectedMode() === 'existing') {
+        setMode('paste');
+      }
+      resetPreview(document.querySelector('.err') ? '❌ Fix the source issue, then validate again.' : '🧪 Paste, drop, upload, or select an existing kubeconfig to validate it before review.');
+      if (document.querySelector('.err')) {
+        setStepCard(stepSource, 'error', '❌', '1. Source validation', 'Fix the source and validate again');
+        setStatus('err', '❌ Fix the source issue, then validate again.');
+      }
+    }
+    window.addEventListener('pageshow', function (event) {
+      if (event.persisted) {
+        initializeFreshSourceState();
+      }
+    });
+    initializeFreshSourceState();
+  })();
+  </script>
+</body>
+</html>`))
+
+var kubeSuccessTemplate = template.Must(template.New("kube-success").Parse(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kubernetes MCP Server — Current State</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; background:#f5f5f5; margin:0; padding:0; }
+    .card { max-width:980px; margin:5vh auto; background:#fff; padding:24px; border-radius:12px; box-shadow:0 4px 20px rgba(0,0,0,0.08); }
+    h1 { margin:0 0 8px 0; font-size:20px; }
+    h2 { margin:0 0 10px 0; font-size:16px; }
+    h3 { margin:0 0 10px 0; font-size:15px; }
+    p { margin:0 0 16px 0; color:#555; font-size:14px; line-height:1.4; }
+    .steps { display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px; margin:12px 0 16px; }
+    .step { border:1px solid #e6e6e6; border-radius:10px; padding:10px 12px; background:#fff; color:#666; font-size:13px; font-weight:700; }
+    .step.active { border-color:#cfe0ff; background:#eef4ff; color:#1f3b7a; }
+    .step.done { border-color:#b7ebc6; background:#e7f7ed; color:#0f5132; }
+    .step small { display:block; margin-top:2px; font-weight:500; font-size:11px; color:inherit; opacity:0.82; }
+    .connected { background:linear-gradient(135deg, #e7f7ed 0%, #f9fffb 100%); border:1px solid #b7ebc6; color:#0f5132; padding:14px; border-radius:12px; margin:14px 0; }
+    .connected-head { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; flex-wrap:wrap; }
+    .connected-title { font-size:16px; font-weight:800; margin-bottom:8px; }
+    .chip { display:inline-block; padding:3px 8px; border-radius:999px; background:#eef4ff; color:#1f3b7a; font-size:12px; font-weight:700; white-space:nowrap; }
+    .chip.ok { background:#0f5132; color:#fff; }
+    .chip.soft { background:#e7f7ed; color:#0f5132; border:1px solid #b7ebc6; }
+    .dashboard { display:grid; grid-template-columns:230px 1fr; gap:16px; margin-top:14px; }
+    .menu { border:1px solid #e6e6e6; border-radius:12px; padding:10px; background:#fbfbfb; align-self:start; }
+    .menu-title { font-size:12px; color:#555; font-weight:800; text-transform:uppercase; letter-spacing:.04em; margin:2px 0 8px; }
+    .menu button { width:100%; text-align:left; margin:4px 0; padding:10px 12px; border:1px solid transparent; border-radius:10px; background:transparent; color:#333; font-weight:700; cursor:pointer; }
+    .menu button:hover { background:#eef4ff; }
+    .menu button.active { background:#0052cc; color:#fff; }
+    .panel { border:1px solid #e6e6e6; border-radius:12px; padding:16px; background:#fff; min-height:260px; }
+    .panel.hidden { display:none; }
+    .panel-header { display:flex; justify-content:space-between; gap:10px; align-items:center; margin-bottom:8px; }
+    .list { list-style:none; margin:10px 0 0; padding:0; display:grid; grid-template-columns:repeat(auto-fit, minmax(210px, 1fr)); gap:8px; }
+    .list li { border:1px solid #f0f0f0; border-radius:10px; padding:9px 10px; font-size:13px; color:#333; background:#fcfcfc; overflow-wrap:anywhere; }
+    .tools { grid-template-columns:repeat(auto-fit, minmax(260px, 1fr)); }
+    .muted { color:#666; font-size:12px; }
+    .warning { background:#fff8e1; border-left:4px solid #ff8f00; padding:10px 12px; border-radius:8px; margin:10px 0; font-size:13px; color:#555; }
+    .info { background:#eef4ff; border:1px solid #cfe0ff; color:#1f3b7a; padding:10px 12px; border-radius:8px; margin:14px 0 0; font-size:13px; }
+    .continue-action { display:block; text-align:center; text-decoration:none; margin-top:14px; padding:10px 12px; border-radius:8px; background:#0052cc; color:#fff; font-weight:700; font-size:14px; }
+    .continue-action:hover { background:#0043a8; }
+    .meta-row { font-size:13px; margin:6px 0; color:#173b22; overflow-wrap:anywhere; }
+    .meta-label { font-weight:700; margin-right:6px; }
+    code { background:rgba(0,0,0,0.06); padding:1px 4px; border-radius:4px; font-family:ui-monospace, SFMono-Regular, Menlo, monospace; }
+    @media (max-width: 780px) {
+      .card { margin:0; border-radius:0; min-height:100vh; }
+      .steps { grid-template-columns:1fr; }
+      .dashboard { grid-template-columns:1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Kubernetes MCP Server</h1>
+    <p>Kubernetes access is enabled. Review the connected cluster inventory and the MCP tools now available to your client.</p>
+
+    <div class="steps">
+      <div class="step done">✅ 1. Source validation<small>Kubeconfig parsed</small></div>
+      <div class="step done">✅ 2. Review target<small>Cluster confirmed</small></div>
+      <div class="step active">✅ 3. Current state<small>Live API inventory</small></div>
+    </div>
+
+    <div class="connected">
+      <div class="connected-head">
+        <div>
+          <div class="connected-title">✅ Kubernetes access enabled</div>
+          <div class="meta-row"><span class="meta-label">URL</span><code>{{.APIServerURL}}</code></div>
+          <div class="meta-row"><span class="meta-label">Host</span><code>{{if .APIHost}}{{.APIHost}}{{else}}n/a{{end}}</code></div>
+        </div>
+        <div>
+          {{if .ClusterVersion}}<span class="chip ok">{{.ClusterVersion}}</span>{{end}}
+          <span class="chip soft">context: {{.ContextName}}</span>
+        </div>
+      </div>
+    </div>
+
+    {{range .InventoryWarnings}}
+      <div class="warning">⚠️ {{.}}</div>
+    {{end}}
+
+    {{if .RedirectURL}}
+      <div class="info">
+        OAuth authorization is ready. Review the current state below, then continue back to your MCP client.
+        <a class="continue-action" href="{{.RedirectURL}}">🚀 Continue to MCP client</a>
+      </div>
+    {{end}}
+
+    <div class="dashboard">
+      <nav class="menu" aria-label="Cluster inventory groups">
+        <div class="menu-title">Group Menu (5)</div>
+        <button type="button" class="active" data-panel="namespaces">📚 Namespaces ({{.NamespaceCount}})</button>
+        <button type="button" data-panel="nodes">🖥️ Nodes ({{.NodeCount}})</button>
+        <button type="button" data-panel="serviceaccounts">👤 Service Accounts ({{.ServiceAccountCount}})</button>
+        <button type="button" data-panel="crds">🧩 CRDs ({{.CRDCount}})</button>
+        <button type="button" data-panel="tools">🛠️ Tools ({{len .Tools}})</button>
+      </nav>
+
+      <main>
+        <section id="panel-namespaces" class="panel">
+          <div class="panel-header"><h2>📚 Namespaces</h2><span class="chip">{{.NamespaceCount}}</span></div>
+          {{if gt .NamespaceCount (len .Namespaces)}}<p class="muted">Showing first {{len .Namespaces}} of {{.NamespaceCount}} namespaces.</p>{{end}}
+          <ul class="list">
+            {{range .Namespaces}}<li>📦 <code>{{.}}</code></li>{{else}}<li>No namespaces returned.</li>{{end}}
+          </ul>
+        </section>
+
+        <section id="panel-nodes" class="panel hidden">
+          <div class="panel-header"><h2>🖥️ Nodes</h2><span class="chip">{{.NodeCount}}</span></div>
+          {{if gt .NodeCount (len .Nodes)}}<p class="muted">Showing first {{len .Nodes}} of {{.NodeCount}} nodes.</p>{{end}}
+          <ul class="list">
+            {{range .Nodes}}<li>🧭 <code>{{.}}</code></li>{{else}}<li>No nodes returned.</li>{{end}}
+          </ul>
+        </section>
+
+        <section id="panel-serviceaccounts" class="panel hidden">
+          <div class="panel-header"><h2>👤 Service Accounts</h2><span class="chip">{{.ServiceAccountCount}}</span></div>
+          {{if gt .ServiceAccountCount (len .ServiceAccounts)}}<p class="muted">Showing first {{len .ServiceAccounts}} of {{.ServiceAccountCount}} service accounts.</p>{{end}}
+          <ul class="list">
+            {{range .ServiceAccounts}}<li>🔐 <code>{{.}}</code></li>{{else}}<li>No service accounts returned.</li>{{end}}
+          </ul>
+        </section>
+
+        <section id="panel-crds" class="panel hidden">
+          <div class="panel-header"><h2>🧩 Custom Resource Definitions</h2><span class="chip">{{.CRDCount}}</span></div>
+          {{if gt .CRDCount (len .CRDs)}}<p class="muted">Showing first {{len .CRDs}} of {{.CRDCount}} CRDs.</p>{{end}}
+          <ul class="list">
+            {{range .CRDs}}<li>🧬 <code>{{.}}</code></li>{{else}}<li>No CRDs returned.</li>{{end}}
+          </ul>
+        </section>
+
+        <section id="panel-tools" class="panel hidden">
+          <div class="panel-header"><h2>🛠️ MCP Tools</h2><span class="chip">{{len .Tools}}</span></div>
+          <p class="muted">These are the tools currently registered by the MCP server after kubeconfig bootstrap and configuration reload.</p>
+          <ul class="list tools">
+            {{range .Tools}}<li>⚙️ <code>{{.}}</code></li>{{else}}<li>No MCP tools are currently enabled.</li>{{end}}
+          </ul>
+        </section>
+      </main>
+    </div>
+
+    <div class="info">
+      It is safe to close this tab. Return to your MCP client and retry the connection or tool call.
+    </div>
+  </div>
+  <script>
+  (function () {
+    var buttons = Array.from(document.querySelectorAll('.menu button[data-panel]'));
+    var panels = Array.from(document.querySelectorAll('.panel'));
+    buttons.forEach(function (button) {
+      button.addEventListener('click', function () {
+        var target = 'panel-' + button.getAttribute('data-panel');
+        buttons.forEach(function (item) { item.classList.toggle('active', item === button); });
+        panels.forEach(function (panel) { panel.classList.toggle('hidden', panel.id !== target); });
+      });
+    });
+  })();
+  </script>
+</body>
+</html>`))
+
+func (s *Server) handleKubeLogin(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.renderKubeLogin(w, r, kubeLoginView{RequestToken: r.URL.Query().Get("request")})
+	case http.MethodPost:
+		s.handleKubeLoginPost(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+type kubePreviewError struct {
+	Valid bool   `json:"valid"`
+	Error string `json:"error"`
+}
+
+func (s *Server) handleKubePreview(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		withCORSHeaders(w)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	content, err := s.readKubePreviewContent(r)
+	if err != nil {
+		writeJSON(w, http.StatusOK, kubePreviewError{Error: err.Error()})
+		return
+	}
+	preview, err := PreviewKubeconfig(content)
+	if err != nil {
+		writeJSON(w, http.StatusOK, kubePreviewError{Error: err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, preview)
+}
+
+func (s *Server) readKubePreviewContent(r *http.Request) ([]byte, error) {
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		var req struct {
+			Mode       string `json:"mode"`
+			Kubeconfig string `json:"kubeconfig"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			return nil, fmt.Errorf("invalid JSON body: %w", err)
+		}
+		if req.Mode == "existing" {
+			b, err := os.ReadFile(s.kubeconfigPath())
+			if err != nil {
+				return nil, fmt.Errorf("failed to read existing kubeconfig: %w", err)
+			}
+			return b, nil
+		}
+		if strings.TrimSpace(req.Kubeconfig) == "" {
+			return nil, fmt.Errorf("kubeconfig content is empty")
+		}
+		return []byte(req.Kubeconfig), nil
+	}
+
+	if err := r.ParseMultipartForm(16 << 20); err != nil {
+		return nil, fmt.Errorf("failed to parse form: %w", err)
+	}
+	if r.FormValue("mode") == "existing" {
+		b, err := os.ReadFile(s.kubeconfigPath())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read existing kubeconfig: %w", err)
+		}
+		return b, nil
+	}
+	if text := r.FormValue("kubeconfig"); strings.TrimSpace(text) != "" {
+		return []byte(text), nil
+	}
+	if text := r.FormValue("kubeconfig_paste"); strings.TrimSpace(text) != "" {
+		return []byte(text), nil
+	}
+
+	f, _, err := r.FormFile("kubeconfig_upload")
+	if err != nil {
+		return nil, fmt.Errorf("kubeconfig content is empty")
+	}
+	defer func() { _ = f.Close() }()
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read uploaded file: %w", err)
+	}
+	return b, nil
+}
+
+func (s *Server) renderKubeLogin(w http.ResponseWriter, r *http.Request, view kubeLoginView) {
+	path := s.kubeconfigPath()
+	view.ExistingPath = path
+	if _, err := os.Stat(path); err == nil {
+		view.HasExisting = true
+	}
+	if view.DefaultMode == "" {
+		view.DefaultMode = "paste"
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	setNoStoreHeaders(w)
+	if err := kubeLoginTemplate.Execute(w, view); err != nil {
+		klog.FromContext(r.Context()).Error(err, "failed to render kube login")
+	}
+}
+
+func (s *Server) handleKubeLoginPost(w http.ResponseWriter, r *http.Request) {
+	logger := klog.FromContext(r.Context())
+	path := s.kubeconfigPath()
+
+	if err := r.ParseMultipartForm(16 << 20); err != nil {
+		s.renderKubeLogin(w, r, kubeLoginView{Error: "Failed to parse form"})
+		return
+	}
+	mode := r.FormValue("mode")
+	oauthReq := r.FormValue("request")
+
+	var content []byte
+	switch mode {
+	case "existing":
+		b, err := os.ReadFile(path)
+		if err != nil {
+			s.renderKubeLogin(w, r, kubeLoginView{Error: fmt.Sprintf("Failed to read existing kubeconfig: %v", err), RequestToken: oauthReq, DefaultMode: "existing"})
+			return
+		}
+		content = b
+	case "paste":
+		text := r.FormValue("kubeconfig_paste")
+		content = []byte(text)
+		if strings.TrimSpace(text) == "" {
+			s.renderKubeLogin(w, r, kubeLoginView{Error: "Pasted kubeconfig is empty", RequestToken: oauthReq, DefaultMode: "paste"})
+			return
+		}
+	case "upload":
+		f, _, err := r.FormFile("kubeconfig_upload")
+		if err != nil {
+			s.renderKubeLogin(w, r, kubeLoginView{Error: "No file uploaded", RequestToken: oauthReq, DefaultMode: "upload"})
+			return
+		}
+		defer func() { _ = f.Close() }()
+		b, err := io.ReadAll(f)
+		if err != nil {
+			s.renderKubeLogin(w, r, kubeLoginView{Error: "Failed to read uploaded file", RequestToken: oauthReq, DefaultMode: "upload"})
+			return
+		}
+		content = b
+	default:
+		s.renderKubeLogin(w, r, kubeLoginView{Error: "Invalid mode", RequestToken: oauthReq})
+		return
+	}
+
+	validationPath := path
+	candidatePath := ""
+	if mode == "paste" || mode == "upload" {
+		var cleanupCandidate func() error
+		var err error
+		candidatePath, cleanupCandidate, err = writeKubeconfigCandidate(path, content)
+		if err != nil {
+			s.renderKubeLogin(w, r, kubeLoginView{Error: err.Error(), RequestToken: oauthReq, DefaultMode: mode})
+			return
+		}
+		defer func() {
+			if candidatePath == "" {
+				return
+			}
+			if err := cleanupCandidate(); err != nil && !errors.Is(err, os.ErrNotExist) {
+				logger.Error(err, "failed to remove temporary kubeconfig candidate")
+			}
+		}()
+		validationPath = candidatePath
+	}
+
+	s.configureMu.Lock()
+	defer s.configureMu.Unlock()
+
+	facts, err := s.validate(r.Context(), validationPath)
+	if err != nil {
+		s.renderKubeLogin(w, r, kubeLoginView{Error: fmt.Sprintf("Kubeconfig validation failed: %v", err), RequestToken: oauthReq, DefaultMode: mode})
+		return
+	}
+
+	if candidatePath != "" {
+		if err := os.Rename(candidatePath, path); err != nil {
+			s.renderKubeLogin(w, r, kubeLoginView{Error: fmt.Sprintf("Failed to write kubeconfig: %v", err), RequestToken: oauthReq, DefaultMode: mode})
+			return
+		}
+		candidatePath = ""
+	}
+
+	prov, err := s.buildProv(r.Context())
+	if err != nil {
+		s.renderKubeLogin(w, r, kubeLoginView{Error: fmt.Sprintf("Failed to build Kubernetes provider: %v", err), RequestToken: oauthReq, DefaultMode: mode})
+		return
+	}
+	s.dyn.SetProvider(prov)
+	if err := s.mcpServer.ReloadConfiguration(r.Context(), s.cfgState.Load()); err != nil {
+		logger.Error(err, "failed to reload MCP configuration after kubeconfig bootstrap")
+		s.renderKubeLogin(w, r, kubeLoginView{Error: fmt.Sprintf("Failed to reload MCP server configuration: %v", err), RequestToken: oauthReq, DefaultMode: mode})
+		return
+	}
+	facts.Tools = sortedCopy(s.mcpServer.GetEnabledTools())
+	facts.normalize()
+
+	if oauthReq != "" {
+		areq := authRequest{}
+		if err := s.sealer.Unseal(tokenTypeAuthRequest, oauthReq, &areq); err != nil {
+			s.renderKubeLogin(w, r, kubeLoginView{Error: "Invalid OAuth request", DefaultMode: mode})
+			return
+		}
+		if err := areq.validate(s.now()); err != nil {
+			s.renderKubeLogin(w, r, kubeLoginView{Error: "OAuth request expired", DefaultMode: mode})
+			return
+		}
+		code, err := s.issueAuthCode(authCode{
+			tokenBase:           newTokenBase(s.now(), 2*time.Minute),
+			ClientID:            areq.ClientID,
+			RedirectURI:         areq.RedirectURI,
+			Scope:               areq.Scope,
+			CodeChallenge:       areq.CodeChallenge,
+			CodeChallengeMethod: areq.CodeChallengeMethod,
+		})
+		if err != nil {
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
+		facts.RedirectURL = template.URL(redirectWithCode(areq.RedirectURI, code, areq.State))
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		setNoStoreHeaders(w)
+		if err := kubeSuccessTemplate.Execute(w, facts); err != nil {
+			logger.Error(err, "failed to render success page")
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	setNoStoreHeaders(w)
+	if err := kubeSuccessTemplate.Execute(w, facts); err != nil {
+		logger.Error(err, "failed to render success page")
+	}
+}
+func writeKubeconfigCandidate(path string, content []byte) (string, func() error, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", nil, fmt.Errorf("failed to create kubeconfig directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".config-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temporary kubeconfig: %w", err)
+	}
+	candidatePath := tmp.Name()
+	cleanup := func() error {
+		return os.Remove(candidatePath)
+	}
+	if _, err := tmp.Write(content); err != nil {
+		closeErr := tmp.Close()
+		removeErr := cleanup()
+		if closeErr != nil {
+			return "", nil, fmt.Errorf("failed to write temporary kubeconfig: %w; close failed: %v", err, closeErr)
+		}
+		if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return "", nil, fmt.Errorf("failed to write temporary kubeconfig: %w; cleanup failed: %v", err, removeErr)
+		}
+		return "", nil, fmt.Errorf("failed to write temporary kubeconfig: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		removeErr := cleanup()
+		if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return "", nil, fmt.Errorf("failed to close temporary kubeconfig: %w; cleanup failed: %v", err, removeErr)
+		}
+		return "", nil, fmt.Errorf("failed to close temporary kubeconfig: %w", err)
+	}
+	if err := os.Chmod(candidatePath, 0o600); err != nil {
+		removeErr := cleanup()
+		if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return "", nil, fmt.Errorf("failed to secure temporary kubeconfig: %w; cleanup failed: %v", err, removeErr)
+		}
+		return "", nil, fmt.Errorf("failed to secure temporary kubeconfig: %w", err)
+	}
+	return candidatePath, cleanup, nil
+}
+
+func sortedCopy(items []string) []string {
+	out := append([]string(nil), items...)
+	sort.Strings(out)
+	return out
+}
+
+func contains(items []string, v string) bool {
+	for _, s := range items {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+	withCORSHeaders(w)
+	w.Header().Set("Content-Type", "application/json")
+	setNoStoreHeaders(w)
+	w.WriteHeader(status)
+	_, _ = w.Write(b)
+}
+
+func setNoStoreHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store, no-cache, max-age=0, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+}
+
+func withCORSHeaders(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+}

--- a/pkg/bootstrap/server.go
+++ b/pkg/bootstrap/server.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -43,13 +44,14 @@ type Options struct {
 }
 
 type Server struct {
-	cfgState  *config.StaticConfigState
-	mcpServer *mcp.Server
-	dyn       *kubernetes.DynamicProvider
-	buildProv func(ctx context.Context) (kubernetes.Provider, error)
-	validate  func(ctx context.Context, kubeconfigPath string) (*ClusterFacts, error)
-	sealer    *Sealer
-	now       func() time.Time
+	cfgState       *config.StaticConfigState
+	mcpServer      *mcp.Server
+	dyn            *kubernetes.DynamicProvider
+	buildProv      func(ctx context.Context) (kubernetes.Provider, error)
+	validate       func(ctx context.Context, kubeconfigPath string) (*ClusterFacts, error)
+	sealer         *Sealer
+	now            func() time.Time
+	accessTokenTTL time.Duration
 
 	configureMu sync.Mutex
 }
@@ -85,14 +87,24 @@ func NewServer(opts Options) (*Server, error) {
 	}
 
 	return &Server{
-		cfgState:  opts.CfgState,
-		mcpServer: opts.McpServer,
-		dyn:       opts.DynamicProvider,
-		buildProv: opts.ProviderBuilder,
-		validate:  validate,
-		sealer:    sealer,
-		now:       time.Now,
+		cfgState:       opts.CfgState,
+		mcpServer:      opts.McpServer,
+		dyn:            opts.DynamicProvider,
+		buildProv:      opts.ProviderBuilder,
+		validate:       validate,
+		sealer:         sealer,
+		now:            time.Now,
+		accessTokenTTL: durationEnv("MCP_AUTH_ACCESS_TTL", 10*time.Hour),
 	}, nil
+}
+
+func durationEnv(key string, fallback time.Duration) time.Duration {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return fallback
 }
 
 func sealerKeyFromEnv() ([]byte, error) {
@@ -104,6 +116,11 @@ func sealerKeyFromEnv() ([]byte, error) {
 	if _, err := io.ReadFull(rand.Reader, key); err != nil {
 		return nil, fmt.Errorf("failed to generate ephemeral auth key: %w", err)
 	}
+	// Log the generated secret so operators can capture it for persistence across restarts.
+	// Set MCP_AUTH_SECRET=<value> to keep bearer tokens valid after a restart.
+	klog.InfoS("MCP_AUTH_SECRET not set — generated ephemeral auth key",
+		"MCP_AUTH_SECRET", base64.RawURLEncoding.EncodeToString(key),
+	)
 	return key, nil
 }
 
@@ -440,11 +457,31 @@ func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	reg, err := s.parseClientRegistration(clientID)
 	if err != nil {
-		http.Error(w, "invalid client_id", http.StatusBadRequest)
+		// The client_id is a sealed registration token. Unsealing fails when the
+		// server's signing key (MCP_AUTH_SECRET) was rotated/regenerated since the
+		// client registered, or when the 24h registration TTL has lapsed. Show the
+		// user a recoverable message instead of a bare "invalid client_id".
+		s.renderAuthError(w, r, http.StatusBadRequest, authErrorView{
+			Title:   "Reconnect required",
+			Summary: "This server could not verify your client registration.",
+			Details: []template.HTML{
+				`Your MCP client authorized here before, but the credential it saved (its OAuth <code>client_id</code>) can no longer be verified by this server.`,
+				`The usual cause is that the server restarted or its signing key (<code>MCP_AUTH_SECRET</code>) was rotated, which invalidates every previously issued registration. Client registrations also expire 24 hours after they are created.`,
+			},
+			Steps: reconnectSteps,
+		})
 		return
 	}
 	if !contains(reg.RedirectURIs, redirectURI) {
-		http.Error(w, "redirect_uri is not registered for client", http.StatusBadRequest)
+		s.renderAuthError(w, r, http.StatusBadRequest, authErrorView{
+			Title:   "Redirect address not recognized",
+			Summary: "The redirect_uri in this request is not registered for your client.",
+			Details: []template.HTML{
+				`Your MCP client asked to be redirected to an address that was not part of its original registration. For security this server only redirects to addresses a client registered up front.`,
+				`This usually means the client's saved registration is stale. Reconnecting re-registers the current redirect address.`,
+			},
+			Steps: reconnectSteps,
+		})
 		return
 	}
 
@@ -566,7 +603,7 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	at := accessToken{
-		tokenBase: newTokenBase(s.now(), 1*time.Hour),
+		tokenBase: newTokenBase(s.now(), s.accessTokenTTL),
 		ClientID:  clientID,
 		Scope:     ac.Scope,
 	}
@@ -578,7 +615,7 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 	resp := tokenResponse{
 		AccessToken: access,
 		TokenType:   "Bearer",
-		ExpiresIn:   3600,
+		ExpiresIn:   int64(s.accessTokenTTL.Seconds()),
 		Scope:       ac.Scope,
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -1284,6 +1321,78 @@ var kubeSuccessTemplate = template.Must(template.New("kube-success").Parse(`<!do
 </body>
 </html>`))
 
+// authErrorView backs authErrorTemplate. Its fields are developer-authored
+// (never request data), so Details/Steps are template.HTML to allow inline
+// <code> formatting without HTML-escaping.
+type authErrorView struct {
+	Title   string
+	Summary string
+	Details []template.HTML
+	Steps   []template.HTML
+}
+
+// reconnectSteps is the standard remediation shown when a client's saved OAuth
+// registration can no longer be honored (rotated signing key or expired
+// registration). Reconnecting forces the client to register again.
+var reconnectSteps = []template.HTML{
+	`In your MCP client, remove or disconnect this server so it drops the stale saved credential. In Claude Code: <code>/mcp</code> &rarr; select this server &rarr; disconnect (or re-run <code>claude mcp add</code>).`,
+	`Reconnect / re-add the server. The client will register again automatically and reopen this login page.`,
+	`Complete the kubeconfig login when the browser opens — access is restored once validation succeeds.`,
+}
+
+// authErrorTemplate renders a browser-facing OAuth failure using the same card
+// styling as the bootstrap login page. RFC 6749 §4.1.2.1 requires that when the
+// client_id or redirect_uri is invalid we inform the user directly instead of
+// redirecting to an untrusted URI — so these are HTML pages, not redirects.
+var authErrorTemplate = template.Must(template.New("auth-error").Parse(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Kubernetes MCP Server — Reconnect required</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; background:#f5f5f5; margin:0; padding:0; }
+    .card { max-width:640px; margin:7vh auto; background:#fff; padding:24px; border-radius:12px; box-shadow:0 4px 20px rgba(0,0,0,0.08); }
+    h1 { margin:0 0 8px 0; font-size:20px; }
+    h2 { margin:0 0 10px 0; font-size:15px; }
+    p { margin:0 0 14px 0; color:#444; font-size:14px; line-height:1.5; }
+    .err { background:#fdecea; border:1px solid #f5c6cb; color:#7a1c1c; padding:12px 14px; border-radius:8px; margin-bottom:16px; font-size:14px; line-height:1.5; }
+    .section { border:1px solid #e6e6e6; border-radius:10px; padding:14px 16px; margin:14px 0; }
+    .section ol { margin:8px 0 0; padding-left:20px; }
+    .section li { margin:8px 0; font-size:14px; color:#333; line-height:1.5; }
+    .note { background:#fff8e1; border-left:4px solid #ff8f00; padding:10px 12px; border-radius:8px; margin-top:14px; font-size:13px; color:#555; line-height:1.5; }
+    code { background:#f1f1f1; padding:1px 5px; border-radius:4px; font-family:ui-monospace, SFMono-Regular, Menlo, monospace; font-size:0.92em; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Kubernetes MCP Server</h1>
+    <div class="err"><strong>⚠️ {{.Title}}</strong><br/>{{.Summary}}</div>
+    {{range .Details}}<p>{{.}}</p>{{end}}
+    {{if .Steps}}
+    <div class="section">
+      <h2>🔁 How to reconnect</h2>
+      <ol>{{range .Steps}}<li>{{.}}</li>{{end}}</ol>
+    </div>
+    {{end}}
+    <div class="note">
+      🔐 If this keeps happening on every restart, the server is generating a new signing key each time it boots.
+      Set a persistent <code>MCP_AUTH_SECRET</code> (unique per server) so client registrations and tokens survive restarts.
+      Rotating that secret intentionally will always force every connected client through this reconnect flow once.
+    </div>
+  </div>
+</body>
+</html>`))
+
+func (s *Server) renderAuthError(w http.ResponseWriter, r *http.Request, status int, view authErrorView) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	setNoStoreHeaders(w)
+	w.WriteHeader(status)
+	if err := authErrorTemplate.Execute(w, view); err != nil {
+		klog.FromContext(r.Context()).Error(err, "failed to render auth error page")
+	}
+}
+
 func (s *Server) handleKubeLogin(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -1489,13 +1598,33 @@ func (s *Server) handleKubeLoginPost(w http.ResponseWriter, r *http.Request) {
 	facts.normalize()
 
 	if oauthReq != "" {
+		// Kubernetes access is already enabled at this point (provider set + config
+		// reloaded above). Only the OAuth code hand-off can still fail if the sealed
+		// auth request can no longer be verified — key rotation, or the 10-minute
+		// auth-request TTL lapsing while the user filled in the login form.
 		areq := authRequest{}
 		if err := s.sealer.Unseal(tokenTypeAuthRequest, oauthReq, &areq); err != nil {
-			s.renderKubeLogin(w, r, kubeLoginView{Error: "Invalid OAuth request", DefaultMode: mode})
+			s.renderAuthError(w, r, http.StatusBadRequest, authErrorView{
+				Title:   "Reconnect required",
+				Summary: "Kubernetes access was enabled, but this sign-in request could not be verified.",
+				Details: []template.HTML{
+					`This server's signing key (<code>MCP_AUTH_SECRET</code>) changed while you were signing in, so the authorization request can no longer be verified.`,
+					`Your kubeconfig was accepted — you only need to restart the sign-in from your MCP client so it can complete the handshake.`,
+				},
+				Steps: reconnectSteps,
+			})
 			return
 		}
 		if err := areq.validate(s.now()); err != nil {
-			s.renderKubeLogin(w, r, kubeLoginView{Error: "OAuth request expired", DefaultMode: mode})
+			s.renderAuthError(w, r, http.StatusBadRequest, authErrorView{
+				Title:   "Sign-in request expired",
+				Summary: "Kubernetes access was enabled, but this sign-in request timed out before it completed.",
+				Details: []template.HTML{
+					`Authorization requests are valid for a short window. This one expired before the login finished.`,
+					`Your kubeconfig was accepted — simply start the connection again from your MCP client to finish authorizing.`,
+				},
+				Steps: reconnectSteps,
+			})
 			return
 		}
 		code, err := s.issueAuthCode(authCode{

--- a/pkg/bootstrap/server_test.go
+++ b/pkg/bootstrap/server_test.go
@@ -1,0 +1,708 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"html"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/containers/kubernetes-mcp-server/pkg/mcp"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type fakeProvider struct{}
+
+func (p *fakeProvider) IsOpenShift(context.Context) bool { return false }
+func (p *fakeProvider) IsMultiTarget() bool              { return false }
+func (p *fakeProvider) GetTargets(context.Context) ([]string, error) {
+	return []string{""}, nil
+}
+
+func TestKubeLoginPostRendersClusterDashboard(t *testing.T) {
+	key := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x44}, 32))
+	t.Setenv("MCP_AUTH_SECRET", key)
+
+	cfg := config.BaseDefault()
+	cfg.BootstrapUI = true
+	cfg.Port = "8080"
+	cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+	cfg.ClusterProviderStrategy = api.ClusterProviderKubeConfig
+	cfg.KubeConfig = t.TempDir() + "/kube/config"
+	cfgState := config.NewStaticConfigState(cfg)
+
+	dyn := kubernetes.NewDynamicProvider()
+	mcpServer, err := mcp.NewServer(context.Background(), mcp.Configuration{StaticConfig: cfg}, dyn)
+	if err != nil {
+		t.Fatalf("mcp.NewServer: %v", err)
+	}
+
+	b, err := NewServer(Options{
+		CfgState:        cfgState,
+		McpServer:       mcpServer,
+		DynamicProvider: dyn,
+		ProviderBuilder: func(ctx context.Context) (kubernetes.Provider, error) { return &fakeProvider{}, nil },
+		KubeconfigValidator: func(ctx context.Context, kubeconfigPath string) (*ClusterFacts, error) {
+			return &ClusterFacts{
+				APIServerURL:   "https://example.invalid:6443",
+				ContextName:    "ctx",
+				UserName:       "user",
+				AuthMethod:     "token",
+				ClusterVersion: "v1.30.0",
+				Namespaces:     []string{"default", "kube-system"},
+				Nodes:          []string{"node-1"},
+				ServiceAccounts: []string{
+					"default/default",
+					"kube-system/coredns",
+				},
+				CRDs: []string{"widgets.example.com"},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	b.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("mode", "paste")
+	_ = mw.WriteField("kubeconfig_paste", "apiVersion: v1\nclusters: []\ncontexts: []\nusers: []\n")
+	_ = mw.Close()
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/kube/login", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /kube/login: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	html := string(body)
+	for _, want := range []string{
+		"✅ 3. Current state",
+		"URL</span><code>https://example.invalid:6443</code>",
+		"Host</span><code>example.invalid:6443</code>",
+		"Namespaces (2)",
+		"Nodes (1)",
+		"Service Accounts (2)",
+		"CRDs (1)",
+		"Tools (",
+		"default/default",
+		"widgets.example.com",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected dashboard HTML to contain %q", want)
+		}
+	}
+}
+
+func TestKubeLoginPostDoesNotPersistInvalidPastedKubeconfig(t *testing.T) {
+	key := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x55}, 32))
+	t.Setenv("MCP_AUTH_SECRET", key)
+
+	kubeconfigPath := t.TempDir() + "/kube/config"
+	original := []byte("apiVersion: v1\nkind: Config\ncurrent-context: original\n")
+	if err := os.MkdirAll(filepath.Dir(kubeconfigPath), 0o700); err != nil {
+		t.Fatalf("mkdir kubeconfig dir: %v", err)
+	}
+	if err := os.WriteFile(kubeconfigPath, original, 0o600); err != nil {
+		t.Fatalf("write original kubeconfig: %v", err)
+	}
+
+	cfg := config.BaseDefault()
+	cfg.BootstrapUI = true
+	cfg.Port = "8080"
+	cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+	cfg.ClusterProviderStrategy = api.ClusterProviderKubeConfig
+	cfg.KubeConfig = kubeconfigPath
+	cfgState := config.NewStaticConfigState(cfg)
+
+	dyn := kubernetes.NewDynamicProvider()
+	mcpServer, err := mcp.NewServer(context.Background(), mcp.Configuration{StaticConfig: cfg}, dyn)
+	if err != nil {
+		t.Fatalf("mcp.NewServer: %v", err)
+	}
+
+	b, err := NewServer(Options{
+		CfgState:        cfgState,
+		McpServer:       mcpServer,
+		DynamicProvider: dyn,
+		ProviderBuilder: func(ctx context.Context) (kubernetes.Provider, error) { return &fakeProvider{}, nil },
+		KubeconfigValidator: func(ctx context.Context, kubeconfigPath string) (*ClusterFacts, error) {
+			content, err := os.ReadFile(kubeconfigPath)
+			if err != nil {
+				return nil, err
+			}
+			if strings.Contains(string(content), "invalid-candidate") {
+				return nil, errors.New("invalid candidate")
+			}
+			return &ClusterFacts{APIServerURL: "https://example.invalid", ContextName: "ctx"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	b.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("mode", "paste")
+	_ = mw.WriteField("kubeconfig_paste", "invalid-candidate")
+	_ = mw.Close()
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/kube/login", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /kube/login: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !strings.Contains(string(body), "Kubeconfig validation failed") {
+		t.Fatalf("expected validation error page")
+	}
+	got, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		t.Fatalf("read final kubeconfig: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("invalid candidate replaced existing kubeconfig")
+	}
+}
+
+func (p *fakeProvider) GetDerivedKubernetes(context.Context, string) (*kubernetes.Kubernetes, error) {
+	return nil, kubernetes.ErrProviderNotConfigured
+}
+func (p *fakeProvider) GetDefaultTarget() string                           { return "" }
+func (p *fakeProvider) GetTargetParameterName() string                     { return "" }
+func (p *fakeProvider) WatchTargets(context.Context, kubernetes.McpReload) {}
+func (p *fakeProvider) Close()                                             {}
+func (p *fakeProvider) HasGVKs(context.Context, []schema.GroupVersionKind) bool {
+	return true
+}
+func TestKubeLoginGetStartsFreshWithThreeSteps(t *testing.T) {
+	key := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x66}, 32))
+	t.Setenv("MCP_AUTH_SECRET", key)
+
+	cfg := config.BaseDefault()
+	cfg.BootstrapUI = true
+	cfg.Port = "8080"
+	cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+	cfg.ClusterProviderStrategy = api.ClusterProviderKubeConfig
+	cfg.KubeConfig = t.TempDir() + "/kube/config"
+	if err := os.MkdirAll(filepath.Dir(cfg.KubeConfig), 0o700); err != nil {
+		t.Fatalf("mkdir kubeconfig dir: %v", err)
+	}
+	if err := os.WriteFile(cfg.KubeConfig, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write existing kubeconfig: %v", err)
+	}
+	cfgState := config.NewStaticConfigState(cfg)
+
+	dyn := kubernetes.NewDynamicProvider()
+	mcpServer, err := mcp.NewServer(context.Background(), mcp.Configuration{StaticConfig: cfg}, dyn)
+	if err != nil {
+		t.Fatalf("mcp.NewServer: %v", err)
+	}
+
+	b, err := NewServer(Options{
+		CfgState:        cfgState,
+		McpServer:       mcpServer,
+		DynamicProvider: dyn,
+		ProviderBuilder: func(ctx context.Context) (kubernetes.Provider, error) { return &fakeProvider{}, nil },
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	b.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/kube/login")
+	if err != nil {
+		t.Fatalf("GET /kube/login: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if got := resp.Header.Get("Cache-Control"); !strings.Contains(got, "no-store") || !strings.Contains(got, "no-cache") {
+		t.Fatalf("expected no-store/no-cache header, got %q", got)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	html := string(body)
+	for _, want := range []string{
+		`<button id="stepSource" type="button" class="step active">`,
+		`<button id="stepReview" type="button" class="step">`,
+		`<button id="stepCurrent" type="button" class="step">`,
+		"🔎 1. Source validation",
+		"⏳ 2. Review target",
+		"⏳ 3. Current state",
+		`autocomplete="off"`,
+		"stepReview.addEventListener('click'",
+		"stepCurrent.addEventListener('click'",
+		"cache: 'no-store'",
+		"button.loading",
+		`<span class="spinner" aria-hidden="true"></span> Enabling Kubernetes Access…`,
+		"form.classList.add('submitting')",
+		"Validating live cluster access and loading the current-state dashboard",
+		"initializeFreshSourceState();",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected login HTML to contain %q", want)
+		}
+	}
+	if strings.Contains(html, `id="mode_existing" type="radio" name="mode" value="existing" autocomplete="off" checked`) {
+		t.Fatalf("expected existing kubeconfig mode not to be selected by default")
+	}
+}
+
+func TestSealerRoundTrip(t *testing.T) {
+	key := bytes.Repeat([]byte{0x11}, 32)
+	sealer, err := NewSealer(key, "test")
+	if err != nil {
+		t.Fatalf("NewSealer: %v", err)
+	}
+	in := map[string]any{"a": "b", "n": 1}
+	tok, err := sealer.Seal("t", in)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	out := map[string]any{}
+	if err := sealer.Unseal("t", tok, &out); err != nil {
+		t.Fatalf("Unseal: %v", err)
+	}
+	if out["a"] != "b" {
+		t.Fatalf("unexpected out[a]=%v", out["a"])
+	}
+}
+
+func TestPKCES256(t *testing.T) {
+	verifier := strings.Repeat("a", 50)
+	challenge, err := S256Challenge(verifier)
+	if err != nil {
+		t.Fatalf("S256Challenge: %v", err)
+	}
+	if err := VerifyPKCES256(challenge, verifier); err != nil {
+		t.Fatalf("VerifyPKCES256: %v", err)
+	}
+}
+
+func TestValidateRedirectURIAllowsMCPClientSchemes(t *testing.T) {
+	tests := []string{
+		"http://localhost:8080/callback",
+		"https://example.com/callback",
+		"warp://mcp/oauth/callback",
+		"warppreview://mcp/oauth/callback",
+	}
+	for _, tt := range tests {
+		t.Run(tt, func(t *testing.T) {
+			if err := validateRedirectURI(tt); err != nil {
+				t.Fatalf("validateRedirectURI(%q): %v", tt, err)
+			}
+		})
+	}
+}
+
+func TestValidateRedirectURIRejectsMalformedValues(t *testing.T) {
+	tests := []string{
+		"",
+		"/relative/callback",
+		"warp:/missing-host",
+		"http://example.com/callback#fragment",
+	}
+	for _, tt := range tests {
+		t.Run(tt, func(t *testing.T) {
+			if err := validateRedirectURI(tt); err == nil {
+				t.Fatalf("expected validateRedirectURI(%q) to fail", tt)
+			}
+		})
+	}
+}
+
+func TestRegisterAcceptsWarpRedirectURI(t *testing.T) {
+	key := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x33}, 32))
+	t.Setenv("MCP_AUTH_SECRET", key)
+
+	cfg := config.BaseDefault()
+	cfg.BootstrapUI = true
+	cfg.Port = "8080"
+	cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+	cfg.ClusterProviderStrategy = api.ClusterProviderKubeConfig
+	cfg.KubeConfig = t.TempDir() + "/kube/config"
+	cfgState := config.NewStaticConfigState(cfg)
+
+	dyn := kubernetes.NewDynamicProvider()
+	mcpServer, err := mcp.NewServer(context.Background(), mcp.Configuration{StaticConfig: cfg}, dyn)
+	if err != nil {
+		t.Fatalf("mcp.NewServer: %v", err)
+	}
+
+	b, err := NewServer(Options{
+		CfgState:        cfgState,
+		McpServer:       mcpServer,
+		DynamicProvider: dyn,
+		ProviderBuilder: func(ctx context.Context) (kubernetes.Provider, error) { return &fakeProvider{}, nil },
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	b.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	callback := "warp://mcp/oauth/callback"
+	regBody, _ := json.Marshal(map[string]any{
+		"redirect_uris": []string{callback},
+		"client_name":   "Warp",
+	})
+	resp, err := http.Post(ts.URL+"/register", "application/json", bytes.NewReader(regBody))
+	if err != nil {
+		t.Fatalf("POST /register: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+
+	var regResp registerResponse
+	if err := json.NewDecoder(resp.Body).Decode(&regResp); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+	if regResp.ClientID == "" {
+		t.Fatalf("expected client_id")
+	}
+	if len(regResp.RedirectURIs) != 1 || regResp.RedirectURIs[0] != callback {
+		t.Fatalf("expected redirect URI %q, got %#v", callback, regResp.RedirectURIs)
+	}
+}
+func TestAuthorizeRedirectsToLoginWhenProviderAlreadyConfigured(t *testing.T) {
+	key := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x77}, 32))
+	t.Setenv("MCP_AUTH_SECRET", key)
+
+	cfg := config.BaseDefault()
+	cfg.BootstrapUI = true
+	cfg.Port = "8080"
+	cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+	cfg.ClusterProviderStrategy = api.ClusterProviderKubeConfig
+	cfg.KubeConfig = t.TempDir() + "/kube/config"
+	cfgState := config.NewStaticConfigState(cfg)
+
+	dyn := kubernetes.NewDynamicProvider()
+	dyn.SetProvider(&fakeProvider{})
+	mcpServer, err := mcp.NewServer(context.Background(), mcp.Configuration{StaticConfig: cfg}, dyn)
+	if err != nil {
+		t.Fatalf("mcp.NewServer: %v", err)
+	}
+
+	b, err := NewServer(Options{
+		CfgState:        cfgState,
+		McpServer:       mcpServer,
+		DynamicProvider: dyn,
+		ProviderBuilder: func(ctx context.Context) (kubernetes.Provider, error) { return &fakeProvider{}, nil },
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	b.RegisterRoutes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	callback := "warp://mcp/oauth2callback"
+	regBody, _ := json.Marshal(map[string]any{"redirect_uris": []string{callback}})
+	resp, err := http.Post(ts.URL+"/register", "application/json", bytes.NewReader(regBody))
+	if err != nil {
+		t.Fatalf("POST /register: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	var regResp struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&regResp); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+
+	verifier := strings.Repeat("b", 50)
+	challenge, err := S256Challenge(verifier)
+	if err != nil {
+		t.Fatalf("S256Challenge: %v", err)
+	}
+	authURL := ts.URL + "/authorize?response_type=code" +
+		"&client_id=" + url.QueryEscape(regResp.ClientID) +
+		"&redirect_uri=" + url.QueryEscape(callback) +
+		"&state=logout-login" +
+		"&code_challenge=" + url.QueryEscape(challenge) +
+		"&code_challenge_method=S256"
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err = client.Get(authURL)
+	if err != nil {
+		t.Fatalf("GET /authorize: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	loc := resp.Header.Get("Location")
+	if !strings.HasPrefix(loc, "/kube/login?request=") {
+		t.Fatalf("expected configured provider to still redirect to kube login, got %q", loc)
+	}
+	if strings.HasPrefix(loc, callback) || strings.Contains(loc, "code=") {
+		t.Fatalf("expected no auto-granted callback code, got %q", loc)
+	}
+}
+
+func TestBootstrapOAuthHappyPath(t *testing.T) {
+	// Ensure a stable test key so NewServer doesn't depend on ambient env.
+	key := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x22}, 32))
+	t.Setenv("MCP_AUTH_SECRET", key)
+
+	cfg := config.BaseDefault()
+	cfg.BootstrapUI = true
+	cfg.Port = "8080"
+	cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+	cfg.ClusterProviderStrategy = api.ClusterProviderKubeConfig
+	cfg.KubeConfig = t.TempDir() + "/kube/config"
+	cfgState := config.NewStaticConfigState(cfg)
+
+	dyn := kubernetes.NewDynamicProvider()
+	mcpServer, err := mcp.NewServer(context.Background(), mcp.Configuration{StaticConfig: cfg}, dyn)
+	if err != nil {
+		t.Fatalf("mcp.NewServer: %v", err)
+	}
+
+	b, err := NewServer(Options{
+		CfgState:        cfgState,
+		McpServer:       mcpServer,
+		DynamicProvider: dyn,
+		ProviderBuilder: func(ctx context.Context) (kubernetes.Provider, error) { return &fakeProvider{}, nil },
+		KubeconfigValidator: func(ctx context.Context, kubeconfigPath string) (*ClusterFacts, error) {
+			return &ClusterFacts{
+				APIServerURL: "https://example.invalid",
+				ContextName:  "ctx",
+				UserName:     "user",
+				AuthMethod:   "token",
+				Namespaces:   []string{"default"},
+				Nodes:        []string{"node-1"},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	b.RegisterRoutes(mux)
+	mux.Handle("/protected", b.Protect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})))
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	// 1) protected endpoint without token => 401 + resource_metadata challenge
+	resp, err := http.Get(ts.URL + "/protected")
+	if err != nil {
+		t.Fatalf("GET /protected: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+	wwwAuth := resp.Header.Get("WWW-Authenticate")
+	if !strings.Contains(wwwAuth, "resource_metadata=") {
+		t.Fatalf("expected WWW-Authenticate resource_metadata challenge, got %q", wwwAuth)
+	}
+
+	// 2) dynamic client registration
+	callback := "warp://mcp/oauth/callback"
+	regBody, _ := json.Marshal(map[string]any{"redirect_uris": []string{callback}})
+	resp, err = http.Post(ts.URL+"/register", "application/json", bytes.NewReader(regBody))
+	if err != nil {
+		t.Fatalf("POST /register: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	var regResp struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&regResp); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+	if regResp.ClientID == "" {
+		t.Fatalf("expected client_id")
+	}
+
+	// 3) authorization request => redirect to /kube/login
+	verifier := strings.Repeat("a", 50)
+	challenge, _ := S256Challenge(verifier)
+	authURL := ts.URL + "/authorize?response_type=code" +
+		"&client_id=" + url.QueryEscape(regResp.ClientID) +
+		"&redirect_uri=" + url.QueryEscape(callback) +
+		"&state=s" +
+		"&code_challenge=" + url.QueryEscape(challenge) +
+		"&code_challenge_method=S256"
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err = client.Get(authURL)
+	if err != nil {
+		t.Fatalf("GET /authorize: %v", err)
+	}
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	loc := resp.Header.Get("Location")
+	if !strings.HasPrefix(loc, "/kube/login") {
+		t.Fatalf("expected redirect to /kube/login, got %q", loc)
+	}
+	u, _ := url.Parse(loc)
+	oauthReq := u.Query().Get("request")
+	if oauthReq == "" {
+		t.Fatalf("expected request token in redirect")
+	}
+
+	// 4) kube login POST (multipart) => current-state dashboard with callback link
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("mode", "paste")
+	_ = mw.WriteField("kubeconfig_paste", "apiVersion: v1\nclusters: []\ncontexts: []\nusers: []\n")
+	_ = mw.WriteField("request", oauthReq)
+	_ = mw.Close()
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/kube/login", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("POST /kube/login: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read dashboard body: %v", err)
+	}
+	dashboardHTML := string(body)
+	if !strings.Contains(dashboardHTML, "✅ 3. Current state") || !strings.Contains(dashboardHTML, "Continue to MCP client") {
+		t.Fatalf("expected current-state dashboard with continue link")
+	}
+	cbLoc := extractHrefByClass(t, dashboardHTML, "continue-action")
+	cbURL, _ := url.Parse(cbLoc)
+	if cbURL.Scheme == "" {
+		// Location might be relative; make it absolute for parsing.
+		cbURL, _ = url.Parse("http://example.com" + cbLoc)
+	}
+	code := cbURL.Query().Get("code")
+	if code == "" {
+		t.Fatalf("expected code in callback redirect, got %q", cbLoc)
+	}
+
+	// 5) exchange code for access token
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", regResp.ClientID)
+	form.Set("redirect_uri", callback)
+	form.Set("code", code)
+	form.Set("code_verifier", verifier)
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /token: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var tokResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokResp); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	if tokResp.AccessToken == "" {
+		t.Fatalf("expected access_token")
+	}
+
+	// 6) protected endpoint with token => 200
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+tokResp.AccessToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /protected with token: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Ensure reload side effects have time to complete (mostly for race builds).
+	time.Sleep(10 * time.Millisecond)
+}
+
+func extractHrefByClass(t *testing.T, page, class string) string {
+	t.Helper()
+
+	classAttr := `class="` + class + `"`
+	classIndex := strings.Index(page, classAttr)
+	if classIndex < 0 {
+		t.Fatalf("expected HTML to contain class %q", class)
+	}
+	anchorStart := strings.LastIndex(page[:classIndex], "<a")
+	if anchorStart < 0 {
+		t.Fatalf("expected class %q to belong to an anchor", class)
+	}
+	anchorEndRelative := strings.Index(page[anchorStart:], ">")
+	if anchorEndRelative < 0 {
+		t.Fatalf("expected anchor with class %q to be closed", class)
+	}
+	anchor := page[anchorStart : anchorStart+anchorEndRelative]
+	hrefStart := strings.Index(anchor, `href="`)
+	if hrefStart < 0 {
+		t.Fatalf("expected anchor with class %q to have href", class)
+	}
+	hrefStart += len(`href="`)
+	hrefEnd := strings.Index(anchor[hrefStart:], `"`)
+	if hrefEnd < 0 {
+		t.Fatalf("expected href for class %q to be quoted", class)
+	}
+	return html.UnescapeString(anchor[hrefStart : hrefStart+hrefEnd])
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,10 @@ type StaticConfig struct {
 	Prompts []api.Prompt `toml:"prompts,omitempty"`
 
 	// Authorization-related fields
+	// BootstrapUI enables a local bootstrap flow for HTTP mode where the server
+	// acts as its own OAuth 2.1 Authorization Server and does not connect to
+	// Kubernetes until the user provides a kubeconfig via /kube/login.
+	BootstrapUI bool `toml:"bootstrap_ui,omitempty"`
 	// RequireOAuth indicates whether the server requires OAuth for authentication.
 	RequireOAuth bool `toml:"require_oauth,omitempty"`
 	// OAuthAudience is the valid audience for the OAuth tokens, used for offline JWT claim validation.
@@ -505,7 +509,7 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 			return fmt.Errorf("invalid cluster-provider: %s, valid values are: %s", c.ClusterProviderStrategy, strings.Join(c.providerStrategies, ", "))
 		}
 	}
-	if !c.RequireOAuth && (c.OAuthAudience != "" || c.AuthorizationURL != "" || c.ServerURL != "" || c.CertificateAuthority != "") {
+	if !c.RequireOAuth && !c.BootstrapUI && (c.OAuthAudience != "" || c.AuthorizationURL != "" || c.ServerURL != "" || c.CertificateAuthority != "") {
 		return fmt.Errorf("oauth-audience, authorization-url, server-url and certificate-authority are only valid if require-oauth is enabled. Missing --port may implicitly set require-oauth to false")
 	}
 	if c.AuthorizationURL != "" {
@@ -548,6 +552,9 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 	if err := c.ValidateRequireTLS(); err != nil {
 		return err
 	}
+	if err := c.validateBootstrapUI(); err != nil {
+		return err
+	}
 	if err := c.ValidateClusterAuthMode(); err != nil {
 		return err
 	}
@@ -559,6 +566,25 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 	}
 	if err := c.HTTP.Validate(); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (c *StaticConfig) validateBootstrapUI() error {
+	if !c.BootstrapUI {
+		return nil
+	}
+	if c.Port == "" {
+		return fmt.Errorf("bootstrap_ui requires port to be set (HTTP mode)")
+	}
+	if c.RequireOAuth {
+		return fmt.Errorf("bootstrap_ui is not compatible with require_oauth=true (bootstrap uses internal OAuth with sealed tokens)")
+	}
+	if c.OAuthAudience != "" || c.AuthorizationURL != "" || c.SkipJWTVerification || c.CertificateAuthority != "" {
+		return fmt.Errorf("bootstrap_ui is not compatible with oauth_audience/authorization_url/skip_jwt_verification/certificate_authority; disable them or disable bootstrap_ui")
+	}
+	if c.ResolveClusterAuthMode() != api.ClusterAuthKubeconfig {
+		return fmt.Errorf("bootstrap_ui requires cluster_auth_mode=%q", api.ClusterAuthKubeconfig)
 	}
 	return nil
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -578,6 +578,58 @@ func (s *ValidateSuite) TestSkipJWTVerification() {
 		s.NoError(cfg.Validate(s.T().Context()))
 	})
 }
+func (s *ValidateSuite) TestBootstrapUI() {
+	s.Run("bootstrap ui with http mode and kubeconfig auth is accepted", func() {
+		cfg := s.validConfig()
+		cfg.Port = "8080"
+		cfg.BootstrapUI = true
+		cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+		cfg.ClusterProviderStrategy = api.ClusterProviderKubeConfig
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("bootstrap ui requires http mode", func() {
+		cfg := s.validConfig()
+		cfg.BootstrapUI = true
+		cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "bootstrap_ui requires port")
+	})
+
+	s.Run("bootstrap ui rejects require_oauth", func() {
+		cfg := s.validConfig()
+		cfg.Port = "8080"
+		cfg.BootstrapUI = true
+		cfg.RequireOAuth = true
+		cfg.AuthorizationURL = "https://example.com/auth"
+		cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "not compatible with require_oauth=true")
+	})
+
+	s.Run("bootstrap ui rejects external oauth fields", func() {
+		cfg := s.validConfig()
+		cfg.Port = "8080"
+		cfg.BootstrapUI = true
+		cfg.OAuthAudience = "kubernetes-mcp-server"
+		cfg.ClusterAuthMode = api.ClusterAuthKubeconfig
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "not compatible with oauth_audience")
+	})
+
+	s.Run("bootstrap ui requires kubeconfig cluster auth mode", func() {
+		cfg := s.validConfig()
+		cfg.Port = "8080"
+		cfg.BootstrapUI = true
+		cfg.ClusterAuthMode = api.ClusterAuthPassthrough
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), `bootstrap_ui requires cluster_auth_mode="kubeconfig"`)
+	})
+}
 
 func (s *ValidateSuite) TestClusterAuthMode() {
 	s.Run("passthrough without require_oauth is accepted", func() {

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -123,12 +123,13 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 	instrumentedHandler := metricsMiddleware(wrappedMux, mcpServer)
 
 	// Note: WriteTimeout is intentionally omitted - it would kill SSE streams.
-	// ReadHeaderTimeout provides Slowloris protection; other timeouts are left
-	// at Go defaults since MCP clients maintain persistent connections.
+	// ReadHeaderTimeout provides Slowloris protection. IdleTimeout limits keep-alive
+	// idle time between requests but does not affect active SSE/streaming connections.
 	httpServer := &http.Server{
 		Addr:              ":" + staticConfig.Port,
 		Handler:           instrumentedHandler,
 		ReadHeaderTimeout: staticConfig.HTTP.ReadHeaderTimeout.Duration(),
+		IdleTimeout:       60 * time.Minute,
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -17,6 +17,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/bootstrap"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcp"
@@ -106,7 +107,7 @@ func statsHandler(mcpServer *mcp.Server) http.HandlerFunc {
 	}
 }
 
-func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticConfigState, oauthState *oauth.State) error {
+func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticConfigState, oauthState *oauth.State, bootstrapServer *bootstrap.Server) error {
 	logger := klog.FromContext(ctx)
 	// Only fields read below are startup-only; middleware reloads via cfgState.
 	staticConfig := cfgState.Load()
@@ -145,9 +146,19 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 
 	sseServer := mcpServer.ServeSse()
 	streamableHttpServer := mcpServer.ServeHTTP()
-	mux.Handle(sseEndpoint, sseServer)
-	mux.Handle(sseMessageEndpoint, sseServer)
-	mux.Handle(mcpEndpoint, streamableHttpServer)
+
+	var sseHandler http.Handler = sseServer
+	var messageHandler http.Handler = sseServer
+	var mcpHandler http.Handler = streamableHttpServer
+	if bootstrapServer != nil {
+		bootstrapServer.RegisterRoutes(mux)
+		sseHandler = bootstrapServer.Protect(sseHandler)
+		messageHandler = bootstrapServer.Protect(messageHandler)
+		mcpHandler = bootstrapServer.Protect(mcpHandler)
+	}
+	mux.Handle(sseEndpoint, sseHandler)
+	mux.Handle(sseMessageEndpoint, messageHandler)
+	mux.Handle(mcpEndpoint, mcpHandler)
 	mux.HandleFunc(healthEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -75,7 +75,7 @@ func (s *BaseHttpSuite) StartServer() {
 		cancelCtx = klog.NewContext(cancelCtx, s.Logger)
 	}
 	group.Go(func() error {
-		return Serve(cancelCtx, s.mcpServer, config.NewStaticConfigState(s.StaticConfig), s.OAuthState)
+		return Serve(cancelCtx, s.mcpServer, config.NewStaticConfigState(s.StaticConfig), s.OAuthState, nil)
 	})
 	s.WaitForShutdown = group.Wait
 	s.Require().NoError(test.WaitForServer(tcpAddr), "HTTP server did not start in time")
@@ -158,7 +158,7 @@ func (c *httpContext) beforeEach(t *testing.T) {
 	group, gc := errgroup.WithContext(timeoutCtx)
 	cancelCtx, c.StopServer = context.WithCancel(gc)
 	group.Go(func() error {
-		return Serve(klog.NewContext(cancelCtx, c.logger), mcpServer, config.NewStaticConfigState(c.StaticConfig), c.OAuthState)
+		return Serve(klog.NewContext(cancelCtx, c.logger), mcpServer, config.NewStaticConfigState(c.StaticConfig), c.OAuthState, nil)
 	})
 	c.WaitForShutdown = group.Wait
 	// Wait for HTTP server to start (using net)

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/bootstrap"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	internalhttp "github.com/containers/kubernetes-mcp-server/pkg/http"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
@@ -74,6 +76,7 @@ const (
 	flagReadOnly             = "read-only"
 	flagDisableDestructive   = "disable-destructive"
 	flagStateless            = "stateless"
+	flagBootstrapUI          = "bootstrap-ui"
 	flagRequireOAuth         = "require-oauth"
 	flagOAuthAudience        = "oauth-audience"
 	flagAuthorizationURL     = "authorization-url"
@@ -99,6 +102,7 @@ type MCPServerOptions struct {
 	ReadOnly             bool
 	DisableDestructive   bool
 	Stateless            bool
+	BootstrapUI          bool
 	RequireOAuth         bool
 	OAuthAudience        string
 	AuthorizationURL     string
@@ -172,6 +176,7 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVar(&o.ReadOnly, flagReadOnly, o.ReadOnly, "If true, only tools annotated with readOnlyHint=true are exposed")
 	cmd.Flags().BoolVar(&o.DisableDestructive, flagDisableDestructive, o.DisableDestructive, "If true, tools annotated with destructiveHint=true are disabled")
 	cmd.Flags().BoolVar(&o.Stateless, flagStateless, o.Stateless, "If true, run the MCP server in stateless mode (disables tool/prompt change notifications). Useful for container deployments and load balancing. Default is false (stateful mode)")
+	cmd.Flags().BoolVar(&o.BootstrapUI, flagBootstrapUI, o.BootstrapUI, "Enable a local bootstrap OAuth UI (/kube/login) and protect /mcp with internal OAuth (no Kubernetes API calls until configured). Only valid in HTTP mode.")
 	cmd.Flags().BoolVar(&o.RequireOAuth, flagRequireOAuth, o.RequireOAuth, "If true, requires OAuth authorization as defined in the Model Context Protocol (MCP) specification. This flag is ignored if transport type is stdio")
 	_ = cmd.Flags().MarkHidden(flagRequireOAuth)
 	cmd.Flags().StringVar(&o.OAuthAudience, flagOAuthAudience, o.OAuthAudience, "OAuth audience for token claims validation. Optional. If not set, the audience is not validated. Only valid if require-oauth is enabled.")
@@ -203,6 +208,19 @@ func (m *MCPServerOptions) Complete(ctx context.Context, cmd *cobra.Command) err
 	}
 
 	m.loadFlags(cmd)
+
+	if m.StaticConfig.BootstrapUI {
+		// Bootstrap UI uses internal sealed-token OAuth for MCP auth and always
+		// connects to Kubernetes using kubeconfig credentials (not per-user bearer).
+		m.StaticConfig.RequireOAuth = false
+		m.StaticConfig.ClusterAuthMode = api.ClusterAuthKubeconfig
+		if m.StaticConfig.ClusterProviderStrategy == "" {
+			m.StaticConfig.ClusterProviderStrategy = api.ClusterProviderKubeConfig
+		}
+		if m.StaticConfig.KubeConfig == "" {
+			m.StaticConfig.KubeConfig = filepath.Join(mustUserHomeDir(), ".kube", "config")
+		}
+	}
 
 	sink, err := logging.New(m.StaticConfig, m.Out, m.ErrOut)
 	if err != nil {
@@ -245,6 +263,9 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 	if cmd.Flag(flagStateless).Changed {
 		m.StaticConfig.Stateless = m.Stateless
+	}
+	if cmd.Flag(flagBootstrapUI).Changed {
+		m.StaticConfig.BootstrapUI = m.BootstrapUI
 	}
 	if cmd.Flag(flagToolsets).Changed {
 		m.StaticConfig.Toolsets = m.Toolsets
@@ -337,16 +358,25 @@ func (m *MCPServerOptions) Run(ctx context.Context) error {
 	oauthState := internaloauth.NewState(internaloauth.SnapshotFromConfig(m.StaticConfig, oidcProvider, httpClient))
 	cfgState := config.NewStaticConfigState(m.StaticConfig)
 
-	provider, err := kubernetes.NewProvider(
-		ctx,
-		m.StaticConfig,
-		kubernetes.WithTokenExchange(oauthState),
-		kubernetes.WithBaseConfigProvider(func() api.BaseConfig {
-			return cfgState.Load()
-		}),
-	)
-	if err != nil {
-		return fmt.Errorf("unable to create kubernetes target provider: %w", err)
+	baseCfgProvider := func() api.BaseConfig {
+		return cfgState.Load()
+	}
+
+	var provider kubernetes.Provider
+	var dynProvider *kubernetes.DynamicProvider
+	if m.StaticConfig.BootstrapUI {
+		dynProvider = kubernetes.NewDynamicProvider()
+		provider = dynProvider
+	} else {
+		provider, err = kubernetes.NewProvider(
+			ctx,
+			m.StaticConfig,
+			kubernetes.WithTokenExchange(oauthState),
+			kubernetes.WithBaseConfigProvider(baseCfgProvider),
+		)
+		if err != nil {
+			return fmt.Errorf("unable to create kubernetes target provider: %w", err)
+		}
 	}
 
 	mcpServer, err := mcp.NewServer(ctx, mcp.Configuration{
@@ -374,7 +404,26 @@ func (m *MCPServerOptions) Run(ctx context.Context) error {
 	}
 
 	if m.StaticConfig.Port != "" {
-		return internalhttp.Serve(ctx, mcpServer, cfgState, oauthState)
+		var bootstrapServer *bootstrap.Server
+		if m.StaticConfig.BootstrapUI {
+			bootstrapServer, err = bootstrap.NewServer(bootstrap.Options{
+				CfgState:        cfgState,
+				McpServer:       mcpServer,
+				DynamicProvider: dynProvider,
+				ProviderBuilder: func(ctx context.Context) (kubernetes.Provider, error) {
+					return kubernetes.NewProvider(
+						ctx,
+						cfgState.Load(),
+						kubernetes.WithTokenExchange(oauthState),
+						kubernetes.WithBaseConfigProvider(baseCfgProvider),
+					)
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("failed to initialize bootstrap UI: %w", err)
+			}
+		}
+		return internalhttp.Serve(ctx, mcpServer, cfgState, oauthState, bootstrapServer)
 	}
 
 	if err := mcpServer.ServeStdio(ctx); err != nil && !errors.Is(err, context.Canceled) {
@@ -382,6 +431,16 @@ func (m *MCPServerOptions) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func mustUserHomeDir() string {
+	h, err := os.UserHomeDir()
+	if err != nil || h == "" {
+		// os.UserHomeDir should always succeed in supported environments.
+		// Falling back to "/" keeps file-path joins deterministic.
+		return "/"
+	}
+	return h
 }
 
 // setupSIGHUPHandler sets up a signal handler to reload configuration on SIGHUP.

--- a/pkg/kubernetes/dynamic_provider.go
+++ b/pkg/kubernetes/dynamic_provider.go
@@ -1,0 +1,136 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ErrProviderNotConfigured is returned when a cluster-scoped operation is
+// attempted before a real provider has been configured.
+var ErrProviderNotConfigured = errors.New("kubernetes provider is not configured; visit /kube/login")
+
+// DynamicProvider starts "unconfigured" and can be swapped to a real Provider at
+// runtime. It is used by the bootstrap UI flow to ensure the server does not
+// connect to Kubernetes until a kubeconfig has been selected/validated.
+type DynamicProvider struct {
+	mu sync.RWMutex
+
+	p Provider
+
+	watchCtx    context.Context
+	watchReload McpReload
+}
+
+var _ Provider = (*DynamicProvider)(nil)
+
+func NewDynamicProvider() *DynamicProvider {
+	return &DynamicProvider{}
+}
+
+// IsConfigured reports whether a real Provider has been installed.
+func (d *DynamicProvider) IsConfigured() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.p != nil
+}
+
+// SetProvider installs p as the active provider. Any previously installed
+// provider is closed.
+func (d *DynamicProvider) SetProvider(p Provider) {
+	d.mu.Lock()
+	old := d.p
+	d.p = p
+	watchCtx := d.watchCtx
+	watchReload := d.watchReload
+	d.mu.Unlock()
+
+	if old != nil && old != p {
+		old.Close()
+	}
+	if p != nil && watchCtx != nil && watchReload != nil {
+		p.WatchTargets(watchCtx, watchReload)
+	}
+}
+
+func (d *DynamicProvider) provider() Provider {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.p
+}
+
+func (d *DynamicProvider) IsOpenShift(ctx context.Context) bool {
+	if p := d.provider(); p != nil {
+		return p.IsOpenShift(ctx)
+	}
+	return false
+}
+
+func (d *DynamicProvider) IsMultiTarget() bool {
+	if p := d.provider(); p != nil {
+		return p.IsMultiTarget()
+	}
+	return false
+}
+
+func (d *DynamicProvider) GetTargets(ctx context.Context) ([]string, error) {
+	if p := d.provider(); p != nil {
+		return p.GetTargets(ctx)
+	}
+	return nil, ErrProviderNotConfigured
+}
+
+func (d *DynamicProvider) GetDerivedKubernetes(ctx context.Context, target string) (*Kubernetes, error) {
+	if p := d.provider(); p != nil {
+		return p.GetDerivedKubernetes(ctx, target)
+	}
+	return nil, ErrProviderNotConfigured
+}
+
+func (d *DynamicProvider) GetDefaultTarget() string {
+	if p := d.provider(); p != nil {
+		return p.GetDefaultTarget()
+	}
+	return ""
+}
+
+func (d *DynamicProvider) GetTargetParameterName() string {
+	if p := d.provider(); p != nil {
+		return p.GetTargetParameterName()
+	}
+	return ""
+}
+
+func (d *DynamicProvider) WatchTargets(ctx context.Context, reload McpReload) {
+	d.mu.Lock()
+	d.watchCtx = ctx
+	d.watchReload = reload
+	p := d.p
+	d.mu.Unlock()
+
+	if p != nil {
+		p.WatchTargets(ctx, reload)
+	}
+}
+
+func (d *DynamicProvider) Close() {
+	d.mu.Lock()
+	p := d.p
+	d.p = nil
+	d.mu.Unlock()
+
+	if p != nil {
+		p.Close()
+	}
+}
+
+func (d *DynamicProvider) HasGVKs(ctx context.Context, gvks []schema.GroupVersionKind) bool {
+	if p := d.provider(); p != nil {
+		return p.HasGVKs(ctx, gvks)
+	}
+	// Providers that have not opted in to discovery should return true so tools
+	// remain visible; the unconfigured provider follows that convention.
+	return true
+}


### PR DESCRIPTION
Those are some of the updates to implement an Oauth-based authentication to the MCP server, in case an organization desires to deploy a centralized version.

# Initial Screen

<img width="1240" height="1003" alt="Screenshot 2026-07-06 at 8 50 40 AM" src="https://github.com/user-attachments/assets/9b0f04e1-3f0b-43b5-8cba-83d49f2c57c8" />

# After uploading kubeconfig

<img width="1197" height="1005" alt="Screenshot 2026-07-06 at 8 50 54 AM copy" src="https://github.com/user-attachments/assets/f683b5b8-31d5-459d-8ecd-faaca9a8c946" />

# Confirming the Kluster connection

<img width="912" height="597" alt="Screenshot 2026-07-06 at 8 51 02 AM copy" src="https://github.com/user-attachments/assets/048b89ad-b8e5-48c2-84fe-cd6e0096ffec" />

# Enabling the MCP server

<img width="1394" height="998" alt="Screenshot 2026-07-06 at 8 51 12 AM copy" src="https://github.com/user-attachments/assets/ebdc0abc-8109-478e-83aa-c489347f79a1" />

# MCP Confirmation and Tools List

<img width="1429" height="835" alt="Screenshot 2026-07-06 at 8 51 18 AM copy" src="https://github.com/user-attachments/assets/e3099d1d-7965-4425-8567-8e3e9c253bfa" />

<img width="895" height="234" alt="Screenshot 2026-07-06 at 8 51 30 AM" src="https://github.com/user-attachments/assets/dc975a35-cd3c-4a53-9e28-4909b18e2584" />
