### PR TITLE
feat(kiali): remove patch version from Kiali

### DIFF
--- a/build/kiali.mk
+++ b/build/kiali.mk
@@ -3,7 +3,7 @@
 ISTIOCTL = $(shell pwd)/_output/tools/bin/istioctl
 ISTIO_ADDONS_DIR = $(shell pwd)/_output/istio-addons
 ISTIO_VERSION = 1.30.1
-KIALI_VERSION = v2.27.0
+KIALI_VERSION = v2.27
 # Release version without patch (e.g. 1.28.0 -> 1.28)
 
 # Download and install istioctl (also copies samples/addons for install-istio)


### PR DESCRIPTION
Update KIALI_VERSION from v2.27.0 to v2.27 so the local Kiali setup tracks the latest patch release in the 2.27 line (e.g. v2.27.1 when available), instead of pinning to a specific patch.

Kiali publishes a floating minor tag on Quay (v2.27) that is updated to point to the newest patch release.