### PR TITLE
cleanup(logs): migrate remaining klog.FromContext to klogutil.FromContext

### DIFF
--- a/pkg/kubernetes/provider_gvk_filter.go
+++ b/pkg/kubernetes/provider_gvk_filter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2"
 )
 
 // ProviderGVKFilter provides GVK-based filtering capabilities for providers.
@@ -31,7 +30,7 @@ func (f *ProviderGVKFilter) AnyTargetHasGVKs(ctx context.Context, gvks []schema.
 		return true
 	}
 
-	logger := klog.FromContext(ctx)
+	logger := klogutil.FromContext(ctx)
 	mgrs, err := f.managerProvider.GetTargetManagers(ctx)
 	// If an error occurs, don't exclude tools
 	if err != nil {


### PR DESCRIPTION
## Description

`pkg/kubernetes/provider_gvk_filter.go` was added in #1196 (target-specific
tool filtering), which merged after the OpenTelemetry logging work in #1260.
As a result it kept calling `klog.FromContext` directly, and it's now the only
production file that does.

This migrates that single call site to `klogutil.FromContext`, matching the
rest of the codebase, for two reasons:

- `klogutil.FromContext` injects the context into the logger's values so the
  OTel log bridge can extract the active trace span. With the old
  `klog.FromContext`, the `AnyTargetHasGVKs` warning logs exported with no
  trace/span IDs and didn't correlate with the surrounding tool-call trace.
- It restores the "do not use `klog.FromContext` directly in production code"
  invariant documented in `AGENTS.md` by #1260.

The `k8s.io/klog/v2` import is dropped since this was its only use in the file.
No behavior change beyond trace correlation; `go build` and `go vet` are clean.