### PR TITLE
feat(kiali): Sync kiali latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 - **kiali_get_mesh_status** - Retrieves the high-level health, topology, and environment details of the Istio service mesh. Returns multi-cluster control plane status (istiod), data plane namespace health (including ambient mesh status), observability stack health (Prometheus, Grafana...), and component connectivity. Use this tool as the first step to diagnose mesh-wide issues, verify Istio/Kiali versions, or check overall health before drilling into specific workloads.
 
-- **kiali_manage_istio_config_read** - Read-only Istio config: list or get objects. For action 'list', returns an array of objects with {name, namespace, type, validation}. For create, patch, or delete use manage_istio_config.
+- **kiali_manage_istio_config_read** - Read Istio config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names. 'get' returns full YAML. For writes use manage_istio_config.
   - `action` (`string`) **(required)** - Action to perform (read-only)
   - `clusterName` (`string`) - Optional cluster name. Defaults to the cluster name in the Kiali configuration.
   - `group` (`string`) - API group of the Istio object. Required for 'get' action.

--- a/pkg/kiali/tests/backend/api_backend_test.go
+++ b/pkg/kiali/tests/backend/api_backend_test.go
@@ -514,20 +514,33 @@ func (s *ContractTestSuite) TestManageIstioConfigRead() {
 		resp, body, err := s.mcpCall(tools.KialiManageIstioConfigReadEndpoint, args)
 		s.Require().NoError(err)
 		s.requireSuccess(tools.KialiManageIstioConfigReadEndpoint, resp, body)
-		obj := s.requireJSONKeys(tools.KialiManageIstioConfigReadEndpoint, body, "cluster", "items")
-		items, ok := obj["items"].([]interface{})
+		obj := s.requireJSONKeys(tools.KialiManageIstioConfigReadEndpoint, body, "cluster", "namespaces")
+		namespaces, ok := obj["namespaces"].(map[string]interface{})
 		s.Require().True(ok,
-			"manage_istio_config_read list 'items' field should be a JSON array, got %T", obj["items"])
-		s.Require().NotEmpty(items,
-			"manage_istio_config_read list response should return at least one item for namespace %q", s.testNS)
+			"manage_istio_config_read list 'namespaces' field should be a JSON object, got %T", obj["namespaces"])
 
-		first, ok := items[0].(map[string]interface{})
+		nsData, ok := namespaces[s.testNS].(map[string]interface{})
 		s.Require().True(ok,
-			"manage_istio_config_read list items should be JSON objects, got %T", items[0])
-		s.Contains(first, "name")
-		s.Contains(first, "namespace")
-		s.Contains(first, "kind")
-		s.Contains(first, "validation")
+			"manage_istio_config_read list response should include namespace %q", s.testNS)
+		s.Require().NotEmpty(nsData,
+			"manage_istio_config_read list response should return at least one GVK group for namespace %q", s.testNS)
+
+		foundResource := false
+		for gvk, val := range nsData {
+			kvr, ok := val.(map[string]interface{})
+			s.Require().True(ok,
+				"manage_istio_config_read list GVK entry %q should be a JSON object, got %T", gvk, val)
+			if valid, ok := kvr["valid"].([]interface{}); ok && len(valid) > 0 {
+				foundResource = true
+				break
+			}
+			if invalid, ok := kvr["invalid"].([]interface{}); ok && len(invalid) > 0 {
+				foundResource = true
+				break
+			}
+		}
+		s.True(foundResource,
+			"manage_istio_config_read list response should contain at least one resource name in valid or invalid for namespace %q", s.testNS)
 	})
 }
 

--- a/pkg/mcp/testdata/toolsets-kiali-tools.json
+++ b/pkg/mcp/testdata/toolsets-kiali-tools.json
@@ -445,7 +445,7 @@
       "readOnlyHint": true,
       "title": "Manage Istio Config: List or Get"
     },
-    "description": "Read-only Istio config: list or get objects. For action 'list', returns an array of objects with {name, namespace, type, validation}. For create, patch, or delete use manage_istio_config.",
+    "description": "Read Istio config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} where valid/invalid arrays contain resource names. 'get' returns full YAML. For writes use manage_istio_config.",
     "inputSchema": {
       "dependentRequired": {
         "object": [

--- a/pkg/toolsets/kiali/tools/manage_istio_config_read.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config_read.go
@@ -16,8 +16,9 @@ func InitManageIstioConfigRead() []api.ServerTool {
 	name := defaults.ToolsetName() + "_manage_istio_config_read"
 	ret = append(ret, api.ServerTool{
 		Tool: api.Tool{
-			Name:        name,
-			Description: "Read-only Istio config: list or get objects. For action 'list', returns an array of objects with {name, namespace, type, validation}. For create, patch, or delete use manage_istio_config.",
+			Name: name,
+			Description: "Read Istio config. 'list' groups by namespace→'group/version/kind'→{valid:[...],invalid:[...]} " +
+				"where valid/invalid arrays contain resource names. 'get' returns full YAML. For writes use manage_istio_config.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{


### PR DESCRIPTION
Sync kiali-mcp-server with Kiali master after [#9970](https://github.com/kiali/kiali/pull/9970), which changed the manage_istio_config_read list response from a flat items[] array to a grouped namespaces structure to reduce LLM token usage.

### Changes

- Update kiali_manage_istio_config_read description to document the grouped list format: namespace -> group/version/kind -> {valid, invalid}
- Update contract test TestManageIstioConfigRead to expect {cluster, namespaces} instead of {cluster, items}
Regenerate toolsets-kiali-tools.json and README tool documentation

### How to test

`cd pkg/kiali/tests/backend `
`KIALI_URL=http://localhost:3001 go test -tags kiali_contract -v .`

