### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ For a secure production setup with dedicated ServiceAccount and read-only access
 
 </details>
 
+### Autohand Code
+
+Register the published npm server with [Autohand Code](https://github.com/autohandai/code-cli/):
+
+```shell
+autohand mcp add kubernetes npx -y kubernetes-mcp-server@latest
+```
+
+Add `--scope project` to keep the registration in the current workspace.
+
 ### Claude Desktop
 
 #### Using npx


### PR DESCRIPTION
## Summary

- add Autohand Code to the existing getting-started client instructions
- reuse the published `kubernetes-mcp-server@latest` npm entry point
- note the project-scoped registration option

## Verification

- `git diff --check`

The commit includes the required DCO sign-off.