### PR TITLE
test: verify that the mcp server works with kuadrant mcp gateway

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,11 +34,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Create Kind cluster
-        run: make kind-create-cluster
-
-      - name: Build and load e2e image
-        run: make e2e-image
+      - name: Setup cluster and build e2e image
+        run: make e2e-full-setup
 
       - name: Run e2e tests
         env:

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,29 @@ local-env-setup-tekton: ## Setup complete local development environment with Kin
 	@echo "Tekton Pipelines is now available!"
 	@echo "Check status with: make tekton-status"
 
+.PHONY: local-env-setup-kuadrant
+local-env-setup-kuadrant: ## Setup complete local development environment with Kind cluster and Kuadrant MCP Gateway
+	@echo "========================================="
+	@echo "Kubernetes MCP Server - Local Setup"
+	@echo "     with Kuadrant MCP Gateway"
+	@echo "========================================="
+	$(MAKE) kind-create-cluster
+	$(MAKE) kuadrant-setup
+	$(MAKE) build
+	@echo ""
+	@echo "========================================="
+	@echo "Local environment ready!"
+	@echo "========================================="
+	@echo ""
+	@echo "Run the MCP server with:"
+	@echo "  ./$(BINARY_NAME)"
+	@echo ""
+	@echo "Or run with MCP inspector:"
+	@echo "  npx @modelcontextprotocol/inspector@latest \$$(pwd)/$(BINARY_NAME)"
+	@echo ""
+	@echo "Kuadrant MCP Gateway is now available!"
+	@echo "Check status with: make kuadrant-status"
+
 .PHONY: local-env-teardown
 local-env-teardown: ## Tear down the local Kind cluster
 	$(MAKE) kind-delete-cluster

--- a/build/e2e.mk
+++ b/build/e2e.mk
@@ -56,6 +56,9 @@ e2e-image: ## Build the e2e container image and load it into the Kind cluster
 	fi; \
 	$(KIND) load docker-image $(E2E_IMAGE) --name $(KIND_CLUSTER_NAME)
 
+.PHONY: e2e-full-setup
+e2e-full-setup: kind-create-cluster kuadrant-setup e2e-image ## Create Kind cluster, install Kuadrant MCP Gateway, and build e2e image
+
 .PHONY: e2e-test
-e2e-test: uv kubectl helm ## Run all e2e tests
+e2e-test: uv kubectl helm ## Run all e2e tests (auto-skips tests whose infrastructure is missing)
 	KUBECTL_BIN=$(KUBECTL) HELM_BIN=$(HELM) MCP_SERVER_IMAGE=$(E2E_IMAGE) $(UV) run --directory $(E2E_DIR) --locked pytest -v $(PYTEST_ARGS)

