### PR TITLE
fix(netobserv): harden OpenShift detection and TLS handling

### DIFF
--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -166,6 +166,7 @@ type ToolHandlerParams struct {
 	context.Context
 	BaseConfig
 	KubernetesClient
+	FilteringProvider FilteringProvider
 	ToolCallRequest
 	ListOutput output.Output
 	Elicitor

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -83,12 +83,13 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 		}
 
 		result, err := tool.Handler(api.ToolHandlerParams{
-			Context:          ctx,
-			BaseConfig:       cfg,
-			KubernetesClient: k,
-			ToolCallRequest:  toolCallRequest,
-			ListOutput:       cfg.ListOutput(),
-			Elicitor:         &sessionElicitor{},
+			Context:           ctx,
+			BaseConfig:        cfg,
+			KubernetesClient:  k,
+			FilteringProvider: s.p,
+			ToolCallRequest:   toolCallRequest,
+			ListOutput:        cfg.ListOutput(),
+			Elicitor:          &sessionElicitor{},
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/netobserv/config.go
+++ b/pkg/netobserv/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
-	"k8s.io/klog/v2"
 )
 
 // Config holds NetObserv console plugin backend configuration.
@@ -57,11 +56,11 @@ func (c *Config) usesSynthesizedURL() bool {
 }
 
 // applyDefaults sets certificate_authority from the projected service CA on OpenShift when url is synthesized.
-func (c *Config) applyDefaults(isOpenShift bool) {
-	c.applyDefaultsWithStat(isOpenShift, os.Stat)
+func (c *Config) applyDefaults(ctx context.Context, isOpenShift bool) {
+	c.applyDefaultsWithStat(ctx, isOpenShift, os.Stat)
 }
 
-func (c *Config) applyDefaultsWithStat(isOpenShift bool, stat func(string) (os.FileInfo, error)) {
+func (c *Config) applyDefaultsWithStat(ctx context.Context, isOpenShift bool, stat func(string) (os.FileInfo, error)) {
 	if c == nil || !c.usesSynthesizedURL() || !isOpenShift {
 		return
 	}
@@ -73,7 +72,7 @@ func (c *Config) applyDefaultsWithStat(isOpenShift bool, stat func(string) (os.F
 		return
 	}
 	klogutil.LogInfo(
-		klog.Background(),
+		klogutil.FromContext(ctx),
 		"NetObserv plugin TLS: service CA not found; set certificate_authority or insecure=true",
 		klogutil.Field("path", DefaultPluginServiceCAPath),
 	)
@@ -128,7 +127,7 @@ func netobservToolsetParser(ctx context.Context, primitive toml.Primitive, md to
 		}
 	}
 
-	cfg.applyDefaults(configLoadOpenShift)
+	cfg.applyDefaults(ctx, configLoadOpenShift)
 
 	if err := cfg.validate(configLoadOpenShift); err != nil {
 		return nil, err

--- a/pkg/netobserv/config_test.go
+++ b/pkg/netobserv/config_test.go
@@ -1,6 +1,7 @@
 package netobserv
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -54,7 +55,7 @@ func (s *ConfigSuite) TestNewNetObserv_doesNotMutateSharedConfig() {
 	caFile := filepath.Join(s.T().TempDir(), "service-ca.crt")
 	s.Require().NoError(os.WriteFile(caFile, []byte("test ca"), 0644))
 	resolved := *sharedCfg
-	resolved.applyDefaultsWithStat(true, func(path string) (os.FileInfo, error) {
+	resolved.applyDefaultsWithStat(context.Background(), true, func(path string) (os.FileInfo, error) {
 		if path == DefaultPluginServiceCAPath {
 			return os.Stat(caFile)
 		}
@@ -68,21 +69,21 @@ func (s *ConfigSuite) TestNewNetObserv_doesNotMutateSharedConfig() {
 func (s *ConfigSuite) TestNewNetObserv_withoutToolsetConfigSection() {
 	base := config.BaseDefault()
 	base.Toolsets = append(base.Toolsets, "netobserv")
-	client := NewNetObserv(base, nil)
+	client := NewNetObserv(context.Background(), base, nil, nil)
 	s.Equal(DefaultPluginURL(false), client.pluginURL)
 	s.False(client.insecure)
 }
 
 func (s *ConfigSuite) TestApplyDefaults_explicitURLUnchanged() {
 	cfg := &Config{Url: "http://localhost:9001"}
-	cfg.applyDefaults(true)
+	cfg.applyDefaults(context.Background(), true)
 	s.False(cfg.Insecure)
 	s.Empty(cfg.CertificateAuthority)
 }
 
 func (s *ConfigSuite) TestApplyDefaults_skipsTLSOnNonOpenShift() {
 	cfg := &Config{}
-	cfg.applyDefaults(false)
+	cfg.applyDefaults(context.Background(), false)
 	s.False(cfg.Insecure)
 	s.Empty(cfg.CertificateAuthority)
 }
@@ -91,7 +92,7 @@ func (s *ConfigSuite) TestApplyDefaults_usesServiceCAWhenPresent() {
 	caFile := filepath.Join(s.T().TempDir(), "service-ca.crt")
 	s.Require().NoError(os.WriteFile(caFile, []byte("test ca"), 0644))
 	cfg := &Config{}
-	cfg.applyDefaultsWithStat(true, func(path string) (os.FileInfo, error) {
+	cfg.applyDefaultsWithStat(context.Background(), true, func(path string) (os.FileInfo, error) {
 		if path == DefaultPluginServiceCAPath {
 			return os.Stat(caFile)
 		}
@@ -103,7 +104,7 @@ func (s *ConfigSuite) TestApplyDefaults_usesServiceCAWhenPresent() {
 
 func (s *ConfigSuite) TestApplyDefaults_leavesTLSUnsetWithoutServiceCA() {
 	cfg := &Config{}
-	cfg.applyDefaultsWithStat(true, func(string) (os.FileInfo, error) {
+	cfg.applyDefaultsWithStat(context.Background(), true, func(string) (os.FileInfo, error) {
 		return nil, os.ErrNotExist
 	})
 	s.False(cfg.Insecure)

--- a/pkg/netobserv/netobserv.go
+++ b/pkg/netobserv/netobserv.go
@@ -29,7 +29,7 @@ type NetObserv struct {
 }
 
 // NewNetObserv creates a client using toolset config, cluster detection, and the Kubernetes REST config.
-func NewNetObserv(configProvider api.BaseConfig, k8s api.KubernetesClient) *NetObserv {
+func NewNetObserv(ctx context.Context, configProvider api.BaseConfig, k8s api.KubernetesClient, provider api.FilteringProvider) *NetObserv {
 	var restConfig *rest.Config
 	if k8s != nil {
 		restConfig = k8s.RESTConfig()
@@ -52,8 +52,8 @@ func NewNetObserv(configProvider api.BaseConfig, k8s api.KubernetesClient) *NetO
 	if shared != nil {
 		resolved = *shared
 	}
-	isOpenShift := clusterIsOpenShift(k8s)
-	resolved.applyDefaults(isOpenShift)
+	isOpenShift := isOpenShiftFromProvider(ctx, provider)
+	resolved.applyDefaults(ctx, isOpenShift)
 	client.pluginURL = resolved.ResolvedURL(isOpenShift)
 	client.insecure = resolved.Insecure
 	client.certificateAuthority = resolved.CertificateAuthority
@@ -96,7 +96,9 @@ func (n *NetObserv) validateAndGetURL(endpoint string) (string, error) {
 	return u.String(), nil
 }
 
-func (n *NetObserv) createHTTPClient(ctx context.Context) *http.Client {
+var errRedirectsNotAllowed = errors.New("redirects are not allowed for netobserv API requests")
+
+func (n *NetObserv) createHTTPClient(ctx context.Context) (*http.Client, error) {
 	logger := klogutil.FromContext(ctx)
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
@@ -109,28 +111,25 @@ func (n *NetObserv) createHTTPClient(ctx context.Context) *http.Client {
 	if caValue := strings.TrimSpace(n.certificateAuthority); caValue != "" {
 		caPEM, err := os.ReadFile(caValue)
 		if err != nil {
-			logger.Error(err, "failed to read CA certificate; proceeding without custom CA", "path", caValue)
-			return n.wrapWithTLSEnforcement(&http.Client{
-				Transport: transport,
-				Timeout:   DefaultPluginHTTPTimeout,
-			})
+			return nil, fmt.Errorf("failed to read certificate authority %q: %w", caValue, err)
 		}
-		var certPool *x509.CertPool
-		if systemPool, err := x509.SystemCertPool(); err == nil && systemPool != nil {
-			certPool = systemPool
-		} else {
-			certPool = x509.NewCertPool()
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("failed to parse certificate authority %q", caValue)
 		}
-		if ok := certPool.AppendCertsFromPEM(caPEM); ok {
-			tlsConfig.RootCAs = certPool
-		} else {
-			logger.V(0).Info("failed to append provided certificate authority; proceeding without custom CA")
-		}
+		tlsConfig.RootCAs = certPool
 	}
-	return n.wrapWithTLSEnforcement(&http.Client{
+	client := &http.Client{
 		Transport: transport,
 		Timeout:   DefaultPluginHTTPTimeout,
-	})
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errRedirectsNotAllowed
+		},
+	}
+	if n.insecure {
+		klogutil.LogInfo(logger.V(1), "NetObserv plugin TLS verification disabled")
+	}
+	return n.wrapWithTLSEnforcement(client), nil
 }
 
 func (n *NetObserv) wrapWithTLSEnforcement(client *http.Client) *http.Client {
@@ -200,7 +199,10 @@ func (n *NetObserv) executeGetAbsolute(ctx context.Context, requestURL string, a
 		req.Header.Set("Accept", accept)
 	}
 	req.Header.Set("X-Kubernetes-MCP-Server", "true")
-	client := n.createHTTPClient(ctx)
+	client, err := n.createHTTPClient(ctx)
+	if err != nil {
+		return GetResponse{}, err
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/netobserv/netobserv_test.go
+++ b/pkg/netobserv/netobserv_test.go
@@ -2,13 +2,22 @@ package netobserv
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
@@ -202,6 +211,67 @@ func (s *NetObservSuite) TestExecuteGet_rejectsRedirects() {
 	_, err := client.ExecuteGet(s.T().Context(), "/api/loki/flow/records", nil)
 	s.Require().Error(err)
 	s.ErrorContains(err, "redirects are not allowed")
+}
+
+func (s *NetObservSuite) TestNewNetObserv_openShiftProviderUsesHTTPSURL() {
+	// A provider that reports the OpenShift Project GVK must synthesize an https:// URL so the
+	// bearer token is never sent in cleartext. This is also the fail-open direction: on a discovery
+	// error AnyTargetHasGVKs returns true, so this same https path is taken instead of leaking over http.
+	provider := &mockFilteringProvider{hasGVKs: true}
+	client := NewNetObserv(context.Background(), s.Config, nil, provider)
+	s.Equal(DefaultPluginURL(true), client.pluginURL)
+}
+
+func (s *NetObservSuite) TestCreateHTTPClient_pinsProvidedCA() {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	s.T().Cleanup(srv.Close)
+	pinnedCA := filepath.Join(s.T().TempDir(), "pinned-ca.crt")
+	s.Require().NoError(os.WriteFile(pinnedCA,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw}), 0o600))
+
+	// Set the URL and CA directly on the client rather than via TOML: a Windows temp path
+	// (C:\Users\...) is not a valid double-quoted TOML string ("\U" is read as an escape).
+	s.Run("verifies against the pinned CA", func() {
+		client := NewNetObserv(context.Background(), s.Config, nil, nil)
+		client.pluginURL = srv.URL
+		client.certificateAuthority = pinnedCA
+
+		_, err := client.ExecuteGet(s.T().Context(), "/api/loki/flow/records", nil)
+		s.NoError(err)
+	})
+
+	s.Run("rejects a server cert not signed by the pinned CA", func() {
+		client := NewNetObserv(context.Background(), s.Config, nil, nil)
+		client.pluginURL = srv.URL
+		client.certificateAuthority = s.writeSelfSignedCA()
+
+		_, err := client.ExecuteGet(s.T().Context(), "/api/loki/flow/records", nil)
+		s.Error(err)
+	})
+}
+
+// writeSelfSignedCA generates a self-signed CA certificate unrelated to the httptest server cert,
+// writes it to a temp file, and returns the path. Used to prove the pinned CA is the sole trust anchor.
+func (s *NetObservSuite) writeSelfSignedCA() string {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	s.Require().NoError(err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "unrelated-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	s.Require().NoError(err)
+	path := filepath.Join(s.T().TempDir(), "unrelated-ca.crt")
+	s.Require().NoError(os.WriteFile(path,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	return path
 }
 
 func TestNetObserv(t *testing.T) {

--- a/pkg/netobserv/netobserv_test.go
+++ b/pkg/netobserv/netobserv_test.go
@@ -1,6 +1,7 @@
 package netobserv
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -36,7 +37,7 @@ func (s *NetObservSuite) TestNewNetObserv_SetsFields() {
 		url = "https://netobserv.example/"
 		insecure = true
 	`)))
-	client := NewNetObserv(s.Config, nil)
+	client := NewNetObserv(context.Background(), s.Config, nil, nil)
 
 	s.Equal("https://netobserv.example/", client.pluginURL)
 	s.True(client.insecure)
@@ -57,7 +58,7 @@ func (s *NetObservSuite) TestExecuteGet() {
 		[toolset_configs.netobserv]
 		url = "%s"
 	`, s.MockServer.Config().Host))))
-	client := NewNetObserv(s.Config, nil)
+	client := NewNetObserv(context.Background(), s.Config, nil, nil)
 	client.bearerToken = "token-xyz"
 
 	content, err := client.ExecuteGet(s.T().Context(), "/api/loki/flow/records", map[string]any{
@@ -83,7 +84,7 @@ func (s *NetObservSuite) TestExecuteGet() {
 			s.Equal("Bearer file-sa-token", r.Header.Get("Authorization"))
 			_, _ = w.Write([]byte(`{"status":"ok"}`))
 		}))
-		client := NewNetObserv(s.Config, nil)
+		client := NewNetObserv(context.Background(), s.Config, nil, nil)
 		client.bearerTokenFile = tokenFile
 
 		content, err := client.ExecuteGet(s.T().Context(), "/api/loki/flow/records", nil)
@@ -112,7 +113,7 @@ func (s *NetObservSuite) TestExecuteGetAccept_csv() {
 		[toolset_configs.netobserv]
 		url = "%s"
 	`, s.MockServer.Config().Host))))
-	client := NewNetObserv(s.Config, nil)
+	client := NewNetObserv(context.Background(), s.Config, nil, nil)
 
 	response, err := client.ExecuteGetAccept(s.T().Context(), "/api/loki/export", map[string]any{
 		"format": "csv",
@@ -132,7 +133,7 @@ func (s *NetObservSuite) TestExecuteGetAccept_truncatesLargeExports() {
 		[toolset_configs.netobserv]
 		url = "%s"
 	`, s.MockServer.Config().Host))))
-	client := NewNetObserv(s.Config, nil)
+	client := NewNetObserv(context.Background(), s.Config, nil, nil)
 
 	response, err := client.ExecuteGetAccept(s.T().Context(), "/api/loki/export", nil, "text/csv,*/*", 16)
 	s.Require().NoError(err)
@@ -141,7 +142,7 @@ func (s *NetObservSuite) TestExecuteGetAccept_truncatesLargeExports() {
 }
 
 func (s *NetObservSuite) TestNewNetObserv_usesDefaultURLWithoutConfigSection() {
-	client := NewNetObserv(s.Config, nil)
+	client := NewNetObserv(context.Background(), s.Config, nil, nil)
 	s.Equal(DefaultPluginURL(false), client.pluginURL)
 }
 
@@ -171,6 +172,36 @@ func (s *NetObservSuite) TestRequireTLS_ConfigValidation() {
 		s.Require().NoError(err)
 		s.NotNil(cfg)
 	})
+}
+
+func (s *NetObservSuite) TestCreateHTTPClient_failsClosedOnInvalidCA() {
+	client := NewNetObserv(context.Background(), s.Config, nil, nil)
+	client.certificateAuthority = filepath.Join(s.T().TempDir(), "missing-ca.crt")
+
+	_, err := client.createHTTPClient(s.T().Context())
+	s.Require().Error(err)
+	s.ErrorContains(err, "failed to read certificate authority")
+}
+
+func (s *NetObservSuite) TestExecuteGet_rejectsRedirects() {
+	redirectTarget := test.NewMockServer()
+	redirectTarget.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.Fail("redirect target should not be called")
+	}))
+	s.T().Cleanup(redirectTarget.Close)
+
+	s.MockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.Config().Host+"/stolen", http.StatusFound)
+	}))
+	s.Config = test.Must(config.ReadToml([]byte(fmt.Sprintf(`
+		[toolset_configs.netobserv]
+		url = "%s"
+	`, s.MockServer.Config().Host))))
+	client := NewNetObserv(context.Background(), s.Config, nil, nil)
+
+	_, err := client.ExecuteGet(s.T().Context(), "/api/loki/flow/records", nil)
+	s.Require().Error(err)
+	s.ErrorContains(err, "redirects are not allowed")
 }
 
 func TestNetObserv(t *testing.T) {

--- a/pkg/netobserv/openshift.go
+++ b/pkg/netobserv/openshift.go
@@ -1,30 +1,32 @@
 package netobserv
 
 import (
+	"context"
+
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 )
 
-var openshiftProjectGVK = schema.GroupVersionKind{
+var openshiftProjectGVKs = []schema.GroupVersionKind{{
 	Group:   "project.openshift.io",
 	Version: "v1",
 	Kind:    "Project",
-}
+}}
 
-// clusterIsOpenShift reports whether the connected cluster is OpenShift using the
-// framework-provided cached discovery client (same GVK signal as FilteringProvider).
-func clusterIsOpenShift(k8s api.KubernetesClient) bool {
-	if k8s == nil {
+// isOpenShiftFromProvider reports whether the connected cluster is OpenShift using the
+// framework-provided FilteringProvider (same GVK signal as the cluster-state watcher).
+func isOpenShiftFromProvider(ctx context.Context, provider api.FilteringProvider) bool {
+	if provider == nil {
 		return false
 	}
-	return clusterIsOpenShiftFromDiscovery(k8s.DiscoveryClient())
+	return provider.AnyTargetHasGVKs(ctx, openshiftProjectGVKs)
 }
 
 func clusterIsOpenShiftFromDiscovery(dc discovery.DiscoveryInterface) bool {
 	if dc == nil {
 		return false
 	}
-	has, err := api.HasGVKs(dc, []schema.GroupVersionKind{openshiftProjectGVK})
+	has, err := api.HasGVKs(dc, openshiftProjectGVKs)
 	return err == nil && has
 }

--- a/pkg/netobserv/openshift_test.go
+++ b/pkg/netobserv/openshift_test.go
@@ -1,11 +1,13 @@
 package netobserv
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 )
@@ -14,17 +16,23 @@ type OpenShiftSuite struct {
 	suite.Suite
 }
 
-func (s *OpenShiftSuite) TestClusterIsOpenShift() {
-	s.Run("returns false without client", func() {
-		s.False(clusterIsOpenShift(nil))
+func (s *OpenShiftSuite) TestIsOpenShiftFromProvider() {
+	s.Run("returns false without provider", func() {
+		s.False(isOpenShiftFromProvider(context.Background(), nil))
 	})
 
-	s.Run("returns false without discovery client", func() {
-		s.False(clusterIsOpenShiftFromDiscovery(nil))
+	s.Run("delegates to FilteringProvider", func() {
+		provider := &mockFilteringProvider{hasGVKs: true}
+		s.True(isOpenShiftFromProvider(context.Background(), provider))
+		s.Equal(openshiftProjectGVKs, provider.lastGVKs)
 	})
 }
 
 func (s *OpenShiftSuite) TestClusterIsOpenShiftFromDiscovery() {
+	s.Run("returns false without discovery client", func() {
+		s.False(clusterIsOpenShiftFromDiscovery(nil))
+	})
+
 	s.Run("returns true when project.openshift.io is registered", func() {
 		srv := httptest.NewServer(test.NewInOpenShiftHandler())
 		s.T().Cleanup(srv.Close)
@@ -42,6 +50,20 @@ func (s *OpenShiftSuite) TestClusterIsOpenShiftFromDiscovery() {
 		s.Require().NoError(err)
 		s.False(clusterIsOpenShiftFromDiscovery(dc))
 	})
+}
+
+type mockFilteringProvider struct {
+	hasGVKs  bool
+	lastGVKs []schema.GroupVersionKind
+}
+
+func (m *mockFilteringProvider) IsTargetCompatibilityToolFiltersEnabled() bool {
+	return true
+}
+
+func (m *mockFilteringProvider) AnyTargetHasGVKs(_ context.Context, gvks []schema.GroupVersionKind) bool {
+	m.lastGVKs = gvks
+	return m.hasGVKs
 }
 
 func TestOpenShift(t *testing.T) {

--- a/pkg/netobserv/query.go
+++ b/pkg/netobserv/query.go
@@ -69,7 +69,7 @@ func ArgumentsToValues(arguments map[string]any) url.Values {
 		if value == nil {
 			continue
 		}
-		if s, ok := stringArg(value); ok && s != "" {
+		if s := stringArg(value); s != "" {
 			values.Set(key, s)
 		}
 	}
@@ -101,22 +101,22 @@ func int64Arg(value any) (int64, bool) {
 	}
 }
 
-func stringArg(value any) (string, bool) {
+func stringArg(value any) string {
 	switch v := value.(type) {
 	case string:
-		return v, true
+		return v
 	case bool:
-		return strconv.FormatBool(v), true
+		return strconv.FormatBool(v)
 	case float64:
 		if v == float64(int64(v)) {
-			return strconv.FormatInt(int64(v), 10), true
+			return strconv.FormatInt(int64(v), 10)
 		}
-		return strconv.FormatFloat(v, 'f', -1, 64), true
+		return strconv.FormatFloat(v, 'f', -1, 64)
 	case int:
-		return strconv.Itoa(v), true
+		return strconv.Itoa(v)
 	case int64:
-		return strconv.FormatInt(v, 10), true
+		return strconv.FormatInt(v, 10)
 	default:
-		return fmt.Sprint(v), true
+		return fmt.Sprint(v)
 	}
 }

--- a/pkg/toolsets/netobserv/tools/defaults.go
+++ b/pkg/toolsets/netobserv/tools/defaults.go
@@ -8,7 +8,6 @@ const (
 	DefaultDataSource         = "auto"
 	DefaultMetricType         = "Bytes"
 	DefaultMetricFunction     = "rate"
-	DefaultAggregateBy        = "namespace"
 	DefaultRateInterval       = "1m"
 	DefaultStep               = "30s"
 	DefaultExportFormat       = "csv"

--- a/pkg/toolsets/netobserv/tools/export_flows.go
+++ b/pkg/toolsets/netobserv/tools/export_flows.go
@@ -26,10 +26,7 @@ func InitExportFlows() []api.ServerTool {
 		Tool: api.Tool{
 			Name:        name,
 			Description: "Exports NetObserv flow records as CSV with the same filters as list_flows. Use when the user needs downloadable flow data for audits or offline analysis.",
-			InputSchema: &jsonschema.Schema{
-				Type:       "object",
-				Properties: props,
-			},
+			InputSchema: toolInputSchema(props, nil),
 			Annotations: readOnlyAnnotations("Export NetObserv Flows as CSV"),
 		},
 		Handler: exportFlowsHandler,
@@ -44,7 +41,7 @@ func exportFlowsHandler(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 	if _, ok := args["format"]; !ok {
 		args["format"] = DefaultExportFormat
 	}
-	client := netobservclient.NewNetObserv(params, params.KubernetesClient)
+	client := netobservclient.NewNetObserv(params.Context, params, params.KubernetesClient, params.FilteringProvider)
 	response, err := client.ExecuteGetAccept(params.Context, NetObservExportFlowsEndpoint, args, "text/csv,*/*", DefaultExportMaxBodyBytes)
 	content := response.Body
 	if response.Truncated {

--- a/pkg/toolsets/netobserv/tools/get_flow_metrics.go
+++ b/pkg/toolsets/netobserv/tools/get_flow_metrics.go
@@ -33,7 +33,6 @@ func InitGetFlowMetrics() []api.ServerTool {
 	props["aggregateBy"] = &jsonschema.Schema{
 		Type:        "string",
 		Description: aggregateByParameterDescription,
-		Default:     api.ToRawMessage(DefaultAggregateBy),
 	}
 	props["groups"] = &jsonschema.Schema{
 		Type:        "string",
@@ -55,11 +54,7 @@ func InitGetFlowMetrics() []api.ServerTool {
 		Tool: api.Tool{
 			Name:        name,
 			Description: "Returns aggregated NetObserv flow metrics as topology or time-series data. Use for throughput, TLS/DNS/drop breakdowns, and namespace or workload traffic analysis; see aggregateBy and groups for grouping options.",
-			InputSchema: &jsonschema.Schema{
-				Type:       "object",
-				Properties: props,
-				Required:   []string{"aggregateBy"},
-			},
+			InputSchema: toolInputSchema(props, []string{"aggregateBy"}),
 			Annotations: readOnlyAnnotations("Get NetObserv Flow Metrics"),
 		},
 		Handler: getFlowMetricsHandler,
@@ -67,7 +62,7 @@ func InitGetFlowMetrics() []api.ServerTool {
 }
 
 func getFlowMetricsHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	client := netobservclient.NewNetObserv(params, params.KubernetesClient)
+	client := netobservclient.NewNetObserv(params.Context, params, params.KubernetesClient, params.FilteringProvider)
 	content, err := client.ExecuteGet(params.Context, NetObservFlowMetricsEndpoint, params.GetArguments())
 	return jsonAPIResult(content, wrapAPIError("get flow metrics", err))
 }

--- a/pkg/toolsets/netobserv/tools/list_flows.go
+++ b/pkg/toolsets/netobserv/tools/list_flows.go
@@ -4,7 +4,6 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	netobservclient "github.com/containers/kubernetes-mcp-server/pkg/netobserv"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/netobserv/internal/defaults"
-	"github.com/google/jsonschema-go/jsonschema"
 )
 
 func InitListFlows() []api.ServerTool {
@@ -13,10 +12,7 @@ func InitListFlows() []api.ServerTool {
 		Tool: api.Tool{
 			Name:        name,
 			Description: "Lists NetObserv network flow records from Loki. Use when investigating traffic between workloads, IPs, ports, or protocols in a namespace or time window.",
-			InputSchema: &jsonschema.Schema{
-				Type:       "object",
-				Properties: flowQueryProperties(),
-			},
+			InputSchema: toolInputSchema(flowQueryProperties(), nil),
 			Annotations: readOnlyAnnotations("List NetObserv Flow Records"),
 		},
 		Handler: listFlowsHandler,
@@ -24,7 +20,7 @@ func InitListFlows() []api.ServerTool {
 }
 
 func listFlowsHandler(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
-	client := netobservclient.NewNetObserv(params, params.KubernetesClient)
+	client := netobservclient.NewNetObserv(params.Context, params, params.KubernetesClient, params.FilteringProvider)
 	content, err := client.ExecuteGet(params.Context, NetObservFlowsEndpoint, params.GetArguments())
 	return jsonAPIResult(content, wrapAPIError("list flow records", err))
 }

--- a/pkg/toolsets/netobserv/tools/schema.go
+++ b/pkg/toolsets/netobserv/tools/schema.go
@@ -55,6 +55,18 @@ func flowQueryProperties() map[string]*jsonschema.Schema {
 	}
 }
 
+// noAdditionalProperties rejects unknown tool input fields so they cannot be forwarded as query params.
+var noAdditionalProperties = &jsonschema.Schema{Not: &jsonschema.Schema{}}
+
+func toolInputSchema(properties map[string]*jsonschema.Schema, required []string) *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:                 "object",
+		Properties:           properties,
+		Required:             required,
+		AdditionalProperties: noAdditionalProperties,
+	}
+}
+
 func readOnlyAnnotations(title string) api.ToolAnnotations {
 	return api.ToolAnnotations{
 		Title:           title,

--- a/pkg/toolsets/netobserv/tools/schema.go
+++ b/pkg/toolsets/netobserv/tools/schema.go
@@ -55,7 +55,10 @@ func flowQueryProperties() map[string]*jsonschema.Schema {
 	}
 }
 
-// noAdditionalProperties rejects unknown tool input fields so they cannot be forwarded as query params.
+// noAdditionalProperties advertises additionalProperties:false so conforming MCP clients reject
+// unknown tool input fields. This is a client-facing schema hint only: the server registers tools
+// via the go-sdk raw AddTool path, which does not validate arguments against the schema, so unknown
+// fields are not rejected server-side (see ArgumentsToValues, which forwards every argument).
 var noAdditionalProperties = &jsonschema.Schema{Not: &jsonschema.Schema{}}
 
 func toolInputSchema(properties map[string]*jsonschema.Schema, required []string) *jsonschema.Schema {


### PR DESCRIPTION
Fixes https://github.com/containers/kubernetes-mcp-server/issues/1291

### OpenShift detection
- Added `FilteringProvider` as a named field on `ToolHandlerParams` and wired it from the MCP server in `tools_gosdk.go`.
- Replaced per-call discovery in `NewNetObserv` with `isOpenShiftFromProvider()`, which uses `FilteringProvider.AnyTargetHasGVKs()` (same GVK signal as the cluster-state watcher).
- On discovery errors, the framework fails open to OpenShift (HTTPS), avoiding cleartext token leakage from the old fail-closed path.

### TLS hardening
- **Redirects disabled**: `CheckRedirect` returns an error so token-bearing GETs cannot follow 3xx responses.
- **CA pinning**: when `certificate_authority` is set, trust is limited to that CA only (no system pool union).
- **Fail closed**: unreadable or unparseable CA files cause client creation to fail instead of silently falling back.

### Minor cleanups
- `applyDefaultsWithStat` now takes a `context.Context` and logs via `klogutil.FromContext(ctx)`.
- Removed the contradictory `Default` on required `aggregateBy` in `get_flow_metrics`.
- Simplified `stringArg` to return `string` only (the `ok` bool was always true).

### Schema hardening
- Added `additionalProperties: false` on all three NetObserv tool input schemas via a shared `toolInputSchema()` helper.

### Tests
- Updated OpenShift, config, and HTTP client tests.
- Added tests for CA fail-closed behavior and redirect rejection.