### PR TITLE
feat(http): add bind address and warnings when on 0.0.0.0 with no tls/auth

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,12 +35,13 @@ type ToolOverride struct {
 type StaticConfig struct {
 	DeniedResources []api.GroupVersionKind `toml:"denied_resources"`
 
-	LogLevel   int    `toml:"log_level,omitzero"`
-	LogFile    string `toml:"log_file,omitempty"`
-	Port       string `toml:"port,omitempty"`
-	SSEBaseURL string `toml:"sse_base_url,omitempty"`
-	KubeConfig string `toml:"kubeconfig,omitempty"`
-	ListOutput string `toml:"list_output,omitempty"`
+	LogLevel    int    `toml:"log_level,omitzero"`
+	LogFile     string `toml:"log_file,omitempty"`
+	Port        string `toml:"port,omitempty"`
+	BindAddress string `toml:"bind_address,omitempty"`
+	SSEBaseURL  string `toml:"sse_base_url,omitempty"`
+	KubeConfig  string `toml:"kubeconfig,omitempty"`
+	ListOutput  string `toml:"list_output,omitempty"`
 	// Stateless configures the MCP server to operate in stateless mode.
 	// When true, the server will not send notifications to clients (e.g., tools/list_changed, prompts/list_changed).
 	// This is useful for container deployments, load balancing, and serverless environments where

--- a/pkg/config/config_default.go
+++ b/pkg/config/config_default.go
@@ -12,6 +12,7 @@ import (
 // the raw upstream configuration independent of downstream customization.
 func BaseDefault() *StaticConfig {
 	return &StaticConfig{
+		BindAddress:          "0.0.0.0",
 		ListOutput:           "table",
 		Toolsets:             []string{"core", "config"},
 		ConfirmationFallback: "allow",

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -125,7 +125,7 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 	// ReadHeaderTimeout provides Slowloris protection; other timeouts are left
 	// at Go defaults since MCP clients maintain persistent connections.
 	httpServer := &http.Server{
-		Addr:              ":" + staticConfig.Port,
+		Addr:              net.JoinHostPort(staticConfig.BindAddress, staticConfig.Port),
 		Handler:           instrumentedHandler,
 		ReadHeaderTimeout: staticConfig.HTTP.ReadHeaderTimeout.Duration(),
 		TLSConfig: &tls.Config{
@@ -170,18 +170,26 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 	signal.Notify(sigHupChan, syscall.SIGHUP)
 	defer signal.Stop(sigHupChan)
 
+	if staticConfig.BindAddress == "0.0.0.0" && staticConfig.TLSCert == "" && !staticConfig.RequireOAuth {
+		klogutil.LogWarn(logger,
+			"HTTP server is listening on all interfaces without TLS or authentication, "+
+				"consider setting bind_address to 127.0.0.1, enabling TLS, or enabling OAuth",
+			klogutil.Field("bind_address", staticConfig.BindAddress),
+		)
+	}
+
 	serverErr := make(chan error, 1)
 	go func() {
 		var err error
 		if staticConfig.TLSCert != "" && staticConfig.TLSKey != "" {
 			logger.Info("HTTPS server starting",
-				"server.port", staticConfig.Port,
+				"server.addr", httpServer.Addr,
 				"endpoints", "/mcp, /sse, /message, /healthz, /stats, /metrics",
 			)
 			err = httpServer.ListenAndServeTLS(staticConfig.TLSCert, staticConfig.TLSKey)
 		} else {
 			logger.Info("HTTP server starting",
-				"server.port", staticConfig.Port,
+				"server.addr", httpServer.Addr,
 				"endpoints", "/mcp, /sse, /message, /healthz, /stats, /metrics",
 			)
 			err = httpServer.ListenAndServe()

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -67,6 +67,7 @@ const (
 	flagConfig               = "config"
 	flagConfigDir            = "config-dir"
 	flagPort                 = "port"
+	flagBindAddress          = "bind-address"
 	flagSSEBaseUrl           = "sse-base-url"
 	flagKubeconfig           = "kubeconfig"
 	flagToolsets             = "toolsets"
@@ -92,6 +93,7 @@ type MCPServerOptions struct {
 	LogLevel             int
 	LogFile              string
 	Port                 string
+	BindAddress          string
 	SSEBaseUrl           string
 	Kubeconfig           string
 	Toolsets             []string
@@ -165,6 +167,7 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&o.ConfigPath, flagConfig, o.ConfigPath, "Path of the config file.")
 	cmd.Flags().StringVar(&o.ConfigDir, flagConfigDir, o.ConfigDir, "Path to drop-in configuration directory (files loaded in lexical order). Defaults to "+config.DefaultDropInConfigDir+" relative to the config file if --config is set.")
 	cmd.Flags().StringVar(&o.Port, flagPort, o.Port, "Start a streamable HTTP and SSE HTTP server on the specified port (e.g. 8080)")
+	cmd.Flags().StringVar(&o.BindAddress, flagBindAddress, o.BindAddress, "Address to bind the HTTP server to (e.g. 127.0.0.1). Defaults to 0.0.0.0 (all interfaces)")
 	cmd.Flags().StringVar(&o.SSEBaseUrl, flagSSEBaseUrl, o.SSEBaseUrl, "SSE public base URL to use when sending the endpoint message (e.g. https://example.com)")
 	cmd.Flags().StringVar(&o.Kubeconfig, flagKubeconfig, o.Kubeconfig, "Path to the kubeconfig file to use for authentication")
 	cmd.Flags().StringSliceVar(&o.Toolsets, flagToolsets, o.Toolsets, "Comma-separated list of MCP toolsets to use (available toolsets: "+strings.Join(toolsets.ToolsetNames(), ", ")+"). Defaults to "+strings.Join(o.StaticConfig.Toolsets, ", ")+".")
@@ -227,6 +230,9 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 	if cmd.Flag(flagPort).Changed {
 		m.StaticConfig.Port = m.Port
+	}
+	if cmd.Flag(flagBindAddress).Changed {
+		m.StaticConfig.BindAddress = m.BindAddress
 	}
 	if cmd.Flag(flagSSEBaseUrl).Changed {
 		m.StaticConfig.SSEBaseURL = m.SSEBaseUrl


### PR DESCRIPTION
Fixes #1264
Fixes #1265

These are some hardenings to improve the http server, enabling specifying a bind address and clarifying that if you run on 0.0.0.0 without any auth/tls that you get a warning