### PR TITLE
feat(tls): add TLS_MIN_VERSION and TLS_CIPHER_SUITES env var support

### DIFF
--- a/docs/NETOBSERV.md
+++ b/docs/NETOBSERV.md
@@ -84,6 +84,8 @@ Grant the release ServiceAccount permission to:
 
 On OpenShift, synthesized plugin URLs use HTTPS. Mount the pod service account so the server can use the cluster service CA. For a custom `url` over HTTPS, set `certificate_authority` or `insecure = true` (development only).
 
+Global `tls_min_version` / `tls_cipher_suites` (and `TLS_MIN_VERSION` / `TLS_CIPHER_SUITES` env overrides) apply to the NetObserv HTTP client. See [configuration.md](configuration.md#server-settings).
+
 ## Configuration reference
 
 | Field | Default (OpenShift in-cluster) | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,8 @@ The server will:
 | `tls_cert` | string | `""` | Path to TLS certificate file for HTTPS. When set along with `tls_key`, the server serves HTTPS instead of HTTP. |
 | `tls_key` | string | `""` | Path to TLS private key file for HTTPS. Must be set together with `tls_cert`. |
 | `require_tls` | boolean | `false` | When `true`, enforces TLS for all connections. Server refuses to start without TLS certificates, and outbound connections to non-HTTPS endpoints (e.g., Kiali) are rejected. |
+| `tls_min_version` | string | `""` | Minimum TLS version (e.g., `"1.2"`, `"1.3"`; `"1.0"` and `"1.1"` are accepted for operator parity but not recommended). Defaults to TLS 1.2 if not set. Can be overridden by `TLS_MIN_VERSION`. Applies to inbound HTTPS and outbound clients (Kiali, NetObserv, OAuth, token exchange, well-known metadata). |
+| `tls_cipher_suites` | array | `[]` | TLS 1.2 cipher suites (TLS 1.3 cipher suites are not configurable). If empty, Go's defaults are used. Can be overridden by `TLS_CIPHER_SUITES` (comma-separated). Applies to inbound HTTPS and outbound clients. |
 
 **Example:**
 ```toml
@@ -165,7 +167,42 @@ tls_key = "/etc/tls/tls.key"
 
 # Enforce TLS for all connections (requires tls_cert and tls_key)
 require_tls = true
+
+# Global TLS version and cipher suites (inbound + outbound; env vars override)
+tls_min_version = "1.2"
+tls_cipher_suites = [
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+]
 ```
+
+**TLS Environment Variables:**
+
+`TLS_MIN_VERSION` and `TLS_CIPHER_SUITES` configure TLS for **both** inbound and outbound connections. When set, they override the corresponding global TOML values (`tls_min_version`, `tls_cipher_suites`):
+
+| Setting | Inbound (HTTP server) | Outbound (Kiali, NetObserv, OAuth, token exchange, well-known metadata) |
+|---------|----------------------|-------------------------------------------------------------------------|
+| `tls_min_version` / `tls_cipher_suites` (TOML) | ✅ fallback | ✅ fallback |
+| `TLS_MIN_VERSION` / `TLS_CIPHER_SUITES` (env) | ✅ overrides TOML (at startup) | ✅ overrides TOML |
+
+When neither TOML nor env is set, both inbound and outbound default to TLS 1.2 with Go's default cipher suites.
+
+> **Note:** Inbound HTTPS (`tls_min_version`, `tls_cipher_suites`, and their env overrides) is applied when the server starts. Changing these settings requires a **process restart**; they are not updated on SIGHUP config reload. Outbound clients (OAuth, token exchange, well-known metadata) pick up changes on reload; Kiali and NetObserv re-read TLS settings on each tool invocation.
+
+```bash
+# Example: Enforce TLS 1.3 minimum version (inbound + outbound)
+export TLS_MIN_VERSION="1.3"
+
+# Example: Restrict TLS 1.2 cipher suites (inbound + outbound; TLS 1.3 ciphers are not configurable)
+export TLS_MIN_VERSION="1.2"
+export TLS_CIPHER_SUITES="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+```
+
+> **Note:** TLS 1.3 uses a fixed set of cipher suites that cannot be configured. The `TLS_CIPHER_SUITES` setting only affects TLS 1.2 and earlier connections.
+
+> **Note:** When the minimum TLS version is below `"1.3"` and you set a custom cipher list, include at least one HTTP/2-compatible suite (for example, `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`). Omitting it can break HTTPS/HTTP2 clients even when TLS 1.2 handshakes succeed.
+
+> **Note:** `TLS_MIN_VERSION` values `"1.0"` and `"1.1"` are accepted for operator parity with cluster-wide TLS settings but are not recommended for production use.
 
 ### HTTP Server Security
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -97,6 +97,13 @@ type RequireTLSProvider interface {
 	IsRequireTLS() bool
 }
 
+// TLSConfigProvider provides access to global TLS min version and cipher suite settings.
+// Values include TLS_MIN_VERSION and TLS_CIPHER_SUITES env overrides when set.
+type TLSConfigProvider interface {
+	GetTLSMinVersionConfig() string
+	GetTLSCipherSuitesConfig() []string
+}
+
 // RequireOAuthProvider provides access to require_oauth setting.
 type RequireOAuthProvider interface {
 	IsRequireOAuth() bool
@@ -113,5 +120,6 @@ type BaseConfig interface {
 	ValidationEnabledProvider
 	TargetCompatibilityToolFiltersEnabledProvider
 	RequireTLSProvider
+	TLSConfigProvider
 	RequireOAuthProvider
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,12 +17,17 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/tlsutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 )
 
 const (
 	DefaultDropInConfigDir = "conf.d"
+
+	// Environment variable names for TLS configuration.
+	EnvTLSMinVersion   = "TLS_MIN_VERSION"
+	EnvTLSCipherSuites = "TLS_CIPHER_SUITES"
 )
 
 // ToolOverride contains per-tool configuration overrides.
@@ -126,6 +131,12 @@ type StaticConfig struct {
 	// When true, the server will refuse to start without TLS certificates,
 	// and outbound connections to non-HTTPS endpoints will be rejected.
 	RequireTLS bool `toml:"require_tls,omitempty"`
+	// TLSMinVersion is the minimum TLS version to accept (e.g., "1.2", "1.3").
+	// Defaults to TLS 1.2 if not set. Can be overridden by TLS_MIN_VERSION env var.
+	TLSMinVersion string `toml:"tls_min_version,omitempty"`
+	// TLSCipherSuites is a list of supported cipher suites for TLS connections.
+	// If empty, Go's default cipher suites are used. Can be overridden by TLS_CIPHER_SUITES env var.
+	TLSCipherSuites []string `toml:"tls_cipher_suites,omitempty"`
 
 	// HTTP server configuration (timeouts, size limits)
 	HTTP HTTPConfig `toml:"http,omitempty"`
@@ -471,6 +482,28 @@ func (c *StaticConfig) IsRequireTLS() bool {
 	return c.RequireTLS
 }
 
+// GetTLSMinVersionConfig returns the effective tls_min_version, with TLS_MIN_VERSION
+// env var taking precedence over the TOML/CLI value.
+func (c *StaticConfig) GetTLSMinVersionConfig() string {
+	if envValue := os.Getenv(EnvTLSMinVersion); envValue != "" {
+		return envValue
+	}
+	return c.TLSMinVersion
+}
+
+// GetTLSCipherSuitesConfig returns the effective tls_cipher_suites, with
+// TLS_CIPHER_SUITES env var taking precedence over the TOML/CLI value.
+func (c *StaticConfig) GetTLSCipherSuitesConfig() []string {
+	if envValue := os.Getenv(EnvTLSCipherSuites); envValue != "" {
+		suites := strings.Split(envValue, ",")
+		for i, suite := range suites {
+			suites[i] = strings.TrimSpace(suite)
+		}
+		return suites
+	}
+	return c.TLSCipherSuites
+}
+
 func (c *StaticConfig) IsRequireOAuth() bool {
 	return c.RequireOAuth
 }
@@ -556,6 +589,9 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 		if _, err := os.Stat(c.TLSKey); err != nil {
 			return fmt.Errorf("tls-key must be a valid file path: %w", err)
 		}
+	}
+	if err := c.validateTLSSettings(ctx); err != nil {
+		return err
 	}
 	if err := c.ValidateRequireTLS(); err != nil {
 		return err
@@ -651,6 +687,33 @@ func (c *StaticConfig) validateTokenExchange() error {
 		}
 	default:
 		return fmt.Errorf("invalid sts_auth_style %q: must be %q, %q, %q, or %q", c.StsAuthStyle, tokenexchange.AuthStyleParams, tokenexchange.AuthStyleHeader, tokenexchange.AuthStyleAssertion, tokenexchange.AuthStyleFederated)
+	}
+	return nil
+}
+
+// validateTLSSettings validates TLS settings via the getters so env overrides are included,
+// and logs once at startup/reload when TLS env vars override TOML.
+func (c *StaticConfig) validateTLSSettings(ctx context.Context) error {
+	logger := klogutil.FromContext(ctx).V(1)
+	if os.Getenv(EnvTLSMinVersion) != "" {
+		klogutil.LogInfo(logger, "TLS min version overridden by environment variable",
+			klogutil.Field("env", EnvTLSMinVersion),
+			klogutil.Field("value", c.GetTLSMinVersionConfig()),
+		)
+	}
+	if os.Getenv(EnvTLSCipherSuites) != "" {
+		klogutil.LogInfo(logger, "TLS cipher suites overridden by environment variable",
+			klogutil.Field("env", EnvTLSCipherSuites),
+		)
+	}
+
+	minVersion := c.GetTLSMinVersionConfig()
+	if _, err := tlsutil.ParseTLSVersion(minVersion); err != nil {
+		return err
+	}
+	cipherSuites := c.GetTLSCipherSuitesConfig()
+	if _, err := tlsutil.ParseTLSCipherSuites(cipherSuites); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1191,6 +1191,48 @@ func (s *ConfigSuite) TestConfirmationRulesParsing() {
 	})
 }
 
