### PR TITLE
Config option for toolset prefiltering

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -284,6 +284,7 @@ Control what operations the MCP server can perform on your Kubernetes cluster. T
 |-------|------|---------|-------------|
 | `read_only` | boolean | `false` | When `true`, only exposes tools annotated with `readOnlyHint=true`. Prevents any write operations on the cluster. |
 | `disable_destructive` | boolean | `false` | When `true`, disables tools annotated with `destructiveHint=true` (delete, update operations). Has no effect when `read_only` is `true`. |
+| `experimental_enable_target_compatibility_tool_filters` | boolean | `false` | Controls cluster-capability tool filtering. Tools that require API groups absent from the cluster (for example the OpenShift-only `projects_list`) are hidden. **NOTE:** This feature is experimental, and this option is subject to change or removal in a future release. |
 
 **Example:**
 ```toml
@@ -292,6 +293,9 @@ read_only = true
 
 # Or allow writes but prevent deletions
 disable_destructive = true
+
+# Probe every target for API-group compatibility
+experimental_enable_target_compatibility_tool_filters = true
 ```
 
 ### Toolsets

--- a/internal/tools/update-readme/main.go
+++ b/internal/tools/update-readme/main.go
@@ -32,6 +32,10 @@ func (p *FilterProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVer
 	return true
 }
 
