### PR TITLE
fix(http): extend bind address warning to IPv6 and add tests

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,7 @@ The server will:
 | `log_level` | integer | `0` | Logging verbosity level (0-9). Higher values produce more verbose output. Similar to [kubectl logging levels](https://kubernetes.io/docs/reference/kubectl/quick-reference/#kubectl-output-verbosity-and-debugging). |
 | `log_file` | string | `""` | Path to a server log file. Required for logging in stdio mode (where stdout is reserved for the MCP protocol); replaces stdout logging in HTTP mode. The file is created if it does not exist and opened in append mode (`O_APPEND`, `0o600`). Use the special value `stderr` to route logs to stderr without opening a file. |
 | `port` | string | `""` | When set, starts the MCP server in HTTP mode (Streamable HTTP at `/mcp`, SSE at `/sse`) on the specified port. |
+| `bind_address` | string | `"0.0.0.0"` | Address to bind the HTTP server to. Set to `127.0.0.1` to restrict to localhost. A warning is logged when listening on all interfaces (`0.0.0.0` or `::`) without TLS or OAuth. |
 | `sse_base_url` | string | `""` | Base URL for Server-Sent Events (SSE) connections. Used when the server is behind a reverse proxy. |
 | `list_output` | string | `"table"` | Output format for resource list operations. Valid values: `yaml`, `table`. |
 | `stateless` | boolean | `false` | When `true`, disables tool and prompt change notifications. Useful for container deployments, load balancing, and serverless environments. |
@@ -716,6 +717,7 @@ The following options can be set via command-line arguments. CLI arguments overr
 | Option | Description |
 |--------|-------------|
 | `--port` | Start in HTTP mode on the specified port |
+| `--bind-address` | Address to bind the HTTP server to (default: `0.0.0.0`) |
 | `--log-level` | Logging verbosity (0-9) |
 | `--log-file` | Path to a server log file. Required for logging in stdio mode; replaces stdout logging in HTTP mode. Use `stderr` to log to the standard error stream. |
 | `--config` | Path to main TOML configuration file |
@@ -741,6 +743,7 @@ A comprehensive configuration file demonstrating all major options:
 log_level = 2
 log_file = "/var/log/kubernetes-mcp-server.log"
 port = "8080"
+bind_address = "0.0.0.0"
 list_output = "table"
 stateless = false
 

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -170,7 +170,7 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 	signal.Notify(sigHupChan, syscall.SIGHUP)
 	defer signal.Stop(sigHupChan)
 
-	if staticConfig.BindAddress == "0.0.0.0" && staticConfig.TLSCert == "" && !staticConfig.RequireOAuth {
+	if (staticConfig.BindAddress == "0.0.0.0" || staticConfig.BindAddress == "::") && staticConfig.TLSCert == "" && !staticConfig.RequireOAuth {
 		klogutil.LogWarn(logger,
 			"HTTP server is listening on all interfaces without TLS or authentication, "+
 				"consider setting bind_address to 127.0.0.1, enabling TLS, or enabling OAuth",

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -290,6 +290,72 @@ func TestHealthCheck(t *testing.T) {
 	})
 }
 
+func TestBindAddress(t *testing.T) {
+	t.Run("binds to specified address", func(t *testing.T) {
+		testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{BindAddress: "127.0.0.1"}}, func(ctx *httpContext) {
+			loopbackAddr := net.JoinHostPort("127.0.0.1", ctx.StaticConfig.Port)
+			resp, err := http.Get(fmt.Sprintf("http://%s/healthz", loopbackAddr))
+			if err != nil {
+				t.Fatalf("Failed to reach server on bound address: %v", err)
+			}
+			t.Cleanup(func() { _ = resp.Body.Close() })
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Expected HTTP 200 OK, got %d", resp.StatusCode)
+			}
+		})
+	})
+	t.Run("warns when on 0.0.0.0 without TLS or OAuth", func(t *testing.T) {
+		testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{BindAddress: "0.0.0.0"}}, func(ctx *httpContext) {
+			ctx.StopServer()
+			_ = ctx.WaitForShutdown()
+			logStr := ctx.LogBuffer.String()
+			if !strings.Contains(logStr, "HTTP server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected warning about listening on all interfaces, got: %s", logStr)
+			}
+		})
+	})
+	t.Run("warns when on :: without TLS or OAuth", func(t *testing.T) {
+		testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{BindAddress: "::"}}, func(ctx *httpContext) {
+			ctx.StopServer()
+			_ = ctx.WaitForShutdown()
+			logStr := ctx.LogBuffer.String()
+			if !strings.Contains(logStr, "HTTP server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected warning about listening on all interfaces, got: %s", logStr)
+			}
+		})
+	})
+	t.Run("no warning when on 127.0.0.1", func(t *testing.T) {
+		testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{BindAddress: "127.0.0.1"}}, func(ctx *httpContext) {
+			ctx.StopServer()
+			_ = ctx.WaitForShutdown()
+			logStr := ctx.LogBuffer.String()
+			if strings.Contains(logStr, "HTTP server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected no warning about listening on all interfaces for 127.0.0.1, got: %s", logStr)
+			}
+		})
+	})
+	t.Run("no warning when TLS is configured", func(t *testing.T) {
+		testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{BindAddress: "0.0.0.0", TLSCert: "/dummy-cert.pem"}}, func(ctx *httpContext) {
+			ctx.StopServer()
+			_ = ctx.WaitForShutdown()
+			logStr := ctx.LogBuffer.String()
+			if strings.Contains(logStr, "HTTP server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected no warning when TLS cert is configured, got: %s", logStr)
+			}
+		})
+	})
+	t.Run("no warning when OAuth is enabled", func(t *testing.T) {
+		testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{BindAddress: "0.0.0.0", RequireOAuth: true, ClusterProviderStrategy: api.ClusterProviderKubeConfig}}, func(ctx *httpContext) {
+			ctx.StopServer()
+			_ = ctx.WaitForShutdown()
+			logStr := ctx.LogBuffer.String()
+			if strings.Contains(logStr, "HTTP server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected no warning when OAuth is enabled, got: %s", logStr)
+			}
+		})
+	})
+}
+
 func TestMiddlewareLogging(t *testing.T) {
 	testCase(t, func(ctx *httpContext) {
 		_, _ = http.Get(fmt.Sprintf("http://%s/.well-known/oauth-protected-resource", ctx.HttpAddress))


### PR DESCRIPTION
Follow-up to #1276.

- Extend the all-interfaces warning to also fire for IPv6 `::` (not just `0.0.0.0`)
- Add `TestBindAddress` covering bind address wiring, warning presence for `0.0.0.0`
  and `::`, and warning absence for `127.0.0.1` and OAuth-enabled configs
- Document `bind_address` / `--bind-address` in the TOML reference table, CLI flags
  table, and complete example in `docs/configuration.md`

Refs #1264, #1265