--- a/build/kuadrant.mk
+++ b/build/kuadrant.mk
@@ -1,0 +1,117 @@
+# Kuadrant MCP Gateway installation and management
+
+# Pinned version — update periodically
+MCP_GATEWAY_VERSION ?= 0.7.1
+GATEWAY_API_VERSION ?= v1.3.0
+
+##@ Kuadrant MCP Gateway
+
+.PHONY: kuadrant-install-prerequisites
+kuadrant-install-prerequisites: helm ## Install Gateway API CRDs and Istio (prerequisites for Kuadrant MCP Gateway)
+	@echo "========================================="
+	@echo "Installing Kuadrant MCP Gateway Prerequisites"
+	@echo "========================================="
+	@echo ""
+	@echo "Installing Gateway API CRDs $(GATEWAY_API_VERSION)..."
+	@kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/standard-install.yaml
+	@echo "✅ Gateway API CRDs installed"
+	@echo ""
+	@echo "Adding Istio Helm repo..."
+	@$(HELM) repo add istio https://istio-release.storage.googleapis.com/charts
+	@$(HELM) repo update
+	@echo ""
+	@echo "Installing Istio base..."
+	@$(HELM) upgrade --install istio-base istio/base -n istio-system --create-namespace --wait
+	@echo "✅ Istio base installed"
+	@echo ""
+	@echo "Installing Istiod..."
+	@$(HELM) upgrade --install istiod istio/istiod -n istio-system --wait
+	@echo "✅ Istiod installed"
+	@echo ""
+	@echo "Creating gateway-system namespace..."
+	@kubectl create namespace gateway-system --dry-run=client -o yaml | kubectl apply -f -
+	@echo "✅ gateway-system namespace ready"
+	@echo ""
+	@echo "========================================="
+	@echo "Kuadrant Prerequisites Installed"
+	@echo "========================================="
+
+.PHONY: kuadrant-install-gateway
+kuadrant-install-gateway: helm ## Install Kuadrant MCP Gateway via Helm
+	@echo "========================================="
+	@echo "Installing Kuadrant MCP Gateway v$(MCP_GATEWAY_VERSION)"
+	@echo "========================================="
+	@echo ""
+	$(HELM) upgrade --install mcp-gateway oci://ghcr.io/kuadrant/charts/mcp-gateway \
+		--create-namespace \
+		--namespace mcp-system \
+		--version $(MCP_GATEWAY_VERSION) \
+		--set broker.create=true \
+		--set gateway.create=true \
+		--set gateway.name=mcp-gateway \
+		--set gateway.namespace=gateway-system \
+		--set gateway.publicHost=mcp.127-0-0-1.sslip.io \
+		--set envoyFilter.name=mcp-gateway \
+		--set mcpGatewayExtension.gatewayRef.name=mcp-gateway \
+		--set mcpGatewayExtension.gatewayRef.namespace=gateway-system
+	@echo ""
+	@echo "Waiting for MCP Gateway deployments to be created..."
+	@for deploy in mcp-gateway mcp-gateway-controller; do \
+		until kubectl get deployment "$$deploy" -n mcp-system 2>/dev/null; do \
+			echo "  Waiting for deployment/$$deploy to exist..."; \
+			sleep 5; \
+		done; \
+	done
+	@echo "Waiting for MCP Gateway pods to be ready..."
+	@kubectl wait --for=condition=available --timeout=300s deployment/mcp-gateway -n mcp-system
+	@kubectl wait --for=condition=available --timeout=300s deployment/mcp-gateway-controller -n mcp-system
+	@echo "✅ MCP Gateway deployments ready"
+	@echo ""
+	@echo "Waiting for Istio gateway pod..."
+	@kubectl wait --for=condition=ready --timeout=300s pod -l gateway.networking.k8s.io/gateway-name=mcp-gateway -n gateway-system
+	@echo "✅ Istio gateway pod ready"
+	@echo ""
+	@echo "========================================="
+	@echo "Kuadrant MCP Gateway Installed"
+	@echo "========================================="
+	@echo ""
+	@echo "MCP Gateway version: $(MCP_GATEWAY_VERSION)"
+	@echo ""
+	@echo "Verify installation with:"
+	@echo "  make kuadrant-status"
+
+.PHONY: kuadrant-setup
+kuadrant-setup: kuadrant-install-prerequisites kuadrant-install-gateway ## Install all Kuadrant MCP Gateway components (prerequisites + gateway)
+
+.PHONY: kuadrant-uninstall
+kuadrant-uninstall: helm ## Uninstall Kuadrant MCP Gateway
+	@echo "Uninstalling Kuadrant MCP Gateway..."
+	@$(HELM) uninstall mcp-gateway -n mcp-system --ignore-not-found || true
+	@$(HELM) uninstall istiod -n istio-system --ignore-not-found || true
+	@$(HELM) uninstall istio-base -n istio-system --ignore-not-found || true
+	@kubectl delete namespace mcp-system --ignore-not-found
+	@kubectl delete namespace gateway-system --ignore-not-found
+	@kubectl delete namespace istio-system --ignore-not-found
+	@echo "✅ Kuadrant MCP Gateway uninstalled"
+
+.PHONY: kuadrant-status
+kuadrant-status: ## Show Kuadrant MCP Gateway status
+	@echo "========================================="
+	@echo "Kuadrant MCP Gateway Status"
+	@echo "========================================="
+	@echo ""
+	@echo "MCP System Pods:"
+	@kubectl get pods -n mcp-system 2>/dev/null || echo "  (namespace not found)"
+	@echo ""
+	@echo "Gateway System Pods:"
+	@kubectl get pods -n gateway-system 2>/dev/null || echo "  (namespace not found)"
+	@echo ""
+	@echo "Gateway:"
+	@kubectl get gateway -n gateway-system 2>/dev/null || echo "  (not found)"
+	@echo ""
+	@echo "MCPGatewayExtension:"
+	@kubectl get mcpgatewayextension -n mcp-system 2>/dev/null || echo "  (not found)"
+	@echo ""
+	@echo "MCPServerRegistrations (all namespaces):"
+	@kubectl get mcpserverregistration --all-namespaces 2>/dev/null || echo "  (not found)"
+	@echo ""

