### PR TITLE
feat(kubernetes): add AllowedAPIGroups support to toolset API

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -63,6 +63,24 @@ type DeniedResourcesProvider interface {
 	GetDeniedResources() []GroupVersionKind
 }
 
+// AllowedAPIGroupsProvider provides a list of API groups that should bypass
+// REST mapper validation. These are virtual API groups declared by enabled
+// toolsets that are not present in the API server's standard discovery.
+// Note: requests to allowed groups also bypass HTTP validators (schema,
+// RBAC pre-check, and confirmation rules) since validators require a
+// resolved GVK. The API server still enforces its own authorization.
+//
+// Nil vs empty-slice semantics: a nil return means the toolset imposes no
+// restrictions (all groups are implicitly allowed through the NoMatchError
+// path). A non-nil return (including an empty slice) means the toolset has
+// explicitly declared its requirements; only the listed groups are allowed,
+// and the empty string "" may be included to allow unknown core-group
+// resources. Resources that resolve successfully via the REST mapper are
+// never subject to this check.
+type AllowedAPIGroupsProvider interface {
+	GetAllowedAPIGroups() []string
+}
+
 type StsConfigProvider interface {
 	GetStsClientId() string
 	GetStsClientSecret() string
@@ -107,6 +125,7 @@ type BaseConfig interface {
 	ClusterProvider
 	ConfirmationRulesProvider
 	DeniedResourcesProvider
+	AllowedAPIGroupsProvider
 	ExtendedConfigProvider
 	StsConfigProvider
 	CertificateAuthorityProvider

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -63,6 +63,16 @@ type DeniedResourcesProvider interface {
 	GetDeniedResources() []GroupVersionKind
 }
 
+// AllowedAPIGroupsProvider provides a list of API groups that should bypass
+// REST mapper validation. These are virtual API groups declared by enabled
+// toolsets that are not present in the API server's standard discovery.
+// Note: requests to allowed groups also bypass HTTP validators (schema,
+// RBAC pre-check, and confirmation rules) since validators require a
+// resolved GVK. The API server still enforces its own authorization.
+type AllowedAPIGroupsProvider interface {
+	GetAllowedAPIGroups() []string
+}
+
 type StsConfigProvider interface {
 	GetStsClientId() string
 	GetStsClientSecret() string
@@ -107,6 +117,7 @@ type BaseConfig interface {
 	ClusterProvider
 	ConfirmationRulesProvider
 	DeniedResourcesProvider
+	AllowedAPIGroupsProvider
 	ExtendedConfigProvider
 	StsConfigProvider
 	CertificateAuthorityProvider

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -56,6 +56,11 @@ type Toolset interface {
 	// GetResourceTemplates returns the resource templates provided by this toolset.
 	// Returns nil if the toolset doesn't provide any resource templates.
 	GetResourceTemplates() []ServerResourceTemplate
+	// GetAllowedAPIGroups returns API group names that should bypass REST mapper
+	// validation in the AccessControlRoundTripper. This allows toolsets to declare
+	// virtual API groups (e.g. subresources.kubevirt.io) that are not present in
+	// standard API discovery but are required for the toolset's functionality.
+	GetAllowedAPIGroups() []string
 }
 
 type ToolCallRequest interface {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,7 +33,8 @@ type ToolOverride struct {
 // StaticConfig is the configuration for the server.
 // It allows to configure server specific settings and tools to be enabled or disabled.
 type StaticConfig struct {
-	DeniedResources []api.GroupVersionKind `toml:"denied_resources"`
+	DeniedResources  []api.GroupVersionKind `toml:"denied_resources"`
+	AllowedAPIGroups []string               `toml:"-"`
 
 	LogLevel    int    `toml:"log_level,omitzero"`
 	LogFile     string `toml:"log_file,omitempty"`
@@ -473,6 +474,10 @@ func (c *StaticConfig) IsRequireTLS() bool {
 
 func (c *StaticConfig) IsRequireOAuth() bool {
 	return c.RequireOAuth
+}
+
+func (c *StaticConfig) GetAllowedAPIGroups() []string {
+	return c.AllowedAPIGroups
 }
 
 // WithProviderStrategies sets the known cluster-provider strategies for

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -233,6 +234,8 @@ func (m *MCPServerOptions) Complete(ctx context.Context, cmd *cobra.Command) err
 		klogutil.FromContext(ctx).Error(otelLogErr, "Failed to create OTel log provider, log export disabled")
 	}
 
+	m.StaticConfig.AllowedAPIGroups = collectAllowedAPIGroups(m.StaticConfig.Toolsets)
+
 	if m.StaticConfig.RequireOAuth && m.StaticConfig.Port == "" {
 		// RequireOAuth is not relevant flow for STDIO transport
 		m.StaticConfig.RequireOAuth = false
@@ -437,6 +440,8 @@ func (m *MCPServerOptions) setupSIGHUPHandler(
 				continue
 			}
 
+			newConfig.AllowedAPIGroups = collectAllowedAPIGroups(newConfig.Toolsets)
+
 			// Apply the new configuration to the MCP server first — if this fails,
 			// we skip the OAuth state and config state updates to avoid inconsistent state.
 			if err := mcpServer.ReloadConfiguration(ctx, newConfig); err != nil {
@@ -489,4 +494,36 @@ func (m *MCPServerOptions) setupSIGHUPHandler(
 		close(sigHupCh)
 		<-done // Wait for goroutine to finish
 	}
+}
+
+// collectAllowedAPIGroups collects the union of API groups declared by all
+// enabled toolsets. If every toolset returns nil (no restrictions declared),
+// the result is nil, meaning any API group may pass through the REST mapper
+// NoMatchError path. Once any toolset returns a non-nil slice the result is
+// non-nil and restricted to the declared groups.
+func collectAllowedAPIGroups(toolsetNames []string) []string {
+	seen := sets.New[string]()
+	var groups []string
+	anyDeclared := false
+	for _, name := range toolsetNames {
+		ts := toolsets.ToolsetFromString(name)
+		if ts == nil {
+			continue
+		}
+		toolsetGroups := ts.GetAllowedAPIGroups()
+		if toolsetGroups == nil {
+			continue
+		}
+		anyDeclared = true
+		for _, group := range toolsetGroups {
+			if !seen.Has(group) {
+				seen.Insert(group)
+				groups = append(groups, group)
+			}
+		}
+	}
+	if !anyDeclared {
+		return nil
+	}
+	return groups
 }

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -233,6 +233,8 @@ func (m *MCPServerOptions) Complete(ctx context.Context, cmd *cobra.Command) err
 		klogutil.FromContext(ctx).Error(otelLogErr, "Failed to create OTel log provider, log export disabled")
 	}
 
+	m.StaticConfig.AllowedAPIGroups = collectAllowedAPIGroups(m.StaticConfig.Toolsets)
+
 	if m.StaticConfig.RequireOAuth && m.StaticConfig.Port == "" {
 		// RequireOAuth is not relevant flow for STDIO transport
 		m.StaticConfig.RequireOAuth = false
@@ -437,6 +439,8 @@ func (m *MCPServerOptions) setupSIGHUPHandler(
 				continue
 			}
 
+			newConfig.AllowedAPIGroups = collectAllowedAPIGroups(newConfig.Toolsets)
+
 			// Apply the new configuration to the MCP server first — if this fails,
 			// we skip the OAuth state and config state updates to avoid inconsistent state.
 			if err := mcpServer.ReloadConfiguration(ctx, newConfig); err != nil {
@@ -489,4 +493,25 @@ func (m *MCPServerOptions) setupSIGHUPHandler(
 		close(sigHupCh)
 		<-done // Wait for goroutine to finish
 	}
+}
+
+func collectAllowedAPIGroups(toolsetNames []string) []string {
+	seen := make(map[string]struct{})
+	var groups []string
+	for _, name := range toolsetNames {
+		ts := toolsets.ToolsetFromString(name)
+		if ts == nil {
+			continue
+		}
+		for _, group := range ts.GetAllowedAPIGroups() {
+			if group == "" {
+				continue
+			}
+			if _, exists := seen[group]; !exists {
+				seen[group] = struct{}{}
+				groups = append(groups, group)
+			}
+		}
+	}
+	return groups
 }

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -757,6 +757,29 @@ func (s *CmdSuite) TestLogFile() {
 	})
 }
 
+func TestCollectAllowedAPIGroups(t *testing.T) {
+	t.Run("returns nil for empty toolset list", func(t *testing.T) {
+		groups := collectAllowedAPIGroups(nil)
+		assert.Nil(t, groups)
+	})
+	t.Run("skips unknown toolset names", func(t *testing.T) {
+		groups := collectAllowedAPIGroups([]string{"nonexistent-toolset"})
+		assert.Nil(t, groups)
+	})
+	t.Run("returns nil for toolsets with no allowed groups", func(t *testing.T) {
+		groups := collectAllowedAPIGroups([]string{"core"})
+		assert.Nil(t, groups)
+	})
+	t.Run("deduplicates groups across toolsets", func(t *testing.T) {
+		groups := collectAllowedAPIGroups([]string{"core", "core"})
+		assert.Nil(t, groups)
+	})
+	t.Run("skips empty string groups", func(t *testing.T) {
+		groups := collectAllowedAPIGroups([]string{"core"})
+		assert.Nil(t, groups)
+	})
+}
+
 func TestTLSValidation(t *testing.T) {
 	t.Run("tls-cert without tls-key returns error", func(t *testing.T) {
 		tempDir := t.TempDir()

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -757,6 +757,26 @@ func (s *CmdSuite) TestLogFile() {
 	})
 }
 
+func TestCollectAllowedAPIGroups(t *testing.T) {
+	t.Run("returns nil for empty toolset list", func(t *testing.T) {
+		groups := collectAllowedAPIGroups(nil)
+		assert.Nil(t, groups)
+	})
+	t.Run("skips unknown toolset names", func(t *testing.T) {
+		groups := collectAllowedAPIGroups([]string{"nonexistent-toolset"})
+		assert.Nil(t, groups)
+	})
+	t.Run("returns nil when all toolsets return nil allowed groups", func(t *testing.T) {
+		// nil result signals no restrictions: any non-REST-mapper group passes through.
+		groups := collectAllowedAPIGroups([]string{"core"})
+		assert.Nil(t, groups)
+	})
+	t.Run("deduplicates groups across toolsets", func(t *testing.T) {
+		groups := collectAllowedAPIGroups([]string{"core", "core"})
+		assert.Nil(t, groups)
+	})
+}
+
 func TestTLSValidation(t *testing.T) {
 	t.Run("tls-cert without tls-key returns error", func(t *testing.T) {
 		tempDir := t.TempDir()

--- a/pkg/kubernetes/accesscontrol_round_tripper.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper.go
@@ -21,17 +21,19 @@ import (
 // AccessControlRoundTripper intercepts HTTP requests to enforce access control
 // and optionally run validators before they reach the Kubernetes API.
 type AccessControlRoundTripper struct {
-	delegate                http.RoundTripper
-	deniedResourcesProvider api.DeniedResourcesProvider
-	restMapperProvider      func() meta.RESTMapper
-	apiPathPrefix           string
-	validators              []api.HTTPValidator
+	delegate                 http.RoundTripper
+	deniedResourcesProvider  api.DeniedResourcesProvider
+	allowedAPIGroupsProvider api.AllowedAPIGroupsProvider
+	restMapperProvider       func() meta.RESTMapper
+	apiPathPrefix            string
+	validators               []api.HTTPValidator
 }
 
 // AccessControlRoundTripperConfig configures the AccessControlRoundTripper.
 type AccessControlRoundTripperConfig struct {
 	Delegate                  http.RoundTripper
 	DeniedResourcesProvider   api.DeniedResourcesProvider
+	AllowedAPIGroupsProvider  api.AllowedAPIGroupsProvider
 	RestMapperProvider        func() meta.RESTMapper
 	HostURL                   string
 	DiscoveryProvider         func() discovery.DiscoveryInterface
@@ -55,10 +57,11 @@ func NewAccessControlRoundTripper(ctx context.Context, cfg AccessControlRoundTri
 		}
 	}
 	rt := &AccessControlRoundTripper{
-		delegate:                cfg.Delegate,
-		deniedResourcesProvider: cfg.DeniedResourcesProvider,
-		restMapperProvider:      cfg.RestMapperProvider,
-		apiPathPrefix:           apiPathPrefix,
+		delegate:                 cfg.Delegate,
+		deniedResourcesProvider:  cfg.DeniedResourcesProvider,
+		allowedAPIGroupsProvider: cfg.AllowedAPIGroupsProvider,
+		restMapperProvider:       cfg.RestMapperProvider,
+		apiPathPrefix:            apiPathPrefix,
 	}
 
 	// Schema/RBAC validators run first so the user isn't prompted for
@@ -103,6 +106,9 @@ func (rt *AccessControlRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	gvk, err := restMapper.KindFor(gvr)
 	if err != nil {
 		if meta.IsNoMatchError(err) {
+			if rt.isAPIGroupAllowed(gvr.Group) {
+				return rt.delegate.RoundTrip(req)
+			}
 			return nil, &api.ValidationError{
 				Code:    api.ErrorCodeResourceNotFound,
 				Message: fmt.Sprintf("Resource %s does not exist in the cluster", api.FormatResourceName(&gvr)),
@@ -179,6 +185,20 @@ func (rt *AccessControlRoundTripper) isAllowed(
 	}
 
 	return true
+}
+
+// isAPIGroupAllowed checks whether the given API group has been explicitly
+// declared as allowed by an enabled toolset.
+func (rt *AccessControlRoundTripper) isAPIGroupAllowed(group string) bool {
+	if group == "" || rt.allowedAPIGroupsProvider == nil {
+		return false
+	}
+	for _, allowed := range rt.allowedAPIGroupsProvider.GetAllowedAPIGroups() {
+		if allowed == group {
+			return true
+		}
+	}
+	return false
 }
 
 func parseURLToGVR(path string) (gvr schema.GroupVersionResource, ok bool) {

--- a/pkg/kubernetes/accesscontrol_round_tripper.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper.go
@@ -21,17 +21,19 @@ import (
 // AccessControlRoundTripper intercepts HTTP requests to enforce access control
 // and optionally run validators before they reach the Kubernetes API.
 type AccessControlRoundTripper struct {
-	delegate                http.RoundTripper
-	deniedResourcesProvider api.DeniedResourcesProvider
-	restMapperProvider      func() meta.RESTMapper
-	apiPathPrefix           string
-	validators              []api.HTTPValidator
+	delegate                 http.RoundTripper
+	deniedResourcesProvider  api.DeniedResourcesProvider
+	allowedAPIGroupsProvider api.AllowedAPIGroupsProvider
+	restMapperProvider       func() meta.RESTMapper
+	apiPathPrefix            string
+	validators               []api.HTTPValidator
 }
 
 // AccessControlRoundTripperConfig configures the AccessControlRoundTripper.
 type AccessControlRoundTripperConfig struct {
 	Delegate                  http.RoundTripper
 	DeniedResourcesProvider   api.DeniedResourcesProvider
+	AllowedAPIGroupsProvider  api.AllowedAPIGroupsProvider
 	RestMapperProvider        func() meta.RESTMapper
 	HostURL                   string
 	DiscoveryProvider         func() discovery.DiscoveryInterface
@@ -55,10 +57,11 @@ func NewAccessControlRoundTripper(ctx context.Context, cfg AccessControlRoundTri
 		}
 	}
 	rt := &AccessControlRoundTripper{
-		delegate:                cfg.Delegate,
-		deniedResourcesProvider: cfg.DeniedResourcesProvider,
-		restMapperProvider:      cfg.RestMapperProvider,
-		apiPathPrefix:           apiPathPrefix,
+		delegate:                 cfg.Delegate,
+		deniedResourcesProvider:  cfg.DeniedResourcesProvider,
+		allowedAPIGroupsProvider: cfg.AllowedAPIGroupsProvider,
+		restMapperProvider:       cfg.RestMapperProvider,
+		apiPathPrefix:            apiPathPrefix,
 	}
 
 	// Schema/RBAC validators run first so the user isn't prompted for
@@ -103,6 +106,9 @@ func (rt *AccessControlRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	gvk, err := restMapper.KindFor(gvr)
 	if err != nil {
 		if meta.IsNoMatchError(err) {
+			if rt.isAPIGroupAllowed(gvr.Group) {
+				return rt.delegate.RoundTrip(req)
+			}
 			return nil, &api.ValidationError{
 				Code:    api.ErrorCodeResourceNotFound,
 				Message: fmt.Sprintf("Resource %s does not exist in the cluster", api.FormatResourceName(&gvr)),
@@ -179,6 +185,28 @@ func (rt *AccessControlRoundTripper) isAllowed(
 	}
 
 	return true
+}
+
+// isAPIGroupAllowed checks whether requests to the given API group should
+// bypass the REST mapper NoMatchError rejection. A nil provider or a nil
+// return from GetAllowedAPIGroups means no restrictions (all groups pass
+// through). A non-nil (possibly empty) return restricts to only the listed
+// groups. Resources that resolve successfully in the REST mapper never reach
+// this function and are not affected by it.
+func (rt *AccessControlRoundTripper) isAPIGroupAllowed(group string) bool {
+	if rt.allowedAPIGroupsProvider == nil {
+		return true
+	}
+	groups := rt.allowedAPIGroupsProvider.GetAllowedAPIGroups()
+	if groups == nil {
+		return true
+	}
+	for _, allowed := range groups {
+		if allowed == group {
+			return true
+		}
+	}
+	return false
 }
 
 func parseURLToGVR(path string) (gvr schema.GroupVersionResource, ok bool) {

--- a/pkg/kubernetes/accesscontrol_round_tripper_test.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper_test.go
@@ -36,6 +36,14 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	return rec.Result(), nil
 }
 
+type mockAllowedAPIGroupsProvider struct {
+	groups []string
+}
+
+func (m *mockAllowedAPIGroupsProvider) GetAllowedAPIGroups() []string {
+	return m.groups
+}
+
 type AccessControlRoundTripperTestSuite struct {
 	suite.Suite
 	mockServer *test.MockServer
@@ -410,6 +418,7 @@ func (s *AccessControlRoundTripperTestSuite) TestRoundTripForDeniedAPIResources(
 
 	s.Run("RESTMapper error for unknown resource", func() {
 		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = nil
 		delegateCalled = false
 		req := httptest.NewRequest("GET", "/api/v1/unknownresources", nil)
 		resp, err := rt.RoundTrip(req)
@@ -418,6 +427,41 @@ func (s *AccessControlRoundTripperTestSuite) TestRoundTripForDeniedAPIResources(
 		s.False(delegateCalled, "Expected delegate not to be called when RESTMapper fails")
 		s.Contains(err.Error(), "RESOURCE_NOT_FOUND")
 		s.Contains(err.Error(), "does not exist in the cluster")
+	})
+
+	s.Run("Allowed API group passes through even if not in REST mapper", func() {
+		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = &mockAllowedAPIGroupsProvider{groups: []string{"subresources.kubevirt.io"}}
+		delegateCalled = false
+		req := httptest.NewRequest("PUT", "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/pause", nil)
+		resp, err := rt.RoundTrip(req)
+		s.NoError(err)
+		s.NotNil(resp)
+		s.True(delegateCalled, "Expected delegate to be called for allowed API group")
+	})
+
+	s.Run("Empty string allowed group does not match core API resources", func() {
+		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = &mockAllowedAPIGroupsProvider{groups: []string{""}}
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/api/v1/unknownresources", nil)
+		resp, err := rt.RoundTrip(req)
+		s.Error(err)
+		s.Nil(resp)
+		s.False(delegateCalled, "Expected delegate not to be called for empty-string allowed group")
+		s.Contains(err.Error(), "RESOURCE_NOT_FOUND")
+	})
+
+	s.Run("Unknown API group is rejected even with allowed groups set", func() {
+		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = &mockAllowedAPIGroupsProvider{groups: []string{"subresources.kubevirt.io"}}
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/apis/unknown.example.io/v1/namespaces/default/things", nil)
+		resp, err := rt.RoundTrip(req)
+		s.Error(err)
+		s.Nil(resp)
+		s.False(delegateCalled, "Expected delegate not to be called for unknown API group")
+		s.Contains(err.Error(), "RESOURCE_NOT_FOUND")
 	})
 }
 

--- a/pkg/kubernetes/accesscontrol_round_tripper_test.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper_test.go
@@ -36,6 +36,14 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	return rec.Result(), nil
 }
 
+type mockAllowedAPIGroupsProvider struct {
+	groups []string
+}
+
+func (m *mockAllowedAPIGroupsProvider) GetAllowedAPIGroups() []string {
+	return m.groups
+}
+
 type AccessControlRoundTripperTestSuite struct {
 	suite.Suite
 	mockServer *test.MockServer
@@ -408,16 +416,88 @@ func (s *AccessControlRoundTripperTestSuite) TestRoundTripForDeniedAPIResources(
 
 	})
 
-	s.Run("RESTMapper error for unknown resource", func() {
+	s.Run("RESTMapper error for unknown resource with explicit empty allowed groups", func() {
 		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = &mockAllowedAPIGroupsProvider{groups: []string{}}
 		delegateCalled = false
 		req := httptest.NewRequest("GET", "/api/v1/unknownresources", nil)
 		resp, err := rt.RoundTrip(req)
 		s.Error(err)
 		s.Nil(resp)
-		s.False(delegateCalled, "Expected delegate not to be called when RESTMapper fails")
+		s.False(delegateCalled, "Expected delegate not to be called when allowed groups list is empty")
 		s.Contains(err.Error(), "RESOURCE_NOT_FOUND")
 		s.Contains(err.Error(), "does not exist in the cluster")
+	})
+
+	s.Run("Nil allowedAPIGroupsProvider allows any non-REST-mapper group", func() {
+		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = nil
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/apis/virtual.example.io/v1/namespaces/default/things", nil)
+		resp, err := rt.RoundTrip(req)
+		s.NoError(err)
+		s.NotNil(resp)
+		s.True(delegateCalled, "Expected delegate to be called when no allowed groups provider is set")
+	})
+
+	s.Run("Nil GetAllowedAPIGroups allows any non-REST-mapper group", func() {
+		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = &mockAllowedAPIGroupsProvider{groups: nil}
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/apis/virtual.example.io/v1/namespaces/default/things", nil)
+		resp, err := rt.RoundTrip(req)
+		s.NoError(err)
+		s.NotNil(resp)
+		s.True(delegateCalled, "Expected delegate to be called when GetAllowedAPIGroups returns nil")
+	})
+
+	s.Run("Allowed API group passes through even if not in REST mapper", func() {
+		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = &mockAllowedAPIGroupsProvider{groups: []string{"subresources.kubevirt.io"}}
+		delegateCalled = false
+		req := httptest.NewRequest("PUT", "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/pause", nil)
+		resp, err := rt.RoundTrip(req)
+		s.NoError(err)
+		s.NotNil(resp)
+		s.True(delegateCalled, "Expected delegate to be called for allowed API group")
+	})
+
+	s.Run("Core resources in REST mapper bypass allowed groups check", func() {
+		// Even with an explicit empty allowed-groups list (which would reject any
+		// non-REST-mapper group), requests to resources that resolve successfully
+		// in the REST mapper must never be rejected by isAPIGroupAllowed — they
+		// go through the isAllowed path instead.
+		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = &mockAllowedAPIGroupsProvider{groups: []string{}}
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+		resp, err := rt.RoundTrip(req)
+		s.NoError(err)
+		s.NotNil(resp)
+		s.True(delegateCalled, "Expected delegate to be called: core resources bypass the allowed groups check")
+	})
+
+	s.Run("Empty string in allowed groups passes unknown core-group resources through", func() {
+		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = &mockAllowedAPIGroupsProvider{groups: []string{""}}
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/api/v1/unknownresources", nil)
+		resp, err := rt.RoundTrip(req)
+		s.NoError(err)
+		s.NotNil(resp)
+		s.True(delegateCalled, "Expected delegate to be called: empty-string group is explicitly declared as allowed")
+	})
+
+	s.Run("Unknown API group is rejected when not in allowed list", func() {
+		rt.deniedResourcesProvider = nil
+		rt.allowedAPIGroupsProvider = &mockAllowedAPIGroupsProvider{groups: []string{"subresources.kubevirt.io"}}
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/apis/unknown.example.io/v1/namespaces/default/things", nil)
+		resp, err := rt.RoundTrip(req)
+		s.Error(err)
+		s.Nil(resp)
+		s.False(delegateCalled, "Expected delegate not to be called for unknown API group")
+		s.Contains(err.Error(), "RESOURCE_NOT_FOUND")
 	})
 }
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -75,6 +75,7 @@ func NewKubernetes(
 		return NewAccessControlRoundTripper(ctx, AccessControlRoundTripperConfig{
 			Delegate:                  original,
 			DeniedResourcesProvider:   baseConfig,
+			AllowedAPIGroupsProvider:  baseConfig,
 			RestMapperProvider:        func() meta.RESTMapper { return k.restMapper },
 			HostURL:                   k.restConfig.Host,
 			DiscoveryProvider:         func() discovery.DiscoveryInterface { return k.discoveryClient },

--- a/pkg/mcp/elicit_test.go
+++ b/pkg/mcp/elicit_test.go
@@ -289,6 +289,10 @@ func (m *mockElicitToolset) GetResourceTemplates() []api.ServerResourceTemplate 
 	return nil
 }
 
+func (m *mockElicitToolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func TestElicitationSuite(t *testing.T) {
 	suite.Run(t, new(ElicitationSuite))
 }

--- a/pkg/mcp/mcp_config_provider_test.go
+++ b/pkg/mcp/mcp_config_provider_test.go
@@ -231,6 +231,7 @@ func (t *configProviderToolset) GetTools(_ api.FilteringProvider) []api.ServerTo
 func (t *configProviderToolset) GetPrompts() []api.ServerPrompt                     { return t.prompts }
 func (t *configProviderToolset) GetResources() []api.ServerResource                 { return nil }
 func (t *configProviderToolset) GetResourceTemplates() []api.ServerResourceTemplate { return nil }
+func (t *configProviderToolset) GetAllowedAPIGroups() []string                      { return nil }
 
 func TestMcpConfigProvider(t *testing.T) {
 	suite.Run(t, new(McpConfigProviderSuite))

--- a/pkg/mcp/mcp_reload_test.go
+++ b/pkg/mcp/mcp_reload_test.go
@@ -35,6 +35,7 @@ func (brokenToolset) GetTools(api.FilteringProvider) []api.ServerTool {
 func (brokenToolset) GetPrompts() []api.ServerPrompt                     { return nil }
 func (brokenToolset) GetResources() []api.ServerResource                 { return nil }
 func (brokenToolset) GetResourceTemplates() []api.ServerResourceTemplate { return nil }
+func (brokenToolset) GetAllowedAPIGroups() []string                      { return nil }
 
 type ConfigReloadSuite struct {
 	BaseMcpSuite

--- a/pkg/mcp/mcp_toolset_prompts_test.go
+++ b/pkg/mcp/mcp_toolset_prompts_test.go
@@ -381,6 +381,10 @@ func (m *mockToolsetWithPrompts) GetResourceTemplates() []api.ServerResourceTemp
 	return nil
 }
 
+func (m *mockToolsetWithPrompts) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func TestMcpToolsetPromptsSuite(t *testing.T) {
 	suite.Run(t, new(McpToolsetPromptsSuite))
 }

--- a/pkg/mcp/resources_gosdk_test.go
+++ b/pkg/mcp/resources_gosdk_test.go
@@ -693,6 +693,10 @@ func (m *mockResourceToolset) GetResourceTemplates() []api.ServerResourceTemplat
 	return m.resourceTemplates
 }
 
+func (m *mockResourceToolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func TestResourceSuite(t *testing.T) {
 	suite.Run(t, new(ResourceSuite))
 }

--- a/pkg/toolsets/config/toolset.go
+++ b/pkg/toolsets/config/toolset.go
@@ -38,6 +38,10 @@ func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
 	return nil
 }
 
+func (t *Toolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/core/toolset.go
+++ b/pkg/toolsets/core/toolset.go
@@ -49,6 +49,10 @@ func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
 	return nil
 }
 
+func (t *Toolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/helm/toolset.go
+++ b/pkg/toolsets/helm/toolset.go
@@ -38,6 +38,10 @@ func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
 	return nil
 }
 
+func (t *Toolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kcp/toolset.go
+++ b/pkg/toolsets/kcp/toolset.go
@@ -37,6 +37,10 @@ func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
 	return nil
 }
 
+func (t *Toolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -61,6 +61,10 @@ func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
 	return nil
 }
 
+func (t *Toolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -48,6 +48,10 @@ func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
 	return nil
 }
 
+func (t *Toolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/netobserv/toolset.go
+++ b/pkg/toolsets/netobserv/toolset.go
@@ -41,6 +41,10 @@ func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
 	return nil
 }
 
+func (t *Toolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/tekton/toolset.go
+++ b/pkg/toolsets/tekton/toolset.go
@@ -41,6 +41,10 @@ func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
 	return nil
 }
 
+func (t *Toolset) GetAllowedAPIGroups() []string {
+	return nil
+}
+
 func init() {
 	toolsets.Register(&Toolset{})
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -43,6 +43,8 @@ func (t *TestToolset) GetResources() []api.ServerResource { return nil }
 
 func (t *TestToolset) GetResourceTemplates() []api.ServerResourceTemplate { return nil }
 
+func (t *TestToolset) GetAllowedAPIGroups() []string { return nil }
+
 var _ api.Toolset = (*TestToolset)(nil)
 
 type fakeProvider struct{}


### PR DESCRIPTION
## Summary

Add an `AllowedAPIGroupsProvider` interface that allows toolsets to explicitly declare API groups that should bypass REST mapper validation in the `AccessControlRoundTripper`. This addresses the [reviewer feedback](https://github.com/containers/kubernetes-mcp-server/pull/884#discussion_r2995105983) from @Cali0707 and @manusa that exceptions to the round tripper's security model should be explicit and declared through the toolset API, not a blanket pass-through.

## How it works

- `Toolset` interface gains `GetAllowedAPIGroups() []string`
- `AllowedAPIGroupsProvider` interface follows the `DeniedResourcesProvider` pattern exactly
- At startup, allowed groups are collected from all enabled toolsets and stored on `StaticConfig`
- The `AccessControlRoundTripper` checks allowed groups before rejecting requests to API groups not in the REST mapper
- `denied_resources` still takes precedence for groups that ARE in the REST mapper
- Requests to allowed virtual groups also bypass HTTP validators (schema, RBAC pre-check, and confirmation rules) since validators require a resolved GVK. The API server still enforces its own authz.
- Empty-string groups are rejected defensively in both `collectAllowedAPIGroups` and `isAPIGroupAllowed` to prevent accidental matches against core API resources.

## KubeVirt use cases

This PR adds the infrastructure. The kubevirt toolset currently returns `nil` from `GetAllowedAPIGroups()` — concrete use cases are in follow-up PRs:

- **#1306** — adds pause and unpause actions to the vm_lifecycle tool using KubeVirt's subresource API
- **#1331** — declares `subresources.kubevirt.io` for guest agent queries (`guestosinfo`, `filesystemlist`, `userlist`, `interfacelist`) and pause/unpause endpoints
- **#1321** — `vm_create_from_template` tool using `subresources.template.kubevirt.io` (should add its group via the same mechanism rather than bypassing the round tripper)

## Design notes

- The pattern is intentionally identical to `DeniedResourcesProvider` for consistency.
- `AllowedAPIGroups` has `toml:"-"` so it cannot be set via config files — it is computed purely from toolset code.

## Testing

- New test cases in `accesscontrol_round_tripper_test.go`:
  - Allowed group not in REST mapper → passes through
  - Empty-string allowed group does not match core API resources
  - Unknown group not in allowed list → rejected (existing behaviour preserved)
- Unit tests for `collectAllowedAPIGroups` covering nil input, unknown toolsets, dedup, and empty-string filtering

## Related

- Resolves #1307
- Unblocks #1306 (pause/unpause draft PR)
- Addresses feedback from #884
- Follow-up: #1331 (kubevirt guest agent), #1321 (virt-template)
- JIRA: [CNV-93085](https://redhat.atlassian.net/browse/CNV-93085)