### PR TITLE
fix!: internalize enabled check for target filtering

### DIFF
--- a/internal/tools/update-readme/main.go
+++ b/internal/tools/update-readme/main.go
@@ -32,10 +32,6 @@ func (p *FilterProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVer
 	return true
 }
 
-func (p *FilterProvider) IsTargetCompatibilityToolFiltersEnabled() bool {
-	return false
-}
-
 var _ api.FilteringProvider = (*FilterProvider)(nil)
 
 type evalTask struct {

--- a/pkg/api/filtering.go
+++ b/pkg/api/filtering.go
@@ -10,9 +10,8 @@ import (
 // (GVKs, features, etc.). Toolsets use this interface to determine which tools should
 // be exposed.
 type FilteringProvider interface {
-	TargetCompatibilityToolFiltersEnabledProvider
 	// AnyTargetHasGVKs reports whether every GVK in gvks is available on at least one target
-	// exposed by this provider. Providers that have not opted in to GVK discovery
-	// should return true so existing tools remain visible.
+	// exposed by this provider. Implementations that have filtering disabled or have not
+	// opted in to GVK discovery should return true so existing tools remain visible.
 	AnyTargetHasGVKs(context.Context, []schema.GroupVersionKind) bool
 }

--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -52,7 +52,7 @@ func newKcpClusterProvider(ctx context.Context, cfg api.BaseConfig) (kubernetes.
 	if err := ret.reset(ctx); err != nil {
 		return nil, err
 	}
-	ret.ProviderGVKFilter = kubernetes.NewProviderGVKFilter(ret)
+	ret.ProviderGVKFilter = kubernetes.NewProviderGVKFilter(ret, cfg.IsTargetCompatibilityToolFiltersEnabled)
 	return ret, nil
 }
 

--- a/pkg/kubernetes/provider_gvk_filter.go
+++ b/pkg/kubernetes/provider_gvk_filter.go
@@ -12,20 +12,27 @@ import (
 // ProviderGVKFilter provides GVK-based filtering capabilities for providers.
 // It can be embedded in provider implementations to add AnyTargetHasGVKs functionality.
 type ProviderGVKFilter struct {
-	managerProvider ManagerProvider
+	managerProvider  ManagerProvider
+	filteringEnabled func() bool
 }
 
 // NewProviderGVKFilter creates a new ProviderGVKFilter that wraps a ManagerProvider.
-func NewProviderGVKFilter(mp ManagerProvider) *ProviderGVKFilter {
+// The filteringEnabled function controls whether filtering is active; when it returns
+// false, AnyTargetHasGVKs unconditionally returns true so that all tools remain visible.
+func NewProviderGVKFilter(mp ManagerProvider, filteringEnabled func() bool) *ProviderGVKFilter {
 	return &ProviderGVKFilter{
-		managerProvider: mp,
+		managerProvider:  mp,
+		filteringEnabled: filteringEnabled,
 	}
 }
 
 // AnyTargetHasGVKs reports whether every GVK in gvks is available on at least one target
-// exposed by this provider. Returns true if an error occurs during discovery to avoid
-// excluding tools due to transient issues.
+// exposed by this provider. Returns true when filtering is disabled or if an error occurs
+// during discovery to avoid excluding tools due to transient issues.
 func (f *ProviderGVKFilter) AnyTargetHasGVKs(ctx context.Context, gvks []schema.GroupVersionKind) bool {
+	if !f.filteringEnabled() {
+		return true
+	}
 	if len(gvks) == 0 {
 		return true
 	}

--- a/pkg/kubernetes/provider_kubeconfig.go
+++ b/pkg/kubernetes/provider_kubeconfig.go
@@ -43,7 +43,7 @@ func newKubeConfigClusterProvider(ctx context.Context, cfg api.BaseConfig) (Prov
 	if err := ret.reset(ctx); err != nil {
 		return nil, err
 	}
-	ret.ProviderGVKFilter = NewProviderGVKFilter(ret)
+	ret.ProviderGVKFilter = NewProviderGVKFilter(ret, cfg.IsTargetCompatibilityToolFiltersEnabled)
 	return ret, nil
 }
 

--- a/pkg/kubernetes/provider_kubeconfig_test.go
+++ b/pkg/kubernetes/provider_kubeconfig_test.go
@@ -27,7 +27,11 @@ func (s *ProviderKubeconfigTestSuite) SetupTest() {
 	s.mockServer = test.NewMockServer()
 	// Default discovery simulates a vanilla (non-OpenShift) cluster.
 	s.mockServer.Handle(test.NewDiscoveryClientHandler())
-	provider, err := NewProvider(s.T().Context(), &config.StaticConfig{KubeConfig: s.mockServer.KubeconfigFile(s.T())})
+	cfg := test.Must(config.ReadToml([]byte(`
+		kubeconfig = "` + s.mockServer.KubeconfigFile(s.T()) + `"
+		experimental_enable_target_compatibility_tool_filters = true
+	`)))
+	provider, err := NewProvider(s.T().Context(), cfg)
 	s.Require().NoError(err, "Expected no error creating provider with kubeconfig")
 	s.provider = provider
 }

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -41,7 +41,7 @@ func newSingleClusterProvider(strategy string) ProviderFactory {
 		if err := ret.reset(ctx); err != nil {
 			return nil, err
 		}
-		ret.ProviderGVKFilter = NewProviderGVKFilter(ret)
+		ret.ProviderGVKFilter = NewProviderGVKFilter(ret, cfg.IsTargetCompatibilityToolFiltersEnabled)
 		return ret, nil
 	}
 }

--- a/pkg/kubernetes/provider_single_test.go
+++ b/pkg/kubernetes/provider_single_test.go
@@ -27,7 +27,10 @@ func (s *ProviderSingleTestSuite) SetupTest() {
 	InClusterConfig = func() (*rest.Config, error) {
 		return s.mockServer.Config(), nil
 	}
-	provider, err := NewProvider(s.T().Context(), &config.StaticConfig{})
+	cfg := test.Must(config.ReadToml([]byte(`
+		experimental_enable_target_compatibility_tool_filters = true
+	`)))
+	provider, err := NewProvider(s.T().Context(), cfg)
 	s.Require().NoError(err, "Expected no error creating provider")
 	s.provider = provider
 }

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -195,7 +195,3 @@ func (p *tokenExchangingProvider) Close() {
 func (p *tokenExchangingProvider) AnyTargetHasGVKs(ctx context.Context, gvks []schema.GroupVersionKind) bool {
 	return p.provider.AnyTargetHasGVKs(ctx, gvks)
 }
-
-func (p *tokenExchangingProvider) IsTargetCompatibilityToolFiltersEnabled() bool {
-	return p.provider.IsTargetCompatibilityToolFiltersEnabled()
-}

--- a/pkg/kubernetes/provider_token_exchange_test.go
+++ b/pkg/kubernetes/provider_token_exchange_test.go
@@ -65,9 +65,6 @@ func (fakeDerivedProvider) GetDerivedKubernetes(context.Context, string) (*Kuber
 func (fakeDerivedProvider) AnyTargetHasGVKs(context.Context, []schema.GroupVersionKind) bool {
 	return true
 }
-func (fakeDerivedProvider) IsTargetCompatibilityToolFiltersEnabled() bool {
-	return false
-}
 
 func (s *TokenExchangingProviderSuite) TestGetDerivedKubernetes() {
 	s.Run("uses reloaded STS config from live config provider", func() {

--- a/pkg/kubernetes/token_exchange_test.go
+++ b/pkg/kubernetes/token_exchange_test.go
@@ -138,9 +138,6 @@ func (f fakeTokenExchangeProvider) GetTokenExchangeStrategy() string { return f.
 func (f fakeTokenExchangeProvider) AnyTargetHasGVKs(context.Context, []schema.GroupVersionKind) bool {
 	return true
 }
-func (f fakeTokenExchangeProvider) IsTargetCompatibilityToolFiltersEnabled() bool {
-	return false
-}
 
 func (s *TokenExchangeRoutingSuite) TestRequireTLS_BlocksExCfgTokenExchange() {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -78,11 +78,9 @@ func (c *Configuration) isToolApplicable(tool api.ServerTool) bool {
 	if c.DisabledTools != nil && slices.Contains(c.DisabledTools, tool.Tool.Name) {
 		return false
 	}
-	if c.EnableTargetCompatibilityToolFilters {
-		for _, filter := range tool.TargetCompatibilityFilters {
-			if !filter() {
-				return false
-			}
+	for _, filter := range tool.TargetCompatibilityFilters {
+		if !filter() {
+			return false
 		}
 	}
 	return true

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -20,15 +20,9 @@ func initResources(p api.FilteringProvider) []api.ServerTool {
 	// target-specific kinds (e.g. OpenShift Route) when a target cluster exposes them,
 	// so the examples the model sees match the cluster it is talking to.
 	commonApiVersion := "v1 Pod, v1 Service, v1 Node, apps/v1 Deployment, networking.k8s.io/v1 Ingress"
-	// Only check GVKs when target compatibility filtering is enabled
-	if p.IsTargetCompatibilityToolFiltersEnabled() {
-		if p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{
-			{Group: "route.openshift.io", Version: "v1", Kind: "Route"},
-		}) {
-			commonApiVersion += ", route.openshift.io/v1 Route"
-		}
-	} else {
-		// When filtering disabled, optimistically include OpenShift resources in description
+	if p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{
+		{Group: "route.openshift.io", Version: "v1", Kind: "Route"},
+	}) {
 		commonApiVersion += ", route.openshift.io/v1 Route"
 	}
 	commonApiVersion = fmt.Sprintf("(common apiVersion and kind include: %s)", commonApiVersion)

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -59,8 +59,6 @@ func (f *fakeProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVersi
 	return true
 }
 
-func (f *fakeProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return false }
-
 func (s *ToolsetsSuite) TestRegisterPanicsOnDuplicate() {
 	Register(&TestToolset{name: "duplicate"})
 	s.Panics(func() {


### PR DESCRIPTION
In #1293 we added a config option to disable target filtering. However, currently we wire that interface and check throughout the codebase.

This PR tries to simplify this code and prep for a possibly more expressive flag that goes beyond just enabling/disabling by internalizing the check within the actual filtering provider method.