+func (p *FilterProvider) IsTargetCompatibilityToolFiltersEnabled() bool {
+	return false
+}
+
 var _ api.FilteringProvider = (*FilterProvider)(nil)
 
 type evalTask struct {

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -87,6 +87,11 @@ type ValidationEnabledProvider interface {
 	IsValidationEnabled() bool
 }
 
+// TargetCompatibilityToolFiltersEnabledProvider provides access to target compatibility tool filters setting.
+type TargetCompatibilityToolFiltersEnabledProvider interface {
+	IsTargetCompatibilityToolFiltersEnabled() bool
+}
+
 // RequireTLSProvider provides access to require_tls setting.
 type RequireTLSProvider interface {
 	IsRequireTLS() bool
@@ -106,6 +111,7 @@ type BaseConfig interface {
 	StsConfigProvider
 	CertificateAuthorityProvider
 	ValidationEnabledProvider
+	TargetCompatibilityToolFiltersEnabledProvider
 	RequireTLSProvider
 	RequireOAuthProvider
 }

--- a/pkg/api/filtering.go
+++ b/pkg/api/filtering.go
@@ -10,6 +10,7 @@ import (
 // (GVKs, features, etc.). Toolsets use this interface to determine which tools should
 // be exposed.
 type FilteringProvider interface {
+	TargetCompatibilityToolFiltersEnabledProvider
 	// AnyTargetHasGVKs reports whether every GVK in gvks is available on at least one target
 	// exposed by this provider. Providers that have not opted in to GVK discovery
 	// should return true so existing tools remain visible.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,6 +156,13 @@ type StaticConfig struct {
 	// Defaults to false.
 	ValidationEnabled bool `toml:"validation_enabled,omitempty"`
 
+	// EnableTargetCompatibilityToolFilters enables filtering of tools based on
+	// cluster target compatibility (e.g., hiding OpenShift-specific tools when
+	// connected to a non-OpenShift cluster). This feature is experimental, and
+	// this option is subject to change or removal in a future release.
+	// Defaults to false.
+	EnableTargetCompatibilityToolFilters bool `toml:"experimental_enable_target_compatibility_tool_filters,omitempty"`
+
 	// ConfirmationFallback is the global default fallback behavior when a client
 	// does not support elicitation. Valid values are "deny" and "allow".
 	ConfirmationFallback string `toml:"confirmation_fallback,omitempty"`
@@ -446,6 +453,10 @@ func (c *StaticConfig) GetCertificateAuthority() string {
 
 func (c *StaticConfig) IsValidationEnabled() bool {
 	return c.ValidationEnabled
+}
+
+func (c *StaticConfig) IsTargetCompatibilityToolFiltersEnabled() bool {
+	return c.EnableTargetCompatibilityToolFilters
 }
 
 func (c *StaticConfig) GetConfirmationRules() []api.ConfirmationRule {

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -195,3 +195,7 @@ func (p *tokenExchangingProvider) Close() {
 func (p *tokenExchangingProvider) AnyTargetHasGVKs(ctx context.Context, gvks []schema.GroupVersionKind) bool {
 	return p.provider.AnyTargetHasGVKs(ctx, gvks)
 }
+
+func (p *tokenExchangingProvider) IsTargetCompatibilityToolFiltersEnabled() bool {
+	return p.provider.IsTargetCompatibilityToolFiltersEnabled()
+}

--- a/pkg/kubernetes/provider_token_exchange_test.go
+++ b/pkg/kubernetes/provider_token_exchange_test.go
@@ -65,6 +65,9 @@ func (fakeDerivedProvider) GetDerivedKubernetes(context.Context, string) (*Kuber
 func (fakeDerivedProvider) AnyTargetHasGVKs(context.Context, []schema.GroupVersionKind) bool {
 	return true
 }
+func (fakeDerivedProvider) IsTargetCompatibilityToolFiltersEnabled() bool {
+	return false
+}
 
 func (s *TokenExchangingProviderSuite) TestGetDerivedKubernetes() {
 	s.Run("uses reloaded STS config from live config provider", func() {

--- a/pkg/kubernetes/token_exchange_test.go
+++ b/pkg/kubernetes/token_exchange_test.go
@@ -138,6 +138,9 @@ func (f fakeTokenExchangeProvider) GetTokenExchangeStrategy() string { return f.
 func (f fakeTokenExchangeProvider) AnyTargetHasGVKs(context.Context, []schema.GroupVersionKind) bool {
 	return true
 }
+func (f fakeTokenExchangeProvider) IsTargetCompatibilityToolFiltersEnabled() bool {
+	return false
+}
 
 func (s *TokenExchangeRoutingSuite) TestRequireTLS_BlocksExCfgTokenExchange() {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -78,12 +78,11 @@ func (c *Configuration) isToolApplicable(tool api.ServerTool) bool {
 	if c.DisabledTools != nil && slices.Contains(c.DisabledTools, tool.Tool.Name) {
 		return false
 	}
-	// TODO: A future config option could be used to decide whether to perform
-	// target compatibility checking/filtering, which may be expensive in
-	// environments where multiple endpoints would need to be consulted.
-	for _, filter := range tool.TargetCompatibilityFilters {
-		if !filter() {
-			return false
+	if c.EnableTargetCompatibilityToolFilters {
+		for _, filter := range tool.TargetCompatibilityFilters {
+			if !filter() {
+				return false
+			}
 		}
 	}
 	return true

--- a/pkg/mcp/mcp_watch_test.go
+++ b/pkg/mcp/mcp_watch_test.go
@@ -109,40 +109,87 @@ func (s *WatchKubeConfigSuite) TestNotifiesPromptsChangeMultipleTimes() {
 }
 
 func (s *WatchKubeConfigSuite) TestClearsNoLongerAvailableTools() {
-	s.mockServer.Handle(test.NewInOpenShiftHandler())
-	s.InitMcpClient()
+	s.Run("with target compatibility filtering disabled", func() {
+		// When filtering is disabled, OpenShift tools are always present
+		s.Cfg.EnableTargetCompatibilityToolFilters = false
+		s.mockServer.Handle(test.NewInOpenShiftHandler())
+		s.InitMcpClient()
 
-	s.Run("OpenShift tool is available on OpenShift cluster", func() {
-		tools, err := s.ListTools()
-		s.Require().NoError(err, "call ListTools failed")
-		s.Require().NotNil(tools, "list tools failed")
-		var found bool
-		for _, tool := range tools.Tools {
-			if tool.Name == "projects_list" {
-				found = true
-				break
+		s.Run("OpenShift tool is available on OpenShift cluster", func() {
+			tools, err := s.ListTools()
+			s.Require().NoError(err, "call ListTools failed")
+			s.Require().NotNil(tools, "list tools failed")
+			var found bool
+			for _, tool := range tools.Tools {
+				if tool.Name == "projects_list" {
+					found = true
+					break
+				}
 			}
-		}
-		s.Truef(found, "expected OpenShift tool to be available")
+			s.Truef(found, "expected OpenShift tool to be available")
+		})
+
+		s.Run("OpenShift tool remains after switching to non-OpenShift", func() {
+			capture := s.StartCapturingNotifications()
+
+			// Reload Config without OpenShift
+			s.mockServer.ResetHandlers()
+			s.WriteKubeconfig()
+			capture.RequireNotification(s.T(), 5*time.Second, "notifications/tools/list_changed")
+			time.Sleep(serverSettleDelay)
+
+			tools, err := s.ListTools()
+			s.Require().NoError(err, "call ListTools failed")
+			s.Require().NotNil(tools, "list tools failed")
+			var found bool
+			for _, tool := range tools.Tools {
+				if tool.Name == "projects_list" {
+					found = true
+					break
+				}
+			}
+			s.Truef(found, "expected OpenShift tool to remain when filtering disabled")
+		})
 	})
 
-	s.Run("OpenShift tool is removed after switching to non-OpenShift", func() {
-		capture := s.StartCapturingNotifications()
+	s.Run("with target compatibility filtering enabled", func() {
+		// When filtering is enabled, OpenShift tools are dynamically filtered
+		s.Cfg.EnableTargetCompatibilityToolFilters = true
+		s.mockServer.Handle(test.NewInOpenShiftHandler())
+		s.InitMcpClient()
 
-		// Reload Config without OpenShift
-		s.mockServer.ResetHandlers()
-		// Add back non-OpenShift discovery handler
-		s.mockServer.Handle(test.NewDiscoveryClientHandler())
-		s.WriteKubeconfig()
-		capture.RequireNotification(s.T(), 5*time.Second, "notifications/tools/list_changed")
-		time.Sleep(serverSettleDelay)
+		s.Run("OpenShift tool is available on OpenShift cluster", func() {
+			tools, err := s.ListTools()
+			s.Require().NoError(err, "call ListTools failed")
+			s.Require().NotNil(tools, "list tools failed")
+			var found bool
+			for _, tool := range tools.Tools {
+				if tool.Name == "projects_list" {
+					found = true
+					break
+				}
+			}
+			s.Truef(found, "expected OpenShift tool to be available")
+		})
 
-		tools, err := s.ListTools()
-		s.Require().NoError(err, "call ListTools failed")
-		s.Require().NotNil(tools, "list tools failed")
-		for _, tool := range tools.Tools {
-			s.Require().Falsef(tool.Name == "projects_list", "expected OpenShift tool to be removed after cluster change")
-		}
+		s.Run("OpenShift tool is removed after switching to non-OpenShift", func() {
+			capture := s.StartCapturingNotifications()
+
+			// Reload Config without OpenShift
+			s.mockServer.ResetHandlers()
+			// Add back non-OpenShift discovery handler
+			s.mockServer.Handle(test.NewDiscoveryClientHandler())
+			s.WriteKubeconfig()
+			capture.RequireNotification(s.T(), 5*time.Second, "notifications/tools/list_changed")
+			time.Sleep(serverSettleDelay)
+
+			tools, err := s.ListTools()
+			s.Require().NoError(err, "call ListTools failed")
+			s.Require().NotNil(tools, "list tools failed")
+			for _, tool := range tools.Tools {
+				s.Require().Falsef(tool.Name == "projects_list", "expected OpenShift tool to be removed when filtering enabled")
+			}
+		})
 	})
 }
 
@@ -206,39 +253,63 @@ func (s *WatchClusterStateSuite) TestNotifiesToolsChangeMultipleTimes() {
 }
 
 func (s *WatchClusterStateSuite) TestDetectsOpenShiftClusterStateChange() {
-	s.InitMcpClient()
+	s.Run("with target compatibility filtering disabled", func() {
+		// When filtering is disabled, OpenShift tools are always present
+		s.Cfg.EnableTargetCompatibilityToolFilters = false
+		s.InitMcpClient()
 
-	s.Run("OpenShift tool is not available initially", func() {
-		tools, err := s.ListTools()
-		s.Require().NoError(err, "call ListTools failed")
-		s.Require().NotNil(tools, "list tools failed")
-		for _, tool := range tools.Tools {
-			s.Require().Falsef(tool.Name == "projects_list", "expected OpenShift tool to not be available initially")
-		}
+		s.Run("OpenShift tool is available even on non-OpenShift", func() {
+			tools, err := s.ListTools()
+			s.Require().NoError(err, "call ListTools failed")
+			s.Require().NotNil(tools, "list tools failed")
+			var found bool
+			for _, tool := range tools.Tools {
+				if tool.Name == "projects_list" {
+					found = true
+					break
+				}
+			}
+			s.Truef(found, "expected OpenShift tool to be available when filtering disabled")
+		})
 	})
 
-	s.Run("OpenShift tool is added after cluster becomes OpenShift", func() {
-		capture := s.StartCapturingNotifications()
+	s.Run("with target compatibility filtering enabled", func() {
+		// When filtering is enabled, OpenShift tools are dynamically filtered
+		s.Cfg.EnableTargetCompatibilityToolFilters = true
+		s.InitMcpClient()
 
-		// Simulate cluster becoming OpenShift by adding OpenShift API groups
-		s.mockServer.ResetHandlers()
-		s.mockServer.Handle(test.NewInOpenShiftHandler())
-
-		capture.RequireNotification(s.T(), 5*time.Second, "notifications/tools/list_changed")
-		time.Sleep(serverSettleDelay)
-
-		tools, err := s.ListTools()
-		s.Require().NoError(err, "call ListTools failed")
-		s.Require().NotNil(tools, "list tools failed")
-
-		var found bool
-		for _, tool := range tools.Tools {
-			if tool.Name == "projects_list" {
-				found = true
-				break
+		s.Run("OpenShift tool is not available initially", func() {
+			tools, err := s.ListTools()
+			s.Require().NoError(err, "call ListTools failed")
+			s.Require().NotNil(tools, "list tools failed")
+			for _, tool := range tools.Tools {
+				s.Require().Falsef(tool.Name == "projects_list", "expected OpenShift tool to not be available initially")
 			}
-		}
-		s.Truef(found, "expected OpenShift tool to be available after cluster state change")
+		})
+
+		s.Run("OpenShift tool is added after cluster becomes OpenShift", func() {
+			capture := s.StartCapturingNotifications()
+
+			// Simulate cluster becoming OpenShift by adding OpenShift API groups
+			s.mockServer.ResetHandlers()
+			s.mockServer.Handle(test.NewInOpenShiftHandler())
+
+			capture.RequireNotification(s.T(), 5*time.Second, "notifications/tools/list_changed")
+			time.Sleep(serverSettleDelay)
+
+			tools, err := s.ListTools()
+			s.Require().NoError(err, "call ListTools failed")
+			s.Require().NotNil(tools, "list tools failed")
+
+			var found bool
+			for _, tool := range tools.Tools {
+				if tool.Name == "projects_list" {
+					found = true
+					break
+				}
+			}
+			s.Truef(found, "expected OpenShift tool to be available after cluster state change")
+		})
 	})
 }
 

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -391,12 +391,27 @@
   },
   {
     "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Projects: List"
+    },
+    "description": "List all the OpenShift projects in the current cluster",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "projects_list",
+    "title": "Projects: List"
+  },
+  {
+    "annotations": {
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
       "title": "Resources: Create or Update"
     },
-    "description": "Create or update a Kubernetes resource via Server-Side Apply. The manifest is the complete desired state: any field this tool previously set and the new manifest omits is removed. To edit an existing resource, fetch it with resources_get, modify it, then re-apply the full resource.\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Create or update a Kubernetes resource via Server-Side Apply. The manifest is the complete desired state: any field this tool previously set and the new manifest omits is removed. To edit an existing resource, fetch it with resources_get, modify it, then re-apply the full resource.\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "resource": {
@@ -419,7 +434,7 @@
       "openWorldHint": true,
       "title": "Resources: Delete"
     },
-    "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
@@ -460,7 +475,7 @@
       "readOnlyHint": true,
       "title": "Resources: Get"
     },
-    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
@@ -497,7 +512,7 @@
       "readOnlyHint": true,
       "title": "Resources: List"
     },
-    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "apiVersion": {

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -411,12 +411,27 @@
   },
   {
     "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Projects: List"
+    },
+    "description": "List all the OpenShift projects in the current cluster",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "projects_list",
+    "title": "Projects: List"
+  },
+  {
+    "annotations": {
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": true,
       "title": "Resources: Create or Update"
     },
-    "description": "Create or update a Kubernetes resource via Server-Side Apply. The manifest is the complete desired state: any field this tool previously set and the new manifest omits is removed. To edit an existing resource, fetch it with resources_get, modify it, then re-apply the full resource.\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Create or update a Kubernetes resource via Server-Side Apply. The manifest is the complete desired state: any field this tool previously set and the new manifest omits is removed. To edit an existing resource, fetch it with resources_get, modify it, then re-apply the full resource.\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "resource": {
@@ -439,7 +454,7 @@
       "openWorldHint": true,
       "title": "Resources: Delete"
     },
-    "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Delete a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
@@ -480,7 +495,7 @@
       "readOnlyHint": true,
       "title": "Resources: Get"
     },
-    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "Get a Kubernetes resource in the current cluster by providing its apiVersion, kind, optionally the namespace, and its name\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "apiVersion": {
@@ -517,7 +532,7 @@
       "readOnlyHint": true,
       "title": "Resources: List"
     },
-    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress)",
+    "description": "List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector\n(common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)",
     "inputSchema": {
       "properties": {
         "apiVersion": {

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -110,7 +110,8 @@ func (s *ToolsetsSuite) TestDefaultToolsetsToolsInOpenShift() {
 }
 
 func (s *ToolsetsSuite) TestDefaultToolsetsToolsWithFilteringEnabled() {
-	s.Run("Default configuration toolsets on non-OpenShift", func() {
+	s.Run("Default configuration toolsets with filtering enabled on non-OpenShift", func() {
+		s.Cfg.EnableTargetCompatibilityToolFilters = true
 		s.InitMcpClient()
 		tools, err := s.ListTools()
 		s.Run("ListTools returns tools", func() {
@@ -119,7 +120,7 @@ func (s *ToolsetsSuite) TestDefaultToolsetsToolsWithFilteringEnabled() {
 		})
 		s.Run("projects_list tool is not present", func() {
 			for _, tool := range tools.Tools {
-				s.Require().NotEqual("projects_list", tool.Name, "Expected projects_list to not be present on non-OpenShift cluster")
+				s.Require().NotEqual("projects_list", tool.Name, "Expected projects_list to not be present when filtering enabled on non-OpenShift cluster")
 			}
 		})
 	})

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -20,12 +20,15 @@ func initResources(p api.FilteringProvider) []api.ServerTool {
 	// target-specific kinds (e.g. OpenShift Route) when a target cluster exposes them,
 	// so the examples the model sees match the cluster it is talking to.
 	commonApiVersion := "v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress"
-	// TODO: A future config option could be used to decide whether to perform
-	// target compatibility checking/filtering, which may be expensive in
-	// environments where multiple endpoints would need to be consulted.
-	if p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{
-		{Group: "route.openshift.io", Version: "v1", Kind: "Route"},
-	}) {
+	// Only check GVKs when target compatibility filtering is enabled
+	if p.IsTargetCompatibilityToolFiltersEnabled() {
+		if p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{
+			{Group: "route.openshift.io", Version: "v1", Kind: "Route"},
+		}) {
+			commonApiVersion += ", route.openshift.io/v1 Route"
+		}
+	} else {
+		// When filtering disabled, optimistically include OpenShift resources in description
 		commonApiVersion += ", route.openshift.io/v1 Route"
 	}
 	commonApiVersion = fmt.Sprintf("(common apiVersion and kind include: %s)", commonApiVersion)

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -59,6 +59,8 @@ func (f *fakeProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVersi
 	return true
 }
 
+func (f *fakeProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return false }
+
 func (s *ToolsetsSuite) TestRegisterPanicsOnDuplicate() {
 	Register(&TestToolset{name: "duplicate"})
 	s.Panics(func() {


### PR DESCRIPTION
A recent change (#1196) introduced the framework for prefiltering toolsets based on the compatibility of the configured target(s). The initial implementation included a filter to expose the `projects_list` tool based on whether any target is OpenShift or not. This functionality was always on, which was problematic in certain setups.

This change gates this functionality behind a config option:

```
experimental_enable_target_compatibility_tool_filters = true
```

As implied by the name, we consider the feature experimental, and will rename/redesign/remove the config option in the future.


Co-Authored-By: claude