### PR TITLE
feat: Add scaling, rolling updates, exec, port-forward, autoscaling, and node management APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,33 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `label_selector` (`string`) - Kubernetes label selector (e.g. 'node-role.kubernetes.io/worker=') to filter nodes by label (Optional, only applicable when name is not provided)
   - `name` (`string`) - Name of the Node to get the resource consumption from (Optional, all Nodes if not provided)
 
+- **nodes_cordon** - Cordon a Kubernetes Node, marking it as unschedulable so no new pods are placed on it. Existing pods are not evicted. Mirrors `kubectl cordon`
+  - `name` (`string`) **(required)** - Name of the Node to cordon
+
+- **nodes_uncordon** - Uncordon a Kubernetes Node, marking it as schedulable again so new pods can be placed on it. Mirrors `kubectl uncordon`
+  - `name` (`string`) **(required)** - Name of the Node to uncordon
+
+- **nodes_drain** - Drain a Kubernetes Node by cordoning it and evicting all its pods. Mirrors `kubectl drain`. Use caution: this evicts running workloads. DaemonSet pods and mirror pods are skipped by default when ignore_all_daemonsets is true
+  - `delete_emptydir_data` (`boolean`) - If true, continue even if pods are using emptyDir volumes (Optional, default: false)
+  - `disable_eviction` (`boolean`) - If true, force-delete pods instead of evicting them. Use only if eviction is blocked (Optional, default: false)
+  - `force` (`boolean`) - If true, continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet, or StatefulSet (Optional, default: false)
+  - `grace_period_seconds` (`integer`) - Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used (Optional, default: -1)
+  - `ignore_all_daemonsets` (`boolean`) - If true, ignore DaemonSet-managed pods and continue draining (Optional, default: true)
+  - `name` (`string`) **(required)** - Name of the Node to drain
+  - `timeout` (`integer`) - The length of time in seconds to wait before giving up on draining a node, zero means infinite (Optional, default: 0)
+
+- **nodes_patch_label** - Set or remove a single label on a Kubernetes Node. Providing an empty value removes the label. Useful for managing scheduling constraints and node grouping
+  - `key` (`string`) **(required)** - Label key to set or remove (e.g. 'node-role.kubernetes.io/worker')
+  - `name` (`string`) **(required)** - Name of the Node to patch
+  - `value` (`string`) - Label value to set. An empty string removes the label
+
+- **nodes_patch_taint** - Set or remove a single taint on a Kubernetes Node. Taints repel pods unless a pod tolerates them. Use effect values NoSchedule, PreferNoSchedule, or NoExecute
+  - `effect` (`string`) **(required)** - Taint effect: NoSchedule, PreferNoSchedule, or NoExecute
+  - `key` (`string`) **(required)** - Taint key (e.g. 'dedicated')
+  - `name` (`string`) **(required)** - Name of the Node to patch
+  - `remove` (`boolean`) - If true, remove the taint matching key/effect instead of adding it (Optional, default: false)
+  - `value` (`string`) - Taint value (e.g. 'gpu'). Optional when removing
+
 - **pods_list** - List all the Kubernetes pods in the current cluster from all namespaces
   - `fieldSelector` (`string`) - Optional Kubernetes field selector to filter pods by field values (e.g. 'status.phase=Running', 'spec.nodeName=node1'). Supported fields: metadata.name, metadata.namespace, spec.nodeName, spec.restartPolicy, spec.schedulerName, spec.serviceAccountName, status.phase (Pending/Running/Succeeded/Failed/Unknown), status.podIP, status.nominatedNodeName. Note: CrashLoopBackOff is a container state, not a pod phase, so it cannot be filtered directly. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
   - `labelSelector` (`string`) - Optional Kubernetes label selector (e.g. 'app=myapp,env=prod' or 'app in (myapp,yourapp)'), use this option when you want to filter the pods by label
@@ -372,9 +399,11 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 - **pods_log** - Get the logs of a Kubernetes Pod in the current or provided namespace with the provided name
   - `container` (`string`) - Name of the Pod container to get the logs from (Optional)
+  - `follow` (`boolean`) - Follow the log output, streaming new log lines as they are produced. The call blocks until the timeout (since_seconds) elapses or the container exits, then returns all lines collected so far (Optional, default: false)
   - `name` (`string`) **(required)** - Name of the Pod to get the logs from
   - `namespace` (`string`) - Namespace to get the Pod logs from
   - `previous` (`boolean`) - Return previous terminated container logs (Optional)
+  - `since_seconds` (`integer`) - When follow is true, the maximum number of seconds to stream logs before returning. A value of 0 means no timeout (block until the container exits) (Optional, default: 10). Ignored when follow is false
   - `tail` (`integer`) - Number of lines to retrieve from the end of the logs (Optional, default: 100)
 
 - **pods_run** - Run a Kubernetes Pod in the current or provided namespace with the provided container image and optional name
@@ -382,6 +411,95 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `name` (`string`) - Name of the Pod (Optional, random name if not provided)
   - `namespace` (`string`) - Namespace to run the Pod in
   - `port` (`number`) - TCP/IP port to expose from the Pod container (Optional, no port exposed if not provided)
+
+- **pods_port_forward** - Start port-forwarding a local port to a port on a Kubernetes Pod. Runs in the background and returns a session id plus the local address you can connect to. Use pods_port_forward_stop with the returned id to terminate the session. Mirrors `kubectl port-forward pod`
+  - `local_port` (`integer`) - Local port to listen on. If 0 or omitted, a free port is chosen automatically
+  - `name` (`string`) **(required)** - Name of the Pod to forward to
+  - `namespace` (`string`) - Namespace of the Pod (Optional, current namespace if not provided)
+  - `remote_port` (`integer`) **(required)** - Port on the Pod to forward to (the container port)
+
+- **pods_port_forward_stop** - Stop a running port-forward session by its session id, releasing the local port. Returns the session details that were stopped
+  - `id` (`string`) **(required)** - Session id returned by pods_port_forward
+
+- **pods_port_forward_list** - List all active port-forward sessions, showing their session id, target pod, namespace, and local/remote ports
+
+- **pods_attach** - Attach to a running container in a Kubernetes Pod, capturing its stdout and stderr. Unlike exec, attach connects to the container's primary process (PID 1) rather than starting a new command. Mirrors `kubectl attach`
+  - `container` (`string`) - Name of the Pod container to attach to (Optional, defaults to the first or kubectl default-container annotation)
+  - `name` (`string`) **(required)** - Name of the Pod to attach to
+  - `namespace` (`string`) - Namespace of the Pod (Optional, current namespace if not provided)
+
+- **rollout_status** - Check the rollout status of a Kubernetes Deployment in the current or provided namespace. Reports whether the rollout is complete, in progress, or has failed (e.g. progress deadline exceeded). Mirrors `kubectl rollout status deployment`
+  - `name` (`string`) **(required)** - Name of the Deployment to check rollout status for
+  - `namespace` (`string`) - Namespace of the Deployment (Optional, current namespace if not provided)
+
+- **rollout_history** - View the rollout history (revisions) of a Kubernetes Deployment in the current or provided namespace. Lists each revision with its image. Mirrors `kubectl rollout history deployment`
+  - `name` (`string`) **(required)** - Name of the Deployment to view rollout history for
+  - `namespace` (`string`) - Namespace of the Deployment (Optional, current namespace if not provided)
+
+- **rollout_undo** - Rollback a Kubernetes Deployment to a previous revision. If to_revision is not provided, rolls back to the immediately previous revision. Mirrors `kubectl rollout undo deployment`
+  - `name` (`string`) **(required)** - Name of the Deployment to roll back
+  - `namespace` (`string`) - Namespace of the Deployment (Optional, current namespace if not provided)
+  - `to_revision` (`integer`) - Revision number to roll back to (Optional, defaults to the previous revision)
+
+- **rollout_restart** - Trigger a rolling restart of a Kubernetes Deployment by patching the pod template with a restart timestamp. Existing pods are replaced gradually. Mirrors `kubectl rollout restart deployment`
+  - `name` (`string`) **(required)** - Name of the Deployment to restart
+  - `namespace` (`string`) - Namespace of the Deployment (Optional, current namespace if not provided)
+
+- **horizontalpodautoscalers_list** - List Kubernetes HorizontalPodAutoscalers (HPAs) in the current cluster from all namespaces or the provided namespace. Shows autoscaling rules and current/target metrics for workloads
+  - `namespace` (`string`) - Optional Namespace to retrieve HPAs from. If not provided, lists HPAs from all namespaces
+
+- **horizontalpodautoscalers_get** - Get a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, showing its scaling rules, targets, and current status
+  - `name` (`string`) **(required)** - Name of the HPA
+  - `namespace` (`string`) - Namespace to get the HPA from (Optional, current namespace if not provided)
+
+- **horizontalpodautoscalers_create** - Create a Kubernetes HorizontalPodAutoscaler (HPA) from a YAML or JSON manifest. The manifest must be a complete HPA definition with apiVersion autoscaling/v2
+  - `manifest` (`string`) **(required)** - Complete YAML or JSON manifest of the HorizontalPodAutoscaler (apiVersion: autoscaling/v2, kind: HorizontalPodAutoscaler)
+
+- **horizontalpodautoscalers_delete** - Delete a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, removing its autoscaling rules
+  - `name` (`string`) **(required)** - Name of the HPA to delete
+  - `namespace` (`string`) - Namespace to delete the HPA from (Optional, current namespace if not provided)
+
+- **poddisruptionbudgets_list** - List Kubernetes PodDisruptionBudgets (PDBs) in the current cluster from all namespaces or the provided namespace. Shows the allowed disruptions and current/min available pod counts
+  - `namespace` (`string`) - Optional Namespace to retrieve PDBs from. If not provided, lists PDBs from all namespaces
+
+- **poddisruptionbudgets_get** - Get a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace, showing its selector, allowed disruptions, and status
+  - `name` (`string`) **(required)** - Name of the PDB
+  - `namespace` (`string`) - Namespace to get the PDB from (Optional, current namespace if not provided)
+
+- **poddisruptionbudgets_create** - Create a Kubernetes PodDisruptionBudget (PDB) from a YAML or JSON manifest. The manifest must be a complete PDB definition with apiVersion policy/v1
+  - `manifest` (`string`) **(required)** - Complete YAML or JSON manifest of the PodDisruptionBudget (apiVersion: policy/v1, kind: PodDisruptionBudget)
+
+- **poddisruptionbudgets_delete** - Delete a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace
+  - `name` (`string`) **(required)** - Name of the PDB to delete
+  - `namespace` (`string`) - Namespace to delete the PDB from (Optional, current namespace if not provided)
+
+- **resourcequotas_list** - List Kubernetes ResourceQuotas in the current cluster from all namespaces or the provided namespace. Shows namespace-level resource limits and current usage
+  - `namespace` (`string`) - Optional Namespace to retrieve ResourceQuotas from. If not provided, lists ResourceQuotas from all namespaces
+
+- **resourcequotas_get** - Get a Kubernetes ResourceQuota by name in the current or provided namespace, showing its hard limits and current usage
+  - `name` (`string`) **(required)** - Name of the ResourceQuota
+  - `namespace` (`string`) - Namespace to get the ResourceQuota from (Optional, current namespace if not provided)
+
+- **resourcequotas_create** - Create a Kubernetes ResourceQuota from a YAML or JSON manifest. The manifest must be a complete ResourceQuota definition with apiVersion v1
+  - `manifest` (`string`) **(required)** - Complete YAML or JSON manifest of the ResourceQuota (apiVersion: v1, kind: ResourceQuota)
+
+- **resourcequotas_delete** - Delete a Kubernetes ResourceQuota by name in the current or provided namespace
+  - `name` (`string`) **(required)** - Name of the ResourceQuota to delete
+  - `namespace` (`string`) - Namespace to delete the ResourceQuota from (Optional, current namespace if not provided)
+
+- **limitranges_list** - List Kubernetes LimitRanges in the current cluster from all namespaces or the provided namespace. Shows per-container default resource limits enforced in each namespace
+  - `namespace` (`string`) - Optional Namespace to retrieve LimitRanges from. If not provided, lists LimitRanges from all namespaces
+
+- **limitranges_get** - Get a Kubernetes LimitRange by name in the current or provided namespace, showing its per-container resource default/min/max limits
+  - `name` (`string`) **(required)** - Name of the LimitRange
+  - `namespace` (`string`) - Namespace to get the LimitRange from (Optional, current namespace if not provided)
+
+- **limitranges_create** - Create a Kubernetes LimitRange from a YAML or JSON manifest. The manifest must be a complete LimitRange definition with apiVersion v1
+  - `manifest` (`string`) **(required)** - Complete YAML or JSON manifest of the LimitRange (apiVersion: v1, kind: LimitRange)
+
+- **limitranges_delete** - Delete a Kubernetes LimitRange by name in the current or provided namespace
+  - `name` (`string`) **(required)** - Name of the LimitRange to delete
+  - `namespace` (`string`) - Namespace to delete the LimitRange from (Optional, current namespace if not provided)
 
 - **resources_list** - List Kubernetes resources and objects in the current cluster by providing their apiVersion and kind and optionally the namespace and label selector
 (common apiVersion and kind include: v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress, route.openshift.io/v1 Route)

--- a/pkg/api/params.go
+++ b/pkg/api/params.go
@@ -198,3 +198,22 @@ func (p *Params) OptionalInt64(key string, defaultVal int64) int64 {
 	}
 	return v
 }
+
+// RequiredInt64 extracts a required int64 parameter. A missing or
+// present-but-wrong-type value records a sticky error and returns 0.
+func (p *Params) RequiredInt64(key string) int64 {
+	if p.err != nil {
+		return 0
+	}
+	val, ok := p.GetArguments()[key]
+	if !ok || val == nil {
+		p.err = fmt.Errorf("%s parameter required", key)
+		return 0
+	}
+	v, err := ParseInt64(val)
+	if err != nil {
+		p.err = fmt.Errorf("%s parameter must be an integer: %w", key, err)
+		return 0
+	}
+	return v
+}

--- a/pkg/kubernetes/attach.go
+++ b/pkg/kubernetes/attach.go
@@ -1,0 +1,70 @@
+package kubernetes
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// PodsAttach attaches to a running container in a pod, capturing stdout and
+// stderr. Unlike exec, attach connects to the container's primary process
+// (PID 1) rather than starting a new command. Mirrors `kubectl attach`.
+func (c *Core) PodsAttach(ctx context.Context, namespace, name, container string) (string, string, error) {
+	namespace = c.NamespaceOrDefault(namespace)
+	pods := c.CoreV1().Pods(namespace)
+	pod, err := pods.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", "", err
+	}
+	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+		return "", "", fmt.Errorf("cannot attach to a container in a completed pod; current phase is %s", pod.Status.Phase)
+	}
+	container = resolveContainer(pod, container)
+
+	attachOptions := &v1.PodAttachOptions{
+		Container: container,
+		Stdout:    true,
+		Stderr:    true,
+		Stdin:     false,
+		TTY:       false,
+	}
+	attachRequest := c.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(name).
+		SubResource("attach")
+	attachRequest.VersionedParams(attachOptions, ParameterCodec)
+
+	restConfig, err := c.ToRESTConfig()
+	if err != nil {
+		return "", "", err
+	}
+	spdyExec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", attachRequest.URL())
+	if err != nil {
+		return "", "", err
+	}
+	webSocketExec, err := remotecommand.NewWebSocketExecutor(restConfig, "GET", attachRequest.URL().String())
+	if err != nil {
+		return "", "", err
+	}
+	executor, err := remotecommand.NewFallbackExecutor(webSocketExec, spdyExec, func(err error) bool {
+		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+	})
+	if err != nil {
+		return "", "", err
+	}
+	stdout := bytes.NewBuffer(make([]byte, 0))
+	stderr := bytes.NewBuffer(make([]byte, 0))
+	if err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: stdout, Stderr: stderr, Tty: false,
+	}); err != nil {
+		return "", "", err
+	}
+	return stdout.String(), stderr.String(), nil
+}

--- a/pkg/kubernetes/manifest.go
+++ b/pkg/kubernetes/manifest.go
@@ -1,0 +1,28 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	yml "sigs.k8s.io/yaml"
+)
+
+// decodeManifest decodes a YAML or JSON manifest string into a typed
+// Kubernetes runtime.Object using the registered scheme. The caller is
+// expected to type-assert the result to the concrete kind.
+func decodeManifest(manifest string) (runtime.Object, error) {
+	if manifest == "" {
+		return nil, fmt.Errorf("manifest must not be empty")
+	}
+	jsonBytes, err := yml.YAMLToJSON([]byte(manifest))
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert manifest to JSON: %w", err)
+	}
+	deserializer := serializer.NewCodecFactory(Scheme).UniversalDeserializer()
+	obj, _, err := deserializer.Decode(jsonBytes, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode manifest: %w", err)
+	}
+	return obj, nil
+}

