### PR TITLE
fix(nodes): omit tailLines for file log queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,8 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 - **nodes_log** - Get logs from a Kubernetes node (kubelet, kube-proxy, or other system logs). This accesses node logs through the Kubernetes API proxy to the kubelet
   - `name` (`string`) **(required)** - Name of the node to get logs from
-  - `query` (`string`) **(required)** - query specifies services(s) or files from which to return logs (required). Example: "kubelet" to fetch kubelet logs, "/<log-file-name>" to fetch a specific log file from the node (e.g., "/var/log/kubelet.log" or "/var/log/kube-proxy.log")
-  - `tailLines` (`integer`) - Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)
+  - `query` (`string`) **(required)** - query specifies services(s) or files from which to return logs (required). Example: "kubelet" to fetch kubelet logs, "/<log-file-name>" to fetch a specific log file relative to /var/log on the node (e.g., "/kubelet.log" or "/kube-proxy.log")
+  - `tailLines` (`integer`) - Number of lines to retrieve from the end of service logs (Optional, 0 means all logs; ignored for file queries)
 
 - **nodes_stats_summary** - Get detailed resource usage statistics from a Kubernetes node via the kubelet's Summary API. Provides comprehensive metrics including CPU, memory, filesystem, and network usage at the node, pod, and container levels. On systems with cgroup v2 and kernel 4.20+, also includes PSI (Pressure Stall Information) metrics that show resource pressure for CPU, memory, and I/O. See https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/ for details on PSI metrics
   - `name` (`string`) **(required)** - Name of the node to get stats from

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,10 +15,10 @@ import (
 func (c *Core) NodesLog(ctx context.Context, name string, query string, tailLines int64) (string, error) {
 	// Use the node proxy API to access logs from the kubelet
 	// https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#log-query
-	// Common log paths:
-	// - /var/log/kubelet.log - kubelet logs
-	// - /var/log/kube-proxy.log - kube-proxy logs
-	// - /var/log/containers/ - container logs
+	// File paths are relative to /var/log and must contain a slash:
+	// - /kubelet.log - kubelet logs
+	// - /kube-proxy.log - kube-proxy logs
+	// - /containers/ - container logs
 
 	if _, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{}); err != nil {
 		return "", fmt.Errorf("failed to get node %s: %w", name, err)
@@ -27,8 +28,8 @@ func (c *Core) NodesLog(ctx context.Context, name string, query string, tailLine
 		Get().
 		AbsPath("api", "v1", "nodes", name, "proxy", "logs")
 	req.Param("query", query)
-	// Query parameters for tail
-	if tailLines > 0 {
+	// The kubelet only supports tailLines for service log queries.
+	if tailLines > 0 && !strings.ContainsAny(query, `/\`) {
 		req.Param("tailLines", fmt.Sprintf("%d", tailLines))
 	}
 

--- a/pkg/mcp/nodes_test.go
+++ b/pkg/mcp/nodes_test.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"net/http"
-	"strconv"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -51,17 +50,23 @@ func (s *NodesSuite) TestNodesLog() {
 			query := req.URL.Query().Get("query")
 			var logContent string
 			switch query {
+			case "kubelet":
+				if req.URL.Query().Get("tailLines") != "2" {
+					w.WriteHeader(http.StatusNotAcceptable)
+					return
+				}
+				logContent = "Line 4\nLine 5\n"
 			case "/empty.log":
 				logContent = ""
 			case "/kubelet.log":
+				if req.URL.Query().Has("tailLines") {
+					w.WriteHeader(http.StatusNotAcceptable)
+					return
+				}
 				logContent = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
 			default:
 				w.WriteHeader(http.StatusNotFound)
 				return
-			}
-			_, err := strconv.Atoi(req.URL.Query().Get("tailLines"))
-			if err == nil {
-				logContent = "Line 4\nLine 5\n"
 			}
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(logContent))
@@ -163,6 +168,23 @@ func (s *NodesSuite) TestNodesLog() {
 		})
 	})
 	for _, tailCase := range []interface{}{2, int64(2), float64(2)} {
+		s.Run("nodes_log(name=existing-node, query=kubelet, tailLines=2)", func() {
+			toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
+				"name":      "existing-node",
+				"query":     "kubelet",
+				"tailLines": tailCase,
+			})
+			s.Require().NotNil(toolResult, "toolResult should not be nil")
+			s.Run("no error", func() {
+				s.Falsef(toolResult.IsError, "call tool should succeed")
+				s.Nilf(err, "call tool should not return error object")
+			})
+			s.Run("returns tail log", func() {
+				expectedMessage := "Line 4\nLine 5\n"
+				s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+					"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
+			})
+		})
 		s.Run("nodes_log(name=existing-node, query=/kubelet.log, tailLines=2)", func() {
 			toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
 				"name":      "existing-node",
@@ -174,8 +196,8 @@ func (s *NodesSuite) TestNodesLog() {
 				s.Falsef(toolResult.IsError, "call tool should succeed")
 				s.Nilf(err, "call tool should not return error object")
 			})
-			s.Run("returns tail log", func() {
-				expectedMessage := "Line 4\nLine 5\n"
+			s.Run("returns full log", func() {
+				expectedMessage := "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
 				s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
 					"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 			})

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -60,12 +60,12 @@
           "type": "string"
         },
         "query": {
-          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file from the node (e.g., \"/var/log/kubelet.log\" or \"/var/log/kube-proxy.log\")",
+          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file relative to /var/log on the node (e.g., \"/kubelet.log\" or \"/kube-proxy.log\")",
           "type": "string"
         },
         "tailLines": {
           "default": 100,
-          "description": "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
+          "description": "Number of lines to retrieve from the end of service logs (Optional, 0 means all logs; ignored for file queries)",
           "minimum": 0,
           "type": "integer"
         }

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -108,12 +108,12 @@
           "type": "string"
         },
         "query": {
-          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file from the node (e.g., \"/var/log/kubelet.log\" or \"/var/log/kube-proxy.log\")",
+          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file relative to /var/log on the node (e.g., \"/kubelet.log\" or \"/kube-proxy.log\")",
           "type": "string"
         },
         "tailLines": {
           "default": 100,
-          "description": "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
+          "description": "Number of lines to retrieve from the end of service logs (Optional, 0 means all logs; ignored for file queries)",
           "minimum": 0,
           "type": "integer"
         }

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -80,12 +80,12 @@
           "type": "string"
         },
         "query": {
-          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file from the node (e.g., \"/var/log/kubelet.log\" or \"/var/log/kube-proxy.log\")",
+          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file relative to /var/log on the node (e.g., \"/kubelet.log\" or \"/kube-proxy.log\")",
           "type": "string"
         },
         "tailLines": {
           "default": 100,
-          "description": "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
+          "description": "Number of lines to retrieve from the end of service logs (Optional, 0 means all logs; ignored for file queries)",
           "minimum": 0,
           "type": "integer"
         }

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -80,12 +80,12 @@
           "type": "string"
         },
         "query": {
-          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file from the node (e.g., \"/var/log/kubelet.log\" or \"/var/log/kube-proxy.log\")",
+          "description": "query specifies services(s) or files from which to return logs (required). Example: \"kubelet\" to fetch kubelet logs, \"/\u003clog-file-name\u003e\" to fetch a specific log file relative to /var/log on the node (e.g., \"/kubelet.log\" or \"/kube-proxy.log\")",
           "type": "string"
         },
         "tailLines": {
           "default": 100,
-          "description": "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
+          "description": "Number of lines to retrieve from the end of service logs (Optional, 0 means all logs; ignored for file queries)",
           "minimum": 0,
           "type": "integer"
         }

--- a/pkg/toolsets/core/nodes.go
+++ b/pkg/toolsets/core/nodes.go
@@ -30,11 +30,11 @@ func initNodes() []api.ServerTool {
 					},
 					"query": {
 						Type:        "string",
-						Description: `query specifies services(s) or files from which to return logs (required). Example: "kubelet" to fetch kubelet logs, "/<log-file-name>" to fetch a specific log file from the node (e.g., "/var/log/kubelet.log" or "/var/log/kube-proxy.log")`,
+						Description: `query specifies services(s) or files from which to return logs (required). Example: "kubelet" to fetch kubelet logs, "/<log-file-name>" to fetch a specific log file relative to /var/log on the node (e.g., "/kubelet.log" or "/kube-proxy.log")`,
 					},
 					"tailLines": {
 						Type:        "integer",
-						Description: "Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)",
+						Description: "Number of lines to retrieve from the end of service logs (Optional, 0 means all logs; ignored for file queries)",
 						Default:     api.ToRawMessage(100),
 						Minimum:     ptr.To(float64(0)),
 					},


### PR DESCRIPTION
## Summary

- stop forwarding `tailLines` for file-based node log queries
- document file paths relative to `/var/log` and cover service/file behavior

## Why

The kubelet rejects options on file queries, so `nodes_log` returned 406 whenever a file path was used with `tailLines`. The existing examples also double-prefixed `/var/log`.

Fixes #1262.

## Validation

- `go test -p 1 ./pkg/mcp -run 'TestNodes/TestNodesLog' -count=1`
- `go test -p 1 -count=1 ./...`
- `make lint`
- `make build`