### PR TITLE
[wip] OAuth Scoping for MCP resources

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,6 +85,14 @@ type StaticConfig struct {
 	DisableDynamicClientRegistration bool `toml:"disable_dynamic_client_registration,omitempty"`
 	// OAuthScopes are the supported **client** scopes requested during the **client/frontend** OAuth flow.
 	OAuthScopes []string `toml:"oauth_scopes,omitempty"`
+	// ScopePolicies maps OAuth scopes to lists of tool names that require them.
+	// A tool listed under a scope can only be called by tokens that carry that scope.
+	// Tools not listed in any scope policy remain accessible to all authenticated users (overlay model).
+	ScopePolicies map[string][]string `toml:"scope_policies,omitempty"`
+	// ResourceScopePolicies maps OAuth scopes to lists of MCP resource URI prefixes.
+	// A resource whose URI matches a prefix can only be read by tokens carrying that scope.
+	// Resources not matching any prefix remain accessible to all authenticated users (overlay model).
+	ResourceScopePolicies map[string][]string `toml:"resource_scope_policies,omitempty"`
 	// StsClientId is the OAuth client ID used for backend token exchange
 	StsClientId string `toml:"sts_client_id,omitempty"`
 	// StsClientSecret is the OAuth client secret used for backend token exchange
@@ -602,6 +610,9 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 	if err := c.validateTokenExchange(); err != nil {
 		return err
 	}
+	if err := c.validateScopePolicies(); err != nil {
+		return err
+	}
 	if err := c.validateConfirmation(); err != nil {
 		return err
 	}
@@ -653,6 +664,31 @@ func (c *StaticConfig) validateSkipJWTVerification(ctx context.Context) error {
 // validateTokenExchange validates token-exchange-related fields:
 //   - token_exchange_strategy must be a known strategy (when registry is provided)
 //   - sts_auth_style must be one of "params", "header", "assertion", "federated"
+func (c *StaticConfig) validateScopePolicies() error {
+	if len(c.ScopePolicies) == 0 {
+		return nil
+	}
+	if !c.RequireOAuth {
+		return fmt.Errorf("scope_policies requires require_oauth to be enabled")
+	}
+	for scope, tools := range c.ScopePolicies {
+		if len(tools) == 0 {
+			return fmt.Errorf("scope_policies: scope %q has an empty tool list", scope)
+		}
+	}
+	if len(c.ResourceScopePolicies) > 0 {
+		if !c.RequireOAuth {
+			return fmt.Errorf("resource_scope_policies requires require_oauth to be enabled")
+		}
+		for scope, prefixes := range c.ResourceScopePolicies {
+			if len(prefixes) == 0 {
+				return fmt.Errorf("resource_scope_policies: scope %q has an empty prefix list", scope)
+			}
+		}
+	}
+	return nil
+}
+
 //   - when sts_auth_style is "assertion", sts_client_cert_file and sts_client_key_file
 //     must both be set and reference existing files
 //   - when sts_auth_style is "federated", sts_federated_token_file must be set and exist

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -119,6 +119,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 					klogutil.LogWarn(logger, "Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
 				})
 				ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
+				ctx = context.WithValue(ctx, internalk8s.OAuthScopesKey, []string(nil))
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -174,6 +175,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 			// Store the validated Authorization header in context for MCP handlers
 			// This is necessary because SSE transport doesn't propagate HTTP headers to MCP requests
 			ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
+			ctx = context.WithValue(ctx, internalk8s.OAuthScopesKey, claims.GetScopes())
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -28,6 +28,7 @@ type HeaderKey string
 const (
 	CustomAuthorizationHeader = HeaderKey("kubernetes-authorization")
 	OAuthAuthorizationHeader  = HeaderKey("Authorization")
+	OAuthScopesKey            = HeaderKey("oauth-scopes")
 	UserAgentHeader           = HeaderKey("User-Agent")
 
 	CustomUserAgent         = "kubernetes-mcp-server/bearer-token-auth"

--- a/pkg/mcp/resources_gosdk.go
+++ b/pkg/mcp/resources_gosdk.go
@@ -15,7 +15,7 @@ import (
 // ServerResourceToGoSdkResource converts an api.ServerResource to MCP SDK types.
 // It validates the URI upfront so callers can surface a wrapped error instead of
 // letting the SDK panic during registration on hot reload.
-func ServerResourceToGoSdkResource(_ *Server, res api.ServerResource) (*mcp.Resource, mcp.ResourceHandler, error) {
+func ServerResourceToGoSdkResource(s *Server, res api.ServerResource) (*mcp.Resource, mcp.ResourceHandler, error) {
 	if _, err := url.Parse(res.Resource.URI); err != nil {
 		return nil, nil, fmt.Errorf("invalid URI %q: %w", res.Resource.URI, err)
 	}
@@ -26,6 +26,9 @@ func ServerResourceToGoSdkResource(_ *Server, res api.ServerResource) (*mcp.Reso
 		MIMEType:    res.Resource.MIMEType,
 	}
 	handler := func(ctx context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		if err := checkResourceScopePolicy(ctx, s.configuration.Load(), res.Resource.URI); err != nil {
+			return nil, err
+		}
 		content, err := res.Handler(ctx)
 		if err != nil {
 			return nil, err
@@ -55,7 +58,7 @@ func ServerResourceToGoSdkResource(_ *Server, res api.ServerResource) (*mcp.Reso
 // ServerResourceTemplateToGoSdkResourceTemplate converts an api.ServerResourceTemplate to MCP SDK types.
 // It validates the URITemplate upfront so callers can surface a wrapped error instead of letting
 // the SDK panic during registration on hot reload.
-func ServerResourceTemplateToGoSdkResourceTemplate(_ *Server, rt api.ServerResourceTemplate) (*mcp.ResourceTemplate, mcp.ResourceHandler, error) {
+func ServerResourceTemplateToGoSdkResourceTemplate(s *Server, rt api.ServerResourceTemplate) (*mcp.ResourceTemplate, mcp.ResourceHandler, error) {
 	if _, err := uritemplate.New(rt.ResourceTemplate.URITemplate); err != nil {
 		return nil, nil, fmt.Errorf("invalid URITemplate %q: %w", rt.ResourceTemplate.URITemplate, err)
 	}
@@ -66,6 +69,9 @@ func ServerResourceTemplateToGoSdkResourceTemplate(_ *Server, rt api.ServerResou
 		MIMEType:    rt.ResourceTemplate.MIMEType,
 	}
 	handler := func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		if err := checkResourceScopePolicy(ctx, s.configuration.Load(), req.Params.URI); err != nil {
+			return nil, err
+		}
 		content, err := rt.Handler(ctx, req.Params.URI)
 		if err != nil {
 			return nil, err

--- a/pkg/mcp/scope_policy.go
+++ b/pkg/mcp/scope_policy.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+)
+
+// checkScopePolicy enforces OAuth scope-based tool authorization.
+// Tools listed in scope_policies require the caller's JWT to carry at least one
+// matching scope. Tools not listed in any policy are unrestricted (overlay model).
+func checkScopePolicy(ctx context.Context, cfg *Configuration, toolName string) error {
+	if len(cfg.ScopePolicies) == 0 {
+		return nil
+	}
+	var requiredScopes []string
+	for scope, tools := range cfg.ScopePolicies {
+		if slices.Contains(tools, toolName) {
+			requiredScopes = append(requiredScopes, scope)
+		}
+	}
+	if len(requiredScopes) == 0 {
+		return nil
+	}
+	userScopes, _ := ctx.Value(internalk8s.OAuthScopesKey).([]string)
+	for _, us := range userScopes {
+		if slices.Contains(requiredScopes, us) {
+			return nil
+		}
+	}
+	return fmt.Errorf("insufficient scope: tool %q requires one of scopes: [%s]", toolName, strings.Join(requiredScopes, ", "))
+}
+
+// checkResourceScopePolicy enforces OAuth scope-based resource authorization.
+// Resources whose URI matches a prefix in resource_scope_policies require the
+// caller's JWT to carry at least one matching scope. Resources not matching any
+// configured prefix are unrestricted (overlay model).
+func checkResourceScopePolicy(ctx context.Context, cfg *Configuration, resourceURI string) error {
+	if len(cfg.ResourceScopePolicies) == 0 {
+		return nil
+	}
+	var requiredScopes []string
+	for scope, prefixes := range cfg.ResourceScopePolicies {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(resourceURI, prefix) {
+				requiredScopes = append(requiredScopes, scope)
+				break
+			}
+		}
+	}
+	if len(requiredScopes) == 0 {
+		return nil
+	}
+	userScopes, _ := ctx.Value(internalk8s.OAuthScopesKey).([]string)
+	for _, us := range userScopes {
+		if slices.Contains(requiredScopes, us) {
+			return nil
+		}
+	}
+	return fmt.Errorf("insufficient scope: resource %q requires one of scopes: [%s]", resourceURI, strings.Join(requiredScopes, ", "))
+}

--- a/pkg/mcp/scope_policy_test.go
+++ b/pkg/mcp/scope_policy_test.go
@@ -1,0 +1,153 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cfgWithPolicies(policies map[string][]string) *Configuration {
+	return &Configuration{
+		StaticConfig: &config.StaticConfig{
+			ScopePolicies: policies,
+		},
+	}
+}
+
+func cfgWithResourcePolicies(policies map[string][]string) *Configuration {
+	return &Configuration{
+		StaticConfig: &config.StaticConfig{
+			ResourceScopePolicies: policies,
+		},
+	}
+}
+
+func ctxWithScopes(scopes []string) context.Context {
+	return context.WithValue(context.Background(), internalk8s.OAuthScopesKey, scopes)
+}
+
+func TestCheckScopePolicy_NoPolicies(t *testing.T) {
+	cfg := cfgWithPolicies(nil)
+	err := checkScopePolicy(context.Background(), cfg, "pods_list")
+	assert.NoError(t, err)
+}
+
+func TestCheckScopePolicy_ToolNotInAnyPolicy(t *testing.T) {
+	cfg := cfgWithPolicies(map[string][]string{
+		"mcp:read": {"pods_list", "pods_get"},
+	})
+	ctx := ctxWithScopes([]string{"mcp:read"})
+	err := checkScopePolicy(ctx, cfg, "namespaces_list")
+	assert.NoError(t, err)
+}
+
+func TestCheckScopePolicy_MatchingScope(t *testing.T) {
+	cfg := cfgWithPolicies(map[string][]string{
+		"mcp:read": {"pods_list", "pods_get"},
+	})
+	ctx := ctxWithScopes([]string{"mcp:read"})
+	err := checkScopePolicy(ctx, cfg, "pods_list")
+	assert.NoError(t, err)
+}
+
+func TestCheckScopePolicy_NoMatchingScope(t *testing.T) {
+	cfg := cfgWithPolicies(map[string][]string{
+		"mcp:admin": {"resources_delete"},
+	})
+	ctx := ctxWithScopes([]string{"mcp:read"})
+	err := checkScopePolicy(ctx, cfg, "resources_delete")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient scope")
+	assert.Contains(t, err.Error(), "resources_delete")
+	assert.Contains(t, err.Error(), "mcp:admin")
+}
+
+func TestCheckScopePolicy_NoScopesInToken(t *testing.T) {
+	cfg := cfgWithPolicies(map[string][]string{
+		"mcp:read": {"pods_list"},
+	})
+	ctx := ctxWithScopes(nil)
+	err := checkScopePolicy(ctx, cfg, "pods_list")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient scope")
+}
+
+func TestCheckScopePolicy_NoScopesInContext(t *testing.T) {
+	cfg := cfgWithPolicies(map[string][]string{
+		"mcp:read": {"pods_list"},
+	})
+	err := checkScopePolicy(context.Background(), cfg, "pods_list")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient scope")
+}
+
+func TestCheckScopePolicy_MultipleScopesUnion(t *testing.T) {
+	cfg := cfgWithPolicies(map[string][]string{
+		"mcp:read":  {"pods_list", "pods_get"},
+		"mcp:admin": {"pods_list", "resources_delete"},
+	})
+	ctx := ctxWithScopes([]string{"mcp:admin"})
+	assert.NoError(t, checkScopePolicy(ctx, cfg, "pods_list"))
+	assert.NoError(t, checkScopePolicy(ctx, cfg, "resources_delete"))
+	require.Error(t, checkScopePolicy(ctx, cfg, "pods_get"))
+}
+
+func TestCheckResourceScopePolicy_NoPolicies(t *testing.T) {
+	cfg := cfgWithResourcePolicies(nil)
+	err := checkResourceScopePolicy(context.Background(), cfg, "must-gather://current")
+	assert.NoError(t, err)
+}
+
+func TestCheckResourceScopePolicy_URINotMatchingAnyPrefix(t *testing.T) {
+	cfg := cfgWithResourcePolicies(map[string][]string{
+		"mcp:mustgather": {"must-gather://"},
+	})
+	ctx := ctxWithScopes([]string{"mcp:read"})
+	err := checkResourceScopePolicy(ctx, cfg, "other://something")
+	assert.NoError(t, err)
+}
+
+func TestCheckResourceScopePolicy_MatchingScope(t *testing.T) {
+	cfg := cfgWithResourcePolicies(map[string][]string{
+		"mcp:mustgather": {"must-gather://"},
+	})
+	ctx := ctxWithScopes([]string{"mcp:mustgather"})
+	assert.NoError(t, checkResourceScopePolicy(ctx, cfg, "must-gather://current"))
+	assert.NoError(t, checkResourceScopePolicy(ctx, cfg, "must-gather://current/namespaces"))
+	assert.NoError(t, checkResourceScopePolicy(ctx, cfg, "must-gather://current/resources/apps/v1/Deployment/ns/name"))
+}
+
+func TestCheckResourceScopePolicy_NoMatchingScope(t *testing.T) {
+	cfg := cfgWithResourcePolicies(map[string][]string{
+		"mcp:mustgather": {"must-gather://"},
+	})
+	ctx := ctxWithScopes([]string{"mcp:read"})
+	err := checkResourceScopePolicy(ctx, cfg, "must-gather://current")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient scope")
+	assert.Contains(t, err.Error(), "must-gather://current")
+	assert.Contains(t, err.Error(), "mcp:mustgather")
+}
+
+func TestCheckResourceScopePolicy_NoScopesInContext(t *testing.T) {
+	cfg := cfgWithResourcePolicies(map[string][]string{
+		"mcp:mustgather": {"must-gather://"},
+	})
+	err := checkResourceScopePolicy(context.Background(), cfg, "must-gather://current")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient scope")
+}
+
+func TestCheckResourceScopePolicy_MultiplePrefixes(t *testing.T) {
+	cfg := cfgWithResourcePolicies(map[string][]string{
+		"mcp:mustgather": {"must-gather://"},
+		"mcp:etcd":       {"must-gather://current/etcd/"},
+	})
+	ctx := ctxWithScopes([]string{"mcp:etcd"})
+	assert.NoError(t, checkResourceScopePolicy(ctx, cfg, "must-gather://current/etcd/members"))
+	require.Error(t, checkResourceScopePolicy(ctx, cfg, "must-gather://current/namespaces"))
+}

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -67,6 +67,9 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 		// Snapshot the live configuration once so a concurrent reload
 		// can't split BaseConfig and ListOutput across two configs.
 		cfg := s.configuration.Load()
+		if err := checkScopePolicy(ctx, cfg, tool.Tool.Name); err != nil {
+			return NewTextResult("", err), nil
+		}
 		// Check confirmation rules before executing the tool
 		if confirmErr := confirmation.CheckToolRules(
 			ctx, cfg, &sessionElicitor{},


### PR DESCRIPTION
_Draft implementation for oauth scoping MCP resource prefix(es)._

Introduces OAuth ScopePolicies where each policy is defined as a list of permissible scopes on MCP server startup config, individual MCP requests over OAuth check if given user have access to the necessary scope.

Motivation: https://redhat-internal.slack.com/archives/C08LQ6ZVBHR/p1784208298540599?thread_ts=1776290133.586099&cid=C08LQ6ZVBHR