--- a/pkg/kubernetes/node_ops.go
+++ b/pkg/kubernetes/node_ops.go
@@ -1,0 +1,145 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubectl/pkg/drain"
+)
+
+// NodeDrainOptions controls node drain behaviour, mirroring kubectl drain flags.
+type NodeDrainOptions struct {
+	Force               bool
+	IgnoreAllDaemonSets bool
+	DeleteEmptyDirData  bool
+	DisableEviction     bool
+	GracePeriodSeconds  int
+	Timeout             int
+}
+
+// NodeCordon marks a node as unschedulable, mirroring `kubectl cordon`.
+func (c *Core) NodeCordon(ctx context.Context, name string) (string, error) {
+	return c.nodeSetUnschedulable(ctx, name, true)
+}
+
+// NodeUncordon marks a node as schedulable, mirroring `kubectl uncordon`.
+func (c *Core) NodeUncordon(ctx context.Context, name string) (string, error) {
+	return c.nodeSetUnschedulable(ctx, name, false)
+}
+
+func (c *Core) nodeSetUnschedulable(ctx context.Context, name string, unschedulable bool) (string, error) {
+	if _, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{}); err != nil {
+		return "", fmt.Errorf("failed to get node %s: %w", name, err)
+	}
+	patch := fmt.Sprintf(`{"spec":{"unschedulable":%t}}`, unschedulable)
+	if _, err := c.CoreV1().Nodes().Patch(ctx, name, types.MergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
+		return "", fmt.Errorf("failed to patch node %s: %w", name, err)
+	}
+	verb := "cordoned"
+	if !unschedulable {
+		verb = "uncordoned"
+	}
+	return fmt.Sprintf("node/%s %s", name, verb), nil
+}
+
+// NodeDrain evicts all pods from a node, mirroring `kubectl drain`.
+// It cordons the node first, then evicts pods honoring the provided options.
+func (c *Core) NodeDrain(ctx context.Context, name string, opts NodeDrainOptions) (string, error) {
+	node, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get node %s: %w", name, err)
+	}
+
+	// Cordon first so no new pods land while we drain.
+	if _, err := c.NodeCordon(ctx, name); err != nil {
+		return "", fmt.Errorf("failed to cordon node %s before draining: %w", name, err)
+	}
+
+	helper := &drain.Helper{
+		Ctx:                 ctx,
+		Client:              c,
+		Force:               opts.Force,
+		GracePeriodSeconds:  opts.GracePeriodSeconds,
+		IgnoreAllDaemonSets: opts.IgnoreAllDaemonSets,
+		Timeout:             time.Duration(opts.Timeout) * time.Second,
+		DeleteEmptyDirData:  opts.DeleteEmptyDirData,
+		DisableEviction:     opts.DisableEviction,
+		Out:                 io.Discard,
+		ErrOut:              os.Stderr,
+	}
+
+	if err := drain.RunCordonOrUncordon(helper, node, true); err != nil {
+		return "", fmt.Errorf("failed to cordon during drain: %w", err)
+	}
+	if err := drain.RunNodeDrain(helper, name); err != nil {
+		return "", fmt.Errorf("failed to drain node %s: %w", name, err)
+	}
+	return fmt.Sprintf("node/%s drained", name), nil
+}
+
+// NodePatchLabel sets or removes a single label on a node. A value of ""
+// removes the label.
+func (c *Core) NodePatchLabel(ctx context.Context, name, key, value string) (string, error) {
+	if key == "" {
+		return "", errors.New("label key must not be empty")
+	}
+	if value == "" {
+		patch := fmt.Sprintf(`[{"op":"remove","path":"/metadata/labels/%s"}]`, escapeJSONPointer(key))
+		if _, err := c.CoreV1().Nodes().Patch(ctx, name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
+			return "", fmt.Errorf("failed to remove label %s on node %s: %w", key, name, err)
+		}
+		return fmt.Sprintf("label %s removed from node/%s", key, name), nil
+	}
+	patch := fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, key, value)
+	if _, err := c.CoreV1().Nodes().Patch(ctx, name, types.MergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
+		return "", fmt.Errorf("failed to set label %s on node %s: %w", key, name, err)
+	}
+	return fmt.Sprintf("label %s=%s set on node/%s", key, value, name), nil
+}
+
+// NodePatchTaint sets or removes a single taint on a node.
+func (c *Core) NodePatchTaint(ctx context.Context, name, key, value, effect string, remove bool) (string, error) {
+	if key == "" || effect == "" {
+		return "", errors.New("taint key and effect must not be empty")
+	}
+	var patch []byte
+	if remove {
+		patch = []byte(fmt.Sprintf(`{"spec":{"taints":[{"key":%q,"effect":%q,"$patch":"delete"}]}}`, key, effect))
+	} else {
+		patch = []byte(fmt.Sprintf(`{"spec":{"taints":[{"key":%q,"value":%q,"effect":%q}]}}`, key, value, effect))
+	}
+	if _, err := c.CoreV1().Nodes().Patch(ctx, name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return "", fmt.Errorf("failed to patch taint on node %s: %w", name, err)
+	}
+	verb := "added"
+	if remove {
+		verb = "removed"
+	}
+	return fmt.Sprintf("taint %s=%s:%s %s on node/%s", key, value, effect, verb, name), nil
+}
+
+// escapeJSONPointer escapes a key per RFC 6901 for use in a JSON patch path.
+func escapeJSONPointer(key string) string {
+	out := make([]byte, 0, len(key))
+	for i := 0; i < len(key); i++ {
+		switch key[i] {
+		case '~':
+			out = append(out, '~', '0')
+		case '/':
+			out = append(out, '~', '1')
+		default:
+			out = append(out, key[i])
+		}
+	}
+	return string(out)
+}
+
+// _ keeps corev1 referenced for the NodeDrain node helper.
+var _ = corev1.Node{}

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -116,7 +116,7 @@ func (c *Core) PodsDelete(ctx context.Context, namespace, name string) (string, 
 		c.ResourcesDelete(ctx, &schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, namespace, name, nil)
 }
 
-func (c *Core) PodsLog(ctx context.Context, namespace, name, container string, previous bool, tail int64) (string, error) {
+func (c *Core) PodsLog(ctx context.Context, namespace, name, container string, previous bool, tail int64, follow bool, sinceSeconds int64) (string, error) {
 	namespace = c.NamespaceOrDefault(namespace)
 	pods := c.CoreV1().Pods(namespace)
 
@@ -131,6 +131,10 @@ func (c *Core) PodsLog(ctx context.Context, namespace, name, container string, p
 	logOptions := &v1.PodLogOptions{
 		Container: container,
 		Previous:  previous,
+		Follow:    follow,
+	}
+	if follow && sinceSeconds > 0 {
+		logOptions.SinceSeconds = &sinceSeconds
 	}
 
 	// Only set tailLines if a value is provided (non-zero)

--- a/pkg/kubernetes/portforward.go
+++ b/pkg/kubernetes/portforward.go
@@ -1,0 +1,202 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// portForwardReadyTimeout is how long we wait for the forwarder to signal
+// readiness before returning to the caller.
+const portForwardReadyTimeout = 5 * time.Second
+
+// PortForwardSession represents an active port-forward session.
+type PortForwardSession struct {
+	ID         string
+	Namespace  string
+	PodName    string
+	LocalPort  int
+	RemotePort int
+	stopChan   chan struct{}
+	readyChan  chan struct{}
+	out        *stringsBuilder
+	forwarder  *portforward.PortForwarder
+	cancel     context.CancelFunc
+	done       chan struct{}
+}
+
+var (
+	portForwardMu       sync.Mutex
+	portForwardSessions = make(map[string]*PortForwardSession)
+	portForwardCounter  atomic.Uint64
+)
+
+// stringsBuilder is a minimal io.Writer wrapping a byte buffer with a mutex.
+type stringsBuilder struct {
+	b []byte
+	m sync.Mutex
+}
+
+func (sb *stringsBuilder) Write(p []byte) (int, error) {
+	sb.m.Lock()
+	defer sb.m.Unlock()
+	sb.b = append(sb.b, p...)
+	return len(p), nil
+}
+
+func (sb *stringsBuilder) String() string {
+	sb.m.Lock()
+	defer sb.m.Unlock()
+	return string(sb.b)
+}
+
+// PodsPortForward starts a port-forward from a local port to a port on a pod.
+// It runs in the background and returns a session id that can be used to stop
+// the forward later. If localPort is 0, a free port is chosen.
+func (c *Core) PodsPortForward(ctx context.Context, namespace, name string, localPort, remotePort int) (*PortForwardSession, error) {
+	namespace = c.NamespaceOrDefault(namespace)
+	pods := c.CoreV1().Pods(namespace)
+	pod, err := pods.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pod %s/%s: %w", namespace, name, err)
+	}
+	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+		return nil, fmt.Errorf("cannot port-forward to a completed pod; current phase is %s", pod.Status.Phase)
+	}
+
+	// Choose a free local port if none requested.
+	if localPort == 0 {
+		free, ferr := freePort()
+		if ferr != nil {
+			return nil, fmt.Errorf("failed to find a free local port: %w", ferr)
+		}
+		localPort = free
+	}
+
+	req := c.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(name).
+		SubResource("portforward")
+
+	restConfig, err := c.ToRESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get REST config: %w", err)
+	}
+	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SPDY round tripper: %w", err)
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+
+	stopChan := make(chan struct{}, 1)
+	readyChan := make(chan struct{}, 1)
+	sb := &stringsBuilder{}
+
+	ports := []string{fmt.Sprintf("%d:%d", localPort, remotePort)}
+	fw, err := portforward.New(dialer, ports, stopChan, readyChan, sb, sb)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create port forwarder: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+
+	session := &PortForwardSession{
+		ID:         fmt.Sprintf("pf-%d", portForwardCounter.Add(1)),
+		Namespace:  namespace,
+		PodName:    name,
+		LocalPort:  localPort,
+		RemotePort: remotePort,
+		stopChan:   stopChan,
+		readyChan:  readyChan,
+		out:        sb,
+		forwarder:  fw,
+		cancel:     cancel,
+		done:       done,
+	}
+
+	portForwardMu.Lock()
+	portForwardSessions[session.ID] = session
+	portForwardMu.Unlock()
+
+	go func() {
+		defer close(done)
+		defer cancel()
+		_ = fw.ForwardPorts()
+	}()
+
+	// Wait for readiness, timeout, or early exit.
+	select {
+	case <-readyChan:
+	case <-time.After(portForwardReadyTimeout):
+		// The forwarder did not signal readiness; it may still be dialing.
+	case <-done:
+		return session, fmt.Errorf("port forwarder exited: %s", sb.String())
+	}
+
+	return session, nil
+}
+
+// StopPortForward stops a port-forward session by id.
+func StopPortForward(id string) error {
+	portForwardMu.Lock()
+	session, ok := portForwardSessions[id]
+	portForwardMu.Unlock()
+	if !ok {
+		return fmt.Errorf("port forward session %s not found", id)
+	}
+	close(session.stopChan)
+	session.cancel()
+	<-session.done
+	portForwardMu.Lock()
+	delete(portForwardSessions, id)
+	portForwardMu.Unlock()
+	return nil
+}
+
+// ListPortForwards returns a summary of active port-forward sessions.
+func ListPortForwards() []PortForwardSummary {
+	portForwardMu.Lock()
+	defer portForwardMu.Unlock()
+	out := make([]PortForwardSummary, 0, len(portForwardSessions))
+	for _, s := range portForwardSessions {
+		out = append(out, PortForwardSummary{
+			ID:         s.ID,
+			Namespace:  s.Namespace,
+			PodName:    s.PodName,
+			LocalPort:  s.LocalPort,
+			RemotePort: s.RemotePort,
+		})
+	}
+	return out
+}
+
+// PortForwardSummary is a serializable view of a port-forward session.
+type PortForwardSummary struct {
+	ID         string
+	Namespace  string
+	PodName    string
+	LocalPort  int
+	RemotePort int
+}
+
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	addr := l.Addr().(*net.TCPAddr)
+	return addr.Port, nil
+}

--- a/pkg/kubernetes/rollout.go
+++ b/pkg/kubernetes/rollout.go
@@ -1,0 +1,223 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// revisionAnnotation is the annotation key kubectl uses to track rollout revisions.
+	revisionAnnotation = "deployment.kubernetes.io/revision"
+)
+
+// DeploymentRolloutStatus returns a human-readable status of a deployment
+// rollout, mirroring `kubectl rollout status deployment`.
+func (c *Core) DeploymentRolloutStatus(ctx context.Context, namespace, name string) (string, error) {
+	namespace = c.NamespaceOrDefault(namespace)
+	dep, err := c.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get deployment %s/%s: %w", namespace, name, err)
+	}
+	return deploymentStatusMessage(dep), nil
+}
+
+// deploymentStatusMessage mimics the messages printed by kubectl rollout status.
+func deploymentStatusMessage(dep *appsv1.Deployment) string {
+	if dep.Generation <= dep.Status.ObservedGeneration {
+		cond := getDeploymentCondition(dep.Status, appsv1.DeploymentProgressing)
+		if cond != nil && cond.Reason == "ProgressDeadlineExceeded" {
+			return fmt.Sprintf("deployment %s has exceeded its progress deadline.", dep.Name)
+		}
+		if dep.Spec.Replicas != nil && dep.Status.UpdatedReplicas < *dep.Spec.Replicas {
+			return fmt.Sprintf("Waiting for deployment %q rollout to finish: %d out of %d new replicas have been updated...\n",
+				dep.Name, dep.Status.UpdatedReplicas, *dep.Spec.Replicas)
+		}
+		if dep.Status.Replicas > dep.Status.UpdatedReplicas {
+			return fmt.Sprintf("Waiting for deployment %q rollout to finish: %d old replicas are pending termination...\n",
+				dep.Name, dep.Status.Replicas-dep.Status.UpdatedReplicas)
+		}
+		if dep.Status.AvailableReplicas < dep.Status.UpdatedReplicas {
+			return fmt.Sprintf("Waiting for deployment %q rollout to finish: %d of %d updated replicas are available...\n",
+				dep.Name, dep.Status.AvailableReplicas, dep.Status.UpdatedReplicas)
+		}
+		return fmt.Sprintf("deployment %q successfully rolled out\n", dep.Name)
+	}
+	return fmt.Sprintf("Waiting for deployment %q rollout to finish: deployment spec is being updated...\n", dep.Name)
+}
+
+func getDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == condType {
+			return &status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// DeploymentRolloutHistory returns the rollout history (revisions) of a
+// deployment by inspecting its ReplicaSets, mirroring `kubectl rollout history`.
+func (c *Core) DeploymentRolloutHistory(ctx context.Context, namespace, name string) (string, error) {
+	namespace = c.NamespaceOrDefault(namespace)
+	dep, err := c.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get deployment %s/%s: %w", namespace, name, err)
+	}
+	selector, err := metav1.LabelSelectorAsSelector(dep.Spec.Selector)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse deployment selector: %w", err)
+	}
+	rsList, err := c.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return "", fmt.Errorf("failed to list replicasets for deployment %s: %w", name, err)
+	}
+
+	type revInfo struct {
+		revision string
+		image    string
+		current  bool
+	}
+	var revs []revInfo
+	for i := range rsList.Items {
+		rs := &rsList.Items[i]
+		rev, ok := rs.Annotations[revisionAnnotation]
+		if !ok {
+			continue
+		}
+		img := ""
+		if len(rs.Spec.Template.Spec.Containers) > 0 {
+			img = rs.Spec.Template.Spec.Containers[0].Image
+		}
+		revs = append(revs, revInfo{
+			revision: rev,
+			image:    img,
+			current: rs.Annotations["deployment.kubernetes.io/revision"] != "" &&
+				dep.Annotations[revisionAnnotation] == rev,
+		})
+	}
+	sort.Slice(revs, func(i, j int) bool {
+		ai, _ := strconv.Atoi(revs[i].revision)
+		aj, _ := strconv.Atoi(revs[j].revision)
+		return ai < aj
+	})
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("deployment/%s\n", name))
+	b.WriteString("REVISION\tCHANGE-CAUSE\tIMAGE\n")
+	for _, r := range revs {
+		changeCause := ""
+		if r.current {
+			changeCause = "<current>"
+		}
+		b.WriteString(fmt.Sprintf("%s\t%s\t%s\n", r.revision, changeCause, r.image))
+	}
+	if len(revs) == 0 {
+		b.WriteString("No rollout history found\n")
+	}
+	return b.String(), nil
+}
+
+// DeploymentRolloutUndo rolls a deployment back to a previous revision. If
+// toRevision is 0 it rolls back to the previous revision. Mirrors
+// `kubectl rollout undo`.
+func (c *Core) DeploymentRolloutUndo(ctx context.Context, namespace, name string, toRevision int64) (string, error) {
+	namespace = c.NamespaceOrDefault(namespace)
+	dep, err := c.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get deployment %s/%s: %w", namespace, name, err)
+	}
+	selector, err := metav1.LabelSelectorAsSelector(dep.Spec.Selector)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse deployment selector: %w", err)
+	}
+	rsList, err := c.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return "", fmt.Errorf("failed to list replicasets for deployment %s: %w", name, err)
+	}
+
+	currentRev := dep.Annotations[revisionAnnotation]
+	var target *appsv1.ReplicaSet
+	if toRevision == 0 {
+		// Find the previous (second-newest) revision.
+		var all []appsv1.ReplicaSet
+		for i := range rsList.Items {
+			rs := &rsList.Items[i]
+			if _, ok := rs.Annotations[revisionAnnotation]; !ok {
+				continue
+			}
+			if rs.Annotations[revisionAnnotation] == currentRev {
+				continue
+			}
+			all = append(all, *rs)
+		}
+		sort.Slice(all, func(i, j int) bool {
+			ai, _ := strconv.Atoi(all[i].Annotations[revisionAnnotation])
+			aj, _ := strconv.Atoi(all[j].Annotations[revisionAnnotation])
+			return ai > aj
+		})
+		if len(all) == 0 {
+			return "", fmt.Errorf("no previous revision found to roll back to for deployment %s", name)
+		}
+		target = &all[0]
+	} else {
+		for i := range rsList.Items {
+			rs := &rsList.Items[i]
+			if rs.Annotations[revisionAnnotation] == strconv.FormatInt(toRevision, 10) {
+				target = rs
+				break
+			}
+		}
+		if target == nil {
+			return "", fmt.Errorf("revision %d not found in rollout history of deployment %s", toRevision, name)
+		}
+	}
+
+	// Patch the deployment spec template with the target ReplicaSet's template.
+	patchObj := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": target.Spec.Template,
+		},
+	}
+	patch, err := json.Marshal(patchObj)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode rollback patch: %w", err)
+	}
+	// Apply the template patch using a strategic merge patch.
+	_, err = c.AppsV1().Deployments(namespace).Patch(ctx, name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to patch deployment %s for rollback: %w", name, err)
+	}
+	verb := "previous revision"
+	if toRevision != 0 {
+		verb = fmt.Sprintf("revision %d", toRevision)
+	}
+	return fmt.Sprintf("deployment/%s rolled back to %s", name, verb), nil
+}
+
+// DeploymentRestart triggers a rolling restart of a deployment by patching the
+// pod template annotation with a timestamp, mirroring `kubectl rollout restart`.
+func (c *Core) DeploymentRestart(ctx context.Context, namespace, name string) (string, error) {
+	namespace = c.NamespaceOrDefault(namespace)
+	dep, err := c.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get deployment %s/%s: %w", namespace, name, err)
+	}
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = map[string]string{}
+	}
+	dep.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] =
+		metav1.Now().Format("2006-01-02T15:04:05Z07:00")
+
+	_, err = c.AppsV1().Deployments(namespace).Update(ctx, dep, metav1.UpdateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to restart deployment %s: %w", name, err)
+	}
+	return fmt.Sprintf("deployment/%s restarted", name), nil
+}