+func (s *ConfigSuite) TestGetTLSConfig() {
+	s.Run("returns TOML value when env is unset", func() {
+		s.Require().NoError(os.Unsetenv(EnvTLSMinVersion))
+		s.Require().NoError(os.Unsetenv(EnvTLSCipherSuites))
+		cfg := BaseDefault()
+		cfg.TLSMinVersion = "1.3"
+		cfg.TLSCipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}
+		s.Equal("1.3", cfg.GetTLSMinVersionConfig())
+		s.Equal(cfg.TLSCipherSuites, cfg.GetTLSCipherSuitesConfig())
+	})
+
+	s.Run("env overrides TOML in getters", func() {
+		s.Require().NoError(os.Setenv(EnvTLSMinVersion, "1.3"))
+		s.Require().NoError(os.Setenv(EnvTLSCipherSuites, "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"))
+		defer func() {
+			_ = os.Unsetenv(EnvTLSMinVersion)
+			_ = os.Unsetenv(EnvTLSCipherSuites)
+		}()
+		cfg := BaseDefault()
+		cfg.TLSMinVersion = "1.2"
+		cfg.TLSCipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}
+		s.Equal("1.3", cfg.GetTLSMinVersionConfig())
+		s.Equal([]string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"}, cfg.GetTLSCipherSuitesConfig())
+	})
+
+	s.Run("parses comma-separated TLS_CIPHER_SUITES env var", func() {
+		s.Require().NoError(os.Setenv(EnvTLSCipherSuites, "SUITE_A,SUITE_B"))
+		defer func() { _ = os.Unsetenv(EnvTLSCipherSuites) }()
+
+		cfg := BaseDefault()
+		s.Equal([]string{"SUITE_A", "SUITE_B"}, cfg.GetTLSCipherSuitesConfig())
+	})
+
+	s.Run("trims whitespace from TLS_CIPHER_SUITES env var", func() {
+		s.Require().NoError(os.Setenv(EnvTLSCipherSuites, " SUITE_A , SUITE_B "))
+		defer func() { _ = os.Unsetenv(EnvTLSCipherSuites) }()
+
+		cfg := BaseDefault()
+		s.Equal([]string{"SUITE_A", "SUITE_B"}, cfg.GetTLSCipherSuitesConfig())
+	})
+}
+
 func TestConfig(t *testing.T) {
 	suite.Run(t, new(ConfigSuite))
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -243,6 +243,65 @@ func (s *ValidateSuite) TestTLSCertKey() {
 	})
 }
 
