### PR TITLE
ci(mcpchecker): switch PR trigger to pull_request_review + workflow_run 

### DIFF
--- a/.github/workflows/mcpchecker-report.yaml
+++ b/.github/workflows/mcpchecker-report.yaml
@@ -13,7 +13,7 @@ jobs:
   report:
     name: Post Evaluation Results
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'issue_comment'
+    if: github.event.workflow_run.event == 'workflow_run'
     steps:
       - name: Check if evaluation ran
         id: check

--- a/.github/workflows/mcpchecker-trigger.yaml
+++ b/.github/workflows/mcpchecker-trigger.yaml
@@ -1,0 +1,38 @@
+name: mcpchecker MCP Evaluation - Trigger
+
+# Unprivileged trigger workflow for PR-based mcpchecker evaluations.
+#
+# This workflow fires on pull_request_review and exists solely to signal the
+# main mcpchecker workflow (which chains via workflow_run). It passes NO data
+# to the main workflow — the main workflow derives the PR number and commit SHA
+# entirely from the workflow_run event metadata and the GitHub API.
+#
+# SECURITY NOTE: pull_request_review runs the workflow file from the merge ref,
+# so a fork PR can modify this file. This workflow is intentionally a no-op
+# signal. Even if a fork replaces its contents, the main workflow independently
+# verifies permissions, the SHA, and suite via the GitHub API using code from
+# the default branch.
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+# No permissions needed — this workflow is entirely unprivileged.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  route:
+    name: Route evaluation trigger
+    runs-on: ubuntu-latest
+    # Only fire when the review body contains the trigger command.
+    # This is a routing signal only — the main workflow independently verifies.
+    if: >-
+      github.repository == 'containers/kubernetes-mcp-server' &&
+      contains(github.event.review.body, '/run-mcpchecker')
+    steps:
+      - name: Signal
+        run: echo "Routing to mcpchecker evaluation workflow"

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -5,9 +5,10 @@ on:
   schedule:
     - cron: '0 9 * * 1'
 
-  # Manual trigger via PR comments
-  issue_comment:
-    types: [created]
+  # PR evaluation trigger via review comments (chained from mcpchecker-trigger.yaml)
+  workflow_run:
+    workflows: ["mcpchecker MCP Evaluation - Trigger"]
+    types: [completed]
 
   # Allow manual workflow dispatch for testing
   workflow_dispatch:
@@ -35,16 +36,17 @@ on:
         type: boolean
         default: false
 
-# Minimal permissions - no write access to PRs/issues
-# This workflow checks out and runs potentially untrusted PR code
+# Minimal permissions at workflow level. The check-trigger job escalates to
+# pull-requests: write for posting rejection comments on PRs.
 permissions:
   contents: read
   actions: read
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
-  # For issue_comment events, use PR number as group to avoid different PRs canceling each other.
-  group: ${{ github.workflow }}-${{ github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || github.ref }}
+  # For workflow_run events, use head_branch to group by PR branch so different
+  # PRs don't cancel each other.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && format('branch-{0}', github.event.workflow_run.head_branch) || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -62,7 +64,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-      # Needed to comment on the PR when the TOCTOU check fails
+      # Needed to comment on the PR when the evaluation is rejected
       pull-requests: write
     # Never run on forks: the evaluation needs model/judge secrets that forks
     # don't have, so it would only ever fail there.