--- a/pkg/kubernetes/workload_resources.go
+++ b/pkg/kubernetes/workload_resources.go
@@ -1,0 +1,197 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+)
+
+// --- HorizontalPodAutoscaler ---
+
+// HPAsList lists HorizontalPodAutoscalers in the given namespace (all namespaces
+// if namespace is empty).
+func (c *Core) HPAsList(ctx context.Context, namespace string) (string, error) {
+	list, err := c.AutoscalingV2().HorizontalPodAutoscalers(c.NamespaceOrDefault(namespace)).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list horizontalpodautoscalers: %w", err)
+	}
+	return output.MarshalYaml(list)
+}
+
+// HPAGet returns a single HorizontalPodAutoscaler.
+func (c *Core) HPAGet(ctx context.Context, namespace, name string) (string, error) {
+	hpa, err := c.AutoscalingV2().HorizontalPodAutoscalers(c.NamespaceOrDefault(namespace)).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get horizontalpodautoscaler %s: %w", name, err)
+	}
+	return output.MarshalYaml(hpa)
+}
+
+// HPACreate creates a HorizontalPodAutoscaler from a YAML/JSON manifest string.
+func (c *Core) HPACreate(ctx context.Context, manifest string) (string, error) {
+	obj, err := decodeManifest(manifest)
+	if err != nil {
+		return "", err
+	}
+	hpa, ok := obj.(*autoscalingv2.HorizontalPodAutoscaler)
+	if !ok {
+		return "", fmt.Errorf("manifest is not a HorizontalPodAutoscaler")
+	}
+	created, err := c.AutoscalingV2().HorizontalPodAutoscalers(c.NamespaceOrDefault(hpa.Namespace)).Create(ctx, hpa, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to create horizontalpodautoscaler: %w", err)
+	}
+	return output.MarshalYaml(created)
+}
+
+// HPADelete deletes a HorizontalPodAutoscaler.
+func (c *Core) HPADelete(ctx context.Context, namespace, name string) (string, error) {
+	if err := c.AutoscalingV2().HorizontalPodAutoscalers(c.NamespaceOrDefault(namespace)).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return "", fmt.Errorf("failed to delete horizontalpodautoscaler %s: %w", name, err)
+	}
+	return fmt.Sprintf("horizontalpodautoscaler/%s deleted", name), nil
+}
+
+// --- PodDisruptionBudget ---
+
+// PDBsList lists PodDisruptionBudgets in the given namespace (all namespaces if
+// namespace is empty).
+func (c *Core) PDBsList(ctx context.Context, namespace string) (string, error) {
+	list, err := c.PolicyV1().PodDisruptionBudgets(c.NamespaceOrDefault(namespace)).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list poddisruptionbudgets: %w", err)
+	}
+	return output.MarshalYaml(list)
+}
+
+// PDBGet returns a single PodDisruptionBudget.
+func (c *Core) PDBGet(ctx context.Context, namespace, name string) (string, error) {
+	pdb, err := c.PolicyV1().PodDisruptionBudgets(c.NamespaceOrDefault(namespace)).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get poddisruptionbudget %s: %w", name, err)
+	}
+	return output.MarshalYaml(pdb)
+}
+
+// PDBCreate creates a PodDisruptionBudget from a YAML/JSON manifest string.
+func (c *Core) PDBCreate(ctx context.Context, manifest string) (string, error) {
+	obj, err := decodeManifest(manifest)
+	if err != nil {
+		return "", err
+	}
+	pdb, ok := obj.(*policyv1.PodDisruptionBudget)
+	if !ok {
+		return "", fmt.Errorf("manifest is not a PodDisruptionBudget")
+	}
+	created, err := c.PolicyV1().PodDisruptionBudgets(c.NamespaceOrDefault(pdb.Namespace)).Create(ctx, pdb, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to create poddisruptionbudget: %w", err)
+	}
+	return output.MarshalYaml(created)
+}
+
+// PDBDelete deletes a PodDisruptionBudget.
+func (c *Core) PDBDelete(ctx context.Context, namespace, name string) (string, error) {
+	if err := c.PolicyV1().PodDisruptionBudgets(c.NamespaceOrDefault(namespace)).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return "", fmt.Errorf("failed to delete poddisruptionbudget %s: %w", name, err)
+	}
+	return fmt.Sprintf("poddisruptionbudget/%s deleted", name), nil
+}
+
+// --- ResourceQuota ---
+
+// ResourceQuotasList lists ResourceQuotas in the given namespace (all
+// namespaces if empty).
+func (c *Core) ResourceQuotasList(ctx context.Context, namespace string) (string, error) {
+	list, err := c.CoreV1().ResourceQuotas(c.NamespaceOrDefault(namespace)).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list resourcequotas: %w", err)
+	}
+	return output.MarshalYaml(list)
+}
+
+// ResourceQuotaGet returns a single ResourceQuota.
+func (c *Core) ResourceQuotaGet(ctx context.Context, namespace, name string) (string, error) {
+	rq, err := c.CoreV1().ResourceQuotas(c.NamespaceOrDefault(namespace)).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get resourcequota %s: %w", name, err)
+	}
+	return output.MarshalYaml(rq)
+}
+
+// ResourceQuotaCreate creates a ResourceQuota from a YAML/JSON manifest string.
+func (c *Core) ResourceQuotaCreate(ctx context.Context, manifest string) (string, error) {
+	obj, err := decodeManifest(manifest)
+	if err != nil {
+		return "", err
+	}
+	rq, ok := obj.(*corev1.ResourceQuota)
+	if !ok {
+		return "", fmt.Errorf("manifest is not a ResourceQuota")
+	}
+	created, err := c.CoreV1().ResourceQuotas(c.NamespaceOrDefault(rq.Namespace)).Create(ctx, rq, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to create resourcequota: %w", err)
+	}
+	return output.MarshalYaml(created)
+}
+
+// ResourceQuotaDelete deletes a ResourceQuota.
+func (c *Core) ResourceQuotaDelete(ctx context.Context, namespace, name string) (string, error) {
+	if err := c.CoreV1().ResourceQuotas(c.NamespaceOrDefault(namespace)).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return "", fmt.Errorf("failed to delete resourcequota %s: %w", name, err)
+	}
+	return fmt.Sprintf("resourcequota/%s deleted", name), nil
+}
+
+// --- LimitRange ---
+
+// LimitRangesList lists LimitRanges in the given namespace (all namespaces if
+// empty).
+func (c *Core) LimitRangesList(ctx context.Context, namespace string) (string, error) {
+	list, err := c.CoreV1().LimitRanges(c.NamespaceOrDefault(namespace)).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list limitranges: %w", err)
+	}
+	return output.MarshalYaml(list)
+}
+
+// LimitRangeGet returns a single LimitRange.
+func (c *Core) LimitRangeGet(ctx context.Context, namespace, name string) (string, error) {
+	lr, err := c.CoreV1().LimitRanges(c.NamespaceOrDefault(namespace)).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get limitrange %s: %w", name, err)
+	}
+	return output.MarshalYaml(lr)
+}
+
+// LimitRangeCreate creates a LimitRange from a YAML/JSON manifest string.
+func (c *Core) LimitRangeCreate(ctx context.Context, manifest string) (string, error) {
+	obj, err := decodeManifest(manifest)
+	if err != nil {
+		return "", err
+	}
+	lr, ok := obj.(*corev1.LimitRange)
+	if !ok {
+		return "", fmt.Errorf("manifest is not a LimitRange")
+	}
+	created, err := c.CoreV1().LimitRanges(c.NamespaceOrDefault(lr.Namespace)).Create(ctx, lr, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to create limitrange: %w", err)
+	}
+	return output.MarshalYaml(created)
+}
+
+// LimitRangeDelete deletes a LimitRange.
+func (c *Core) LimitRangeDelete(ctx context.Context, namespace, name string) (string, error) {
+	if err := c.CoreV1().LimitRanges(c.NamespaceOrDefault(namespace)).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return "", fmt.Errorf("failed to delete limitrange %s: %w", name, err)
+	}
+	return fmt.Sprintf("limitrange/%s deleted", name), nil
+}

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -26,6 +26,198 @@
   },
   {
     "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "HorizontalPodAutoscaler: Create"
+    },
+    "description": "Create a Kubernetes HorizontalPodAutoscaler (HPA) from a YAML or JSON manifest. The manifest must be a complete HPA definition with apiVersion autoscaling/v2",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the HorizontalPodAutoscaler (apiVersion: autoscaling/v2, kind: HorizontalPodAutoscaler)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_create",
+    "title": "HorizontalPodAutoscaler: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "HorizontalPodAutoscaler: Delete"
+    },
+    "description": "Delete a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, removing its autoscaling rules",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the HPA to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the HPA from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_delete",
+    "title": "HorizontalPodAutoscaler: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "HorizontalPodAutoscaler: Get"
+    },
+    "description": "Get a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, showing its scaling rules, targets, and current status",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the HPA",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the HPA from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_get",
+    "title": "HorizontalPodAutoscaler: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "HorizontalPodAutoscalers: List"
+    },
+    "description": "List Kubernetes HorizontalPodAutoscalers (HPAs) in the current cluster from all namespaces or the provided namespace. Shows autoscaling rules and current/target metrics for workloads",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve HPAs from. If not provided, lists HPAs from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_list",
+    "title": "HorizontalPodAutoscalers: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "LimitRange: Create"
+    },
+    "description": "Create a Kubernetes LimitRange from a YAML or JSON manifest. The manifest must be a complete LimitRange definition with apiVersion v1",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the LimitRange (apiVersion: v1, kind: LimitRange)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_create",
+    "title": "LimitRange: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "LimitRange: Delete"
+    },
+    "description": "Delete a Kubernetes LimitRange by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the LimitRange to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the LimitRange from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_delete",
+    "title": "LimitRange: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "LimitRange: Get"
+    },
+    "description": "Get a Kubernetes LimitRange by name in the current or provided namespace, showing its per-container resource default/min/max limits",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the LimitRange",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the LimitRange from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_get",
+    "title": "LimitRange: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "LimitRanges: List"
+    },
+    "description": "List Kubernetes LimitRanges in the current cluster from all namespaces or the provided namespace. Shows per-container default resource limits enforced in each namespace",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve LimitRanges from. If not provided, lists LimitRanges from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "limitranges_list",
+    "title": "LimitRanges: List"
+  },
+  {
+    "annotations": {
       "destructiveHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
@@ -44,6 +236,81 @@
     },
     "name": "namespaces_list",
     "title": "Namespaces: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Cordon"
+    },
+    "description": "Cordon a Kubernetes Node, marking it as unschedulable so no new pods are placed on it. Existing pods are not evicted. Mirrors `kubectl cordon`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Node to cordon",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_cordon",
+    "title": "Node: Cordon"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "Node: Drain"
+    },
+    "description": "Drain a Kubernetes Node by cordoning it and evicting all its pods. Mirrors `kubectl drain`. Use caution: this evicts running workloads. DaemonSet pods and mirror pods are skipped by default when ignore_all_daemonsets is true",
+    "inputSchema": {
+      "properties": {
+        "delete_emptydir_data": {
+          "default": false,
+          "description": "If true, continue even if pods are using emptyDir volumes (Optional, default: false)",
+          "type": "boolean"
+        },
+        "disable_eviction": {
+          "default": false,
+          "description": "If true, force-delete pods instead of evicting them. Use only if eviction is blocked (Optional, default: false)",
+          "type": "boolean"
+        },
+        "force": {
+          "default": false,
+          "description": "If true, continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet, or StatefulSet (Optional, default: false)",
+          "type": "boolean"
+        },
+        "grace_period_seconds": {
+          "default": -1,
+          "description": "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used (Optional, default: -1)",
+          "type": "integer"
+        },
+        "ignore_all_daemonsets": {
+          "default": true,
+          "description": "If true, ignore DaemonSet-managed pods and continue draining (Optional, default: true)",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Name of the Node to drain",
+          "type": "string"
+        },
+        "timeout": {
+          "default": 0,
+          "description": "The length of time in seconds to wait before giving up on draining a node, zero means infinite (Optional, default: 0)",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_drain",
+    "title": "Node: Drain"
   },
   {
     "annotations": {
@@ -78,6 +345,85 @@
     },
     "name": "nodes_log",
     "title": "Node: Log"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Patch Label"
+    },
+    "description": "Set or remove a single label on a Kubernetes Node. Providing an empty value removes the label. Useful for managing scheduling constraints and node grouping",
+    "inputSchema": {
+      "properties": {
+        "key": {
+          "description": "Label key to set or remove (e.g. 'node-role.kubernetes.io/worker')",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to patch",
+          "type": "string"
+        },
+        "value": {
+          "description": "Label value to set. An empty string removes the label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "key"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_patch_label",
+    "title": "Node: Patch Label"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Patch Taint"
+    },
+    "description": "Set or remove a single taint on a Kubernetes Node. Taints repel pods unless a pod tolerates them. Use effect values NoSchedule, PreferNoSchedule, or NoExecute",
+    "inputSchema": {
+      "properties": {
+        "effect": {
+          "description": "Taint effect: NoSchedule, PreferNoSchedule, or NoExecute",
+          "enum": [
+            "NoSchedule",
+            "PreferNoSchedule",
+            "NoExecute"
+          ],
+          "type": "string"
+        },
+        "key": {
+          "description": "Taint key (e.g. 'dedicated')",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to patch",
+          "type": "string"
+        },
+        "remove": {
+          "default": false,
+          "description": "If true, remove the taint matching key/effect instead of adding it (Optional, default: false)",
+          "type": "boolean"
+        },
+        "value": {
+          "description": "Taint value (e.g. 'gpu'). Optional when removing",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "key",
+        "effect"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_patch_taint",
+    "title": "Node: Patch Taint"
   },
   {
     "annotations": {
@@ -127,6 +473,155 @@
     },
     "name": "nodes_top",
     "title": "Nodes: Top"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Uncordon"
+    },
+    "description": "Uncordon a Kubernetes Node, marking it as schedulable again so new pods can be placed on it. Mirrors `kubectl uncordon`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Node to uncordon",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_uncordon",
+    "title": "Node: Uncordon"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "PodDisruptionBudget: Create"
+    },
+    "description": "Create a Kubernetes PodDisruptionBudget (PDB) from a YAML or JSON manifest. The manifest must be a complete PDB definition with apiVersion policy/v1",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the PodDisruptionBudget (apiVersion: policy/v1, kind: PodDisruptionBudget)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_create",
+    "title": "PodDisruptionBudget: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "PodDisruptionBudget: Delete"
+    },
+    "description": "Delete a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the PDB to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the PDB from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_delete",
+    "title": "PodDisruptionBudget: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "PodDisruptionBudget: Get"
+    },
+    "description": "Get a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace, showing its selector, allowed disruptions, and status",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the PDB",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the PDB from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_get",
+    "title": "PodDisruptionBudget: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "PodDisruptionBudgets: List"
+    },
+    "description": "List Kubernetes PodDisruptionBudgets (PDBs) in the current cluster from all namespaces or the provided namespace. Shows the allowed disruptions and current/min available pod counts",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve PDBs from. If not provided, lists PDBs from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_list",
+    "title": "PodDisruptionBudgets: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "Pods: Attach"
+    },
+    "description": "Attach to a running container in a Kubernetes Pod, capturing its stdout and stderr. Unlike exec, attach connects to the container's primary process (PID 1) rather than starting a new command. Mirrors `kubectl attach`",
+    "inputSchema": {
+      "properties": {
+        "container": {
+          "description": "Name of the Pod container to attach to (Optional, defaults to the first or kubectl default-container annotation)",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Pod to attach to",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Pod (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "pods_attach",
+    "title": "Pods: Attach"
   },
   {
     "annotations": {
@@ -293,6 +788,11 @@
           "description": "Name of the Pod container to get the logs from (Optional)",
           "type": "string"
         },
+        "follow": {
+          "default": false,
+          "description": "Follow the log output, streaming new log lines as they are produced. The call blocks until the timeout (since_seconds) elapses or the container exits, then returns all lines collected so far (Optional, default: false)",
+          "type": "boolean"
+        },
         "name": {
           "description": "Name of the Pod to get the logs from",
           "type": "string"
@@ -304,6 +804,12 @@
         "previous": {
           "description": "Return previous terminated container logs (Optional)",
           "type": "boolean"
+        },
+        "since_seconds": {
+          "default": 10,
+          "description": "When follow is true, the maximum number of seconds to stream logs before returning. A value of 0 means no timeout (block until the container exits) (Optional, default: 10). Ignored when follow is false",
+          "minimum": 0,
+          "type": "integer"
         },
         "tail": {
           "default": 100,
@@ -319,6 +825,82 @@
     },
     "name": "pods_log",
     "title": "Pods: Log"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "title": "Pods: Port Forward"
+    },
+    "description": "Start port-forwarding a local port to a port on a Kubernetes Pod. Runs in the background and returns a session id plus the local address you can connect to. Use pods_port_forward_stop with the returned id to terminate the session. Mirrors `kubectl port-forward pod`",
+    "inputSchema": {
+      "properties": {
+        "local_port": {
+          "description": "Local port to listen on. If 0 or omitted, a free port is chosen automatically",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "name": {
+          "description": "Name of the Pod to forward to",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Pod (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "remote_port": {
+          "description": "Port on the Pod to forward to (the container port)",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "remote_port"
+      ],
+      "type": "object"
+    },
+    "name": "pods_port_forward",
+    "title": "Pods: Port Forward"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Port Forward List"
+    },
+    "description": "List all active port-forward sessions, showing their session id, target pod, namespace, and local/remote ports",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "pods_port_forward_list",
+    "title": "Pods: Port Forward List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Pods: Port Forward Stop"
+    },
+    "description": "Stop a running port-forward session by its session id, releasing the local port. Returns the session details that were stopped",
+    "inputSchema": {
+      "properties": {
+        "id": {
+          "description": "Session id returned by pods_port_forward",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "name": "pods_port_forward_stop",
+    "title": "Pods: Port Forward Stop"
   },
   {
     "annotations": {
@@ -403,6 +985,102 @@
     },
     "name": "projects_list",
     "title": "Projects: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "ResourceQuota: Create"
+    },
+    "description": "Create a Kubernetes ResourceQuota from a YAML or JSON manifest. The manifest must be a complete ResourceQuota definition with apiVersion v1",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the ResourceQuota (apiVersion: v1, kind: ResourceQuota)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_create",
+    "title": "ResourceQuota: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "ResourceQuota: Delete"
+    },
+    "description": "Delete a Kubernetes ResourceQuota by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the ResourceQuota to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the ResourceQuota from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_delete",
+    "title": "ResourceQuota: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "ResourceQuota: Get"
+    },
+    "description": "Get a Kubernetes ResourceQuota by name in the current or provided namespace, showing its hard limits and current usage",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the ResourceQuota",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the ResourceQuota from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_get",
+    "title": "ResourceQuota: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "ResourceQuotas: List"
+    },
+    "description": "List Kubernetes ResourceQuotas in the current cluster from all namespaces or the provided namespace. Shows namespace-level resource limits and current usage",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve ResourceQuotas from. If not provided, lists ResourceQuotas from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "resourcequotas_list",
+    "title": "ResourceQuotas: List"
   },
   {
     "annotations": {
@@ -587,5 +1265,120 @@
     },
     "name": "resources_scale",
     "title": "Resources: Scale"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Rollout: History"
+    },
+    "description": "View the rollout history (revisions) of a Kubernetes Deployment in the current or provided namespace. Lists each revision with its image. Mirrors `kubectl rollout history deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to view rollout history for",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_history",
+    "title": "Rollout: History"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Rollout: Restart"
+    },
+    "description": "Trigger a rolling restart of a Kubernetes Deployment by patching the pod template with a restart timestamp. Existing pods are replaced gradually. Mirrors `kubectl rollout restart deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to restart",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_restart",
+    "title": "Rollout: Restart"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Rollout: Status"
+    },
+    "description": "Check the rollout status of a Kubernetes Deployment in the current or provided namespace. Reports whether the rollout is complete, in progress, or has failed (e.g. progress deadline exceeded). Mirrors `kubectl rollout status deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to check rollout status for",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_status",
+    "title": "Rollout: Status"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Rollout: Undo"
+    },
+    "description": "Rollback a Kubernetes Deployment to a previous revision. If to_revision is not provided, rolls back to the immediately previous revision. Mirrors `kubectl rollout undo deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to roll back",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "to_revision": {
+          "description": "Revision number to roll back to (Optional, defaults to the previous revision)",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_undo",
+    "title": "Rollout: Undo"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -66,6 +66,230 @@
   },
   {
     "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "HorizontalPodAutoscaler: Create"
+    },
+    "description": "Create a Kubernetes HorizontalPodAutoscaler (HPA) from a YAML or JSON manifest. The manifest must be a complete HPA definition with apiVersion autoscaling/v2",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the HorizontalPodAutoscaler (apiVersion: autoscaling/v2, kind: HorizontalPodAutoscaler)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_create",
+    "title": "HorizontalPodAutoscaler: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "HorizontalPodAutoscaler: Delete"
+    },
+    "description": "Delete a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, removing its autoscaling rules",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the HPA to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the HPA from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_delete",
+    "title": "HorizontalPodAutoscaler: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "HorizontalPodAutoscaler: Get"
+    },
+    "description": "Get a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, showing its scaling rules, targets, and current status",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the HPA",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the HPA from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_get",
+    "title": "HorizontalPodAutoscaler: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "HorizontalPodAutoscalers: List"
+    },
+    "description": "List Kubernetes HorizontalPodAutoscalers (HPAs) in the current cluster from all namespaces or the provided namespace. Shows autoscaling rules and current/target metrics for workloads",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Optional Namespace to retrieve HPAs from. If not provided, lists HPAs from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_list",
+    "title": "HorizontalPodAutoscalers: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "LimitRange: Create"
+    },
+    "description": "Create a Kubernetes LimitRange from a YAML or JSON manifest. The manifest must be a complete LimitRange definition with apiVersion v1",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the LimitRange (apiVersion: v1, kind: LimitRange)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_create",
+    "title": "LimitRange: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "LimitRange: Delete"
+    },
+    "description": "Delete a Kubernetes LimitRange by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the LimitRange to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the LimitRange from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_delete",
+    "title": "LimitRange: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "LimitRange: Get"
+    },
+    "description": "Get a Kubernetes LimitRange by name in the current or provided namespace, showing its per-container resource default/min/max limits",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the LimitRange",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the LimitRange from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_get",
+    "title": "LimitRange: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "LimitRanges: List"
+    },
+    "description": "List Kubernetes LimitRanges in the current cluster from all namespaces or the provided namespace. Shows per-container default resource limits enforced in each namespace",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Optional Namespace to retrieve LimitRanges from. If not provided, lists LimitRanges from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "limitranges_list",
+    "title": "LimitRanges: List"
+  },
+  {
+    "annotations": {
       "destructiveHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
@@ -88,6 +312,89 @@
     },
     "name": "namespaces_list",
     "title": "Namespaces: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Cordon"
+    },
+    "description": "Cordon a Kubernetes Node, marking it as unschedulable so no new pods are placed on it. Existing pods are not evicted. Mirrors `kubectl cordon`",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to cordon",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_cordon",
+    "title": "Node: Cordon"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "Node: Drain"
+    },
+    "description": "Drain a Kubernetes Node by cordoning it and evicting all its pods. Mirrors `kubectl drain`. Use caution: this evicts running workloads. DaemonSet pods and mirror pods are skipped by default when ignore_all_daemonsets is true",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "delete_emptydir_data": {
+          "default": false,
+          "description": "If true, continue even if pods are using emptyDir volumes (Optional, default: false)",
+          "type": "boolean"
+        },
+        "disable_eviction": {
+          "default": false,
+          "description": "If true, force-delete pods instead of evicting them. Use only if eviction is blocked (Optional, default: false)",
+          "type": "boolean"
+        },
+        "force": {
+          "default": false,
+          "description": "If true, continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet, or StatefulSet (Optional, default: false)",
+          "type": "boolean"
+        },
+        "grace_period_seconds": {
+          "default": -1,
+          "description": "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used (Optional, default: -1)",
+          "type": "integer"
+        },
+        "ignore_all_daemonsets": {
+          "default": true,
+          "description": "If true, ignore DaemonSet-managed pods and continue draining (Optional, default: true)",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Name of the Node to drain",
+          "type": "string"
+        },
+        "timeout": {
+          "default": 0,
+          "description": "The length of time in seconds to wait before giving up on draining a node, zero means infinite (Optional, default: 0)",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_drain",
+    "title": "Node: Drain"
   },
   {
     "annotations": {
@@ -126,6 +433,93 @@
     },
     "name": "nodes_log",
     "title": "Node: Log"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Patch Label"
+    },
+    "description": "Set or remove a single label on a Kubernetes Node. Providing an empty value removes the label. Useful for managing scheduling constraints and node grouping",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "key": {
+          "description": "Label key to set or remove (e.g. 'node-role.kubernetes.io/worker')",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to patch",
+          "type": "string"
+        },
+        "value": {
+          "description": "Label value to set. An empty string removes the label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "key"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_patch_label",
+    "title": "Node: Patch Label"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Patch Taint"
+    },
+    "description": "Set or remove a single taint on a Kubernetes Node. Taints repel pods unless a pod tolerates them. Use effect values NoSchedule, PreferNoSchedule, or NoExecute",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "effect": {
+          "description": "Taint effect: NoSchedule, PreferNoSchedule, or NoExecute",
+          "enum": [
+            "NoSchedule",
+            "PreferNoSchedule",
+            "NoExecute"
+          ],
+          "type": "string"
+        },
+        "key": {
+          "description": "Taint key (e.g. 'dedicated')",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to patch",
+          "type": "string"
+        },
+        "remove": {
+          "default": false,
+          "description": "If true, remove the taint matching key/effect instead of adding it (Optional, default: false)",
+          "type": "boolean"
+        },
+        "value": {
+          "description": "Taint value (e.g. 'gpu'). Optional when removing",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "key",
+        "effect"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_patch_taint",
+    "title": "Node: Patch Taint"
   },
   {
     "annotations": {
@@ -183,6 +577,179 @@
     },
     "name": "nodes_top",
     "title": "Nodes: Top"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Uncordon"
+    },
+    "description": "Uncordon a Kubernetes Node, marking it as schedulable again so new pods can be placed on it. Mirrors `kubectl uncordon`",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to uncordon",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_uncordon",
+    "title": "Node: Uncordon"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "PodDisruptionBudget: Create"
+    },
+    "description": "Create a Kubernetes PodDisruptionBudget (PDB) from a YAML or JSON manifest. The manifest must be a complete PDB definition with apiVersion policy/v1",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the PodDisruptionBudget (apiVersion: policy/v1, kind: PodDisruptionBudget)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_create",
+    "title": "PodDisruptionBudget: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "PodDisruptionBudget: Delete"
+    },
+    "description": "Delete a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the PDB to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the PDB from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_delete",
+    "title": "PodDisruptionBudget: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "PodDisruptionBudget: Get"
+    },
+    "description": "Get a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace, showing its selector, allowed disruptions, and status",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the PDB",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the PDB from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_get",
+    "title": "PodDisruptionBudget: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "PodDisruptionBudgets: List"
+    },
+    "description": "List Kubernetes PodDisruptionBudgets (PDBs) in the current cluster from all namespaces or the provided namespace. Shows the allowed disruptions and current/min available pod counts",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Optional Namespace to retrieve PDBs from. If not provided, lists PDBs from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_list",
+    "title": "PodDisruptionBudgets: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "Pods: Attach"
+    },
+    "description": "Attach to a running container in a Kubernetes Pod, capturing its stdout and stderr. Unlike exec, attach connects to the container's primary process (PID 1) rather than starting a new command. Mirrors `kubectl attach`",
+    "inputSchema": {
+      "properties": {
+        "container": {
+          "description": "Name of the Pod container to attach to (Optional, defaults to the first or kubectl default-container annotation)",
+          "type": "string"
+        },
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Pod to attach to",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Pod (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "pods_attach",
+    "title": "Pods: Attach"
   },
   {
     "annotations": {
@@ -373,6 +940,11 @@
           "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
           "type": "string"
         },
+        "follow": {
+          "default": false,
+          "description": "Follow the log output, streaming new log lines as they are produced. The call blocks until the timeout (since_seconds) elapses or the container exits, then returns all lines collected so far (Optional, default: false)",
+          "type": "boolean"
+        },
         "name": {
           "description": "Name of the Pod to get the logs from",
           "type": "string"
@@ -384,6 +956,12 @@
         "previous": {
           "description": "Return previous terminated container logs (Optional)",
           "type": "boolean"
+        },
+        "since_seconds": {
+          "default": 10,
+          "description": "When follow is true, the maximum number of seconds to stream logs before returning. A value of 0 means no timeout (block until the container exits) (Optional, default: 10). Ignored when follow is false",
+          "minimum": 0,
+          "type": "integer"
         },
         "tail": {
           "default": 100,
@@ -399,6 +977,95 @@
     },
     "name": "pods_log",
     "title": "Pods: Log"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "title": "Pods: Port Forward"
+    },
+    "description": "Start port-forwarding a local port to a port on a Kubernetes Pod. Runs in the background and returns a session id plus the local address you can connect to. Use pods_port_forward_stop with the returned id to terminate the session. Mirrors `kubectl port-forward pod`",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "local_port": {
+          "description": "Local port to listen on. If 0 or omitted, a free port is chosen automatically",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "name": {
+          "description": "Name of the Pod to forward to",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Pod (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "remote_port": {
+          "description": "Port on the Pod to forward to (the container port)",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "remote_port"
+      ],
+      "type": "object"
+    },
+    "name": "pods_port_forward",
+    "title": "Pods: Port Forward"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Port Forward List"
+    },
+    "description": "List all active port-forward sessions, showing their session id, target pod, namespace, and local/remote ports",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "pods_port_forward_list",
+    "title": "Pods: Port Forward List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Pods: Port Forward Stop"
+    },
+    "description": "Stop a running port-forward session by its session id, releasing the local port. Returns the session details that were stopped",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "id": {
+          "description": "Session id returned by pods_port_forward",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "name": "pods_port_forward_stop",
+    "title": "Pods: Port Forward Stop"
   },
   {
     "annotations": {
@@ -496,6 +1163,118 @@
     },
     "name": "projects_list",
     "title": "Projects: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "ResourceQuota: Create"
+    },
+    "description": "Create a Kubernetes ResourceQuota from a YAML or JSON manifest. The manifest must be a complete ResourceQuota definition with apiVersion v1",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the ResourceQuota (apiVersion: v1, kind: ResourceQuota)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_create",
+    "title": "ResourceQuota: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "ResourceQuota: Delete"
+    },
+    "description": "Delete a Kubernetes ResourceQuota by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the ResourceQuota to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the ResourceQuota from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_delete",
+    "title": "ResourceQuota: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "ResourceQuota: Get"
+    },
+    "description": "Get a Kubernetes ResourceQuota by name in the current or provided namespace, showing its hard limits and current usage",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the ResourceQuota",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the ResourceQuota from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_get",
+    "title": "ResourceQuota: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "ResourceQuotas: List"
+    },
+    "description": "List Kubernetes ResourceQuotas in the current cluster from all namespaces or the provided namespace. Shows namespace-level resource limits and current usage",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Optional Namespace to retrieve ResourceQuotas from. If not provided, lists ResourceQuotas from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "resourcequotas_list",
+    "title": "ResourceQuotas: List"
   },
   {
     "annotations": {
@@ -700,5 +1479,136 @@
     },
     "name": "resources_scale",
     "title": "Resources: Scale"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Rollout: History"
+    },
+    "description": "View the rollout history (revisions) of a Kubernetes Deployment in the current or provided namespace. Lists each revision with its image. Mirrors `kubectl rollout history deployment`",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Deployment to view rollout history for",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_history",
+    "title": "Rollout: History"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Rollout: Restart"
+    },
+    "description": "Trigger a rolling restart of a Kubernetes Deployment by patching the pod template with a restart timestamp. Existing pods are replaced gradually. Mirrors `kubectl rollout restart deployment`",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Deployment to restart",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_restart",
+    "title": "Rollout: Restart"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Rollout: Status"
+    },
+    "description": "Check the rollout status of a Kubernetes Deployment in the current or provided namespace. Reports whether the rollout is complete, in progress, or has failed (e.g. progress deadline exceeded). Mirrors `kubectl rollout status deployment`",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Deployment to check rollout status for",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_status",
+    "title": "Rollout: Status"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Rollout: Undo"
+    },
+    "description": "Rollback a Kubernetes Deployment to a previous revision. If to_revision is not provided, rolls back to the immediately previous revision. Mirrors `kubectl rollout undo deployment`",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Deployment to roll back",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "to_revision": {
+          "description": "Revision number to roll back to (Optional, defaults to the previous revision)",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_undo",
+    "title": "Rollout: Undo"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -46,6 +46,198 @@
   },
   {
     "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "HorizontalPodAutoscaler: Create"
+    },
+    "description": "Create a Kubernetes HorizontalPodAutoscaler (HPA) from a YAML or JSON manifest. The manifest must be a complete HPA definition with apiVersion autoscaling/v2",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the HorizontalPodAutoscaler (apiVersion: autoscaling/v2, kind: HorizontalPodAutoscaler)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_create",
+    "title": "HorizontalPodAutoscaler: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "HorizontalPodAutoscaler: Delete"
+    },
+    "description": "Delete a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, removing its autoscaling rules",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the HPA to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the HPA from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_delete",
+    "title": "HorizontalPodAutoscaler: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "HorizontalPodAutoscaler: Get"
+    },
+    "description": "Get a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, showing its scaling rules, targets, and current status",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the HPA",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the HPA from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_get",
+    "title": "HorizontalPodAutoscaler: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "HorizontalPodAutoscalers: List"
+    },
+    "description": "List Kubernetes HorizontalPodAutoscalers (HPAs) in the current cluster from all namespaces or the provided namespace. Shows autoscaling rules and current/target metrics for workloads",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve HPAs from. If not provided, lists HPAs from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_list",
+    "title": "HorizontalPodAutoscalers: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "LimitRange: Create"
+    },
+    "description": "Create a Kubernetes LimitRange from a YAML or JSON manifest. The manifest must be a complete LimitRange definition with apiVersion v1",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the LimitRange (apiVersion: v1, kind: LimitRange)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_create",
+    "title": "LimitRange: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "LimitRange: Delete"
+    },
+    "description": "Delete a Kubernetes LimitRange by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the LimitRange to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the LimitRange from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_delete",
+    "title": "LimitRange: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "LimitRange: Get"
+    },
+    "description": "Get a Kubernetes LimitRange by name in the current or provided namespace, showing its per-container resource default/min/max limits",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the LimitRange",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the LimitRange from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_get",
+    "title": "LimitRange: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "LimitRanges: List"
+    },
+    "description": "List Kubernetes LimitRanges in the current cluster from all namespaces or the provided namespace. Shows per-container default resource limits enforced in each namespace",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve LimitRanges from. If not provided, lists LimitRanges from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "limitranges_list",
+    "title": "LimitRanges: List"
+  },
+  {
+    "annotations": {
       "destructiveHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
@@ -64,6 +256,81 @@
     },
     "name": "namespaces_list",
     "title": "Namespaces: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Cordon"
+    },
+    "description": "Cordon a Kubernetes Node, marking it as unschedulable so no new pods are placed on it. Existing pods are not evicted. Mirrors `kubectl cordon`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Node to cordon",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_cordon",
+    "title": "Node: Cordon"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "Node: Drain"
+    },
+    "description": "Drain a Kubernetes Node by cordoning it and evicting all its pods. Mirrors `kubectl drain`. Use caution: this evicts running workloads. DaemonSet pods and mirror pods are skipped by default when ignore_all_daemonsets is true",
+    "inputSchema": {
+      "properties": {
+        "delete_emptydir_data": {
+          "default": false,
+          "description": "If true, continue even if pods are using emptyDir volumes (Optional, default: false)",
+          "type": "boolean"
+        },
+        "disable_eviction": {
+          "default": false,
+          "description": "If true, force-delete pods instead of evicting them. Use only if eviction is blocked (Optional, default: false)",
+          "type": "boolean"
+        },
+        "force": {
+          "default": false,
+          "description": "If true, continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet, or StatefulSet (Optional, default: false)",
+          "type": "boolean"
+        },
+        "grace_period_seconds": {
+          "default": -1,
+          "description": "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used (Optional, default: -1)",
+          "type": "integer"
+        },
+        "ignore_all_daemonsets": {
+          "default": true,
+          "description": "If true, ignore DaemonSet-managed pods and continue draining (Optional, default: true)",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Name of the Node to drain",
+          "type": "string"
+        },
+        "timeout": {
+          "default": 0,
+          "description": "The length of time in seconds to wait before giving up on draining a node, zero means infinite (Optional, default: 0)",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_drain",
+    "title": "Node: Drain"
   },
   {
     "annotations": {
@@ -98,6 +365,85 @@
     },
     "name": "nodes_log",
     "title": "Node: Log"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Patch Label"
+    },
+    "description": "Set or remove a single label on a Kubernetes Node. Providing an empty value removes the label. Useful for managing scheduling constraints and node grouping",
+    "inputSchema": {
+      "properties": {
+        "key": {
+          "description": "Label key to set or remove (e.g. 'node-role.kubernetes.io/worker')",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to patch",
+          "type": "string"
+        },
+        "value": {
+          "description": "Label value to set. An empty string removes the label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "key"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_patch_label",
+    "title": "Node: Patch Label"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Patch Taint"
+    },
+    "description": "Set or remove a single taint on a Kubernetes Node. Taints repel pods unless a pod tolerates them. Use effect values NoSchedule, PreferNoSchedule, or NoExecute",
+    "inputSchema": {
+      "properties": {
+        "effect": {
+          "description": "Taint effect: NoSchedule, PreferNoSchedule, or NoExecute",
+          "enum": [
+            "NoSchedule",
+            "PreferNoSchedule",
+            "NoExecute"
+          ],
+          "type": "string"
+        },
+        "key": {
+          "description": "Taint key (e.g. 'dedicated')",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to patch",
+          "type": "string"
+        },
+        "remove": {
+          "default": false,
+          "description": "If true, remove the taint matching key/effect instead of adding it (Optional, default: false)",
+          "type": "boolean"
+        },
+        "value": {
+          "description": "Taint value (e.g. 'gpu'). Optional when removing",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "key",
+        "effect"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_patch_taint",
+    "title": "Node: Patch Taint"
   },
   {
     "annotations": {
@@ -147,6 +493,155 @@
     },
     "name": "nodes_top",
     "title": "Nodes: Top"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Uncordon"
+    },
+    "description": "Uncordon a Kubernetes Node, marking it as schedulable again so new pods can be placed on it. Mirrors `kubectl uncordon`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Node to uncordon",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_uncordon",
+    "title": "Node: Uncordon"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "PodDisruptionBudget: Create"
+    },
+    "description": "Create a Kubernetes PodDisruptionBudget (PDB) from a YAML or JSON manifest. The manifest must be a complete PDB definition with apiVersion policy/v1",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the PodDisruptionBudget (apiVersion: policy/v1, kind: PodDisruptionBudget)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_create",
+    "title": "PodDisruptionBudget: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "PodDisruptionBudget: Delete"
+    },
+    "description": "Delete a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the PDB to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the PDB from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_delete",
+    "title": "PodDisruptionBudget: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "PodDisruptionBudget: Get"
+    },
+    "description": "Get a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace, showing its selector, allowed disruptions, and status",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the PDB",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the PDB from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_get",
+    "title": "PodDisruptionBudget: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "PodDisruptionBudgets: List"
+    },
+    "description": "List Kubernetes PodDisruptionBudgets (PDBs) in the current cluster from all namespaces or the provided namespace. Shows the allowed disruptions and current/min available pod counts",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve PDBs from. If not provided, lists PDBs from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_list",
+    "title": "PodDisruptionBudgets: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "Pods: Attach"
+    },
+    "description": "Attach to a running container in a Kubernetes Pod, capturing its stdout and stderr. Unlike exec, attach connects to the container's primary process (PID 1) rather than starting a new command. Mirrors `kubectl attach`",
+    "inputSchema": {
+      "properties": {
+        "container": {
+          "description": "Name of the Pod container to attach to (Optional, defaults to the first or kubectl default-container annotation)",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Pod to attach to",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Pod (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "pods_attach",
+    "title": "Pods: Attach"
   },
   {
     "annotations": {
@@ -313,6 +808,11 @@
           "description": "Name of the Pod container to get the logs from (Optional)",
           "type": "string"
         },
+        "follow": {
+          "default": false,
+          "description": "Follow the log output, streaming new log lines as they are produced. The call blocks until the timeout (since_seconds) elapses or the container exits, then returns all lines collected so far (Optional, default: false)",
+          "type": "boolean"
+        },
         "name": {
           "description": "Name of the Pod to get the logs from",
           "type": "string"
@@ -324,6 +824,12 @@
         "previous": {
           "description": "Return previous terminated container logs (Optional)",
           "type": "boolean"
+        },
+        "since_seconds": {
+          "default": 10,
+          "description": "When follow is true, the maximum number of seconds to stream logs before returning. A value of 0 means no timeout (block until the container exits) (Optional, default: 10). Ignored when follow is false",
+          "minimum": 0,
+          "type": "integer"
         },
         "tail": {
           "default": 100,
@@ -339,6 +845,82 @@
     },
     "name": "pods_log",
     "title": "Pods: Log"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "title": "Pods: Port Forward"
+    },
+    "description": "Start port-forwarding a local port to a port on a Kubernetes Pod. Runs in the background and returns a session id plus the local address you can connect to. Use pods_port_forward_stop with the returned id to terminate the session. Mirrors `kubectl port-forward pod`",
+    "inputSchema": {
+      "properties": {
+        "local_port": {
+          "description": "Local port to listen on. If 0 or omitted, a free port is chosen automatically",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "name": {
+          "description": "Name of the Pod to forward to",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Pod (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "remote_port": {
+          "description": "Port on the Pod to forward to (the container port)",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "remote_port"
+      ],
+      "type": "object"
+    },
+    "name": "pods_port_forward",
+    "title": "Pods: Port Forward"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Port Forward List"
+    },
+    "description": "List all active port-forward sessions, showing their session id, target pod, namespace, and local/remote ports",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "pods_port_forward_list",
+    "title": "Pods: Port Forward List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Pods: Port Forward Stop"
+    },
+    "description": "Stop a running port-forward session by its session id, releasing the local port. Returns the session details that were stopped",
+    "inputSchema": {
+      "properties": {
+        "id": {
+          "description": "Session id returned by pods_port_forward",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "name": "pods_port_forward_stop",
+    "title": "Pods: Port Forward Stop"
   },
   {
     "annotations": {
@@ -423,6 +1005,102 @@
     },
     "name": "projects_list",
     "title": "Projects: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "ResourceQuota: Create"
+    },
+    "description": "Create a Kubernetes ResourceQuota from a YAML or JSON manifest. The manifest must be a complete ResourceQuota definition with apiVersion v1",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the ResourceQuota (apiVersion: v1, kind: ResourceQuota)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_create",
+    "title": "ResourceQuota: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "ResourceQuota: Delete"
+    },
+    "description": "Delete a Kubernetes ResourceQuota by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the ResourceQuota to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the ResourceQuota from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_delete",
+    "title": "ResourceQuota: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "ResourceQuota: Get"
+    },
+    "description": "Get a Kubernetes ResourceQuota by name in the current or provided namespace, showing its hard limits and current usage",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the ResourceQuota",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the ResourceQuota from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_get",
+    "title": "ResourceQuota: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "ResourceQuotas: List"
+    },
+    "description": "List Kubernetes ResourceQuotas in the current cluster from all namespaces or the provided namespace. Shows namespace-level resource limits and current usage",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve ResourceQuotas from. If not provided, lists ResourceQuotas from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "resourcequotas_list",
+    "title": "ResourceQuotas: List"
   },
   {
     "annotations": {
@@ -607,5 +1285,120 @@
     },
     "name": "resources_scale",
     "title": "Resources: Scale"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Rollout: History"
+    },
+    "description": "View the rollout history (revisions) of a Kubernetes Deployment in the current or provided namespace. Lists each revision with its image. Mirrors `kubectl rollout history deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to view rollout history for",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_history",
+    "title": "Rollout: History"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Rollout: Restart"
+    },
+    "description": "Trigger a rolling restart of a Kubernetes Deployment by patching the pod template with a restart timestamp. Existing pods are replaced gradually. Mirrors `kubectl rollout restart deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to restart",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_restart",
+    "title": "Rollout: Restart"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Rollout: Status"
+    },
+    "description": "Check the rollout status of a Kubernetes Deployment in the current or provided namespace. Reports whether the rollout is complete, in progress, or has failed (e.g. progress deadline exceeded). Mirrors `kubectl rollout status deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to check rollout status for",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_status",
+    "title": "Rollout: Status"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Rollout: Undo"
+    },
+    "description": "Rollback a Kubernetes Deployment to a previous revision. If to_revision is not provided, rolls back to the immediately previous revision. Mirrors `kubectl rollout undo deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to roll back",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "to_revision": {
+          "description": "Revision number to roll back to (Optional, defaults to the previous revision)",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_undo",
+    "title": "Rollout: Undo"
   }
 ]

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -46,6 +46,198 @@
   },
   {
     "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "HorizontalPodAutoscaler: Create"
+    },
+    "description": "Create a Kubernetes HorizontalPodAutoscaler (HPA) from a YAML or JSON manifest. The manifest must be a complete HPA definition with apiVersion autoscaling/v2",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the HorizontalPodAutoscaler (apiVersion: autoscaling/v2, kind: HorizontalPodAutoscaler)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_create",
+    "title": "HorizontalPodAutoscaler: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "HorizontalPodAutoscaler: Delete"
+    },
+    "description": "Delete a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, removing its autoscaling rules",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the HPA to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the HPA from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_delete",
+    "title": "HorizontalPodAutoscaler: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "HorizontalPodAutoscaler: Get"
+    },
+    "description": "Get a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, showing its scaling rules, targets, and current status",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the HPA",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the HPA from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_get",
+    "title": "HorizontalPodAutoscaler: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "HorizontalPodAutoscalers: List"
+    },
+    "description": "List Kubernetes HorizontalPodAutoscalers (HPAs) in the current cluster from all namespaces or the provided namespace. Shows autoscaling rules and current/target metrics for workloads",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve HPAs from. If not provided, lists HPAs from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "horizontalpodautoscalers_list",
+    "title": "HorizontalPodAutoscalers: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "LimitRange: Create"
+    },
+    "description": "Create a Kubernetes LimitRange from a YAML or JSON manifest. The manifest must be a complete LimitRange definition with apiVersion v1",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the LimitRange (apiVersion: v1, kind: LimitRange)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_create",
+    "title": "LimitRange: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "LimitRange: Delete"
+    },
+    "description": "Delete a Kubernetes LimitRange by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the LimitRange to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the LimitRange from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_delete",
+    "title": "LimitRange: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "LimitRange: Get"
+    },
+    "description": "Get a Kubernetes LimitRange by name in the current or provided namespace, showing its per-container resource default/min/max limits",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the LimitRange",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the LimitRange from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "limitranges_get",
+    "title": "LimitRange: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "LimitRanges: List"
+    },
+    "description": "List Kubernetes LimitRanges in the current cluster from all namespaces or the provided namespace. Shows per-container default resource limits enforced in each namespace",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve LimitRanges from. If not provided, lists LimitRanges from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "limitranges_list",
+    "title": "LimitRanges: List"
+  },
+  {
+    "annotations": {
       "destructiveHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,
@@ -64,6 +256,81 @@
     },
     "name": "namespaces_list",
     "title": "Namespaces: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Cordon"
+    },
+    "description": "Cordon a Kubernetes Node, marking it as unschedulable so no new pods are placed on it. Existing pods are not evicted. Mirrors `kubectl cordon`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Node to cordon",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_cordon",
+    "title": "Node: Cordon"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "Node: Drain"
+    },
+    "description": "Drain a Kubernetes Node by cordoning it and evicting all its pods. Mirrors `kubectl drain`. Use caution: this evicts running workloads. DaemonSet pods and mirror pods are skipped by default when ignore_all_daemonsets is true",
+    "inputSchema": {
+      "properties": {
+        "delete_emptydir_data": {
+          "default": false,
+          "description": "If true, continue even if pods are using emptyDir volumes (Optional, default: false)",
+          "type": "boolean"
+        },
+        "disable_eviction": {
+          "default": false,
+          "description": "If true, force-delete pods instead of evicting them. Use only if eviction is blocked (Optional, default: false)",
+          "type": "boolean"
+        },
+        "force": {
+          "default": false,
+          "description": "If true, continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet, or StatefulSet (Optional, default: false)",
+          "type": "boolean"
+        },
+        "grace_period_seconds": {
+          "default": -1,
+          "description": "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used (Optional, default: -1)",
+          "type": "integer"
+        },
+        "ignore_all_daemonsets": {
+          "default": true,
+          "description": "If true, ignore DaemonSet-managed pods and continue draining (Optional, default: true)",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Name of the Node to drain",
+          "type": "string"
+        },
+        "timeout": {
+          "default": 0,
+          "description": "The length of time in seconds to wait before giving up on draining a node, zero means infinite (Optional, default: 0)",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_drain",
+    "title": "Node: Drain"
   },
   {
     "annotations": {
@@ -98,6 +365,85 @@
     },
     "name": "nodes_log",
     "title": "Node: Log"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Patch Label"
+    },
+    "description": "Set or remove a single label on a Kubernetes Node. Providing an empty value removes the label. Useful for managing scheduling constraints and node grouping",
+    "inputSchema": {
+      "properties": {
+        "key": {
+          "description": "Label key to set or remove (e.g. 'node-role.kubernetes.io/worker')",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to patch",
+          "type": "string"
+        },
+        "value": {
+          "description": "Label value to set. An empty string removes the label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "key"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_patch_label",
+    "title": "Node: Patch Label"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Patch Taint"
+    },
+    "description": "Set or remove a single taint on a Kubernetes Node. Taints repel pods unless a pod tolerates them. Use effect values NoSchedule, PreferNoSchedule, or NoExecute",
+    "inputSchema": {
+      "properties": {
+        "effect": {
+          "description": "Taint effect: NoSchedule, PreferNoSchedule, or NoExecute",
+          "enum": [
+            "NoSchedule",
+            "PreferNoSchedule",
+            "NoExecute"
+          ],
+          "type": "string"
+        },
+        "key": {
+          "description": "Taint key (e.g. 'dedicated')",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Node to patch",
+          "type": "string"
+        },
+        "remove": {
+          "default": false,
+          "description": "If true, remove the taint matching key/effect instead of adding it (Optional, default: false)",
+          "type": "boolean"
+        },
+        "value": {
+          "description": "Taint value (e.g. 'gpu'). Optional when removing",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "key",
+        "effect"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_patch_taint",
+    "title": "Node: Patch Taint"
   },
   {
     "annotations": {
@@ -147,6 +493,155 @@
     },
     "name": "nodes_top",
     "title": "Nodes: Top"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Node: Uncordon"
+    },
+    "description": "Uncordon a Kubernetes Node, marking it as schedulable again so new pods can be placed on it. Mirrors `kubectl uncordon`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Node to uncordon",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "nodes_uncordon",
+    "title": "Node: Uncordon"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "PodDisruptionBudget: Create"
+    },
+    "description": "Create a Kubernetes PodDisruptionBudget (PDB) from a YAML or JSON manifest. The manifest must be a complete PDB definition with apiVersion policy/v1",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the PodDisruptionBudget (apiVersion: policy/v1, kind: PodDisruptionBudget)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_create",
+    "title": "PodDisruptionBudget: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "PodDisruptionBudget: Delete"
+    },
+    "description": "Delete a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the PDB to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the PDB from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_delete",
+    "title": "PodDisruptionBudget: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "PodDisruptionBudget: Get"
+    },
+    "description": "Get a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace, showing its selector, allowed disruptions, and status",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the PDB",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the PDB from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_get",
+    "title": "PodDisruptionBudget: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "PodDisruptionBudgets: List"
+    },
+    "description": "List Kubernetes PodDisruptionBudgets (PDBs) in the current cluster from all namespaces or the provided namespace. Shows the allowed disruptions and current/min available pod counts",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve PDBs from. If not provided, lists PDBs from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "poddisruptionbudgets_list",
+    "title": "PodDisruptionBudgets: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "Pods: Attach"
+    },
+    "description": "Attach to a running container in a Kubernetes Pod, capturing its stdout and stderr. Unlike exec, attach connects to the container's primary process (PID 1) rather than starting a new command. Mirrors `kubectl attach`",
+    "inputSchema": {
+      "properties": {
+        "container": {
+          "description": "Name of the Pod container to attach to (Optional, defaults to the first or kubectl default-container annotation)",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Pod to attach to",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Pod (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "pods_attach",
+    "title": "Pods: Attach"
   },
   {
     "annotations": {
@@ -313,6 +808,11 @@
           "description": "Name of the Pod container to get the logs from (Optional)",
           "type": "string"
         },
+        "follow": {
+          "default": false,
+          "description": "Follow the log output, streaming new log lines as they are produced. The call blocks until the timeout (since_seconds) elapses or the container exits, then returns all lines collected so far (Optional, default: false)",
+          "type": "boolean"
+        },
         "name": {
           "description": "Name of the Pod to get the logs from",
           "type": "string"
@@ -324,6 +824,12 @@
         "previous": {
           "description": "Return previous terminated container logs (Optional)",
           "type": "boolean"
+        },
+        "since_seconds": {
+          "default": 10,
+          "description": "When follow is true, the maximum number of seconds to stream logs before returning. A value of 0 means no timeout (block until the container exits) (Optional, default: 10). Ignored when follow is false",
+          "minimum": 0,
+          "type": "integer"
         },
         "tail": {
           "default": 100,
@@ -339,6 +845,82 @@
     },
     "name": "pods_log",
     "title": "Pods: Log"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "title": "Pods: Port Forward"
+    },
+    "description": "Start port-forwarding a local port to a port on a Kubernetes Pod. Runs in the background and returns a session id plus the local address you can connect to. Use pods_port_forward_stop with the returned id to terminate the session. Mirrors `kubectl port-forward pod`",
+    "inputSchema": {
+      "properties": {
+        "local_port": {
+          "description": "Local port to listen on. If 0 or omitted, a free port is chosen automatically",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "name": {
+          "description": "Name of the Pod to forward to",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Pod (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "remote_port": {
+          "description": "Port on the Pod to forward to (the container port)",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "remote_port"
+      ],
+      "type": "object"
+    },
+    "name": "pods_port_forward",
+    "title": "Pods: Port Forward"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Pods: Port Forward List"
+    },
+    "description": "List all active port-forward sessions, showing their session id, target pod, namespace, and local/remote ports",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "pods_port_forward_list",
+    "title": "Pods: Port Forward List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Pods: Port Forward Stop"
+    },
+    "description": "Stop a running port-forward session by its session id, releasing the local port. Returns the session details that were stopped",
+    "inputSchema": {
+      "properties": {
+        "id": {
+          "description": "Session id returned by pods_port_forward",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "name": "pods_port_forward_stop",
+    "title": "Pods: Port Forward Stop"
   },
   {
     "annotations": {
@@ -423,6 +1005,102 @@
     },
     "name": "projects_list",
     "title": "Projects: List"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true,
+      "title": "ResourceQuota: Create"
+    },
+    "description": "Create a Kubernetes ResourceQuota from a YAML or JSON manifest. The manifest must be a complete ResourceQuota definition with apiVersion v1",
+    "inputSchema": {
+      "properties": {
+        "manifest": {
+          "description": "Complete YAML or JSON manifest of the ResourceQuota (apiVersion: v1, kind: ResourceQuota)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_create",
+    "title": "ResourceQuota: Create"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "ResourceQuota: Delete"
+    },
+    "description": "Delete a Kubernetes ResourceQuota by name in the current or provided namespace",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the ResourceQuota to delete",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to delete the ResourceQuota from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_delete",
+    "title": "ResourceQuota: Delete"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "ResourceQuota: Get"
+    },
+    "description": "Get a Kubernetes ResourceQuota by name in the current or provided namespace, showing its hard limits and current usage",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the ResourceQuota",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to get the ResourceQuota from (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "resourcequotas_get",
+    "title": "ResourceQuota: Get"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "ResourceQuotas: List"
+    },
+    "description": "List Kubernetes ResourceQuotas in the current cluster from all namespaces or the provided namespace. Shows namespace-level resource limits and current usage",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "Optional Namespace to retrieve ResourceQuotas from. If not provided, lists ResourceQuotas from all namespaces",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "name": "resourcequotas_list",
+    "title": "ResourceQuotas: List"
   },
   {
     "annotations": {
@@ -607,5 +1285,120 @@
     },
     "name": "resources_scale",
     "title": "Resources: Scale"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Rollout: History"
+    },
+    "description": "View the rollout history (revisions) of a Kubernetes Deployment in the current or provided namespace. Lists each revision with its image. Mirrors `kubectl rollout history deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to view rollout history for",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_history",
+    "title": "Rollout: History"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Rollout: Restart"
+    },
+    "description": "Trigger a rolling restart of a Kubernetes Deployment by patching the pod template with a restart timestamp. Existing pods are replaced gradually. Mirrors `kubectl rollout restart deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to restart",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_restart",
+    "title": "Rollout: Restart"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "Rollout: Status"
+    },
+    "description": "Check the rollout status of a Kubernetes Deployment in the current or provided namespace. Reports whether the rollout is complete, in progress, or has failed (e.g. progress deadline exceeded). Mirrors `kubectl rollout status deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to check rollout status for",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_status",
+    "title": "Rollout: Status"
+  },
+  {
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "title": "Rollout: Undo"
+    },
+    "description": "Rollback a Kubernetes Deployment to a previous revision. If to_revision is not provided, rolls back to the immediately previous revision. Mirrors `kubectl rollout undo deployment`",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "Name of the Deployment to roll back",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the Deployment (Optional, current namespace if not provided)",
+          "type": "string"
+        },
+        "to_revision": {
+          "description": "Revision number to roll back to (Optional, defaults to the previous revision)",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "rollout_undo",
+    "title": "Rollout: Undo"
   }
 ]

--- a/pkg/toolsets/core/new_tools_test.go
+++ b/pkg/toolsets/core/new_tools_test.go
@@ -1,0 +1,208 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// mockFilteringProvider is a minimal FilteringProvider for unit tests that do
+// not need a real cluster. It disables target-compatibility filtering so
+// initResources takes its else branch without contacting discovery.
+type mockFilteringProvider struct{}
+
+func (mockFilteringProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return false }
+func (mockFilteringProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVersionKind) bool {
+	return true
+}
+
+// NewToolsSuite verifies that all newly added tools (node management, rollout,
+// port-forward, attach, HPA, PDB, ResourceQuota, LimitRange) are registered
+// in the core toolset with correct names, descriptions, required parameters,
+// and handlers.
+type NewToolsSuite struct {
+	suite.Suite
+	toolset *Toolset
+}
+
+func (s *NewToolsSuite) SetupTest() {
+	s.toolset = &Toolset{}
+}
+
+// toolsByName builds a lookup map of tool name -> ServerTool from the toolset.
+func (s *NewToolsSuite) toolsByName() map[string]any {
+	tools := s.toolset.GetTools(mockFilteringProvider{})
+	m := make(map[string]any, len(tools))
+	for _, t := range tools {
+		m[t.Tool.Name] = t
+	}
+	return m
+}
+
+func (s *NewToolsSuite) hasTool(name string) bool {
+	_, ok := s.toolsByName()[name]
+	return ok
+}
+
+func (s *NewToolsSuite) TestNodeManagementToolsRegistered() {
+	s.Run("nodes_cordon is registered", func() {
+		s.True(s.hasTool("nodes_cordon"), "nodes_cordon should be registered")
+	})
+	s.Run("nodes_uncordon is registered", func() {
+		s.True(s.hasTool("nodes_uncordon"), "nodes_uncordon should be registered")
+	})
+	s.Run("nodes_drain is registered", func() {
+		s.True(s.hasTool("nodes_drain"), "nodes_drain should be registered")
+	})
+	s.Run("nodes_patch_label is registered", func() {
+		s.True(s.hasTool("nodes_patch_label"), "nodes_patch_label should be registered")
+	})
+	s.Run("nodes_patch_taint is registered", func() {
+		s.True(s.hasTool("nodes_patch_taint"), "nodes_patch_taint should be registered")
+	})
+}
+
+func (s *NewToolsSuite) TestRolloutToolsRegistered() {
+	s.Run("rollout_status is registered", func() {
+		s.True(s.hasTool("rollout_status"), "rollout_status should be registered")
+	})
+	s.Run("rollout_history is registered", func() {
+		s.True(s.hasTool("rollout_history"), "rollout_history should be registered")
+	})
+	s.Run("rollout_undo is registered", func() {
+		s.True(s.hasTool("rollout_undo"), "rollout_undo should be registered")
+	})
+	s.Run("rollout_restart is registered", func() {
+		s.True(s.hasTool("rollout_restart"), "rollout_restart should be registered")
+	})
+}
+
+func (s *NewToolsSuite) TestPortForwardAndAttachToolsRegistered() {
+	s.Run("pods_port_forward is registered", func() {
+		s.True(s.hasTool("pods_port_forward"), "pods_port_forward should be registered")
+	})
+	s.Run("pods_port_forward_stop is registered", func() {
+		s.True(s.hasTool("pods_port_forward_stop"), "pods_port_forward_stop should be registered")
+	})
+	s.Run("pods_port_forward_list is registered", func() {
+		s.True(s.hasTool("pods_port_forward_list"), "pods_port_forward_list should be registered")
+	})
+	s.Run("pods_attach is registered", func() {
+		s.True(s.hasTool("pods_attach"), "pods_attach should be registered")
+	})
+}
+
+func (s *NewToolsSuite) TestHPAToolsRegistered() {
+	s.Run("horizontalpodautoscalers_list is registered", func() {
+		s.True(s.hasTool("horizontalpodautoscalers_list"), "horizontalpodautoscalers_list should be registered")
+	})
+	s.Run("horizontalpodautoscalers_get is registered", func() {
+		s.True(s.hasTool("horizontalpodautoscalers_get"), "horizontalpodautoscalers_get should be registered")
+	})
+	s.Run("horizontalpodautoscalers_create is registered", func() {
+		s.True(s.hasTool("horizontalpodautoscalers_create"), "horizontalpodautoscalers_create should be registered")
+	})
+	s.Run("horizontalpodautoscalers_delete is registered", func() {
+		s.True(s.hasTool("horizontalpodautoscalers_delete"), "horizontalpodautoscalers_delete should be registered")
+	})
+}
+
+func (s *NewToolsSuite) TestPDBToolsRegistered() {
+	s.Run("poddisruptionbudgets_list is registered", func() {
+		s.True(s.hasTool("poddisruptionbudgets_list"), "poddisruptionbudgets_list should be registered")
+	})
+	s.Run("poddisruptionbudgets_get is registered", func() {
+		s.True(s.hasTool("poddisruptionbudgets_get"), "poddisruptionbudgets_get should be registered")
+	})
+	s.Run("poddisruptionbudgets_create is registered", func() {
+		s.True(s.hasTool("poddisruptionbudgets_create"), "poddisruptionbudgets_create should be registered")
+	})
+	s.Run("poddisruptionbudgets_delete is registered", func() {
+		s.True(s.hasTool("poddisruptionbudgets_delete"), "poddisruptionbudgets_delete should be registered")
+	})
+}
+
+func (s *NewToolsSuite) TestResourceQuotaToolsRegistered() {
+	s.Run("resourcequotas_list is registered", func() {
+		s.True(s.hasTool("resourcequotas_list"), "resourcequotas_list should be registered")
+	})
+	s.Run("resourcequotas_get is registered", func() {
+		s.True(s.hasTool("resourcequotas_get"), "resourcequotas_get should be registered")
+	})
+	s.Run("resourcequotas_create is registered", func() {
+		s.True(s.hasTool("resourcequotas_create"), "resourcequotas_create should be registered")
+	})
+	s.Run("resourcequotas_delete is registered", func() {
+		s.True(s.hasTool("resourcequotas_delete"), "resourcequotas_delete should be registered")
+	})
+}
+
+func (s *NewToolsSuite) TestLimitRangeToolsRegistered() {
+	s.Run("limitranges_list is registered", func() {
+		s.True(s.hasTool("limitranges_list"), "limitranges_list should be registered")
+	})
+	s.Run("limitranges_get is registered", func() {
+		s.True(s.hasTool("limitranges_get"), "limitranges_get should be registered")
+	})
+	s.Run("limitranges_create is registered", func() {
+		s.True(s.hasTool("limitranges_create"), "limitranges_create should be registered")
+	})
+	s.Run("limitranges_delete is registered", func() {
+		s.True(s.hasTool("limitranges_delete"), "limitranges_delete should be registered")
+	})
+}
+
+func (s *NewToolsSuite) TestPodsLogHasFollowParameter() {
+	s.Run("pods_log schema includes follow parameter", func() {
+		tools := s.toolset.GetTools(mockFilteringProvider{})
+		for _, t := range tools {
+			if t.Tool.Name == "pods_log" {
+				props := t.Tool.InputSchema.Properties
+				_, hasFollow := props["follow"]
+				s.True(hasFollow, "pods_log should have a 'follow' parameter")
+				_, hasSinceSeconds := props["since_seconds"]
+				s.True(hasSinceSeconds, "pods_log should have a 'since_seconds' parameter")
+				return
+			}
+		}
+		s.Fail("pods_log tool not found")
+	})
+}
+
+func (s *NewToolsSuite) TestAllNewToolsHaveHandlers() {
+	s.Run("every new tool has a non-nil handler", func() {
+		tools := s.toolset.GetTools(mockFilteringProvider{})
+		newToolNames := []string{
+			"nodes_cordon", "nodes_uncordon", "nodes_drain",
+			"nodes_patch_label", "nodes_patch_taint",
+			"rollout_status", "rollout_history", "rollout_undo", "rollout_restart",
+			"pods_port_forward", "pods_port_forward_stop", "pods_port_forward_list",
+			"pods_attach",
+			"horizontalpodautoscalers_list", "horizontalpodautoscalers_get",
+			"horizontalpodautoscalers_create", "horizontalpodautoscalers_delete",
+			"poddisruptionbudgets_list", "poddisruptionbudgets_get",
+			"poddisruptionbudgets_create", "poddisruptionbudgets_delete",
+			"resourcequotas_list", "resourcequotas_get",
+			"resourcequotas_create", "resourcequotas_delete",
+			"limitranges_list", "limitranges_get",
+			"limitranges_create", "limitranges_delete",
+		}
+		for _, name := range newToolNames {
+			found := false
+			for _, t := range tools {
+				if t.Tool.Name == name {
+					found = true
+					s.NotNil(t.Handler, "tool %s should have a non-nil handler", name)
+					break
+				}
+			}
+			s.Truef(found, "tool %s should be registered", name)
+		}
+	})
+}
+
+func TestNewToolsSuite(t *testing.T) {
+	suite.Run(t, new(NewToolsSuite))
+}

--- a/pkg/toolsets/core/nodes_ops.go
+++ b/pkg/toolsets/core/nodes_ops.go
@@ -1,0 +1,265 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/utils/ptr"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+)
+
+func initNodeOps() []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "nodes_cordon",
+				Description: "Cordon a Kubernetes Node, marking it as unschedulable so no new pods are placed on it. Existing pods are not evicted. Mirrors `kubectl cordon`",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"name": {
+							Type:        "string",
+							Description: "Name of the Node to cordon",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Node: Cordon",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: nodesCordon,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "nodes_uncordon",
+				Description: "Uncordon a Kubernetes Node, marking it as schedulable again so new pods can be placed on it. Mirrors `kubectl uncordon`",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"name": {
+							Type:        "string",
+							Description: "Name of the Node to uncordon",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Node: Uncordon",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: nodesUncordon,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "nodes_drain",
+				Description: "Drain a Kubernetes Node by cordoning it and evicting all its pods. Mirrors `kubectl drain`. Use caution: this evicts running workloads. DaemonSet pods and mirror pods are skipped by default when ignore_all_daemonsets is true",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"name": {
+							Type:        "string",
+							Description: "Name of the Node to drain",
+						},
+						"force": {
+							Type:        "boolean",
+							Description: "If true, continue even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet, or StatefulSet (Optional, default: false)",
+							Default:     api.ToRawMessage(false),
+						},
+						"ignore_all_daemonsets": {
+							Type:        "boolean",
+							Description: "If true, ignore DaemonSet-managed pods and continue draining (Optional, default: true)",
+							Default:     api.ToRawMessage(true),
+						},
+						"delete_emptydir_data": {
+							Type:        "boolean",
+							Description: "If true, continue even if pods are using emptyDir volumes (Optional, default: false)",
+							Default:     api.ToRawMessage(false),
+						},
+						"disable_eviction": {
+							Type:        "boolean",
+							Description: "If true, force-delete pods instead of evicting them. Use only if eviction is blocked (Optional, default: false)",
+							Default:     api.ToRawMessage(false),
+						},
+						"grace_period_seconds": {
+							Type:        "integer",
+							Description: "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used (Optional, default: -1)",
+							Default:     api.ToRawMessage(-1),
+						},
+						"timeout": {
+							Type:        "integer",
+							Description: "The length of time in seconds to wait before giving up on draining a node, zero means infinite (Optional, default: 0)",
+							Default:     api.ToRawMessage(0),
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Node: Drain",
+					DestructiveHint: ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: nodesDrain,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "nodes_patch_label",
+				Description: "Set or remove a single label on a Kubernetes Node. Providing an empty value removes the label. Useful for managing scheduling constraints and node grouping",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"name": {
+							Type:        "string",
+							Description: "Name of the Node to patch",
+						},
+						"key": {
+							Type:        "string",
+							Description: "Label key to set or remove (e.g. 'node-role.kubernetes.io/worker')",
+						},
+						"value": {
+							Type:        "string",
+							Description: "Label value to set. An empty string removes the label",
+						},
+					},
+					Required: []string{"name", "key"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Node: Patch Label",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: nodesPatchLabel,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "nodes_patch_taint",
+				Description: "Set or remove a single taint on a Kubernetes Node. Taints repel pods unless a pod tolerates them. Use effect values NoSchedule, PreferNoSchedule, or NoExecute",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"name": {
+							Type:        "string",
+							Description: "Name of the Node to patch",
+						},
+						"key": {
+							Type:        "string",
+							Description: "Taint key (e.g. 'dedicated')",
+						},
+						"value": {
+							Type:        "string",
+							Description: "Taint value (e.g. 'gpu'). Optional when removing",
+						},
+						"effect": {
+							Type:        "string",
+							Description: "Taint effect: NoSchedule, PreferNoSchedule, or NoExecute",
+							Enum:        []any{"NoSchedule", "PreferNoSchedule", "NoExecute"},
+						},
+						"remove": {
+							Type:        "boolean",
+							Description: "If true, remove the taint matching key/effect instead of adding it (Optional, default: false)",
+							Default:     api.ToRawMessage(false),
+						},
+					},
+					Required: []string{"name", "key", "effect"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Node: Patch Taint",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: nodesPatchTaint,
+		},
+	}
+}
+
+func nodesCordon(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to cordon node: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).NodeCordon(params.Context, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to cordon node %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func nodesUncordon(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to uncordon node: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).NodeUncordon(params.Context, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to uncordon node %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func nodesDrain(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	opts := kubernetes.NodeDrainOptions{
+		Force:               p.OptionalBool("force", false),
+		IgnoreAllDaemonSets: p.OptionalBool("ignore_all_daemonsets", true),
+		DeleteEmptyDirData:  p.OptionalBool("delete_emptydir_data", false),
+		DisableEviction:     p.OptionalBool("disable_eviction", false),
+		GracePeriodSeconds:  int(p.OptionalInt64("grace_period_seconds", -1)),
+		Timeout:             int(p.OptionalInt64("timeout", 0)),
+	}
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to drain node: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).NodeDrain(params.Context, name, opts)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to drain node %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func nodesPatchLabel(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	key := p.RequiredString("key")
+	value := p.OptionalString("value", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to patch node label: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).NodePatchLabel(params.Context, name, key, value)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to patch label on node %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func nodesPatchTaint(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	name := p.RequiredString("name")
+	key := p.RequiredString("key")
+	effect := p.RequiredString("effect")
+	value := p.OptionalString("value", "")
+	remove := p.OptionalBool("remove", false)
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to patch node taint: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).NodePatchTaint(params.Context, name, key, value, effect, remove)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to patch taint on node %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}

--- a/pkg/toolsets/core/pod_ops.go
+++ b/pkg/toolsets/core/pod_ops.go
@@ -1,0 +1,194 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/utils/ptr"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+)
+
+func initPodOps() []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "pods_port_forward",
+				Description: "Start port-forwarding a local port to a port on a Kubernetes Pod. Runs in the background and returns a session id plus the local address you can connect to. Use pods_port_forward_stop with the returned id to terminate the session. Mirrors `kubectl port-forward pod`",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace of the Pod (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the Pod to forward to",
+						},
+						"local_port": {
+							Type:        "integer",
+							Description: "Local port to listen on. If 0 or omitted, a free port is chosen automatically",
+							Minimum:     ptr.To(float64(0)),
+						},
+						"remote_port": {
+							Type:        "integer",
+							Description: "Port on the Pod to forward to (the container port)",
+							Minimum:     ptr.To(float64(1)),
+						},
+					},
+					Required: []string{"name", "remote_port"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Pods: Port Forward",
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: podsPortForward,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "pods_port_forward_stop",
+				Description: "Stop a running port-forward session by its session id, releasing the local port. Returns the session details that were stopped",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"id": {
+							Type:        "string",
+							Description: "Session id returned by pods_port_forward",
+						},
+					},
+					Required: []string{"id"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Pods: Port Forward Stop",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: podsPortForwardStop,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "pods_port_forward_list",
+				Description: "List all active port-forward sessions, showing their session id, target pod, namespace, and local/remote ports",
+				InputSchema: &jsonschema.Schema{
+					Type:       "object",
+					Properties: map[string]*jsonschema.Schema{},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Pods: Port Forward List",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: podsPortForwardList,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "pods_attach",
+				Description: "Attach to a running container in a Kubernetes Pod, capturing its stdout and stderr. Unlike exec, attach connects to the container's primary process (PID 1) rather than starting a new command. Mirrors `kubectl attach`",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace of the Pod (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the Pod to attach to",
+						},
+						"container": {
+							Type:        "string",
+							Description: "Name of the Pod container to attach to (Optional, defaults to the first or kubectl default-container annotation)",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Pods: Attach",
+					DestructiveHint: ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: podsAttach,
+		},
+	}
+}
+
+func podsPortForward(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	localPort := int(p.OptionalInt64("local_port", 0))
+	remotePort := int(p.RequiredInt64("remote_port"))
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to start port forward: %w", err)), nil
+	}
+	session, err := kubernetes.NewCore(params).PodsPortForward(params.Context, ns, name, localPort, remotePort)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to start port forward to pod %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(fmt.Sprintf(
+		"Port forward started (session %s): 127.0.0.1:%d -> %s/%s:%d\nUse pods_port_forward_stop with id %s to stop.",
+		session.ID, session.LocalPort, session.Namespace, session.PodName, session.RemotePort, session.ID,
+	), nil), nil
+}
+
+func podsPortForwardStop(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	id := p.RequiredString("id")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to stop port forward: %w", err)), nil
+	}
+	if err := kubernetes.StopPortForward(id); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to stop port forward %s: %w", id, err)), nil
+	}
+	return api.NewToolCallResult(fmt.Sprintf("Port forward session %s stopped", id), nil), nil
+}
+
+func podsPortForwardList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	sessions := kubernetes.ListPortForwards()
+	if len(sessions) == 0 {
+		return api.NewToolCallResult("No active port forward sessions", nil), nil
+	}
+	var b []byte
+	b = fmtAppendf(b, "ID\tNAMESPACE\tPOD\tLOCAL\tREMOTE\n")
+	for _, s := range sessions {
+		b = fmtAppendf(b, "%s\t%s\t%s\t%d\t%d\n", s.ID, s.Namespace, s.PodName, s.LocalPort, s.RemotePort)
+	}
+	return api.NewToolCallResult(string(b), nil), nil
+}
+
+func podsAttach(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	container := p.OptionalString("container", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to attach to pod: %w", err)), nil
+	}
+	stdout, stderr, err := kubernetes.NewCore(params).PodsAttach(params.Context, ns, name, container)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to attach to pod %s in namespace %s: %w", name, ns, err)), nil
+	}
+	ret := stdout
+	if ret == "" && stderr != "" {
+		ret = stderr
+	}
+	if ret == "" {
+		ret = fmt.Sprintf("Attached to pod %s in namespace %s; no output produced", name, ns)
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+// fmtAppendf appends a formatted string to a byte slice.
+func fmtAppendf(b []byte, format string, args ...interface{}) []byte {
+	return append(b, []byte(fmt.Sprintf(format, args...))...)
+}

--- a/pkg/toolsets/core/pods.go
+++ b/pkg/toolsets/core/pods.go
@@ -215,6 +215,17 @@ func initPods() []api.ServerTool {
 						Type:        "boolean",
 						Description: "Return previous terminated container logs (Optional)",
 					},
+					"follow": {
+						Type:        "boolean",
+						Description: "Follow the log output, streaming new log lines as they are produced. The call blocks until the timeout (since_seconds) elapses or the container exits, then returns all lines collected so far (Optional, default: false)",
+						Default:     api.ToRawMessage(false),
+					},
+					"since_seconds": {
+						Type:        "integer",
+						Description: "When follow is true, the maximum number of seconds to stream logs before returning. A value of 0 means no timeout (block until the container exits) (Optional, default: 10). Ignored when follow is false",
+						Default:     api.ToRawMessage(10),
+						Minimum:     ptr.To(float64(0)),
+					},
 				},
 				Required: []string{"name"},
 			},
