### PR TITLE
fix(evals): add security context to pod manifest

### DIFF
--- a/evals/tasks/core/debug-app-logs/artifacts/calc-app-pod.yaml
+++ b/evals/tasks/core/debug-app-logs/artifacts/calc-app-pod.yaml
@@ -5,11 +5,23 @@ metadata:
   name: calc-app-pod
   namespace: calc-app
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: calc-app-executor
     image: python:3.9-slim-buster
     command: ["python"]
     args: ["/etc/config/calc-app.py"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     volumeMounts:
     - name: calc-app-volume
       mountPath: /etc/config

--- a/evals/tasks/core/filter-events-by-type/setup.sh
+++ b/evals/tasks/core/filter-events-by-type/setup.sh
@@ -17,10 +17,22 @@ metadata:
   name: bad-pod
   namespace: ${NAMESPACE}
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: bad
     image: quay.io/this-image-does-not-exist:latest
     imagePullPolicy: Always
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 EOF
 
 # Create a healthy pod to generate Normal events
@@ -31,9 +43,21 @@ metadata:
   name: good-pod
   namespace: ${NAMESPACE}
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: good
     image: quay.io/nginx/nginx-unprivileged:latest
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 EOF
 
 # Wait for the good-pod to be ready (will generate a Normal event)

--- a/evals/tasks/core/fix-pending-pod/artifacts/homepage-pod.yaml
+++ b/evals/tasks/core/fix-pending-pod/artifacts/homepage-pod.yaml
@@ -4,11 +4,23 @@ metadata:
   name: homepage-pod
   namespace: homepage-ns
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: nginx
       image: quay.io/nginx/nginx-unprivileged:latest
       ports:
         - containerPort: 80
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: my-persistent-storage
           mountPath: /usr/share/nginx/html

--- a/evals/tasks/core/resize-pvc/artifacts/storage-pod.yaml
+++ b/evals/tasks/core/resize-pvc/artifacts/storage-pod.yaml
@@ -4,6 +4,10 @@ metadata:
   name: storage-pod
   namespace: resize-pv
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   volumes:
     - name: my-storage
       persistentVolumeClaim:
@@ -11,6 +15,14 @@ spec:
   containers:
     - name: storage-user
       image: quay.io/nginx/nginx-unprivileged:alpine
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumeMounts:
         - name: my-storage
           mountPath: /usr/share/nginx/html


### PR DESCRIPTION
This PR adds security context to the existing pod manifests used in the setup phase of the core evals tasks. This ensures that, along with a kind cluster, the evals can be run on an openshift cluster as well without any issues.