### PR TITLE
fix(evals): install claude-agent-acp locally instead of globally

### DIFF
--- a/build/evals.mk
+++ b/build/evals.mk
@@ -45,7 +45,6 @@ claude-agent-acp: ## Install the claude-agent-acp adapter for the claude-code ev
 	@[ -f $(CLAUDE_AGENT_ACP) ] || { \
 		set -e ;\
 		echo "Installing claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) to $(CLAUDE_AGENT_ACP)..." ;\
-		mkdir -p $(shell dirname $(CLAUDE_AGENT_ACP))/.. ;\
 		npm install --prefix $(shell pwd)/_output/tools @agentclientprotocol/claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) ;\
 		echo "✅ claude-agent-acp installed" ;\
 	}

--- a/build/evals.mk
+++ b/build/evals.mk
@@ -45,7 +45,14 @@ claude-agent-acp: ## Install the claude-agent-acp adapter for the claude-code ev
 		set -e ;\
 		echo "Installing claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) (npm install -g)..." ;\
 		npm install -g @agentclientprotocol/claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) ;\
-		echo "✅ claude-agent-acp installed" ;\
+		if command -v claude-agent-acp >/dev/null 2>&1; then \
+			echo "✅ claude-agent-acp installed" ;\
+		else \
+			NPM_BIN=$$(npm prefix -g)/bin ;\
+			echo "⚠️  claude-agent-acp installed but not found on PATH." ;\
+			echo "   Add the npm global bin directory to your PATH:" ;\
+			echo "   export PATH=\"\$$PATH:$$NPM_BIN\"" ;\
+		fi ;\
 	}
 
 .PHONY: run-evals

--- a/build/evals.mk
+++ b/build/evals.mk
@@ -7,6 +7,7 @@ MCP_CONFIG_DIR ?= dev/config/mcp-configs
 
 MCPCHECKER = $(shell pwd)/_output/tools/bin/mcpchecker
 MCPCHECKER_VERSION ?= latest
+CLAUDE_AGENT_ACP = $(shell pwd)/_output/tools/node_modules/.bin/claude-agent-acp
 CLAUDE_AGENT_ACP_VERSION ?= latest
 
 # High-level knobs for local single-suite runs, e.g.:
@@ -37,27 +38,21 @@ mcpchecker:
 
 ##@ Evals
 
-# Install the claude-agent-acp adapter, required by the claude-code eval agent
-# (evals/claude-code/agent.yaml runs `claude-agent-acp`). No-op if already present.
+# Install the claude-agent-acp adapter locally under _output/tools, required by
+# the claude-code eval agent (evals/claude-code/agent.yaml runs `claude-agent-acp`).
 .PHONY: claude-agent-acp
 claude-agent-acp: ## Install the claude-agent-acp adapter for the claude-code eval agent
-	@command -v claude-agent-acp >/dev/null 2>&1 || { \
+	@[ -f $(CLAUDE_AGENT_ACP) ] || { \
 		set -e ;\
-		echo "Installing claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) (npm install -g)..." ;\
-		npm install -g @agentclientprotocol/claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) ;\
-		if command -v claude-agent-acp >/dev/null 2>&1; then \
-			echo "✅ claude-agent-acp installed" ;\
-		else \
-			NPM_BIN=$$(npm prefix -g)/bin ;\
-			echo "⚠️  claude-agent-acp installed but not found on PATH." ;\
-			echo "   Add the npm global bin directory to your PATH:" ;\
-			echo "   export PATH=\"\$$PATH:$$NPM_BIN\"" ;\
-		fi ;\
+		echo "Installing claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) to $(CLAUDE_AGENT_ACP)..." ;\
+		mkdir -p $(shell dirname $(CLAUDE_AGENT_ACP))/.. ;\
+		npm install --prefix $(shell pwd)/_output/tools @agentclientprotocol/claude-agent-acp@$(CLAUDE_AGENT_ACP_VERSION) ;\
+		echo "✅ claude-agent-acp installed" ;\
 	}
 
 .PHONY: run-evals
 run-evals: mcpchecker $(if $(filter claude-code,$(AGENT)),claude-agent-acp) ## Run mcpchecker evals (knobs: SUITE, AGENT, MODEL; see evals/README.md)
-	$(if $(MODEL),ANTHROPIC_MODEL=$(MODEL) )$(MCPCHECKER) check $(EVAL_CONFIG) \
+	$(if $(MODEL),ANTHROPIC_MODEL=$(MODEL) )PATH="$(shell pwd)/_output/tools/node_modules/.bin:$(PATH)" $(MCPCHECKER) check $(EVAL_CONFIG) \
 		$(if $(EVAL_LABEL_SELECTOR),--label-selector $(EVAL_LABEL_SELECTOR),) \
 		$(if $(EVAL_TASK_FILTER),--run "$(EVAL_TASK_FILTER)",) \
 		$(if $(filter true,$(EVAL_VERBOSE)),--verbose,) \

--- a/evals/README.md
+++ b/evals/README.md
@@ -41,10 +41,9 @@ Tasks are grouped into suites via a `suite: <name>` label. The available suites 
     subscription (or an `ANTHROPIC_API_KEY`) covers the agent and no separate key
     is needed. Run `claude` once interactively to log in if you have not already.
   - The `claude-agent-acp` adapter, which bridges mcpchecker to that `claude` CLI,
-    installed with `make claude-agent-acp` (runs
-    `npm install -g @agentclientprotocol/claude-agent-acp`, so it needs Node.js/npm).
-    Without it, `mcpchecker check` fails at agent-spec load with
-    `'claude-agent-acp' binary not found in PATH`.
+    installed with `make claude-agent-acp` (installs locally under                                        
+    `_output/tools/node_modules/`, so it needs Node.js/npm). `make run-evals`                             
+    prepends `_output/tools/node_modules/.bin` to `PATH` automatically.   
 
 ## Quickstart: run one suite locally with Claude Code
 


### PR DESCRIPTION
## Summary
- Install `claude-agent-acp` under `_output/tools/` (alongside `mcpchecker`) instead of using `npm install -g`
- `run-evals` target prepends the local bin directory to PATH automatically
- Eliminates PATH issues entirely — no global install, no manual PATH setup

Closes #1281

## Test plan
- [ ] Run `make claude-agent-acp` — installs to `_output/tools/node_modules/.bin/claude-agent-acp`
- [ ] Run `make run-evals AGENT=claude-code SUITE=core` — finds `claude-agent-acp` without manual PATH changes
- [ ] Verify `_output/tools/` can be cleaned with `rm -rf _output` as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)