@@ -70,9 +72,8 @@ jobs:
       github.repository == 'containers/kubernetes-mcp-server' &&
       (github.event_name == 'schedule' ||
        github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/run-mcpchecker')))
+       (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success'))
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
       toolsets: ${{ steps.suite.outputs.toolsets }}
@@ -88,97 +89,110 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
 
-            if (context.eventName === 'issue_comment') {
-              const commenter = context.payload.comment.user.login;
-              const prNum = context.payload.issue.number;
-              const commentId = context.payload.comment.id;
+            if (context.eventName === 'workflow_run') {
+              // PR evaluation path: the trigger workflow fired on
+              // pull_request_review.  We independently verify everything from
+              // the GitHub API — the trigger workflow is untrusted (runs from
+              // the merge ref, so forks can modify it).
 
-              // Only repository collaborators with admin/write access may trigger a run.
+              // Find the PR by matching the head branch name from the
+              // workflow_run metadata.  We avoid the pulls.list head: filter
+              // (which requires "owner:branch") because for fork PRs
+              // head_repository may point to the base repo or be null
+              // (deleted fork), causing the owner-qualified lookup to miss.
+              const headBranch = context.payload.workflow_run.head_branch;
+              let pr = null;
+              for await (const { data: page } of github.paginate.iterator(
+                github.rest.pulls.list,
+                { owner, repo, state: 'open', sort: 'updated', direction: 'desc', per_page: 100 },
+              )) {
+                pr = page.find(p => p.head.ref === headBranch);
+                if (pr) break;
+              }
+
+              if (!pr) {
+                core.setOutput('should-run', 'false');
+                core.info(`No open PR found for branch ${headBranch}`);
+                return;
+              }
+
+              const prNum = pr.number;
+              const currentHead = pr.head.sha;
+
+              // Fetch all reviews and find the most recent non-dismissed review
+              // containing /run-mcpchecker.
+              const reviews = await github.paginate(
+                github.rest.pulls.listReviews,
+                { owner, repo, pull_number: prNum, per_page: 100 },
+              );
+
+              let triggerReview = null;
+              for (let i = reviews.length - 1; i >= 0; i--) {
+                const r = reviews[i];
+                if (r.state === 'DISMISSED') continue;
+                if (r.body && r.body.includes('/run-mcpchecker')) {
+                  triggerReview = r;
+                  break;
+                }
+              }
+
+              if (!triggerReview) {
+                core.setOutput('should-run', 'false');
+                core.info('No review found containing /run-mcpchecker');
+                return;
+              }
+
+              // Verify the reviewer has write/admin access.
+              const reviewer = triggerReview.user.login;
               const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
-                owner, repo, username: commenter,
+                owner, repo, username: reviewer,
               });
               if (permData.permission !== 'admin' && permData.permission !== 'write') {
                 core.setOutput('should-run', 'false');
                 core.setOutput('is-pr', 'true');
                 core.setOutput('pr-number', String(prNum));
                 core.setOutput('pr-sha', '');
-                core.info(`User ${commenter} does not have permission to trigger evaluations`);
+                core.info(`Reviewer ${reviewer} does not have permission to trigger evaluations`);
                 return;
               }
 
-              // TOCTOU guard: walk the PR timeline and extract the SHA of the
-              // last commit *before* the /run-mcpchecker comment.  This is the
-              // exact code the maintainer reviewed.  If any commits or force-pushes
-              // landed after the comment, the run is rejected.  Timeline ordering
-              // is controlled by GitHub's servers and cannot be spoofed.
-              const timeline = await github.paginate(
-                github.rest.issues.listEventsForTimeline,
-                { owner, repo, issue_number: prNum, per_page: 100 },
-              );
+              // review.commit_id is set by GitHub's server when the review is
+              // created against a specific commit's diff.  It is immutable and
+              // cannot be changed by later pushes or force-pushes.
+              const reviewSha = triggerReview.commit_id;
 
-              let seenComment = false;
-              let lastCommitSha = null;
-              for (const event of timeline) {
-                if (event.event === 'committed') {
-                  if (!seenComment) {
-                    lastCommitSha = event.sha;
-                  } else {
-                    core.setOutput('should-run', 'false');
-                    core.setOutput('is-pr', 'true');
-                    core.setOutput('pr-number', String(prNum));
-                    core.setOutput('pr-sha', '');
-                    core.info('TOCTOU: PR was updated after the /run-mcpchecker comment');
-                    await github.rest.issues.createComment({
-                      owner, repo, issue_number: prNum,
-                      body: '**Evaluation not started:** the PR was updated after this ' +
-                            '`/run-mcpchecker` comment was posted. Please re-review and ' +
-                            'comment `/run-mcpchecker` again.',
-                    });
-                    return;
-                  }
-                } else if (event.event === 'head_ref_force_pushed') {
-                  if (seenComment) {
-                    core.setOutput('should-run', 'false');
-                    core.setOutput('is-pr', 'true');
-                    core.setOutput('pr-number', String(prNum));
-                    core.setOutput('pr-sha', '');
-                    core.info('TOCTOU: PR was force-pushed after the /run-mcpchecker comment');
-                    await github.rest.issues.createComment({
-                      owner, repo, issue_number: prNum,
-                      body: '**Evaluation not started:** the PR was force-pushed after this ' +
-                            '`/run-mcpchecker` comment was posted. Please re-review and ' +
-                            'comment `/run-mcpchecker` again.',
-                    });
-                    return;
-                  }
-                  // After a force-push the old commit SHAs are invalid; reset
-                  // and let subsequent committed events repopulate.
-                  lastCommitSha = null;
-                } else if (event.event === 'commented' && event.id === commentId) {
-                  seenComment = true;
-                }
-              }
-
-              if (!seenComment) {
-                core.setOutput('should-run', 'false');
-                return
-              }
-
-              if (!lastCommitSha) {
+              // Reject if the PR head has changed since the review was submitted.
+              if (currentHead !== reviewSha) {
                 core.setOutput('should-run', 'false');
                 core.setOutput('is-pr', 'true');
                 core.setOutput('pr-number', String(prNum));
                 core.setOutput('pr-sha', '');
-                core.warning('Could not determine the PR head SHA from the timeline');
+                core.info(`PR head (${currentHead}) differs from review SHA (${reviewSha})`);
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: prNum,
+                  body: '**Evaluation not started:** the PR was updated after the ' +
+                        '`/run-mcpchecker` review was submitted (review SHA: `' +
+                        reviewSha.substring(0, 7) + '`, current HEAD: `' +
+                        currentHead.substring(0, 7) + '`). Please re-review and ' +
+                        'submit a new review with `/run-mcpchecker`.',
+                });
                 return;
               }
+
+              // Parse suite from the review body (trusted — fetched from API).
+              const suiteMatch = triggerReview.body.match(
+                /\/run-mcpchecker\s+(core|helm|kubevirt|kiali|tekton|netobserv|all)/i,
+              );
+              const suite = suiteMatch ? suiteMatch[1].toLowerCase() : '';
 
               core.setOutput('should-run', 'true');
               core.setOutput('is-pr', 'true');
               core.setOutput('pr-number', String(prNum));
-              core.setOutput('pr-sha', lastCommitSha);
-              core.info(`Pinned to SHA: ${lastCommitSha}`);
+              core.setOutput('pr-sha', reviewSha);
+              core.setOutput('suite', suite);
+              core.info(`Verified review by ${reviewer}, pinned to SHA: ${reviewSha}`);
             } else {
+              // schedule or workflow_dispatch
               core.setOutput('should-run', 'true');
               core.setOutput('is-pr', 'false');
               core.setOutput('pr-sha', context.sha);
@@ -188,24 +202,19 @@ jobs:
         id: suite
         env:
           EVENT_NAME: ${{ github.event_name }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          VERIFIED_SUITE: ${{ steps.check.outputs.suite }}
           INPUT_SUITE: ${{ github.event.inputs.suite }}
         run: |
-          # Suite selection: defaults to 'core', can be overridden by workflow_dispatch input or PR comment
-          SUITE="${INPUT_SUITE:-core}"
-
-          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
-            # Parse /run-mcpchecker [suite] from PR comment
-            BODY="${COMMENT_BODY//[[:space:]]/ }"
-            read -r _ FIRST_WORD _ <<< "$BODY"
-            case "${FIRST_WORD,,}" in
-              core|helm|kubevirt|kiali|tekton|netobserv|all)
-                SUITE="${FIRST_WORD,,}"
-                ;;
-            esac
+          # Suite selection: for workflow_run use the suite parsed from the review
+          # body (verified via API), for workflow_dispatch use the input, otherwise
+          # default to 'core'.
+          if [[ "$EVENT_NAME" == "workflow_run" && -n "$VERIFIED_SUITE" ]]; then
+            SUITE="$VERIFIED_SUITE"
+          else
+            SUITE="${INPUT_SUITE:-core}"
           fi
 
-          # Select label-selector and infrastructure based on suite
+          # Select label-selector and infrastructure based on suite.
           # All suites use the same eval.yaml file; suite controls label-selector + infra.
           case "$SUITE" in
             helm)