--- a/build/kuadrant.mk
+++ b/build/kuadrant.mk
@@ -1,8 +1,9 @@
 # Kuadrant MCP Gateway installation and management
 
-# Pinned version — update periodically
+# Pinned versions — update periodically
 MCP_GATEWAY_VERSION ?= 0.7.1
 GATEWAY_API_VERSION ?= v1.3.0
+KUADRANT_ISTIO_VERSION ?= 1.30.1
 
 ##@ Kuadrant MCP Gateway
 
@@ -21,11 +22,11 @@ kuadrant-install-prerequisites: helm ## Install Gateway API CRDs and Istio (prer
 	@$(HELM) repo update
 	@echo ""
 	@echo "Installing Istio base..."
-	@$(HELM) upgrade --install istio-base istio/base -n istio-system --create-namespace --wait
+	@$(HELM) upgrade --install istio-base istio/base -n istio-system --create-namespace --version $(KUADRANT_ISTIO_VERSION) --wait
 	@echo "✅ Istio base installed"
 	@echo ""
 	@echo "Installing Istiod..."
-	@$(HELM) upgrade --install istiod istio/istiod -n istio-system --wait
+	@$(HELM) upgrade --install istiod istio/istiod -n istio-system --version $(KUADRANT_ISTIO_VERSION) --wait
 	@echo "✅ Istiod installed"
 	@echo ""
 	@echo "Creating gateway-system namespace..."
@@ -89,9 +90,6 @@ kuadrant-uninstall: helm ## Uninstall Kuadrant MCP Gateway
 	@$(HELM) uninstall mcp-gateway -n mcp-system --ignore-not-found || true
 	@$(HELM) uninstall istiod -n istio-system --ignore-not-found || true
 	@$(HELM) uninstall istio-base -n istio-system --ignore-not-found || true