+func (s *ValidateSuite) TestTLSSettings() {
+	s.Run("default config passes with empty TLS settings", func() {
+		s.Require().NoError(os.Unsetenv(config.EnvTLSMinVersion))
+		s.Require().NoError(os.Unsetenv(config.EnvTLSCipherSuites))
+		cfg := s.validConfig()
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("valid tls_min_version in config is accepted", func() {
+		s.Require().NoError(os.Unsetenv(config.EnvTLSMinVersion))
+		s.Require().NoError(os.Unsetenv(config.EnvTLSCipherSuites))
+		cfg := s.validConfig()
+		cfg.TLSMinVersion = "1.3"
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("valid tls_cipher_suites in config is accepted", func() {
+		s.Require().NoError(os.Unsetenv(config.EnvTLSMinVersion))
+		s.Require().NoError(os.Unsetenv(config.EnvTLSCipherSuites))
+		cfg := s.validConfig()
+		cfg.TLSCipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("TLS_MIN_VERSION env overrides invalid config value", func() {
+		s.Require().NoError(os.Setenv(config.EnvTLSMinVersion, "1.3"))
+		defer func() { _ = os.Unsetenv(config.EnvTLSMinVersion) }()
+		cfg := s.validConfig()
+		cfg.TLSMinVersion = "invalid"
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("invalid TLS_MIN_VERSION env is rejected", func() {
+		s.Require().NoError(os.Setenv(config.EnvTLSMinVersion, "bad"))
+		defer func() { _ = os.Unsetenv(config.EnvTLSMinVersion) }()
+		cfg := s.validConfig()
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid TLS version")
+	})
+
+	s.Run("TLS_CIPHER_SUITES env overrides invalid config value", func() {
+		s.Require().NoError(os.Setenv(config.EnvTLSCipherSuites, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"))
+		defer func() { _ = os.Unsetenv(config.EnvTLSCipherSuites) }()
+		cfg := s.validConfig()
+		cfg.TLSCipherSuites = []string{"UNKNOWN_CIPHER"}
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("invalid TLS_CIPHER_SUITES env is rejected", func() {
+		s.Require().NoError(os.Setenv(config.EnvTLSCipherSuites, "UNKNOWN_CIPHER"))
+		defer func() { _ = os.Unsetenv(config.EnvTLSCipherSuites) }()
+		cfg := s.validConfig()
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "invalid cipher suites")
+	})
+}
+
 func (s *ValidateSuite) TestTokenExchangeStrategy() {
 	s.Run("unknown strategy is skipped without WithTokenExchangeStrategies", func() {
 		cfg := s.validConfig()

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -2,9 +2,9 @@ package http
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -21,6 +21,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcp"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
+	"github.com/containers/kubernetes-mcp-server/pkg/tlsutil"
 )
 
 // tlsErrorFilterWriter filters out noisy TLS handshake errors from health checks
@@ -121,6 +122,12 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 	)
 	instrumentedHandler := metricsMiddleware(wrappedMux, mcpServer)
 
+	// Inbound TLS min version and cipher suites are fixed for the process lifetime.
+	tlsConfig, err := tlsutil.BuildTLSConfig(staticConfig.GetTLSMinVersionConfig(), staticConfig.GetTLSCipherSuitesConfig())
+	if err != nil {
+		return fmt.Errorf("failed to build TLS config: %w", err)
+	}
+
 	// Note: WriteTimeout is intentionally omitted - it would kill SSE streams.
 	// ReadHeaderTimeout provides Slowloris protection; other timeouts are left
 	// at Go defaults since MCP clients maintain persistent connections.
@@ -128,9 +135,7 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 		Addr:              net.JoinHostPort(staticConfig.BindAddress, staticConfig.Port),
 		Handler:           instrumentedHandler,
 		ReadHeaderTimeout: staticConfig.HTTP.ReadHeaderTimeout.Duration(),
-		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		},
+		TLSConfig:         tlsConfig,
 		// BaseContext propagates the server context (including the klog logger)
 		// to all incoming request contexts, so klogutil.FromContext(r.Context())
 		// returns the contextual logger rather than the global fallback.

--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
+	"github.com/containers/kubernetes-mcp-server/pkg/tlsutil"
 )
 
 const maxWellKnownResponseSize = 1 << 20 // 1 MB
@@ -123,13 +124,26 @@ func (w *WellKnown) authorizationURL() string {
 }
 
 // wellKnownHTTPClient returns the current HTTP client from the oauth snapshot,
-// falling back to a TLS-enforcing client if none is available.
-func (w *WellKnown) wellKnownHTTPClient() *http.Client {
+// falling back to a TLS-enforcing client with operator TLS settings if none is available.
+func (w *WellKnown) wellKnownHTTPClient() (*http.Client, error) {
 	snap := w.oauthState.Load()
 	if snap != nil && snap.HTTPClient != nil {
-		return snap.HTTPClient
+		return snap.HTTPClient, nil
 	}
-	return config.NewTLSEnforcingClient(nil, w.cfgState.Load().IsRequireTLS)
+
+	cfg := w.cfgState.Load()
+	tlsConfig, err := tlsutil.BuildTLSConfig(
+		cfg.GetTLSMinVersionConfig(),
+		cfg.GetTLSCipherSuitesConfig(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %w", err)
+	}
+
+	transport := config.NewTLSEnforcingTransport(&http.Transport{
+		TLSClientConfig: tlsConfig,
+	}, cfg.IsRequireTLS)
+	return &http.Client{Transport: transport}, nil
 }
 
 func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -234,7 +248,11 @@ func (w *WellKnown) fetchWellKnownEndpoint(request *http.Request, url string) (m
 // fetchWellKnownEndpointFromRequest performs the HTTP fetch using a pre-built request.
 // Returns nil metadata if the endpoint returns 404 or an empty body (to allow fallback).
 func (w *WellKnown) fetchWellKnownEndpointFromRequest(req *http.Request) (map[string]interface{}, http.Header, error) {
-	resp, err := w.wellKnownHTTPClient().Do(req)
+	client, err := w.wellKnownHTTPClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to perform request: %w", err)
 	}

--- a/pkg/kiali/kiali.go
+++ b/pkg/kiali/kiali.go
@@ -2,7 +2,6 @@ package kiali
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
@@ -17,6 +16,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+	"github.com/containers/kubernetes-mcp-server/pkg/tlsutil"
 )
 
 type Kiali struct {
@@ -24,14 +24,18 @@ type Kiali struct {
 	kialiURL             string
 	kialiInsecure        bool
 	certificateAuthority string
+	tlsMinVersion        string
+	tlsCipherSuites      []string
 	requireTLS           func() bool
 }
 
 // NewKiali creates a new Kiali instance
 func NewKiali(configProvider api.BaseConfig, kubernetes *rest.Config) *Kiali {
 	kiali := &Kiali{
-		bearerToken: kubernetes.BearerToken,
-		requireTLS:  configProvider.IsRequireTLS,
+		bearerToken:     kubernetes.BearerToken,
+		tlsMinVersion:   configProvider.GetTLSMinVersionConfig(),
+		tlsCipherSuites: configProvider.GetTLSCipherSuitesConfig(),
+		requireTLS:      configProvider.IsRequireTLS,
 	}
 	if cfg, ok := configProvider.GetToolsetConfig("kiali"); ok {
 		if kc, ok := cfg.(*Config); ok && kc != nil {
@@ -87,46 +91,48 @@ func (k *Kiali) validateAndGetURL(endpoint string) (string, error) {
 	return u.String(), nil
 }
 
-func (k *Kiali) createHTTPClient(ctx context.Context) *http.Client {
+func (k *Kiali) createHTTPClient(ctx context.Context) (*http.Client, error) {
 	logger := klogutil.FromContext(ctx)
-	// Base TLS configuration with minimum version for security
-	tlsConfig := &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: k.kialiInsecure,
+	// Build TLS options based on configuration
+	var tlsOpts []tlsutil.TLSConfigOption
+
+	// Apply InsecureSkipVerify if configured
+	if k.kialiInsecure {
+		tlsOpts = append(tlsOpts, tlsutil.WithInsecureSkipVerify(true))
 	}
 
 	// If a custom Certificate Authority is configured, load and add it
 	if caValue := strings.TrimSpace(k.certificateAuthority); caValue != "" {
-		// Read the certificate from file
 		caPEM, err := os.ReadFile(caValue)
 		if err != nil {
 			logger.Error(err, "failed to read CA certificate from file, proceeding without custom CA", "ca_file", caValue)
-			return k.wrapWithTLSEnforcement(&http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: tlsConfig,
-				},
-			})
+		} else {
+			// Start with the host system pool when possible so we don't drop system roots
+			var certPool *x509.CertPool
+			if systemPool, err := x509.SystemCertPool(); err == nil && systemPool != nil {
+				certPool = systemPool
+			} else {
+				certPool = x509.NewCertPool()
+			}
+			if ok := certPool.AppendCertsFromPEM(caPEM); ok {
+				tlsOpts = append(tlsOpts, tlsutil.WithRootCAs(certPool))
+			} else {
+				logger.V(0).Info("failed to append provided certificate authority; proceeding without custom CA")
+			}
 		}
+	}
 
-		// Start with the host system pool when possible so we don't drop system roots
-		var certPool *x509.CertPool
-		if systemPool, err := x509.SystemCertPool(); err == nil && systemPool != nil {
-			certPool = systemPool
-		} else {
-			certPool = x509.NewCertPool()
-		}
-		if ok := certPool.AppendCertsFromPEM(caPEM); ok {
-			tlsConfig.RootCAs = certPool
-		} else {
-			logger.V(0).Info("failed to append provided certificate authority; proceeding without custom CA")
-		}
+	// Build TLS config from stored min version and cipher suites.
+	tlsConfig, err := tlsutil.BuildTLSConfig(k.tlsMinVersion, k.tlsCipherSuites, tlsOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
 
 	return k.wrapWithTLSEnforcement(&http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},
-	})
+	}), nil
 }
 
 // wrapWithTLSEnforcement wraps the HTTP client with TLS enforcement if require_tls is configured.
@@ -186,7 +192,10 @@ func (k *Kiali) ExecuteRequest(ctx context.Context, endpoint string, arguments m
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Kubernetes-MCP-Server", "true")
-	client := k.createHTTPClient(ctx)
+	client, err := k.createHTTPClient(ctx)
+	if err != nil {
+		return "", err
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -116,6 +116,8 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 		ClientKeyFile:      baseConfig.GetStsClientKeyFile(),
 		FederatedTokenFile: baseConfig.GetStsFederatedTokenFile(),
 		CAFile:             baseConfig.GetCertificateAuthority(),
+		TLSMinVersion:      baseConfig.GetTLSMinVersionConfig(),
+		TLSCipherSuites:    append([]string(nil), baseConfig.GetTLSCipherSuitesConfig()...),
 	}
 	cfg.SetRequireTLS(baseConfig.IsRequireTLS)
 	if err := cfg.Validate(); err != nil {
@@ -148,6 +150,8 @@ type stsConfigCacheKey struct {
 	ClientKeyFile      string
 	FederatedTokenFile string
 	CAFile             string
+	TLSMinVersion      string
+	TLSCipherSuites    string
 	RequireTLS         bool
 }
 
@@ -164,6 +168,8 @@ func newStsConfigCacheKey(tokenURL string, cfg api.BaseConfig) stsConfigCacheKey
 		ClientKeyFile:      cfg.GetStsClientKeyFile(),
 		FederatedTokenFile: cfg.GetStsFederatedTokenFile(),
 		CAFile:             cfg.GetCertificateAuthority(),
+		TLSMinVersion:      cfg.GetTLSMinVersionConfig(),
+		TLSCipherSuites:    strings.Join(cfg.GetTLSCipherSuitesConfig(), "\x00"),
 		RequireTLS:         cfg.IsRequireTLS(),
 	}
 }

--- a/pkg/kubernetes/provider_token_exchange_test.go
+++ b/pkg/kubernetes/provider_token_exchange_test.go
@@ -252,6 +252,45 @@ func (s *TokenExchangingProviderSuite) TestGetOrBuildStsConfig() {
 			s.Require().NotNil(second)
 			s.NotSame(first, second)
 		})
+
+		s.Run("tls_min_version", func() {
+			snap := s.newSnapshot()
+			cfg := config.Default()
+			cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+			cfg.StsClientId = "client"
+			cfg.StsAudience = "audience"
+			cfg.TLSMinVersion = "1.2"
+			p := newProvider(cfg)
+
+			first := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(first)
+			s.Equal("1.2", first.TLSMinVersion)
+
+			cfg.TLSMinVersion = "1.3"
+			second := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(second)
+			s.NotSame(first, second)
+			s.Equal("1.3", second.TLSMinVersion)
+		})
+
+		s.Run("tls_cipher_suites", func() {
+			snap := s.newSnapshot()
+			cfg := config.Default()
+			cfg.TokenExchangeStrategy = tokenexchange.StrategyRFC8693
+			cfg.StsClientId = "client"
+			cfg.StsAudience = "audience"
+			cfg.TLSCipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}
+			p := newProvider(cfg)
+
+			first := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(first)
+
+			cfg.TLSCipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"}
+			second := p.getOrBuildStsConfig(context.Background(), snap, cfg)
+			s.Require().NotNil(second)
+			s.NotSame(first, second)
+			s.Equal([]string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"}, second.TLSCipherSuites)
+		})
 	})
 
 	s.Run("wires require_tls enforcement into the built config", func() {

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -180,6 +180,8 @@ func strategyBasedTokenExchange(
 			ClientKeyFile:      baseConfig.GetStsClientKeyFile(),
 			FederatedTokenFile: baseConfig.GetStsFederatedTokenFile(),
 			CAFile:             baseConfig.GetCertificateAuthority(),
+			TLSMinVersion:      baseConfig.GetTLSMinVersionConfig(),
+			TLSCipherSuites:    append([]string(nil), baseConfig.GetTLSCipherSuitesConfig()...),
 		}
 		if err := cfg.Validate(); err != nil {
 			return ctx, fmt.Errorf("token exchange config validation: %w", err)

--- a/pkg/netobserv/netobserv.go
+++ b/pkg/netobserv/netobserv.go
@@ -2,7 +2,6 @@ package netobserv
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -15,6 +14,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+	"github.com/containers/kubernetes-mcp-server/pkg/tlsutil"
 	"k8s.io/client-go/rest"
 )
 
@@ -25,6 +25,8 @@ type NetObserv struct {
 	pluginURL            string
 	insecure             bool
 	certificateAuthority string
+	tlsMinVersion        string
+	tlsCipherSuites      []string
 	requireTLS           func() bool
 }
 
@@ -35,8 +37,10 @@ func NewNetObserv(ctx context.Context, configProvider api.BaseConfig, k8s api.Ku
 		restConfig = k8s.RESTConfig()
 	}
 	client := &NetObserv{
-		bearerToken: "",
-		requireTLS:  configProvider.IsRequireTLS,
+		bearerToken:     "",
+		tlsMinVersion:   configProvider.GetTLSMinVersionConfig(),
+		tlsCipherSuites: configProvider.GetTLSCipherSuitesConfig(),
+		requireTLS:      configProvider.IsRequireTLS,
 	}
 	if restConfig != nil {
 		client.bearerToken = strings.TrimSpace(restConfig.BearerToken)
@@ -100,14 +104,12 @@ var errRedirectsNotAllowed = errors.New("redirects are not allowed for netobserv
 
 func (n *NetObserv) createHTTPClient(ctx context.Context) (*http.Client, error) {
 	logger := klogutil.FromContext(ctx)
-	tlsConfig := &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: n.insecure,
+	var tlsOpts []tlsutil.TLSConfigOption
+
+	if n.insecure {
+		tlsOpts = append(tlsOpts, tlsutil.WithInsecureSkipVerify(true))
 	}
-	transport := &http.Transport{
-		TLSClientConfig:       tlsConfig,
-		ResponseHeaderTimeout: DefaultPluginHTTPTimeout,
-	}
+
 	if caValue := strings.TrimSpace(n.certificateAuthority); caValue != "" {
 		caPEM, err := os.ReadFile(caValue)
 		if err != nil {
@@ -117,11 +119,20 @@ func (n *NetObserv) createHTTPClient(ctx context.Context) (*http.Client, error) 
 		if !certPool.AppendCertsFromPEM(caPEM) {
 			return nil, fmt.Errorf("failed to parse certificate authority %q", caValue)
 		}
-		tlsConfig.RootCAs = certPool
+		tlsOpts = append(tlsOpts, tlsutil.WithRootCAs(certPool))
 	}
+
+	tlsConfig, err := tlsutil.BuildTLSConfig(n.tlsMinVersion, n.tlsCipherSuites, tlsOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %w", err)
+	}
+
 	client := &http.Client{
-		Transport: transport,
-		Timeout:   DefaultPluginHTTPTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig:       tlsConfig,
+			ResponseHeaderTimeout: DefaultPluginHTTPTimeout,
+		},
+		Timeout: DefaultPluginHTTPTimeout,
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return errRedirectsNotAllowed
 		},

--- a/pkg/netobserv/netobserv_test.go
+++ b/pkg/netobserv/netobserv_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -42,6 +43,8 @@ func (s *NetObservSuite) TearDownTest() {
 
 func (s *NetObservSuite) TestNewNetObserv_SetsFields() {
 	s.Config = test.Must(config.ReadToml([]byte(`
+		tls_min_version = "1.3"
+		tls_cipher_suites = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
 		[toolset_configs.netobserv]
 		url = "https://netobserv.example/"
 		insecure = true
@@ -50,6 +53,8 @@ func (s *NetObservSuite) TestNewNetObserv_SetsFields() {
 
 	s.Equal("https://netobserv.example/", client.pluginURL)
 	s.True(client.insecure)
+	s.Equal("1.3", client.tlsMinVersion)
+	s.Equal([]string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}, client.tlsCipherSuites)
 }
 
 func (s *NetObservSuite) TestExecuteGet() {
@@ -153,6 +158,46 @@ func (s *NetObservSuite) TestExecuteGetAccept_truncatesLargeExports() {
 func (s *NetObservSuite) TestNewNetObserv_usesDefaultURLWithoutConfigSection() {
 	client := NewNetObserv(context.Background(), s.Config, nil, nil)
 	s.Equal(DefaultPluginURL(false), client.pluginURL)
+}
+
+func (s *NetObservSuite) TestCreateHTTPClient_AppliesTLSSettings() {
+	tlsConfigFromClient := func(httpClient *http.Client) *tls.Config {
+		s.T().Helper()
+		enforcing, ok := httpClient.Transport.(*config.TLSEnforcingTransport)
+		s.Require().True(ok, "expected TLSEnforcingTransport wrapper")
+		transport, ok := enforcing.Base.(*http.Transport)
+		s.Require().True(ok, "expected base http.Transport")
+		s.Require().NotNil(transport.TLSClientConfig)
+		return transport.TLSClientConfig
+	}
+
+	s.Run("uses configured min version and cipher suites", func() {
+		s.Config = test.Must(config.ReadToml([]byte(`
+			tls_min_version = "1.3"
+			tls_cipher_suites = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
+			[toolset_configs.netobserv]
+			url = "https://netobserv.example/"
+			insecure = true
+		`)))
+		client := NewNetObserv(context.Background(), s.Config, nil, nil)
+
+		httpClient, err := client.createHTTPClient(s.T().Context())
+		s.Require().NoError(err)
+		tlsConfig := tlsConfigFromClient(httpClient)
+		s.Equal(uint16(tls.VersionTLS13), tlsConfig.MinVersion)
+		s.Equal([]uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}, tlsConfig.CipherSuites)
+		s.True(tlsConfig.InsecureSkipVerify)
+	})
+
+	s.Run("returns error for invalid TLS min version", func() {
+		client := NewNetObserv(context.Background(), s.Config, nil, nil)
+		client.tlsMinVersion = "9.9"
+
+		httpClient, err := client.createHTTPClient(s.T().Context())
+		s.Error(err, "expected error for invalid TLS min version")
+		s.Nil(httpClient, "client should be nil when TLS config fails")
+		s.ErrorContains(err, "failed to build TLS config")
+	})
 }
 
 func (s *NetObservSuite) TestRequireTLS_ConfigValidation() {

--- a/pkg/oauth/state.go
+++ b/pkg/oauth/state.go
@@ -2,7 +2,6 @@ package oauth
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/tlsutil"
 	"github.com/coreos/go-oidc/v3/oidc"
 )
 
@@ -21,6 +21,8 @@ type Snapshot struct {
 	HTTPClient                       *http.Client
 	AuthorizationURL                 string
 	CertificateAuthority             string
+	TLSMinVersion                    string
+	TLSCipherSuites                  []string
 	OAuthScopes                      []string
 	DisableDynamicClientRegistration bool
 }
@@ -32,7 +34,9 @@ func (s *Snapshot) HasProviderConfigChanged(other *Snapshot) bool {
 		return s != other
 	}
 	return s.AuthorizationURL != other.AuthorizationURL ||
-		s.CertificateAuthority != other.CertificateAuthority
+		s.CertificateAuthority != other.CertificateAuthority ||
+		s.TLSMinVersion != other.TLSMinVersion ||
+		!slices.Equal(s.TLSCipherSuites, other.TLSCipherSuites)
 }
 
 // HasWellKnownConfigChanged reports whether any WellKnown-serving fields changed.
@@ -82,6 +86,8 @@ func SnapshotFromConfig(cfg *config.StaticConfig, provider *oidc.Provider, httpC
 		HTTPClient:                       httpClient,
 		AuthorizationURL:                 cfg.AuthorizationURL,
 		CertificateAuthority:             cfg.CertificateAuthority,
+		TLSMinVersion:                    cfg.GetTLSMinVersionConfig(),
+		TLSCipherSuites:                  append([]string(nil), cfg.GetTLSCipherSuitesConfig()...),
 		OAuthScopes:                      cfg.OAuthScopes,
 		DisableDynamicClientRegistration: cfg.DisableDynamicClientRegistration,
 	}
@@ -95,7 +101,9 @@ func CreateOIDCProviderAndClient(cfg *config.StaticConfig) (*oidc.Provider, *htt
 	}
 
 	ctx := context.Background()
-	var httpClient *http.Client
+
+	// Build TLS options for outbound client
+	var tlsOpts []tlsutil.TLSConfigOption
 
 	if cfg.CertificateAuthority != "" {
 		caCert, err := os.ReadFile(cfg.CertificateAuthority)
@@ -106,20 +114,20 @@ func CreateOIDCProviderAndClient(cfg *config.StaticConfig) (*oidc.Provider, *htt
 		if !caCertPool.AppendCertsFromPEM(caCert) {
 			return nil, nil, fmt.Errorf("failed to append CA certificate from %s to pool", cfg.CertificateAuthority)
 		}
-		if caCertPool.Equal(x509.NewCertPool()) {
-			caCertPool = nil
-		}
-		var transport http.RoundTripper = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12,
-				RootCAs:    caCertPool,
-			},
-		}
-		transport = config.NewTLSEnforcingTransport(transport, cfg.IsRequireTLS)
-		httpClient = &http.Client{Transport: transport}
-	} else {
-		httpClient = config.NewTLSEnforcingClient(nil, cfg.IsRequireTLS)
+		tlsOpts = append(tlsOpts, tlsutil.WithRootCAs(caCertPool))
 	}
+
+	// Build TLS config from config getters (env/TOML already resolved).
+	tlsConfig, err := tlsutil.BuildTLSConfig(cfg.GetTLSMinVersionConfig(), cfg.GetTLSCipherSuitesConfig(), tlsOpts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build TLS config: %w", err)
+	}
+
+	var transport http.RoundTripper = &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+	transport = config.NewTLSEnforcingTransport(transport, cfg.IsRequireTLS)
+	httpClient := &http.Client{Transport: transport}
 
 	ctx = oidc.ClientContext(ctx, httpClient)
 	provider, err := oidc.NewProvider(ctx, cfg.AuthorizationURL)

--- a/pkg/oauth/state_test.go
+++ b/pkg/oauth/state_test.go
@@ -52,6 +52,32 @@ func (s *OAuthStateSuite) TestHasProviderConfigChanged() {
 		b := &Snapshot{AuthorizationURL: "https://auth.example.com", OAuthScopes: []string{"b"}}
 		s.False(a.HasProviderConfigChanged(b))
 	})
+
+	s.Run("TLS min version changed", func() {
+		a := &Snapshot{TLSMinVersion: "1.2"}
+		b := &Snapshot{TLSMinVersion: "1.3"}
+		s.True(a.HasProviderConfigChanged(b))
+	})
+
+	s.Run("TLS cipher suites changed", func() {
+		a := &Snapshot{TLSCipherSuites: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}}
+		b := &Snapshot{TLSCipherSuites: []string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"}}
+		s.True(a.HasProviderConfigChanged(b))
+	})
+
+	s.Run("same TLS settings do not trigger change", func() {
+		a := &Snapshot{
+			AuthorizationURL: "https://auth.example.com",
+			TLSMinVersion:    "1.3",
+			TLSCipherSuites:  []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+		}
+		b := &Snapshot{
+			AuthorizationURL: "https://auth.example.com",
+			TLSMinVersion:    "1.3",
+			TLSCipherSuites:  []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+		}
+		s.False(a.HasProviderConfigChanged(b))
+	})
 }
 
 func (s *OAuthStateSuite) TestHasWellKnownConfigChanged() {

--- a/pkg/tlsutil/tlsutil.go
+++ b/pkg/tlsutil/tlsutil.go
@@ -1,0 +1,121 @@
+// Package tlsutil provides shared TLS configuration utilities for parsing TLS
+// settings and building crypto/tls.Config values. Callers should pass values
+// from config.GetTLSMinVersionConfig / GetTLSCipherSuitesConfig.
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// tlsVersionMap maps version strings to tls.Version constants
+var tlsVersionMap = map[string]uint16{
+	"1.0": tls.VersionTLS10,
+	"1.1": tls.VersionTLS11,
+	"1.2": tls.VersionTLS12,
+	"1.3": tls.VersionTLS13,
+}
+
+// tlsCipherSuiteMap maps cipher suite names to their IDs.
+var tlsCipherSuiteMap = func() map[string]uint16 {
+	m := make(map[string]uint16)
+	for _, suite := range tls.CipherSuites() {
+		m[suite.Name] = suite.ID
+	}
+	return m
+}()
+
+// ParseTLSVersion parses a TLS version string (e.g., "1.2", "1.3") to a tls.Version constant.
+// Returns tls.VersionTLS12 as default if version is empty.
+func ParseTLSVersion(version string) (uint16, error) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return tls.VersionTLS12, nil
+	}
+	if v, ok := tlsVersionMap[version]; ok {
+		return v, nil
+	}
+	validVersions := make([]string, 0, len(tlsVersionMap))
+	for k := range tlsVersionMap {
+		validVersions = append(validVersions, k)
+	}
+	slices.Sort(validVersions)
+	return 0, fmt.Errorf("invalid TLS version %q: valid values are %s", version, strings.Join(validVersions, ", "))
+}
+
+// ParseTLSCipherSuites parses a slice of cipher suite names to their uint16 IDs.
+// Returns nil if suites is empty or contains only empty strings (Go will use its default cipher suites).
+func ParseTLSCipherSuites(suites []string) ([]uint16, error) {
+	if len(suites) == 0 {
+		return nil, nil
+	}
+	result := make([]uint16, 0, len(suites))
+	var errs []error
+	for _, name := range suites {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if id, ok := tlsCipherSuiteMap[name]; ok {
+			result = append(result, id)
+		} else {
+			errs = append(errs, fmt.Errorf("unknown cipher suite %q", name))
+		}
+	}
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("invalid cipher suites: %w", errors.Join(errs...))
+	}
+	// Return nil if no valid cipher suites were found (all were empty strings)
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
+// BuildTLSConfig creates a tls.Config from TLS settings returned by
+// config.GetTLSMinVersionConfig / GetTLSCipherSuitesConfig.
+// Options (e.g., RootCAs, InsecureSkipVerify) are applied last.
+func BuildTLSConfig(minVersion string, cipherSuites []string, opts ...TLSConfigOption) (*tls.Config, error) {
+	parsedMinVersion, err := ParseTLSVersion(minVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse TLS min version: %w", err)
+	}
+
+	parsedCipherSuites, err := ParseTLSCipherSuites(cipherSuites)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse TLS cipher suites: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion:   parsedMinVersion,
+		CipherSuites: parsedCipherSuites,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(tlsConfig)
+	}
+
+	return tlsConfig, nil
+}
+
+// TLSConfigOption is a function that modifies a tls.Config.
+type TLSConfigOption func(*tls.Config)
+
+// WithRootCAs sets custom root CAs on the TLS config.
+func WithRootCAs(pool *x509.CertPool) TLSConfigOption {
+	return func(cfg *tls.Config) {
+		cfg.RootCAs = pool
+	}
+}
+
+// WithInsecureSkipVerify sets InsecureSkipVerify on the TLS config.
+func WithInsecureSkipVerify(skip bool) TLSConfigOption {
+	return func(cfg *tls.Config) {
+		cfg.InsecureSkipVerify = skip
+	}
+}

--- a/pkg/tlsutil/tlsutil_test.go
+++ b/pkg/tlsutil/tlsutil_test.go
@@ -1,0 +1,150 @@
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TLSUtilSuite struct {
+	suite.Suite
+}
+
+func TestTLSUtil(t *testing.T) {
+	suite.Run(t, new(TLSUtilSuite))
+}
+
+func (s *TLSUtilSuite) TestParseTLSVersion() {
+	s.Run("returns TLS 1.2 for empty string", func() {
+		v, err := ParseTLSVersion("")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS12, int(v))
+	})
+
+	s.Run("parses TLS 1.0", func() {
+		v, err := ParseTLSVersion("1.0")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS10, int(v))
+	})
+
+	s.Run("parses TLS 1.1", func() {
+		v, err := ParseTLSVersion("1.1")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS11, int(v))
+	})
+
+	s.Run("parses TLS 1.2", func() {
+		v, err := ParseTLSVersion("1.2")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS12, int(v))
+	})
+
+	s.Run("parses TLS 1.3", func() {
+		v, err := ParseTLSVersion("1.3")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS13, int(v))
+	})
+
+	s.Run("trims whitespace", func() {
+		v, err := ParseTLSVersion("  1.3  ")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS13, int(v))
+	})
+
+	s.Run("returns error for invalid version", func() {
+		_, err := ParseTLSVersion("1.4")
+		s.Error(err)
+		s.Contains(err.Error(), "invalid TLS version")
+	})
+
+	s.Run("returns error for non-numeric version", func() {
+		_, err := ParseTLSVersion("abc")
+		s.Error(err)
+		s.Contains(err.Error(), "invalid TLS version")
+	})
+}
+
+func (s *TLSUtilSuite) TestParseTLSCipherSuites() {
+	s.Run("returns nil for empty slice", func() {
+		result, err := ParseTLSCipherSuites(nil)
+		s.Require().NoError(err)
+		s.Nil(result)
+	})
+
+	s.Run("returns nil for empty strings", func() {
+		result, err := ParseTLSCipherSuites([]string{"", "  "})
+		s.Require().NoError(err)
+		s.Nil(result)
+	})
+
+	s.Run("parses valid cipher suite", func() {
+		result, err := ParseTLSCipherSuites([]string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"})
+		s.Require().NoError(err)
+		s.Len(result, 1)
+	})
+
+	s.Run("parses multiple cipher suites", func() {
+		result, err := ParseTLSCipherSuites([]string{
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		})
+		s.Require().NoError(err)
+		s.Len(result, 2)
+	})
+
+	s.Run("trims whitespace from suite names", func() {
+		result, err := ParseTLSCipherSuites([]string{"  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256  "})
+		s.Require().NoError(err)
+		s.Len(result, 1)
+	})
+
+	s.Run("returns error for unknown cipher suite", func() {
+		_, err := ParseTLSCipherSuites([]string{"INVALID_CIPHER_SUITE"})
+		s.Error(err)
+		s.Contains(err.Error(), "unknown cipher suite")
+	})
+
+	s.Run("rejects insecure cipher suites", func() {
+		_, err := ParseTLSCipherSuites([]string{"TLS_RSA_WITH_RC4_128_SHA"})
+		s.Error(err)
+		s.Contains(err.Error(), "unknown cipher suite")
+	})
+
+	s.Run("returns combined errors for multiple unknown suites", func() {
+		_, err := ParseTLSCipherSuites([]string{"INVALID_1", "INVALID_2"})
+		s.Error(err)
+		s.Contains(err.Error(), "INVALID_1")
+		s.Contains(err.Error(), "INVALID_2")
+	})
+}
+
+func (s *TLSUtilSuite) TestBuildTLSConfig() {
+	s.Run("returns TLS config with default TLS 1.2", func() {
+		cfg, err := BuildTLSConfig("", nil)
+		s.Require().NoError(err)
+		s.NotNil(cfg)
+		s.Equal(tls.VersionTLS12, int(cfg.MinVersion))
+	})
+
+	s.Run("applies passed min version and cipher suites", func() {
+		cfg, err := BuildTLSConfig("1.3", []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"})
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS13, int(cfg.MinVersion))
+		s.Len(cfg.CipherSuites, 1)
+	})
+
+	s.Run("applies InsecureSkipVerify option", func() {
+		cfg, err := BuildTLSConfig("", nil, WithInsecureSkipVerify(true))
+		s.Require().NoError(err)
+		s.True(cfg.InsecureSkipVerify)
+	})
+
+	s.Run("applies RootCAs option", func() {
+		certPool := x509.NewCertPool()
+		cfg, err := BuildTLSConfig("", nil, WithRootCAs(certPool))
+		s.Require().NoError(err)
+		s.Equal(certPool, cfg.RootCAs)
+	})
+}

--- a/pkg/tokenexchange/config.go
+++ b/pkg/tokenexchange/config.go
@@ -1,15 +1,16 @@
 package tokenexchange
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+	"github.com/containers/kubernetes-mcp-server/pkg/tlsutil"
 )
 
 const (
@@ -66,11 +67,19 @@ type TargetTokenExchangeConfig struct {
 	// identity provider (e.g., SPIRE JWT-SVID). Used with AuthStyleFederated.
 	// The file is re-read on each token request to support token rotation.
 	FederatedTokenFile string `toml:"federated_token_file,omitempty"`
+	// TLSMinVersion is the effective global TLS min version (from GetTLSMinVersionConfig).
+	TLSMinVersion string `toml:"-"`
+	// TLSCipherSuites is the effective global TLS cipher suites (from GetTLSCipherSuitesConfig).
+	TLSCipherSuites []string `toml:"-"`
 
 	// client is a http client configured to work with the IdP for this target
 	client *http.Client `toml:"-"`
 	// clientCAFile tracks which CAFile was used to build the cached client
 	clientCAFile string `toml:"-"`
+	// clientTLSMinVersion tracks the TLS min version used to build the cached client
+	clientTLSMinVersion string `toml:"-"`
+	// clientTLSCipherSuites tracks the TLS cipher suites used to build the cached client
+	clientTLSCipherSuites []string `toml:"-"`
 	// cachedAssertion stores the most recently generated JWT assertion
 	cachedAssertion string `toml:"-"`
 	// cachedAssertionExpiry is when the cached assertion expires
@@ -162,16 +171,16 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 	c.clientMutex.Lock()
 	defer c.clientMutex.Unlock()
 
-	if c.client != nil && c.clientCAFile == c.CAFile {
+	if c.client != nil && c.clientCAFile == c.CAFile &&
+		c.clientTLSMinVersion == c.TLSMinVersion &&
+		slices.Equal(c.clientTLSCipherSuites, c.TLSCipherSuites) {
 		return c.client, nil
 	}
 
 	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
 
-	// Always set MinVersion for security, regardless of CAFile
-	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
+	// Build TLS options for outbound client
+	var tlsOpts []tlsutil.TLSConfigOption
 
 	if c.CAFile != "" {
 		caCert, err := os.ReadFile(c.CAFile)
@@ -184,7 +193,13 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 			return nil, fmt.Errorf("failed to parse CA certificate from '%s'", c.CAFile)
 		}
 
-		tlsConfig.RootCAs = caCertPool
+		tlsOpts = append(tlsOpts, tlsutil.WithRootCAs(caCertPool))
+	}
+
+	// Build TLS config from stored min version and cipher suites.
+	tlsConfig, err := tlsutil.BuildTLSConfig(c.TLSMinVersion, c.TLSCipherSuites, tlsOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
 
 	baseTransport.TLSClientConfig = tlsConfig
@@ -203,6 +218,8 @@ func (c *TargetTokenExchangeConfig) HTTPClient() (*http.Client, error) {
 		Transport: transport,
 	}
 	c.clientCAFile = c.CAFile
+	c.clientTLSMinVersion = c.TLSMinVersion
+	c.clientTLSCipherSuites = append([]string(nil), c.TLSCipherSuites...)
 
 	return c.client, nil
 }

--- a/pkg/tokenexchange/config_test.go
+++ b/pkg/tokenexchange/config_test.go
@@ -113,6 +113,51 @@ func (s *TargetTokenExchangeConfigSuite) TestHTTPClientCAFile() {
 	})
 }
 
+func (s *TargetTokenExchangeConfigSuite) TestHTTPClientTLSSettings() {
+	s.Run("rebuilds client when TLSMinVersion changes", func() {
+		cfg := &TargetTokenExchangeConfig{TLSMinVersion: "1.2"}
+
+		first, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+
+		same, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+		s.Same(first, same, "unchanged TLSMinVersion must reuse the memoized client")
+
+		cfg.TLSMinVersion = "1.3"
+		second, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+		s.NotSame(first, second, "changed TLSMinVersion must rebuild the client")
+
+		wrapper, ok := second.Transport.(*tlsEnforcingTransport)
+		s.Require().True(ok)
+		transport, ok := wrapper.Base.(*http.Transport)
+		s.Require().True(ok)
+		s.Equal(uint16(tls.VersionTLS13), transport.TLSClientConfig.MinVersion)
+	})
+
+	s.Run("rebuilds client when TLSCipherSuites changes", func() {
+		cfg := &TargetTokenExchangeConfig{
+			TLSCipherSuites: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+		}
+
+		first, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+
+		cfg.TLSCipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"}
+		second, err := cfg.HTTPClient()
+		s.Require().NoError(err)
+		s.NotSame(first, second, "changed TLSCipherSuites must rebuild the client")
+
+		wrapper, ok := second.Transport.(*tlsEnforcingTransport)
+		s.Require().True(ok)
+		transport, ok := wrapper.Base.(*http.Transport)
+		s.Require().True(ok)
+		s.Require().Len(transport.TLSClientConfig.CipherSuites, 1)
+		s.Equal(tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, transport.TLSClientConfig.CipherSuites[0])
+	})
+}
+
 func (s *TargetTokenExchangeConfigSuite) TestSetRequireTLS() {
 	s.Run("no enforcement when requireTLS is nil", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
Add support for configuring TLS minimum version and cipher suites via environment variables and global TOML, enabling operator-level control over TLS settings.

Jira Ticket: [Add TLS min version and cipher suite configuration via env vars and global TOML](https://redhat.atlassian.net/browse/OCPMCP-354)

## Changes

- Add `pkg/tlsutil` for parsing TLS settings and building `crypto/tls.Config` (no env resolution or logging)
- Add `TLS_MIN_VERSION` env var (values: `"1.0"`, `"1.1"`, `"1.2"`, `"1.3"`)
- Add `TLS_CIPHER_SUITES` env var (comma-separated cipher suite names)
- Add `tls_min_version` and `tls_cipher_suites` global TOML options
- Resolve env/TOML precedence in `GetTLSMinVersionConfig()` / `GetTLSCipherSuitesConfig()` on `StaticConfig`
- Log env overrides once at startup/reload via `Validate()`
- Wire TLS config into inbound HTTPS and outbound clients (Kiali, NetObserv, OAuth, token exchange, well-known metadata)
- Track TLS settings in the OAuth snapshot so SIGHUP reload rebuilds the OIDC HTTP client when they change
- Invalidate STS/token-exchange client caches when TLS settings change
- Add tests for parsing, validation, env precedence, OAuth snapshot comparison, client cache invalidation, and NetObserv TLS application

## Precedence

`TLS_MIN_VERSION` / `TLS_CIPHER_SUITES` override TOML when set. When neither is set, both inbound and outbound default to TLS 1.2 with Go's default cipher suites. TOML values apply as fallbacks to **both** inbound and outbound paths.

## Reload behavior

- **Inbound HTTPS:** applied at server start; changing TLS settings requires a **process restart**
- **Outbound clients:** OAuth and token exchange pick up TOML/env changes on SIGHUP reload; Kiali and NetObserv re-read settings on each tool invocation

Closes https://github.com/containers/kubernetes-mcp-server/issues/1266