### PR TITLE
fix(kubevirt): avoid article agreement issue in product name templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,12 +535,12 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 <summary>kubevirt</summary>
 
-- **vm_clone** - Clone a KubeVirt VirtualMachine by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the KubeVirt Clone API
+- **vm_clone** - Clone a VirtualMachine on KubeVirt by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the KubeVirt Clone API
   - `name` (`string`) **(required)** - The name of the source virtual machine to clone
   - `namespace` (`string`) **(required)** - The namespace of the source virtual machine
   - `targetName` (`string`) **(required)** - The name for the new cloned virtual machine
 
-- **vm_create** - Create a KubeVirt VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.
+- **vm_create** - Create a VirtualMachine on KubeVirt with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.
   - `autostart` (`boolean`) - Optional flag to automatically start the VM after creation (sets runStrategy to Always instead of Halted). Defaults to false.
   - `instancetype` (`string`) - Optional instance type name for the VM (e.g., 'u1.small', 'u1.medium', 'u1.large')
   - `name` (`string`) **(required)** - The name of the virtual machine

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -6,7 +6,7 @@
       "openWorldHint": false,
       "title": "Virtual Machine: Clone"
     },
-    "description": "Clone a KubeVirt VirtualMachine by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the KubeVirt Clone API",
+    "description": "Clone a VirtualMachine on KubeVirt by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the KubeVirt Clone API",
     "inputSchema": {
       "properties": {
         "name": {
@@ -39,7 +39,7 @@
       "openWorldHint": false,
       "title": "Virtual Machine: Create"
     },
-    "description": "Create a KubeVirt VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.",
+    "description": "Create a VirtualMachine on KubeVirt with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.",
     "inputSchema": {
       "properties": {
         "autostart": {

--- a/pkg/toolsets/kubevirt/vm/clone/tool.go
+++ b/pkg/toolsets/kubevirt/vm/clone/tool.go
@@ -17,7 +17,7 @@ func Tools() []api.ServerTool {
 		{
 			Tool: api.Tool{
 				Name:        "vm_clone",
-				Description: fmt.Sprintf("Clone a %s VirtualMachine by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the %s Clone API", defaults.ProductName(), defaults.ProductName()),
+				Description: fmt.Sprintf("Clone a VirtualMachine on %s by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the %s Clone API", defaults.ProductName(), defaults.ProductName()),
 				InputSchema: &jsonschema.Schema{
 					Type: "object",
 					Properties: map[string]*jsonschema.Schema{

--- a/pkg/toolsets/kubevirt/vm/create/tool.go
+++ b/pkg/toolsets/kubevirt/vm/create/tool.go
@@ -23,7 +23,7 @@ func Tools() []api.ServerTool {
 		{
 			Tool: api.Tool{
 				Name:        "vm_create",
-				Description: fmt.Sprintf("Create a %s VirtualMachine in the cluster with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.", defaults.ProductName()),
+				Description: fmt.Sprintf("Create a VirtualMachine on %s with the specified configuration, automatically resolving instance types, preferences, and container disk images. VM will be created in Halted state by default; use autostart parameter to start it immediately.", defaults.ProductName()),
 				InputSchema: &jsonschema.Schema{
 					Type: "object",
 					Properties: map[string]*jsonschema.Schema{


### PR DESCRIPTION
The vm_clone and vm_create tool descriptions used "a %s VirtualMachine",
which reads fine for "a KubeVirt" but breaks for downstream product name
overrides starting with a vowel sound (e.g. "an OpenShift Virtualization
VirtualMachine"). Rephrase to avoid the leading article before the
templated product name.

/cc @lyarwood 

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Karel Simon <ksimon@redhat.com>