-	@kubectl delete namespace mcp-system --ignore-not-found
-	@kubectl delete namespace gateway-system --ignore-not-found
-	@kubectl delete namespace istio-system --ignore-not-found
 	@echo "✅ Kuadrant MCP Gateway uninstalled"
 
 .PHONY: kuadrant-status

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -22,6 +22,7 @@ import yaml
 from kubernetes_asyncio import config as k8s_config
 from kubernetes_asyncio.client import (
     ApiClient,
+    ApiException,
     CoreV1Api,
     CustomObjectsApi,
     V1Namespace,
@@ -124,6 +125,8 @@ class GatewayConnection:
         """Connect an MCP client session through the gateway."""
         async with httpx.AsyncClient(
             headers={"Host": self.host},
+            follow_redirects=True,
+            timeout=httpx.Timeout(30.0, read=300.0),
         ) as http_client:
             async with streamable_http_client(
                 f"{self.url}/mcp", http_client=http_client,
@@ -453,7 +456,9 @@ async def kuadrant_gateway(k8s_core_v1, kubectl_bin) -> GatewayConnection:
         await k8s_core_v1.read_namespaced_service(
             name=GATEWAY_SERVICE, namespace=GATEWAY_NAMESPACE,
         )
-    except Exception:
+    except ApiException as exc:
+        if exc.status != 404:
+            raise
         pytest.skip(
             f"Kuadrant MCP Gateway service {GATEWAY_NAMESPACE}/{GATEWAY_SERVICE} "
             f"not found — install with 'make kuadrant-setup'"

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -15,6 +15,7 @@ import warnings
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+import httpx
 import pytest
 import pytest_asyncio
 import yaml
@@ -22,6 +23,7 @@ from kubernetes_asyncio import config as k8s_config
 from kubernetes_asyncio.client import (
     ApiClient,
     CoreV1Api,
+    CustomObjectsApi,
     V1Namespace,
     V1ObjectMeta,
 )
@@ -105,8 +107,34 @@ class ServerDeployment:
                 yield session
 
 
+class GatewayConnection:
+    """An MCP gateway reachable via port-forward.
+
+    Wraps the gateway URL and the Host header required by the gateway
+    listener so that callers get the same ``connect_mcp()`` interface as
+    :class:`ServerDeployment`.
+    """
+
+    def __init__(self, url: str, host: str):
+        self.url = url
+        self.host = host
+
+    @asynccontextmanager
+    async def connect_mcp(self):
+        """Connect an MCP client session through the gateway."""
+        async with httpx.AsyncClient(
+            headers={"Host": self.host},
+        ) as http_client:
+            async with streamable_http_client(
+                f"{self.url}/mcp", http_client=http_client,
+            ) as (read, write, _):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    yield session
+
+
 @pytest_asyncio.fixture
-async def deploy_server(kubeconfig, chart_path, server_image, helm_bin, kubectl_bin):
+async def deploy_server(k8s_core_v1, chart_path, server_image, helm_bin, kubectl_bin):
     """Factory fixture for deploying MCP server instances.
 
     Usage::
@@ -119,17 +147,15 @@ async def deploy_server(kubeconfig, chart_path, server_image, helm_bin, kubectl_
             async with server.connect_mcp() as session:
                 result = await session.list_tools()
     """
-    await k8s_config.load_kube_config(config_file=kubeconfig)
-    api = ApiClient()
-    core_v1 = CoreV1Api(api)
-
     deployments: list[ServerDeployment] = []
 
-    async def _deploy(name: str, config_toml: str = "") -> ServerDeployment:
-        namespace = await _create_namespace(core_v1, name)
+    async def _deploy(
+        name: str, config_toml: str = "", extra_values: dict | None = None,
+    ) -> ServerDeployment:
+        namespace = await _create_namespace(k8s_core_v1, name)
         await _helm_install(
-            core_v1, namespace, name, chart_path, server_image, config_toml,
-            helm_bin,
+            k8s_core_v1, namespace, name, chart_path, server_image, config_toml,
+            helm_bin, extra_values,
         )
         server_url, proc = _start_port_forward(namespace, name, kubectl_bin)
         try:
@@ -152,7 +178,7 @@ async def deploy_server(kubeconfig, chart_path, server_image, helm_bin, kubectl_
             except Exception:
                 pass
             if isinstance(exc, TimeoutError):
-                diag = await _dump_pod_diagnostics(core_v1, namespace, name)
+                diag = await _dump_pod_diagnostics(k8s_core_v1, namespace, name)
                 raise RuntimeError(
                     f"Server at {server_url} failed health check.\n"
                     f"--- port-forward stderr ---\n{pf_stderr}\n{diag}"
@@ -183,11 +209,9 @@ async def deploy_server(kubeconfig, chart_path, server_image, helm_bin, kubectl_
                 if fh:
                     fh.close()
         try:
-            await core_v1.delete_namespace(dep.namespace)
+            await k8s_core_v1.delete_namespace(dep.namespace)
         except Exception:
             pass
-
-    await api.close()
 
 
 # ---------------------------------------------------------------------------
@@ -245,6 +269,7 @@ async def _helm_install(
     image: str,
     config_toml: str,
     helm_bin: str,
+    extra_values: dict | None = None,
 ) -> None:
     config = {}
     if config_toml.strip():
@@ -273,6 +298,8 @@ async def _helm_install(
         },
         "ingress": {"enabled": False},
     }
+    if extra_values:
+        values.update(extra_values)
 
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".yaml", delete=False
@@ -376,6 +403,83 @@ async def _wait_for_healthz(url: str, timeout: float = 30.0) -> None:
         except (urllib.error.URLError, OSError):
             await asyncio.sleep(0.5)
     raise TimeoutError(f"Server at {url}/healthz not reachable within {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# Kuadrant MCP Gateway fixtures
+# ---------------------------------------------------------------------------
+
+GATEWAY_NAMESPACE = os.environ.get("GATEWAY_NAMESPACE", "gateway-system")
+GATEWAY_SERVICE = os.environ.get("GATEWAY_SERVICE", "mcp-gateway-istio")
+GATEWAY_HOST = os.environ.get("GATEWAY_HOST", "mcp.127-0-0-1.sslip.io")
+
+
+@pytest_asyncio.fixture
+async def k8s_api_client(kubeconfig) -> ApiClient:
+    """Shared Kubernetes API client.
+
+    Loads the kubeconfig once and provides an :class:`ApiClient` that is
+    closed automatically after the test.  All typed client fixtures
+    (``k8s_core_v1``, ``k8s_custom_objects``) depend on this rather than
+    creating their own connections.
+    """
+    await k8s_config.load_kube_config(config_file=kubeconfig)
+    api = ApiClient()
+    yield api
+    await api.close()
+
+
+@pytest_asyncio.fixture
+async def k8s_core_v1(k8s_api_client) -> CoreV1Api:
+    """Kubernetes CoreV1Api backed by the shared API client."""
+    return CoreV1Api(k8s_api_client)
+
+
+@pytest_asyncio.fixture
+async def k8s_custom_objects(k8s_api_client) -> CustomObjectsApi:
+    """Kubernetes CustomObjectsApi backed by the shared API client."""
+    return CustomObjectsApi(k8s_api_client)
+
+
+@pytest_asyncio.fixture
+async def kuadrant_gateway(k8s_core_v1, kubectl_bin) -> GatewayConnection:
+    """Port-forward to the Kuadrant MCP Gateway and yield a GatewayConnection.
+
+    Auto-skips the test if the gateway service is not present in the cluster.
+    Use the returned object's ``connect_mcp()`` context manager to open an MCP
+    session through the gateway.
+    """
+    try:
+        await k8s_core_v1.read_namespaced_service(
+            name=GATEWAY_SERVICE, namespace=GATEWAY_NAMESPACE,
+        )
+    except Exception:
+        pytest.skip(
+            f"Kuadrant MCP Gateway service {GATEWAY_NAMESPACE}/{GATEWAY_SERVICE} "
+            f"not found — install with 'make kuadrant-setup'"
+        )
+
+    gateway_url, proc = _start_port_forward(
+        GATEWAY_NAMESPACE, GATEWAY_SERVICE, kubectl_bin,
+    )
+    try:
+        yield GatewayConnection(gateway_url, GATEWAY_HOST)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        for attr in ("_stderr_file", "_stdout_file"):
+            fh = getattr(proc, attr, None)
+            if fh:
+                fh.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 async def _dump_pod_diagnostics(

--- a/test/e2e/pyproject.toml
+++ b/test/e2e/pyproject.toml
@@ -12,3 +12,6 @@ dependencies = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "kuadrant: tests requiring Kuadrant MCP Gateway (install with 'make kuadrant-setup')",
+]

--- a/test/e2e/test_kuadrant_gateway.py
+++ b/test/e2e/test_kuadrant_gateway.py
@@ -54,9 +54,13 @@ async def test_kuadrant_gateway_tools(
     deploy_server, k8s_core_v1, k8s_custom_objects, kuadrant_gateway,
 ):
     """Tools should be accessible and callable through the Kuadrant MCP Gateway."""
-    # 1. Deploy the MCP server into the cluster with read-only config and
-    #    RBAC granting cluster-wide read access so tools like namespaces_list
-    #    can query the Kubernetes API.
+    # 1. Deploy the MCP server into the cluster with read-only config,
+    #    RBAC granting cluster-wide read access, and an HTTPRoute to the
+    #    Kuadrant MCP Gateway.  Using the chart's httpRoute template (instead
+    #    of creating the route by hand) gives that template e2e coverage.
+    #    The hostname uses the internal wildcard pattern (*.mcp.local) that
+    #    the gateway's "mcps" listener accepts for broker-to-server hairpin
+    #    routing.
     server = await deploy_server("kuadrant-gw", """
         read_only = true
     """, extra_values={
@@ -86,49 +90,22 @@ async def test_kuadrant_gateway_tools(
                 },
             ],
         },
+        "httpRoute": {
+            "enabled": True,
+            "parentRefs": [{
+                "name": "mcp-gateway",
+                "namespace": "gateway-system",
+            }],
+            "hostnames": ["{{ .Release.Name }}.mcp.local"],
+            "rules": [{
+                "matches": [
+                    {"path": {"type": "PathPrefix", "value": "/"}},
+                ],
+            }],
+        },
     })
 
-    # 2. Create an HTTPRoute from the gateway to the MCP server service.
-    #    The hostname uses the internal wildcard pattern (*.mcp.local) that the
-    #    gateway's "mcps" listener accepts for broker-to-server hairpin routing.
-    await k8s_custom_objects.create_namespaced_custom_object(
-        group="gateway.networking.k8s.io",
-        version="v1",
-        namespace=server.namespace,
-        plural="httproutes",
-        body={
-            "apiVersion": "gateway.networking.k8s.io/v1",
-            "kind": "HTTPRoute",
-            "metadata": {
-                "name": f"{server.name}-route",
-                "namespace": server.namespace,
-            },
-            "spec": {
-                "parentRefs": [
-                    {
-                        "name": "mcp-gateway",
-                        "namespace": "gateway-system",
-                    },
-                ],
-                "hostnames": [f"{server.name}.mcp.local"],
-                "rules": [
-                    {
-                        "matches": [
-                            {"path": {"type": "PathPrefix", "value": "/"}},
-                        ],
-                        "backendRefs": [
-                            {
-                                "name": server.name,
-                                "port": 8080,
-                            },
-                        ],
-                    },
-                ],
-            },
-        },
-    )
-
-    # 3. Create an MCPServerRegistration that registers our MCP server with
+    # 2. Create an MCPServerRegistration that registers our MCP server with
     #    the gateway.  userSpecificList is Enabled so the broker forwards
     #    per-user credentials when listing tools (required for servers that
     #    enforce auth, which we will layer on in a follow-up).
@@ -150,19 +127,19 @@ async def test_kuadrant_gateway_tools(
                 "targetRef": {
                     "group": "gateway.networking.k8s.io",
                     "kind": "HTTPRoute",
-                    "name": f"{server.name}-route",
+                    "name": server.name,
                 },
             },
         },
     )
 
-    # 4. Wait for the registration to become Ready (controller has connected
+    # 3. Wait for the registration to become Ready (controller has connected
     #    the broker to our server and discovered its tools).
     await _wait_for_registration_ready(
         k8s_custom_objects, server.namespace, f"{server.name}-reg",
     )
 
-    # 5. Connect to the MCP Gateway and verify tools.
+    # 4. Connect to the MCP Gateway and verify tools.
     async with kuadrant_gateway.connect_mcp() as session:
         # Verify that tools from our server appear with the prefix.
         result = await session.list_tools()
@@ -173,7 +150,7 @@ async def test_kuadrant_gateway_tools(
             f"got: {tool_names}"
         )
 
-        # 6. Call namespaces_list through the gateway and verify the
+        # 5. Call namespaces_list through the gateway and verify the
         #    response against a direct Kubernetes API call.
         namespaces_tool = f"{TOOL_PREFIX}namespaces_list"
         assert namespaces_tool in tool_names, (

--- a/test/e2e/test_kuadrant_gateway.py
+++ b/test/e2e/test_kuadrant_gateway.py
@@ -1,0 +1,194 @@
+"""End-to-end tests for Kuadrant MCP Gateway integration.
+
+These tests verify that the kubernetes-mcp-server is accessible through the
+Kuadrant MCP Gateway, including tool federation with prefixes and
+user-specific tool listing.
+
+Prerequisites (installed via ``make kuadrant-setup``):
+  - Gateway API CRDs
+  - Istio (base + istiod)
+  - Kuadrant MCP Gateway (controller + broker)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from kubernetes_asyncio.client import CustomObjectsApi
+
+# Prefix applied to all tools federated through the MCPServerRegistration.
+TOOL_PREFIX = "k8s_"
+
+
+async def _wait_for_registration_ready(
+    custom_objects: CustomObjectsApi,
+    namespace: str,
+    name: str,
+    timeout: float = 120.0,
+) -> dict:
+    """Poll until the MCPServerRegistration has a Ready=True condition."""
+    deadline = time.monotonic() + timeout
+    obj: dict = {}
+    while time.monotonic() < deadline:
+        obj = await custom_objects.get_namespaced_custom_object(
+            group="mcp.kuadrant.io",
+            version="v1alpha1",
+            namespace=namespace,
+            plural="mcpserverregistrations",
+            name=name,
+        )
+        for cond in obj.get("status", {}).get("conditions", []):
+            if cond.get("type") == "Ready" and cond.get("status") == "True":
+                return obj
+        await asyncio.sleep(2)
+    raise TimeoutError(
+        f"MCPServerRegistration {namespace}/{name} not ready within {timeout}s. "
+        f"Last status: {obj.get('status', {})}"
+    )
+
+
+@pytest.mark.kuadrant
+async def test_kuadrant_gateway_tools(
+    deploy_server, k8s_core_v1, k8s_custom_objects, kuadrant_gateway,
+):
+    """Tools should be accessible and callable through the Kuadrant MCP Gateway."""
+    # 1. Deploy the MCP server into the cluster with read-only config and
+    #    RBAC granting cluster-wide read access so tools like namespaces_list
+    #    can query the Kubernetes API.
+    server = await deploy_server("kuadrant-gw", """
+        read_only = true
+    """, extra_values={
+        "rbac": {
+            "create": True,
+            "extraClusterRoles": [{
+                "name": "cluster-reader",
+                "rules": [{
+                    "apiGroups": [""],
+                    "resources": ["namespaces", "nodes"],
+                    "verbs": ["get", "list", "watch"],
+                }],
+            }],
+            "extraClusterRoleBindings": [
+                {
+                    "name": "view",
+                    "roleRef": {
+                        "name": "view",
+                        "external": True,
+                    },
+                },
+                {
+                    "name": "cluster-reader",
+                    "roleRef": {
+                        "name": "cluster-reader",
+                    },
+                },
+            ],
+        },
+    })
+
+    # 2. Create an HTTPRoute from the gateway to the MCP server service.
+    #    The hostname uses the internal wildcard pattern (*.mcp.local) that the
+    #    gateway's "mcps" listener accepts for broker-to-server hairpin routing.
+    await k8s_custom_objects.create_namespaced_custom_object(
+        group="gateway.networking.k8s.io",
+        version="v1",
+        namespace=server.namespace,
+        plural="httproutes",
+        body={
+            "apiVersion": "gateway.networking.k8s.io/v1",
+            "kind": "HTTPRoute",
+            "metadata": {
+                "name": f"{server.name}-route",
+                "namespace": server.namespace,
+            },
+            "spec": {
+                "parentRefs": [
+                    {
+                        "name": "mcp-gateway",
+                        "namespace": "gateway-system",
+                    },
+                ],
+                "hostnames": [f"{server.name}.mcp.local"],
+                "rules": [
+                    {
+                        "matches": [
+                            {"path": {"type": "PathPrefix", "value": "/"}},
+                        ],
+                        "backendRefs": [
+                            {
+                                "name": server.name,
+                                "port": 8080,
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+    )
+
+    # 3. Create an MCPServerRegistration that registers our MCP server with
+    #    the gateway.  userSpecificList is Enabled so the broker forwards
+    #    per-user credentials when listing tools (required for servers that
+    #    enforce auth, which we will layer on in a follow-up).
+    await k8s_custom_objects.create_namespaced_custom_object(
+        group="mcp.kuadrant.io",
+        version="v1alpha1",
+        namespace=server.namespace,
+        plural="mcpserverregistrations",
+        body={
+            "apiVersion": "mcp.kuadrant.io/v1alpha1",
+            "kind": "MCPServerRegistration",
+            "metadata": {
+                "name": f"{server.name}-reg",
+                "namespace": server.namespace,
+            },
+            "spec": {
+                "prefix": TOOL_PREFIX,
+                "userSpecificList": "Enabled",
+                "targetRef": {
+                    "group": "gateway.networking.k8s.io",
+                    "kind": "HTTPRoute",
+                    "name": f"{server.name}-route",
+                },
+            },
+        },
+    )
+
+    # 4. Wait for the registration to become Ready (controller has connected
+    #    the broker to our server and discovered its tools).
+    await _wait_for_registration_ready(
+        k8s_custom_objects, server.namespace, f"{server.name}-reg",
+    )
+
+    # 5. Connect to the MCP Gateway and verify tools.
+    async with kuadrant_gateway.connect_mcp() as session:
+        # Verify that tools from our server appear with the prefix.
+        result = await session.list_tools()
+        tool_names = [t.name for t in result.tools]
+        prefixed = [n for n in tool_names if n.startswith(TOOL_PREFIX)]
+        assert len(prefixed) > 0, (
+            f"expected tools with prefix '{TOOL_PREFIX}', "
+            f"got: {tool_names}"
+        )
+
+        # 6. Call namespaces_list through the gateway and verify the
+        #    response against a direct Kubernetes API call.
+        namespaces_tool = f"{TOOL_PREFIX}namespaces_list"
+        assert namespaces_tool in tool_names, (
+            f"expected '{namespaces_tool}' in tool list, got: {tool_names}"
+        )
+        call_result = await session.call_tool(namespaces_tool, {})
+        assert len(call_result.content) > 0, (
+            f"expected content from {namespaces_tool}, got empty response"
+        )
+        tool_output = call_result.content[0].text
+
+        ns_list = await k8s_core_v1.list_namespace()
+        ns_names = [ns.metadata.name for ns in ns_list.items]
+        for ns in ns_names:
+            assert ns in tool_output, (
+                f"expected server namespace '{server.namespace}' in tool output, "
+                f"got: {tool_output[:500]}"
+            )


### PR DESCRIPTION
Kuadrant MCP gateway is a common gateway users of this MCP server will run the MCP server behind on kubernetes.

This adds a set of e2e tests to verify that we can actually connect to the mcp server through the gateway and see tools.