### PR TITLE
chore: always set read-only to false in evals server

### DIFF
--- a/build/evals.mk
+++ b/build/evals.mk
@@ -78,9 +78,9 @@ diff-evals: mcpchecker ## Diff latest mcpchecker results against baseline
 run-server: build ## Start MCP server in background and wait for health check
 	@echo "Starting MCP server on port $(MCP_PORT)..."
 	@if [ -n "$(TOOLSETS)" ]; then \
-		./$(BINARY_NAME) --port $(MCP_PORT) --toolsets $(TOOLSETS) --config-dir $(MCP_CONFIG_DIR) & echo $$! > .mcp-server.pid; \
+		./$(BINARY_NAME) --port $(MCP_PORT) --toolsets $(TOOLSETS) --config-dir $(MCP_CONFIG_DIR) --read-only=false & echo $$! > .mcp-server.pid; \
 	else \
-		./$(BINARY_NAME) --port $(MCP_PORT) & echo $$! > .mcp-server.pid; \
+		./$(BINARY_NAME) --port $(MCP_PORT) --read-only=false & echo $$! > .mcp-server.pid; \
 	fi
 	@echo "MCP server started with PID $$(cat .mcp-server.pid)"
 	@echo "Waiting for MCP server to be ready..."


### PR DESCRIPTION
Our evals are a little inconsistent in different environments as they rely on default configuration in the MCP server to have read only be false. That is not always true and can lead to the evals incorrectly failing, as they generally require write access