### PR TITLE
feat(kubevirt): add TargetCompatibilityFilters to kubevirt toolset

### DIFF
--- a/pkg/kubevirt/gvr.go
+++ b/pkg/kubevirt/gvr.go
@@ -1,6 +1,9 @@
 package kubevirt
 
 import (
+	"context"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -99,6 +102,14 @@ var (
 		Resource: "virtualmachineclones",
 	}
 )
+
+// HasVirtualMachine returns a TargetCompatibilityFilter that checks whether any
+// target cluster has the VirtualMachine GVK registered.
+func HasVirtualMachine(p api.FilteringProvider) func() bool {
+	return func() bool {
+		return p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{VirtualMachineGVK})
+	}
+}
 
 // Kubernetes core resources
 var (

--- a/pkg/kubevirt/gvr_test.go
+++ b/pkg/kubevirt/gvr_test.go
@@ -1,0 +1,49 @@
+package kubevirt
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type fakeFilteringProvider struct {
+	hasGVKs     bool
+	queriedGVKs []schema.GroupVersionKind
+}
+
+func (f *fakeFilteringProvider) AnyTargetHasGVKs(_ context.Context, gvks []schema.GroupVersionKind) bool {
+	f.queriedGVKs = gvks
+	return f.hasGVKs
+}
+
+func (f *fakeFilteringProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return true }
+
+func TestHasVirtualMachine(t *testing.T) {
+	t.Run("queries for VirtualMachine GVK", func(t *testing.T) {
+		p := &fakeFilteringProvider{hasGVKs: true}
+		filter := HasVirtualMachine(p)
+		filter()
+
+		if len(p.queriedGVKs) != 1 {
+			t.Fatalf("expected 1 GVK query, got %d", len(p.queriedGVKs))
+		}
+		if p.queriedGVKs[0] != VirtualMachineGVK {
+			t.Errorf("expected query for %v, got %v", VirtualMachineGVK, p.queriedGVKs[0])
+		}
+	})
+
+	t.Run("returns true when provider has VirtualMachine GVK", func(t *testing.T) {
+		filter := HasVirtualMachine(&fakeFilteringProvider{hasGVKs: true})
+		if !filter() {
+			t.Error("expected HasVirtualMachine to return true")
+		}
+	})
+
+	t.Run("returns false when provider does not have VirtualMachine GVK", func(t *testing.T) {
+		filter := HasVirtualMachine(&fakeFilteringProvider{hasGVKs: false})
+		if filter() {
+			t.Error("expected HasVirtualMachine to return false")
+		}
+	})
+}

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -126,6 +126,27 @@ func (s *ToolsetsSuite) TestDefaultToolsetsToolsWithFilteringEnabled() {
 	})
 }
 
