### PR TITLE
fix(evals): llm judge config is correct with new API

### DIFF
--- a/evals/core-eval-testing/acp-anthropic/eval-config.yaml
+++ b/evals/core-eval-testing/acp-anthropic/eval-config.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/acp-anthropic/eval-core.yaml
+++ b/evals/core-eval-testing/acp-anthropic/eval-core.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/acp-anthropic/eval-helm.yaml
+++ b/evals/core-eval-testing/acp-anthropic/eval-helm.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/acp-google/eval-config.yaml
+++ b/evals/core-eval-testing/acp-google/eval-config.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/acp-google/eval-core.yaml
+++ b/evals/core-eval-testing/acp-google/eval-core.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/acp-google/eval-helm.yaml
+++ b/evals/core-eval-testing/acp-google/eval-helm.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-anthropic/eval-config.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-config.yaml
@@ -11,8 +11,8 @@ config:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     ref:
-      type: builtin.llm-agent
-      model: "anthropic:claude-sonnet-4-6"
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-anthropic/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-core.yaml
@@ -11,8 +11,8 @@ config:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     ref:
-      type: builtin.llm-agent
-      model: "anthropic:claude-sonnet-4-6"
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-anthropic/eval-helm.yaml
+++ b/evals/core-eval-testing/builtin-anthropic/eval-helm.yaml
@@ -11,8 +11,8 @@ config:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     ref:
-      type: builtin.llm-agent
-      model: "anthropic:claude-sonnet-4-6"
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-google/eval-config.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-config.yaml
@@ -11,8 +11,8 @@ config:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     ref:
-      type: builtin.llm-agent
-      model: "google:gemini-3.1-pro-preview"
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-google/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-core.yaml
@@ -11,8 +11,8 @@ config:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     ref:
-      type: builtin.llm-agent
-      model: "google:gemini-3.1-pro-preview"
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-google/eval-helm.yaml
+++ b/evals/core-eval-testing/builtin-google/eval-helm.yaml
@@ -11,8 +11,8 @@ config:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     ref:
-      type: builtin.llm-agent
-      model: "google:gemini-3.1-pro-preview"
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-openai/eval-config.yaml
+++ b/evals/core-eval-testing/builtin-openai/eval-config.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-openai/eval-core.yaml
+++ b/evals/core-eval-testing/builtin-openai/eval-core.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:

--- a/evals/core-eval-testing/builtin-openai/eval-helm.yaml
+++ b/evals/core-eval-testing/builtin-openai/eval-helm.yaml
@@ -10,10 +10,9 @@ config:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
-    env:
-      baseUrlKey: JUDGE_BASE_URL
-      apiKeyKey: JUDGE_API_KEY
-      modelNameKey: JUDGE_MODEL_NAME
+    ref:
+      type: file
+      path: agent.yaml
   taskSets:
     - glob: ../../tasks/*/*/*.yaml
       labelSelector:


### PR DESCRIPTION
Currently, some of the llm judge configs still use the old env var based API, which is deprecated.

Also a few were fixed, but went against the design goal of the core-evals-testing dir, which is that the agent config should be file based and shared.