### PR TITLE
fix(evals): add NetObserv to the validated projects table

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ and only needed for the project-specific scenarios noted.
 | [Kiali](https://kiali.io) | `kiali` | 16 |
 | [Kubernetes](https://kubernetes.io) | - | 32 |
 | [KubeVirt](https://kubevirt.io) | `kubevirt`, `tekton` | 19 |
+| [NetObserv](https://netobserv.io) | `netobserv` | 4 |
 | [Tekton](https://tekton.dev) | `tekton` | 9 |
 
 <!-- VALIDATED-PROJECTS-END -->

--- a/evals/tasks/netobserv/export-flows/export-flows.yaml
+++ b/evals/tasks/netobserv/export-flows/export-flows.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: netobserv
+    project: netobserv
     requires: netobserv
+  annotations:
+    project-name: "NetObserv"
+    project-url: "https://netobserv.io"
   name: "Export flows as CSV"
   category: "Export"
   description: "Exports flow records from NetObserv in CSV format."

--- a/evals/tasks/netobserv/get-flow-metrics/get-flow-metrics.yaml
+++ b/evals/tasks/netobserv/get-flow-metrics/get-flow-metrics.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: netobserv
+    project: netobserv
     requires: netobserv
+  annotations:
+    project-name: "NetObserv"
+    project-url: "https://netobserv.io"
   name: "Get flow byte metrics"
   category: "Metrics"
   description: "Queries aggregated byte metrics from NetObserv for a namespace."

--- a/evals/tasks/netobserv/list-flows/list-flows.yaml
+++ b/evals/tasks/netobserv/list-flows/list-flows.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: netobserv
+    project: netobserv
     requires: netobserv
+  annotations:
+    project-name: "NetObserv"
+    project-url: "https://netobserv.io"
   name: "List flows in default namespace"
   category: "Flow inspection"
   description: "Retrieves recent flow records for the default namespace."

--- a/evals/tasks/netobserv/tls-breakdown/tls-breakdown.yaml
+++ b/evals/tasks/netobserv/tls-breakdown/tls-breakdown.yaml
@@ -3,7 +3,11 @@ apiVersion: mcpchecker/v1alpha2
 metadata:
   labels:
     suite: netobserv
+    project: netobserv
     requires: netobserv
+  annotations:
+    project-name: "NetObserv"
+    project-url: "https://netobserv.io"
   name: "TLS version breakdown"
   category: "Security analysis"
   description: "Investigates TLS version usage for a namespace using flow metrics."


### PR DESCRIPTION
Follow-up to #1159.

The NetObserv eval tasks added in #1159 were missing the `project` label and the `project-name` / `project-url` annotations that `generateValidatedProjects` (in `internal/tools/update-readme/main.go`) reads to build the "Validated Kubernetes Ecosystem Projects" table, so NetObserv never appeared there.

This adds the metadata to all four NetObserv tasks (`list-flows`, `get-flow-metrics`, `tls-breakdown`, `export-flows`) and regenerates the table with `make update-readme-tools`, which adds the row:

| [NetObserv](https://netobserv.io) | `netobserv` | 4 |

Fixes #1290