### PR TITLE
chore(ci): skip mcpchecker evaluation on forks

### DIFF
--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -58,12 +58,15 @@ jobs:
   check-trigger:
     name: Check if evaluation should run
     runs-on: ubuntu-latest
+    # Never run on forks: the evaluation needs model/judge secrets that forks
+    # don't have, so it would only ever fail there.
     if: |
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/run-mcpchecker'))
+      github.repository == 'containers/kubernetes-mcp-server' &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/run-mcpchecker')))
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
       toolsets: ${{ steps.check.outputs.toolsets }}


### PR DESCRIPTION
## Summary

The mcpchecker MCP evaluation pipeline was running on forks even though
forks don't have access to the model/judge API secrets it needs, so it
could only ever fail there.

This gates the `check-trigger` job — which gates the entire pipeline via
`needs` — on `github.repository == 'containers/kubernetes-mcp-server'`,
so the workflow is skipped entirely on forks. This reuses the exact fork
guard already applied across the release workflows (`release.yaml`,
`release-image.yml`, `release-helm.yaml`, `release-mcp-registry.yaml`,
`release-mcpb.yaml`).

## Notes

- The existing three-way event `OR` is wrapped in parentheses so
  precedence is preserved (`repo && (schedule || dispatch || comment)`).
- No change needed in `mcpchecker-report.yaml`: it triggers via
  `workflow_run` (fires only in the repo where the workflow lives) and
  already handles a skipped evaluation gracefully.