+func (s *ToolsetsSuite) TestKubevirtToolsFilteredWithoutCRDs() {
+	s.Run("Kubevirt tools are filtered out when VirtualMachine GVK is not present", func() {
+		s.Cfg.Toolsets = []string{"kubevirt"}
+		s.Cfg.EnableTargetCompatibilityToolFilters = true
+		s.InitMcpClient()
+		tools, err := s.ListTools()
+		s.Run("ListTools returns tools", func() {
+			s.NotNil(tools, "Expected tools from ListTools")
+			s.NoError(err, "Expected no error from ListTools")
+		})
+		s.Run("kubevirt tools are not present", func() {
+			kubevirtTools := []string{"vm_create", "vm_lifecycle", "vm_clone", "vm_guest_info"}
+			for _, tool := range tools.Tools {
+				for _, kvTool := range kubevirtTools {
+					s.Require().NotEqual(kvTool, tool.Name, "Expected %s to not be present when filtering enabled on cluster without KubeVirt", kvTool)
+				}
+			}
+		})
+	})
+}
+
 func (s *ToolsetsSuite) TestDefaultToolsetsToolsInMultiCluster() {
 	s.Run("Default configuration toolsets in multi-cluster (with 11 clusters)", func() {
 		kubeconfig := s.Kubeconfig()

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -24,12 +24,12 @@ func (t *Toolset) GetDescription() string {
 	return kubevirtdefaults.ToolsetDescription()
 }
 
-func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
+func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
 	return slices.Concat(
-		vm_clone.Tools(),
-		vm_create.Tools(),
-		vm_guestagent.Tools(),
-		vm_lifecycle.Tools(),
+		vm_clone.Tools(p),
+		vm_create.Tools(p),
+		vm_guestagent.Tools(p),
+		vm_lifecycle.Tools(p),
 	)
 }
 

--- a/pkg/toolsets/kubevirt/vm/clone/tool.go
+++ b/pkg/toolsets/kubevirt/vm/clone/tool.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func Tools() []api.ServerTool {
+func Tools(p api.FilteringProvider) []api.ServerTool {
 	return []api.ServerTool{
 		{
 			Tool: api.Tool{
@@ -45,6 +45,9 @@ func Tools() []api.ServerTool {
 				},
 			},
 			Handler: cloneVM,
+			TargetCompatibilityFilters: []func() bool{
+				kubevirt.HasVirtualMachine(p),
+			},
 		},
 	}
 }

--- a/pkg/toolsets/kubevirt/vm/create/tool.go
+++ b/pkg/toolsets/kubevirt/vm/create/tool.go
@@ -18,7 +18,7 @@ import (
 //go:embed vm.yaml.tmpl
 var vmYamlTemplate string
 
-func Tools() []api.ServerTool {
+func Tools(p api.FilteringProvider) []api.ServerTool {
 	return []api.ServerTool{
 		{
 			Tool: api.Tool{
@@ -111,6 +111,9 @@ func Tools() []api.ServerTool {
 				},
 			},
 			Handler: create,
+			TargetCompatibilityFilters: []func() bool{
+				kubevirt.HasVirtualMachine(p),
+			},
 		},
 	}
 }

--- a/pkg/toolsets/kubevirt/vm/guestagent/tool.go
+++ b/pkg/toolsets/kubevirt/vm/guestagent/tool.go
@@ -23,7 +23,7 @@ const (
 	InfoTypeNetwork    GuestAgentInfoType = "network"
 )
 
-func Tools() []api.ServerTool {
+func Tools(p api.FilteringProvider) []api.ServerTool {
 	return []api.ServerTool{
 		{
 			Tool: api.Tool{
@@ -58,6 +58,9 @@ func Tools() []api.ServerTool {
 				},
 			},
 			Handler: guestInfo,
+			TargetCompatibilityFilters: []func() bool{
+				kubevirt.HasVirtualMachine(p),
+			},
 		},
 	}
 }

--- a/pkg/toolsets/kubevirt/vm/guestagent/tool_test.go
+++ b/pkg/toolsets/kubevirt/vm/guestagent/tool_test.go
@@ -1,10 +1,21 @@
 package guestagent
 
 import (
+	"context"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/stretchr/testify/suite"
 )
+
+type fakeProvider struct{}
+
+func (f *fakeProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVersionKind) bool {
+	return true
+}
+
+func (f *fakeProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return false }
 
 type GuestAgentToolSuite struct {
 	suite.Suite
@@ -12,16 +23,18 @@ type GuestAgentToolSuite struct {
 
 func (s *GuestAgentToolSuite) TestToolRegistration() {
 	s.Run("tool is registered", func() {
-		tools := Tools()
+		tools := Tools(&fakeProvider{})
 		s.Require().Len(tools, 1, "Expected 1 guest agent tool")
 		s.Equal("vm_guest_info", tools[0].Tool.Name)
 		s.Equal("Virtual Machine: Guest Agent Info", tools[0].Tool.Annotations.Title)
 		s.NotNil(tools[0].Tool.InputSchema)
 		s.NotNil(tools[0].Handler)
+		s.Require().Len(tools[0].TargetCompatibilityFilters, 1, "Expected 1 TargetCompatibilityFilter")
+		s.True(tools[0].TargetCompatibilityFilters[0](), "Filter should return true with fakeProvider")
 	})
 
 	s.Run("tool has correct properties", func() {
-		tools := Tools()
+		tools := Tools(&fakeProvider{})
 		tool := tools[0].Tool
 
 		// Check annotations

--- a/pkg/toolsets/kubevirt/vm/lifecycle/tool.go
+++ b/pkg/toolsets/kubevirt/vm/lifecycle/tool.go
@@ -21,7 +21,7 @@ const (
 	ActionRestart Action = "restart"
 )
 
-func Tools() []api.ServerTool {
+func Tools(p api.FilteringProvider) []api.ServerTool {
 	return []api.ServerTool{
 		{
 			Tool: api.Tool{
@@ -55,6 +55,9 @@ func Tools() []api.ServerTool {
 				},
 			},
 			Handler: lifecycle,
+			TargetCompatibilityFilters: []func() bool{
+				kubevirt.HasVirtualMachine(p),
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- Add a shared `kubevirt.HasVirtualMachine(p)` helper in `pkg/kubevirt/gvr.go` that reuses the existing `VirtualMachineGVK` constant to create a `TargetCompatibilityFilter`
- Pass `FilteringProvider` through to each kubevirt tool sub-package (`vm/clone`, `vm/create`, `vm/guestagent`, `vm/lifecycle`) and wire the shared filter into each tool's `TargetCompatibilityFilters`
- Hides kubevirt tools when no target cluster has KubeVirt installed, following the pattern established for OpenShift `projects_list` filtering in #1196
- Per-tool wiring (rather than toolset-level) so future tools can independently check for HCO, AAQ, or other operator-specific GVKs

Relates to: [CNV-92952](https://issues.redhat.com/browse/CNV-92952)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/kubevirt/...` passes — includes `HasVirtualMachine` unit tests
- [x] `go test ./pkg/toolsets/kubevirt/...` passes — includes `TargetCompatibilityFilters` assertion in guestagent tool test
- [ ] Verify tools are hidden when connecting to a cluster without KubeVirt installed
- [ ] Verify tools remain visible when connecting to a cluster with KubeVirt installed
- [ ] Verify fail-open behavior on discovery errors