### PR TITLE
fix(kubernetes): bound discovery requests during startup

### DIFF
--- a/pkg/kubernetes/accesscontrol_round_tripper_test.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -20,11 +21,15 @@ import (
 )
 
 type mockRoundTripper struct {
+	mu        sync.Mutex
 	called    *bool
 	onRequest func(w http.ResponseWriter, r *http.Request)
 }
 
 func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	*m.called = true
 	rec := httptest.NewRecorder()
 	m.onRequest(rec, req)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -29,7 +30,8 @@ const (
 	OAuthAuthorizationHeader  = HeaderKey("Authorization")
 	UserAgentHeader           = HeaderKey("User-Agent")
 
-	CustomUserAgent = "kubernetes-mcp-server/bearer-token-auth"
+	CustomUserAgent         = "kubernetes-mcp-server/bearer-token-auth"
+	defaultDiscoveryTimeout = 10 * time.Second
 )
 
 type CloseWatchKubeConfig func() error
@@ -89,7 +91,13 @@ func NewKubernetes(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
-	discoveryClient, err := discovery.NewDiscoveryClientForConfigAndClient(k.restConfig, k.httpClient)
+	// Discovery runs synchronously while tools are registered. Use a client copy
+	// so an unreachable cluster cannot block startup without timing out watches or execs.
+	discoveryHTTPClient := *k.httpClient
+	if discoveryHTTPClient.Timeout <= 0 {
+		discoveryHTTPClient.Timeout = defaultDiscoveryTimeout
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfigAndClient(k.restConfig, &discoveryHTTPClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovery client: %w", err)
 	}

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -1,0 +1,56 @@
+package kubernetes
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type KubernetesTestSuite struct {
+	suite.Suite
+}
+
+func (s *KubernetesTestSuite) TestDiscoveryRequestsHaveDefaultTimeout() {
+	called := false
+	requestTimeout := time.Duration(0)
+	discoveryHandler := test.NewDiscoveryClientHandler()
+	transport := &mockRoundTripper{
+		called: &called,
+		onRequest: func(w http.ResponseWriter, r *http.Request) {
+			deadline, ok := r.Context().Deadline()
+			s.True(ok, "Expected discovery request context to have a deadline")
+			if ok {
+				requestTimeout = time.Until(deadline)
+			}
+			discoveryHandler.ServeHTTP(w, r)
+		},
+	}
+
+	rawConfig := clientcmdapi.NewConfig()
+	k, err := NewKubernetes(
+		s.T().Context(),
+		&config.StaticConfig{},
+		clientcmd.NewDefaultClientConfig(*rawConfig, &clientcmd.ConfigOverrides{}),
+		&rest.Config{Host: "https://cluster.example", Transport: transport},
+	)
+	s.Require().NoError(err)
+	s.T().Cleanup(k.close)
+
+	_, err = k.DiscoveryClient().ServerResourcesForGroupVersion("v1")
+	s.NoError(err)
+	s.True(called, "Expected discovery request to reach the transport")
+	s.GreaterOrEqual(requestTimeout, 9*time.Second)
+	s.LessOrEqual(requestTimeout, 10*time.Second)
+	s.Zero(k.httpClient.Timeout, "Expected the shared Kubernetes client to remain unbounded")
+}
+
+func TestKubernetes(t *testing.T) {
+	suite.Run(t, new(KubernetesTestSuite))
+}


### PR DESCRIPTION
## Summary

- apply a 10-second default to discovery requests when no timeout is configured
- keep the shared Kubernetes HTTP client unchanged for watches and streaming operations

## Why

`NewDiscoveryClientForConfigAndClient` receives a pre-built zero-timeout HTTP client, so client-go's discovery default never reaches the request. An unreachable kubeconfig context can therefore block synchronous GVK filtering during startup indefinitely.

Fixes #1284.

## Validation

- `go test ./pkg/kubernetes -count=1`
- `go test ./pkg/api ./pkg/toolsets/core -count=1`
- `go vet ./pkg/kubernetes`
- `_output/tools/bin/golangci-lint run ./pkg/kubernetes/...`
- `git diff --check`
