### PR TITLE
chore(ci): set 30m timeout on e2e job

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,6 +24,7 @@ jobs:
   e2e:
     name: Run E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Follow up on #1228 that adds a timeout to the overall e2e action