@@ -389,10 +400,12 @@ func podsLog(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	container := p.OptionalString("container", "")
 	previousBool := p.OptionalBool("previous", false)
 	tailInt := p.OptionalInt64("tail", 0)
+	followBool := p.OptionalBool("follow", false)
+	sinceSeconds := p.OptionalInt64("since_seconds", 10)
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod log: %w", err)), nil
 	}
-	ret, err := kubernetes.NewCore(params).PodsLog(params.Context, ns, name, container, previousBool, tailInt)
+	ret, err := kubernetes.NewCore(params).PodsLog(params.Context, ns, name, container, previousBool, tailInt, followBool, sinceSeconds)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pod %s log in namespace %s: %w", name, ns, err)), nil
 	} else if ret == "" {

--- a/pkg/toolsets/core/rollout.go
+++ b/pkg/toolsets/core/rollout.go
@@ -1,0 +1,188 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/utils/ptr"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+)
+
+func initRollout() []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "rollout_status",
+				Description: "Check the rollout status of a Kubernetes Deployment in the current or provided namespace. Reports whether the rollout is complete, in progress, or has failed (e.g. progress deadline exceeded). Mirrors `kubectl rollout status deployment`",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace of the Deployment (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the Deployment to check rollout status for",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Rollout: Status",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: rolloutStatus,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "rollout_history",
+				Description: "View the rollout history (revisions) of a Kubernetes Deployment in the current or provided namespace. Lists each revision with its image. Mirrors `kubectl rollout history deployment`",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace of the Deployment (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the Deployment to view rollout history for",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Rollout: History",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: rolloutHistory,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "rollout_undo",
+				Description: "Rollback a Kubernetes Deployment to a previous revision. If to_revision is not provided, rolls back to the immediately previous revision. Mirrors `kubectl rollout undo deployment`",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace of the Deployment (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the Deployment to roll back",
+						},
+						"to_revision": {
+							Type:        "integer",
+							Description: "Revision number to roll back to (Optional, defaults to the previous revision)",
+							Minimum:     ptr.To(float64(0)),
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Rollout: Undo",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: rolloutUndo,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "rollout_restart",
+				Description: "Trigger a rolling restart of a Kubernetes Deployment by patching the pod template with a restart timestamp. Existing pods are replaced gradually. Mirrors `kubectl rollout restart deployment`",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace of the Deployment (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the Deployment to restart",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Rollout: Restart",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: rolloutRestart,
+		},
+	}
+}
+
+func rolloutStatus(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get rollout status: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).DeploymentRolloutStatus(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get rollout status for deployment %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func rolloutHistory(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get rollout history: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).DeploymentRolloutHistory(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get rollout history for deployment %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func rolloutUndo(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	toRevision := p.OptionalInt64("to_revision", 0)
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to roll back deployment: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).DeploymentRolloutUndo(params.Context, ns, name, toRevision)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to roll back deployment %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func rolloutRestart(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to restart deployment: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).DeploymentRestart(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to restart deployment %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}

--- a/pkg/toolsets/core/toolset.go
+++ b/pkg/toolsets/core/toolset.go
@@ -30,7 +30,11 @@ func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
 		initEvents(),
 		initNamespaces(p),
 		initNodes(),
+		initNodeOps(),
 		initPods(),
+		initPodOps(),
+		initRollout(),
+		initWorkloadResources(),
 		initResources(p),
 	)
 }

--- a/pkg/toolsets/core/workload_resources.go
+++ b/pkg/toolsets/core/workload_resources.go
@@ -1,0 +1,636 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/utils/ptr"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+)
+
+func initWorkloadResources() []api.ServerTool {
+	return []api.ServerTool{
+		// --- HorizontalPodAutoscaler ---
+		{
+			Tool: api.Tool{
+				Name:        "horizontalpodautoscalers_list",
+				Description: "List Kubernetes HorizontalPodAutoscalers (HPAs) in the current cluster from all namespaces or the provided namespace. Shows autoscaling rules and current/target metrics for workloads",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Optional Namespace to retrieve HPAs from. If not provided, lists HPAs from all namespaces",
+						},
+					},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "HorizontalPodAutoscalers: List",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: hpasList,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "horizontalpodautoscalers_get",
+				Description: "Get a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, showing its scaling rules, targets, and current status",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace to get the HPA from (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the HPA",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "HorizontalPodAutoscaler: Get",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: hpaGet,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "horizontalpodautoscalers_create",
+				Description: "Create a Kubernetes HorizontalPodAutoscaler (HPA) from a YAML or JSON manifest. The manifest must be a complete HPA definition with apiVersion autoscaling/v2",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"manifest": {
+							Type:        "string",
+							Description: "Complete YAML or JSON manifest of the HorizontalPodAutoscaler (apiVersion: autoscaling/v2, kind: HorizontalPodAutoscaler)",
+						},
+					},
+					Required: []string{"manifest"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "HorizontalPodAutoscaler: Create",
+					DestructiveHint: ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: hpaCreate,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "horizontalpodautoscalers_delete",
+				Description: "Delete a Kubernetes HorizontalPodAutoscaler (HPA) by name in the current or provided namespace, removing its autoscaling rules",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace to delete the HPA from (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the HPA to delete",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "HorizontalPodAutoscaler: Delete",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: hpaDelete,
+		},
+		// --- PodDisruptionBudget ---
+		{
+			Tool: api.Tool{
+				Name:        "poddisruptionbudgets_list",
+				Description: "List Kubernetes PodDisruptionBudgets (PDBs) in the current cluster from all namespaces or the provided namespace. Shows the allowed disruptions and current/min available pod counts",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Optional Namespace to retrieve PDBs from. If not provided, lists PDBs from all namespaces",
+						},
+					},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "PodDisruptionBudgets: List",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: pdbsList,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "poddisruptionbudgets_get",
+				Description: "Get a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace, showing its selector, allowed disruptions, and status",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace to get the PDB from (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the PDB",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "PodDisruptionBudget: Get",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: pdbGet,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "poddisruptionbudgets_create",
+				Description: "Create a Kubernetes PodDisruptionBudget (PDB) from a YAML or JSON manifest. The manifest must be a complete PDB definition with apiVersion policy/v1",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"manifest": {
+							Type:        "string",
+							Description: "Complete YAML or JSON manifest of the PodDisruptionBudget (apiVersion: policy/v1, kind: PodDisruptionBudget)",
+						},
+					},
+					Required: []string{"manifest"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "PodDisruptionBudget: Create",
+					DestructiveHint: ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: pdbCreate,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "poddisruptionbudgets_delete",
+				Description: "Delete a Kubernetes PodDisruptionBudget (PDB) by name in the current or provided namespace",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace to delete the PDB from (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the PDB to delete",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "PodDisruptionBudget: Delete",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: pdbDelete,
+		},
+		// --- ResourceQuota ---
+		{
+			Tool: api.Tool{
+				Name:        "resourcequotas_list",
+				Description: "List Kubernetes ResourceQuotas in the current cluster from all namespaces or the provided namespace. Shows namespace-level resource limits and current usage",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Optional Namespace to retrieve ResourceQuotas from. If not provided, lists ResourceQuotas from all namespaces",
+						},
+					},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "ResourceQuotas: List",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: resourceQuotasList,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "resourcequotas_get",
+				Description: "Get a Kubernetes ResourceQuota by name in the current or provided namespace, showing its hard limits and current usage",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace to get the ResourceQuota from (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the ResourceQuota",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "ResourceQuota: Get",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: resourceQuotaGet,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "resourcequotas_create",
+				Description: "Create a Kubernetes ResourceQuota from a YAML or JSON manifest. The manifest must be a complete ResourceQuota definition with apiVersion v1",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"manifest": {
+							Type:        "string",
+							Description: "Complete YAML or JSON manifest of the ResourceQuota (apiVersion: v1, kind: ResourceQuota)",
+						},
+					},
+					Required: []string{"manifest"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "ResourceQuota: Create",
+					DestructiveHint: ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: resourceQuotaCreate,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "resourcequotas_delete",
+				Description: "Delete a Kubernetes ResourceQuota by name in the current or provided namespace",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace to delete the ResourceQuota from (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the ResourceQuota to delete",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "ResourceQuota: Delete",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: resourceQuotaDelete,
+		},
+		// --- LimitRange ---
+		{
+			Tool: api.Tool{
+				Name:        "limitranges_list",
+				Description: "List Kubernetes LimitRanges in the current cluster from all namespaces or the provided namespace. Shows per-container default resource limits enforced in each namespace",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Optional Namespace to retrieve LimitRanges from. If not provided, lists LimitRanges from all namespaces",
+						},
+					},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "LimitRanges: List",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: limitRangesList,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "limitranges_get",
+				Description: "Get a Kubernetes LimitRange by name in the current or provided namespace, showing its per-container resource default/min/max limits",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace to get the LimitRange from (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the LimitRange",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "LimitRange: Get",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: limitRangeGet,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "limitranges_create",
+				Description: "Create a Kubernetes LimitRange from a YAML or JSON manifest. The manifest must be a complete LimitRange definition with apiVersion v1",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"manifest": {
+							Type:        "string",
+							Description: "Complete YAML or JSON manifest of the LimitRange (apiVersion: v1, kind: LimitRange)",
+						},
+					},
+					Required: []string{"manifest"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "LimitRange: Create",
+					DestructiveHint: ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: limitRangeCreate,
+		},
+		{
+			Tool: api.Tool{
+				Name:        "limitranges_delete",
+				Description: "Delete a Kubernetes LimitRange by name in the current or provided namespace",
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "Namespace to delete the LimitRange from (Optional, current namespace if not provided)",
+						},
+						"name": {
+							Type:        "string",
+							Description: "Name of the LimitRange to delete",
+						},
+					},
+					Required: []string{"name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "LimitRange: Delete",
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(true),
+				},
+			},
+			Handler: limitRangeDelete,
+		},
+	}
+}
+
+// --- HPA handlers ---
+
+func hpasList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list HPAs: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).HPAsList(params.Context, ns)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list horizontalpodautoscalers: %w", err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func hpaGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get HPA: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).HPAGet(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get horizontalpodautoscaler %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func hpaCreate(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	manifest := p.RequiredString("manifest")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to create HPA: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).HPACreate(params.Context, manifest)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to create horizontalpodautoscaler: %w", err)), nil
+	}
+	return api.NewToolCallResult("# The following HorizontalPodAutoscaler (YAML) has been created successfully\n"+ret, nil), nil
+}
+
+func hpaDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to delete HPA: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).HPADelete(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to delete horizontalpodautoscaler %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+// --- PDB handlers ---
+
+func pdbsList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list PDBs: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).PDBsList(params.Context, ns)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list poddisruptionbudgets: %w", err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func pdbGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get PDB: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).PDBGet(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get poddisruptionbudget %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func pdbCreate(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	manifest := p.RequiredString("manifest")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to create PDB: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).PDBCreate(params.Context, manifest)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to create poddisruptionbudget: %w", err)), nil
+	}
+	return api.NewToolCallResult("# The following PodDisruptionBudget (YAML) has been created successfully\n"+ret, nil), nil
+}
+
+func pdbDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to delete PDB: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).PDBDelete(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to delete poddisruptionbudget %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+// --- ResourceQuota handlers ---
+
+func resourceQuotasList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list ResourceQuotas: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).ResourceQuotasList(params.Context, ns)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list resourcequotas: %w", err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func resourceQuotaGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get ResourceQuota: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).ResourceQuotaGet(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get resourcequota %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func resourceQuotaCreate(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	manifest := p.RequiredString("manifest")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to create ResourceQuota: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).ResourceQuotaCreate(params.Context, manifest)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to create resourcequota: %w", err)), nil
+	}
+	return api.NewToolCallResult("# The following ResourceQuota (YAML) has been created successfully\n"+ret, nil), nil
+}
+
+func resourceQuotaDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to delete ResourceQuota: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).ResourceQuotaDelete(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to delete resourcequota %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+// --- LimitRange handlers ---
+
+func limitRangesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list LimitRanges: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).LimitRangesList(params.Context, ns)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to list limitranges: %w", err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func limitRangeGet(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get LimitRange: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).LimitRangeGet(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to get limitrange %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}
+
+func limitRangeCreate(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	manifest := p.RequiredString("manifest")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to create LimitRange: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).LimitRangeCreate(params.Context, manifest)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to create limitrange: %w", err)), nil
+	}
+	return api.NewToolCallResult("# The following LimitRange (YAML) has been created successfully\n"+ret, nil), nil
+}
+
+func limitRangeDelete(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	ns := p.OptionalString("namespace", "")
+	name := p.RequiredString("name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to delete LimitRange: %w", err)), nil
+	}
+	ret, err := kubernetes.NewCore(params).LimitRangeDelete(params.Context, ns, name)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to delete limitrange %s: %w", name, err)), nil
+	}
+	return api.NewToolCallResult(ret, nil), nil
+}