@@ -249,10 +258,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.0
         with:
-          # Use pinned SHA to prevent TOCTOU attacks
-          # For PRs: the SHA captured when maintainer commented
-          # For other triggers: the current commit SHA
+          # For PRs: review.commit_id — the server-assigned SHA from the
+          # maintainer's review (immutable, not derived from forgeable metadata).
+          # For other triggers: the current commit SHA.
           ref: ${{ needs.check-trigger.outputs.pr-sha }}
+          # Required for fork PRs: v7's unsafe-PR-checkout guard blocks
+          # workflow_run checkouts when head_repository is a fork.  This is
+          # safe because the workflow itself runs from the default branch and
+          # the ref is pinned to the immutable, permission-verified
+          # review.commit_id — not to forgeable workflow_run metadata.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/docs/NETOBSERV.md
+++ b/docs/NETOBSERV.md
@@ -137,4 +137,4 @@ make run-netobserv-evals   # mock + MCP server + mcpchecker (target: >= 80% pass
 
 Manual steps: `make setup-netobserv`, `make run-server TOOLSETS=core,netobserv MCP_CONFIG_DIR=dev/config/mcp-configs`, `make run-evals EVAL_LABEL_SELECTOR=suite=netobserv`.
 
-Maintainers can trigger CI with `/run-mcpchecker netobserv` on a pull request. See [evals/README.md](../evals/README.md) and [evals/tasks/netobserv/README.md](../evals/tasks/netobserv/README.md).
+Maintainers can trigger CI by submitting a PR review containing `/run-mcpchecker netobserv`. See [evals/README.md](../evals/README.md) and [evals/tasks/netobserv/README.md](../evals/tasks/netobserv/README.md).

--- a/evals/tasks/netobserv/README.md
+++ b/evals/tasks/netobserv/README.md
@@ -90,7 +90,7 @@ LLM judge strings in tasks assume the **mock** responses (`netobserv-eval`, `eva
 
 ## Maintainer trigger
 
-On a PR, comment:
+On a PR, submit a review (Files changed → Review changes) containing:
 
 ```text
 /run-mcpchecker netobserv


### PR DESCRIPTION
In #1275 we switched to using the timeline API for commit ordering

That approach seems to have some issues (including the fact that the ordering of commit events is not server controlled, while the rest of the events are).

This PR switches to a different trigger (pull request review) as that has an associated commit sha which we can leverage. However given that pull request targets run fork code, we have to split the trigger into a new workflow that triggers the actual mcpchecker action itself