--- a/pkg/toolsets/kubevirt/vm_troubleshoot.go
+++ b/pkg/toolsets/kubevirt/vm_troubleshoot.go
@@ -344,7 +344,7 @@ func fetchVirtLauncherPodLogs(ctx context.Context, client api.KubernetesClient, 
 		fmt.Fprintf(&result, "#### Pod: %s\n\n", podName)
 
 		// Fetch last 50 lines of logs
-		logs, err := core.PodsLog(ctx, namespace, podName, containerName, false, 50)
+		logs, err := core.PodsLog(ctx, namespace, podName, containerName, false, 50, false, 0)
 		if err != nil {
 			return fmt.Sprintf("### virt-launcher Pod Logs\n\n*Error fetching logs: %v*", err)
 		}


### PR DESCRIPTION
## Summary

Adds 29 new MCP tools covering the missing scaling, rollout, pod exec/port-forward/attach, autoscaling, PDB, resource quota, limit range, and node management operations identified in the gap analysis.

## New Tools

### Node Management (5 tools)
- **`nodes_cordon`** / **`nodes_uncordon`** — mark nodes unschedulable/schedulable (mirrors `kubectl cordon`/`uncordon`)
- **`nodes_drain`** — cordon + evict all pods with configurable force, ignore-daemonsets, grace-period, timeout (mirrors `kubectl drain`)
- **`nodes_patch_label`** — set or remove a single node label
- **`nodes_patch_taint`** — set or remove a single node taint (NoSchedule/PreferNoSchedule/NoExecute)

### Rollout Management (4 tools)
- **`rollout_status`** — check deployment rollout status (complete/in-progress/failed)
- **`rollout_history`** — view deployment revision history with images
- **`rollout_undo`** — rollback to previous or specific revision
- **`rollout_restart`** — trigger rolling restart via pod template annotation patch

### Pod Operations (4 tools)
- **`pods_port_forward`** — start background port-forward; returns session id + local address
- **`pods_port_forward_stop`** — stop a port-forward session by id
- **`pods_port_forward_list`** — list active port-forward sessions
- **`pods_attach`** — attach to a running container's primary process (PID 1)

### Log Streaming Enhancement
- **`pods_log`** — added `follow` (boolean) and `since_seconds` (integer) parameters for real-time log streaming with bounded timeout

### Autoscaling (4 tools)
- **`horizontalpodautoscalers_list`** / **`_get`** / **`_create`** / **`_delete`** — full HPA lifecycle (autoscaling/v2)

### PodDisruptionBudget (4 tools)
- **`poddisruptionbudgets_list`** / **`_get`** / **`_create`** / **`_delete`** — full PDB lifecycle (policy/v1)

### Resource Quotas (4 tools)
- **`resourcequotas_list`** / **`_get`** / **`_create`** / **`_delete`** — full ResourceQuota lifecycle (v1)

### LimitRanges (4 tools)
- **`limitranges_list`** / **`_get`** / **`_create`** / **`_delete`** — full LimitRange lifecycle (v1)

## Implementation Details

- Followed the project's toolset architecture: kubernetes client layer methods in `pkg/kubernetes/`, tool definitions in `pkg/toolsets/core/`
- Added `RequiredInt64` helper to `api.Params` for required integer parameters
- Added `decodeManifest` helper using `serializer.NewCodecFactory(Scheme).UniversalDeserializer()` for YAML/JSON manifest decoding
- Port-forward uses managed background goroutines with a session registry (start/stop/list)
- Rollout undo patches the deployment spec template with the target ReplicaSet's template
- Updated kubevirt `vm_troubleshoot.go` to match the new `PodsLog` signature

## Testing

- Added `NewToolsSuite` with registration tests verifying all 29 new tools are registered with correct names, handlers, and schemas
- `pods_log` follow/since_seconds parameter test included
- All existing tests pass (`pkg/toolsets/core`, `pkg/api`, `pkg/kubernetes`, `pkg/mcp`)
- Golden JSON fixtures regenerated with `UPDATE_TOOLSETS_JSON=1`
- `go vet` clean, `gofmt` clean, `go build ./...` succeeds

## Files Changed

**New files:**
- `pkg/kubernetes/node_ops.go` — cordon/uncordon/drain/label/taint client methods
- `pkg/kubernetes/rollout.go` — rollout status/history/undo/restart client methods
- `pkg/kubernetes/portforward.go` — port-forward session management
- `pkg/kubernetes/attach.go` — pod attach client method
- `pkg/kubernetes/workload_resources.go` — HPA/PDB/ResourceQuota/LimitRange client methods
- `pkg/kubernetes/manifest.go` — manifest decoding helper
- `pkg/toolsets/core/nodes_ops.go` — node management tool definitions
- `pkg/toolsets/core/rollout.go` — rollout tool definitions
- `pkg/toolsets/core/pod_ops.go` — port-forward/attach tool definitions
- `pkg/toolsets/core/workload_resources.go` — HPA/PDB/ResourceQuota/LimitRange tool definitions
- `pkg/toolsets/core/new_tools_test.go` — registration tests

**Modified files:**
- `pkg/api/params.go` — added `RequiredInt64`
- `pkg/kubernetes/pods.go` — added `follow`/`sinceSeconds` to `PodsLog`
- `pkg/toolsets/core/pods.go` — added `follow`/`since_seconds` to `pods_log` tool
- `pkg/toolsets/core/toolset.go` — wired new tool initializers
- `pkg/toolsets/kubevirt/vm_troubleshoot.go` — updated `PodsLog` call signature
- `README.md` — auto-generated tool tables updated
- `pkg/mcp/testdata/*.json` — golden JSON fixtures regenerated