### PR TITLE
feat(Kiali): Kiali multicluster evals

### DIFF
--- a/.github/workflows/mcpchecker-report.yaml
+++ b/.github/workflows/mcpchecker-report.yaml
@@ -104,3 +104,97 @@ jobs:
           [View full results](https://github.com/${REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID})
           EOF
           )"
+
+  # Kiali only: posts a separate PR comment when suite=kiali triggers multicluster eval.
+  report-multicluster:
+    name: Post Kiali Multicluster Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'issue_comment'
+    steps:
+      - name: Check if multicluster evaluation ran
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          JOB_CONCLUSION=$(gh api "repos/${REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.name == "Run MCP Multicluster Evaluation") | .conclusion')
+
+          if [[ -n "$JOB_CONCLUSION" && "$JOB_CONCLUSION" != "skipped" ]]; then
+            echo "should-report=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-report=false" >> $GITHUB_OUTPUT
+            echo "Kiali multicluster job was skipped, no report needed"
+          fi
+
+      - name: Download kiali multicluster evaluation context
+        if: steps.check.outputs.should-report == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: eval-context-multicluster
+          path: eval-context-multicluster/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post multicluster results comment
+        if: steps.check.outputs.should-report == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          PR_NUMBER=$(jq -r '.pr_number' eval-context-multicluster/context.json)
+          PR_SHA=$(jq -r '.pr_sha' eval-context-multicluster/context.json)
+          TASKS_PASSED=$(jq -r '.tasks_passed' eval-context-multicluster/context.json)
+          TASKS_TOTAL=$(jq -r '.tasks_total' eval-context-multicluster/context.json)
+          TASK_PASS_RATE=$(jq -r '.task_pass_rate' eval-context-multicluster/context.json)
+          ASSERTIONS_PASSED=$(jq -r '.assertions_passed' eval-context-multicluster/context.json)
+          ASSERTIONS_TOTAL=$(jq -r '.assertions_total' eval-context-multicluster/context.json)
+          PASSED=$(jq -r '.passed' eval-context-multicluster/context.json)
+          HAS_DIFF=$(jq -r '.has_diff // "false"' eval-context-multicluster/context.json)
+
+          PASS_RATE=$(awk "BEGIN {printf \"%.1f\", $TASK_PASS_RATE * 100}")
+
+          if [[ "$RUN_CONCLUSION" != "success" ]]; then
+            OVERALL="⚠️ Workflow failed"
+          elif [[ "$PASSED" == "true" ]]; then
+            OVERALL="✅ Passed"
+          else
+            OVERALL="❌ Failed"
+          fi
+
+          DIFF_SECTION=""
+          if [[ "$HAS_DIFF" == "true" ]] && [[ -f eval-context-multicluster/diff-output.txt ]]; then
+            DIFF_CONTENT=$(cat eval-context-multicluster/diff-output.txt)
+            DIFF_SECTION=$(cat <<DIFF_EOF
+
+          ### Diff vs. Baseline (main)
+
+          <details>
+          <summary>Click to expand mcpchecker diff</summary>
+
+          ${DIFF_CONTENT}
+
+          </details>
+          DIFF_EOF
+          )
+          fi
+
+          gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "$(cat <<EOF
+          ## mcpchecker Kiali Multicluster Evaluation Results
+
+          **Commit:** \`${PR_SHA:0:7}\`
+          **Summary:** ${TASKS_PASSED}/${TASKS_TOTAL} tasks passed (${PASS_RATE}%)
+
+          | Metric | Result |
+          |--------|--------|
+          | Tasks Passed | ${TASKS_PASSED}/${TASKS_TOTAL} |
+          | Assertions Passed | ${ASSERTIONS_PASSED}/${ASSERTIONS_TOTAL} |
+          | Overall | ${OVERALL} |
+          ${DIFF_SECTION}
+
+          [View full results](https://github.com/${REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID})
+          EOF
+          )"

--- a/.github/workflows/mcpchecker-report.yaml
+++ b/.github/workflows/mcpchecker-report.yaml
@@ -109,7 +109,7 @@ jobs:
   report-multicluster:
     name: Post Kiali Multicluster Results
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'issue_comment'
+    if: github.event.workflow_run.event == 'workflow_run'
     steps:
       - name: Check if multicluster evaluation ran
         id: check

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -80,7 +80,6 @@ jobs:
       pr-number: ${{ steps.check.outputs.pr-number }}
       pr-sha: ${{ steps.check.outputs.pr-sha }}
       is-pr: ${{ steps.check.outputs.is-pr }}
-      suite: ${{ steps.suite.outputs.suite }}
     steps:
       - name: Check trigger conditions
         id: check
@@ -443,7 +442,7 @@ jobs:
     needs: check-trigger
     if: |
       needs.check-trigger.outputs.should-run == 'true' &&
-      needs.check-trigger.outputs.suite == 'kiali'
+      needs.check-trigger.outputs.label-selector == 'suite=kiali'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -474,6 +473,7 @@ jobs:
           MCP_CONFIG_DIR: dev/config/mcp-configs-multicluster
 
       - name: Run mcpchecker multicluster evaluation
+        id: mcpchecker
         uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-action@v0.0.18
         with:
           eval-config: 'evals/tasks/kiali/multicluster/eval.yaml'
@@ -493,6 +493,79 @@ jobs:
           JUDGE_BASE_URL: ${{ secrets.JUDGE_BASE_URL }}
           JUDGE_API_KEY: ${{ secrets.JUDGE_API_KEY }}
           JUDGE_MODEL_NAME: ${{ secrets.JUDGE_MODEL_NAME }}
+
+      - name: Fetch multicluster baseline results from main
+        if: needs.check-trigger.outputs.is-pr == 'true'
+        run: |
+          git fetch origin main --depth=1
+          git show "origin/main:evals/results/openai-agent-multicluster-latest.json" > /tmp/baseline-multicluster-results.json 2>/dev/null || true
+
+      - name: Check multicluster diff prerequisites
+        id: diff-check
+        if: needs.check-trigger.outputs.is-pr == 'true'
+        run: |
+          RESULTS_FILE=$(ls -t mcpchecker-*-out.json 2>/dev/null | head -1)
+          if [ -z "$RESULTS_FILE" ]; then
+            echo "No multicluster mcpchecker results file found, skipping diff"
+            echo "has-diff=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [ ! -s /tmp/baseline-multicluster-results.json ]; then
+            echo "No multicluster baseline results found on main branch, skipping diff"
+            echo "has-diff=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "has-diff=true" >> $GITHUB_OUTPUT
+          echo "results-file=$RESULTS_FILE" >> $GITHUB_OUTPUT
+
+      - name: Run multicluster mcpchecker diff
+        id: mcpchecker-diff
+        if: needs.check-trigger.outputs.is-pr == 'true' && steps.diff-check.outputs.has-diff == 'true'
+        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-diff-action@v0.0.18
+        with:
+          base-results: /tmp/baseline-multicluster-results.json
+          current-results: ${{ steps.diff-check.outputs.results-file }}
+          mcpchecker-version: 'latest'
+
+      - name: Save multicluster evaluation context
+        if: always() && needs.check-trigger.outputs.is-pr == 'true'
+        env:
+          DIFF_OUTPUT: ${{ steps.mcpchecker-diff.outputs.diff-output }}
+          PR_NUMBER: ${{ needs.check-trigger.outputs.pr-number }}
+          PR_SHA: ${{ needs.check-trigger.outputs.pr-sha }}
+          TASKS_PASSED: ${{ steps.mcpchecker.outputs.tasks-passed }}
+          TASKS_TOTAL: ${{ steps.mcpchecker.outputs.tasks-total }}
+          TASK_PASS_RATE: ${{ steps.mcpchecker.outputs.task-pass-rate }}
+          ASSERTIONS_PASSED: ${{ steps.mcpchecker.outputs.assertions-passed }}
+          ASSERTIONS_TOTAL: ${{ steps.mcpchecker.outputs.assertions-total }}
+          PASSED: ${{ steps.mcpchecker.outputs.passed }}
+          HAS_DIFF: ${{ steps.diff-check.outputs.has-diff || 'false' }}
+        run: |
+          mkdir -p eval-context-multicluster
+          cat > eval-context-multicluster/context.json << EOF
+          {
+            "pr_number": "${PR_NUMBER}",
+            "pr_sha": "${PR_SHA}",
+            "tasks_passed": "${TASKS_PASSED}",
+            "tasks_total": "${TASKS_TOTAL}",
+            "task_pass_rate": "${TASK_PASS_RATE}",
+            "assertions_passed": "${ASSERTIONS_PASSED}",
+            "assertions_total": "${ASSERTIONS_TOTAL}",
+            "passed": "${PASSED}",
+            "has_diff": "${HAS_DIFF}"
+          }
+          EOF
+          if [ -n "$DIFF_OUTPUT" ]; then
+            echo "$DIFF_OUTPUT" > eval-context-multicluster/diff-output.txt
+          fi
+
+      - name: Upload multicluster PR context
+        if: always() && needs.check-trigger.outputs.is-pr == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: eval-context-multicluster
+          path: eval-context-multicluster/
+          retention-days: 1
 
       - name: Cleanup
         if: always()
@@ -596,6 +669,93 @@ jobs:
             echo "Creating new PR"
             gh pr create \
               --title "chore: update mcpchecker evaluation results" \
+              --body "$PR_BODY" \
+              --base main \
+              --head "$BRANCH"
+          fi
+
+  # Kiali multicluster results only (suite=kiali scheduled runs)
+  commit-multicluster-results:
+    name: Commit Kiali Multicluster Results
+    needs: [check-trigger, run-evaluation-multicluster]
+    if: |
+      always() &&
+      github.event_name == 'schedule' &&
+      needs.check-trigger.outputs.label-selector == 'suite=kiali' &&
+      needs.run-evaluation-multicluster.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: main
+
+      - name: Download mcpchecker multicluster results
+        uses: actions/download-artifact@v8
+        with:
+          name: mcpchecker-multicluster-results
+          path: mcpchecker-multicluster-results/
+
+      - name: Copy multicluster results to evals/results
+        run: |
+          mkdir -p evals/results
+          MC_RESULTS_FILE=$(ls -t mcpchecker-multicluster-results/mcpchecker-*-out.json 2>/dev/null | head -1)
+          if [ -z "$MC_RESULTS_FILE" ]; then
+            echo "Error: No multicluster mcpchecker results file found"
+            exit 1
+          fi
+          cp "$MC_RESULTS_FILE" "evals/results/openai-agent-multicluster-latest.json"
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIGGER: ${{ github.event_name }}
+          COMMIT_SHA: ${{ needs.check-trigger.outputs.pr-sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BRANCH="chore/update-eval-results"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$BRANCH"
+          git add evals/results/openai-agent-multicluster-latest.json
+
+          if git diff --staged --quiet; then
+            echo "No multicluster result changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore(evals): update kiali multicluster mcpchecker results"
+          git push -f origin "$BRANCH"
+
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' || echo "")
+
+          PR_BODY=$(cat <<EOF
+          ## Automated Kiali Multicluster Evaluation Results Update
+
+          This PR updates the kiali multicluster mcpchecker results from the weekly scheduled run.
+
+          **Run details:**
+          - Trigger: $TRIGGER
+          - Commit: $COMMIT_SHA
+          - Workflow run: $RUN_URL
+
+          ---
+          This PR was automatically generated by the mcpchecker workflow.
+          EOF
+          )
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Updating existing PR #$EXISTING_PR"
+            gh pr edit "$EXISTING_PR" --body "$PR_BODY"
+          else
+            echo "Creating new PR"
+            gh pr create \
+              --title "chore: update kiali multicluster mcpchecker results" \
               --body "$PR_BODY" \
               --base main \
               --head "$BRANCH"

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -80,6 +80,7 @@ jobs:
       pr-number: ${{ steps.check.outputs.pr-number }}
       pr-sha: ${{ steps.check.outputs.pr-sha }}
       is-pr: ${{ steps.check.outputs.is-pr }}
+      suite: ${{ steps.suite.outputs.suite }}
     steps:
       - name: Check trigger conditions
         id: check
@@ -264,6 +265,7 @@ jobs:
           esac
 
           echo "matrix=$(echo "$MATRIX" | jq -c .)" >> "$GITHUB_OUTPUT"
+          echo "suite=$SUITE" >> "$GITHUB_OUTPUT"
 
   # Run mcpchecker evaluation with Kind cluster
   run-evaluation:
@@ -435,6 +437,60 @@ jobs:
           name: eval-context-${{ matrix.suite }}
           path: eval-context/
           retention-days: 1
+
+  run-evaluation-multicluster:
+    name: Run MCP Multicluster Evaluation
+    needs: check-trigger
+    if: |
+      needs.check-trigger.outputs.should-run == 'true' &&
+      needs.check-trigger.outputs.suite == 'kiali'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.check-trigger.outputs.pr-sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Setup multicluster Kind + Istio/Kiali
+        run: make setup-kiali-multicluster
+
+      - name: Start MCP server
+        run: make run-server
+        env:
+          TOOLSETS: core,config,kiali
+          MCP_CONFIG_DIR: dev/config/mcp-configs-multicluster
+
+      - name: Run mcpchecker multicluster evaluation
+        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-action@v0.0.18
+        with:
+          eval-config: 'evals/tasks/kiali/multicluster/eval.yaml'
+          mcpchecker-version: 'latest'
+          task-filter: ${{ github.event.inputs.task-filter || '' }}
+          output-format: 'json'
+          verbose: ${{ github.event.inputs.verbose || 'false' }}
+          upload-artifacts: 'true'
+          artifact-name: 'mcpchecker-multicluster-results'
+          fail-on-error: 'false'
+          task-pass-threshold: '0.8'
+          assertion-pass-threshold: '0.8'
+          working-directory: '.'
+        env:
+          MODEL_BASE_URL: ${{ secrets.MODEL_BASE_URL }}
+          MODEL_KEY: ${{ secrets.MODEL_KEY }}
+          JUDGE_BASE_URL: ${{ secrets.JUDGE_BASE_URL }}
+          JUDGE_API_KEY: ${{ secrets.JUDGE_API_KEY }}
+          JUDGE_MODEL_NAME: ${{ secrets.JUDGE_MODEL_NAME }}
+
+      - name: Cleanup
+        if: always()
+        run: |
+          make stop-server || true
+          make kind-delete-multicluster || true
 
   # Create PR with results (scheduled runs only)
   commit-results:

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -77,6 +77,7 @@ jobs:
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
       matrix: ${{ steps.suite.outputs.matrix }}
+      run-multicluster: ${{ steps.suite.outputs.run-multicluster }}
       pr-number: ${{ steps.check.outputs.pr-number }}
       pr-sha: ${{ steps.check.outputs.pr-sha }}
       is-pr: ${{ steps.check.outputs.is-pr }}
@@ -264,7 +265,13 @@ jobs:
           esac
 
           echo "matrix=$(echo "$MATRIX" | jq -c .)" >> "$GITHUB_OUTPUT"
-          echo "suite=$SUITE" >> "$GITHUB_OUTPUT"
+
+          # Multicluster Kiali evals: weekly schedule, explicit kiali suite, or all.
+          if [[ "$SUITE" == "kiali" || "$SUITE" == "all" || "$SUITE" == "schedule-matrix" ]]; then
+            echo "run-multicluster=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-multicluster=false" >> "$GITHUB_OUTPUT"
+          fi
 
   # Run mcpchecker evaluation with Kind cluster
   run-evaluation:
@@ -442,16 +449,17 @@ jobs:
     needs: check-trigger
     if: |
       needs.check-trigger.outputs.should-run == 'true' &&
-      needs.check-trigger.outputs.label-selector == 'suite=kiali'
+      needs.check-trigger.outputs.run-multicluster == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ needs.check-trigger.outputs.pr-sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -474,7 +482,7 @@ jobs:
 
       - name: Run mcpchecker multicluster evaluation
         id: mcpchecker
-        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-action@v0.0.18
+        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-action@v0.0.19
         with:
           eval-config: 'evals/tasks/kiali/multicluster/eval.yaml'
           mcpchecker-version: 'latest'
@@ -521,7 +529,7 @@ jobs:
       - name: Run multicluster mcpchecker diff
         id: mcpchecker-diff
         if: needs.check-trigger.outputs.is-pr == 'true' && steps.diff-check.outputs.has-diff == 'true'
-        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-diff-action@v0.0.18
+        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-diff-action@v0.0.19
         with:
           base-results: /tmp/baseline-multicluster-results.json
           current-results: ${{ steps.diff-check.outputs.results-file }}
@@ -576,9 +584,10 @@ jobs:
   # Create PR with results (scheduled runs only)
   commit-results:
     name: Commit Evaluation Results
-    needs: [check-trigger, run-evaluation]
+    needs: [check-trigger, run-evaluation, run-evaluation-multicluster]
     # Only commit results on scheduled runs. Use != 'cancelled' so partial
     # results from passing suites are still committed when some matrix jobs fail.
+    # Multicluster results are included here to avoid racing on chore/update-eval-results.
     if: always() && github.event_name == 'schedule' && needs.run-evaluation.result != 'cancelled'
     runs-on: ubuntu-latest
     permissions:
@@ -595,6 +604,13 @@ jobs:
         with:
           pattern: mcpchecker-results-*
           path: mcpchecker-results/
+
+      - name: Download mcpchecker multicluster results
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: mcpchecker-multicluster-results
+          path: mcpchecker-multicluster-results/
 
       - name: Copy results to evals/results
         run: |
@@ -618,6 +634,14 @@ jobs:
             cp "$RESULTS_FILE" "evals/results/${RESULT_NAME}-latest.json"
             echo "Copied ${SUITE} results to evals/results/${RESULT_NAME}-latest.json"
           done
+
+          MC_RESULTS_FILE=$(ls -t mcpchecker-multicluster-results/mcpchecker-*-out.json 2>/dev/null | head -1)
+          if [ -n "$MC_RESULTS_FILE" ]; then
+            cp "$MC_RESULTS_FILE" "evals/results/openai-agent-multicluster-latest.json"
+            echo "Copied multicluster results to evals/results/openai-agent-multicluster-latest.json"
+          else
+            echo "No multicluster results artifact present (job skipped or failed); continuing"
+          fi
 
       - name: Create Pull Request
         env:
@@ -669,93 +693,6 @@ jobs:
             echo "Creating new PR"
             gh pr create \
               --title "chore: update mcpchecker evaluation results" \
-              --body "$PR_BODY" \
-              --base main \
-              --head "$BRANCH"
-          fi
-
-  # Kiali multicluster results only (suite=kiali scheduled runs)
-  commit-multicluster-results:
-    name: Commit Kiali Multicluster Results
-    needs: [check-trigger, run-evaluation-multicluster]
-    if: |
-      always() &&
-      github.event_name == 'schedule' &&
-      needs.check-trigger.outputs.label-selector == 'suite=kiali' &&
-      needs.run-evaluation-multicluster.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.0
-        with:
-          ref: main
-
-      - name: Download mcpchecker multicluster results
-        uses: actions/download-artifact@v8
-        with:
-          name: mcpchecker-multicluster-results
-          path: mcpchecker-multicluster-results/
-
-      - name: Copy multicluster results to evals/results
-        run: |
-          mkdir -p evals/results
-          MC_RESULTS_FILE=$(ls -t mcpchecker-multicluster-results/mcpchecker-*-out.json 2>/dev/null | head -1)
-          if [ -z "$MC_RESULTS_FILE" ]; then
-            echo "Error: No multicluster mcpchecker results file found"
-            exit 1
-          fi
-          cp "$MC_RESULTS_FILE" "evals/results/openai-agent-multicluster-latest.json"
-
-      - name: Create Pull Request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TRIGGER: ${{ github.event_name }}
-          COMMIT_SHA: ${{ needs.check-trigger.outputs.pr-sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          BRANCH="chore/update-eval-results"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git checkout -B "$BRANCH"
-          git add evals/results/openai-agent-multicluster-latest.json
-
-          if git diff --staged --quiet; then
-            echo "No multicluster result changes to commit"
-            exit 0
-          fi
-
-          git commit -m "chore(evals): update kiali multicluster mcpchecker results"
-          git push -f origin "$BRANCH"
-
-          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' || echo "")
-
-          PR_BODY=$(cat <<EOF
-          ## Automated Kiali Multicluster Evaluation Results Update
-
-          This PR updates the kiali multicluster mcpchecker results from the weekly scheduled run.
-
-          **Run details:**
-          - Trigger: $TRIGGER
-          - Commit: $COMMIT_SHA
-          - Workflow run: $RUN_URL
-
-          ---
-          This PR was automatically generated by the mcpchecker workflow.
-          EOF
-          )
-
-          if [ -n "$EXISTING_PR" ]; then
-            echo "Updating existing PR #$EXISTING_PR"
-            gh pr edit "$EXISTING_PR" --body "$PR_BODY"
-          else
-            echo "Creating new PR"
-            gh pr create \
-              --title "chore: update kiali multicluster mcpchecker results" \
               --body "$PR_BODY" \
               --base main \
               --head "$BRANCH"

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -456,6 +456,14 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup multicluster Kind + Istio/Kiali
         run: make setup-kiali-multicluster
 

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -80,6 +80,7 @@ jobs:
       pr-number: ${{ steps.check.outputs.pr-number }}
       pr-sha: ${{ steps.check.outputs.pr-sha }}
       is-pr: ${{ steps.check.outputs.is-pr }}
+      suite: ${{ steps.suite.outputs.suite }}
     steps:
       - name: Check trigger conditions
         id: check
@@ -264,6 +265,7 @@ jobs:
           esac
 
           echo "matrix=$(echo "$MATRIX" | jq -c .)" >> "$GITHUB_OUTPUT"
+          echo "suite=$SUITE" >> "$GITHUB_OUTPUT"
 
   # Run mcpchecker evaluation with Minikube cluster
   run-evaluation:
@@ -435,6 +437,60 @@ jobs:
           name: eval-context-${{ matrix.suite }}
           path: eval-context/
           retention-days: 1
+
+  run-evaluation-multicluster:
+    name: Run MCP Multicluster Evaluation
+    needs: check-trigger
+    if: |
+      needs.check-trigger.outputs.should-run == 'true' &&
+      needs.check-trigger.outputs.suite == 'kiali'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.check-trigger.outputs.pr-sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Setup multicluster Kind + Istio/Kiali
+        run: make setup-kiali-multicluster
+
+      - name: Start MCP server
+        run: make run-server
+        env:
+          TOOLSETS: core,config,kiali
+          MCP_CONFIG_DIR: dev/config/mcp-configs-multicluster
+
+      - name: Run mcpchecker multicluster evaluation
+        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-action@v0.0.18
+        with:
+          eval-config: 'evals/tasks/kiali/multicluster/eval.yaml'
+          mcpchecker-version: 'latest'
+          task-filter: ${{ github.event.inputs.task-filter || '' }}
+          output-format: 'json'
+          verbose: ${{ github.event.inputs.verbose || 'false' }}
+          upload-artifacts: 'true'
+          artifact-name: 'mcpchecker-multicluster-results'
+          fail-on-error: 'false'
+          task-pass-threshold: '0.8'
+          assertion-pass-threshold: '0.8'
+          working-directory: '.'
+        env:
+          MODEL_BASE_URL: ${{ secrets.MODEL_BASE_URL }}
+          MODEL_KEY: ${{ secrets.MODEL_KEY }}
+          JUDGE_BASE_URL: ${{ secrets.JUDGE_BASE_URL }}
+          JUDGE_API_KEY: ${{ secrets.JUDGE_API_KEY }}
+          JUDGE_MODEL_NAME: ${{ secrets.JUDGE_MODEL_NAME }}
+
+      - name: Cleanup
+        if: always()
+        run: |
+          make stop-server || true
+          make kind-delete-multicluster || true
 
   # Create PR with results (scheduled runs only)
   commit-results:

--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -77,6 +77,7 @@ jobs:
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
       matrix: ${{ steps.suite.outputs.matrix }}
+      run-multicluster: ${{ steps.suite.outputs.run-multicluster }}
       pr-number: ${{ steps.check.outputs.pr-number }}
       pr-sha: ${{ steps.check.outputs.pr-sha }}
       is-pr: ${{ steps.check.outputs.is-pr }}
@@ -264,7 +265,13 @@ jobs:
           esac
 
           echo "matrix=$(echo "$MATRIX" | jq -c .)" >> "$GITHUB_OUTPUT"
-          echo "suite=$SUITE" >> "$GITHUB_OUTPUT"
+
+          # Multicluster Kiali evals: weekly schedule, explicit kiali suite, or all.
+          if [[ "$SUITE" == "kiali" || "$SUITE" == "all" || "$SUITE" == "schedule-matrix" ]]; then
+            echo "run-multicluster=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-multicluster=false" >> "$GITHUB_OUTPUT"
+          fi
 
   # Run mcpchecker evaluation with Minikube cluster
   run-evaluation:
@@ -442,16 +449,17 @@ jobs:
     needs: check-trigger
     if: |
       needs.check-trigger.outputs.should-run == 'true' &&
-      needs.check-trigger.outputs.label-selector == 'suite=kiali'
+      needs.check-trigger.outputs.run-multicluster == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ needs.check-trigger.outputs.pr-sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -474,7 +482,7 @@ jobs:
 
       - name: Run mcpchecker multicluster evaluation
         id: mcpchecker
-        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-action@v0.0.18
+        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-action@v0.0.19
         with:
           eval-config: 'evals/tasks/kiali/multicluster/eval.yaml'
           mcpchecker-version: 'latest'
@@ -521,7 +529,7 @@ jobs:
       - name: Run multicluster mcpchecker diff
         id: mcpchecker-diff
         if: needs.check-trigger.outputs.is-pr == 'true' && steps.diff-check.outputs.has-diff == 'true'
-        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-diff-action@v0.0.18
+        uses: mcpchecker/mcpchecker/.github/actions/mcpchecker-diff-action@v0.0.19
         with:
           base-results: /tmp/baseline-multicluster-results.json
           current-results: ${{ steps.diff-check.outputs.results-file }}
@@ -576,9 +584,10 @@ jobs:
   # Create PR with results (scheduled runs only)
   commit-results:
     name: Commit Evaluation Results
-    needs: [check-trigger, run-evaluation]
+    needs: [check-trigger, run-evaluation, run-evaluation-multicluster]
     # Only commit results on scheduled runs. Use != 'cancelled' so partial
     # results from passing suites are still committed when some matrix jobs fail.
+    # Multicluster results are included here to avoid racing on chore/update-eval-results.
     if: always() && github.event_name == 'schedule' && needs.run-evaluation.result != 'cancelled'
     runs-on: ubuntu-latest
     permissions:
@@ -595,6 +604,13 @@ jobs:
         with:
           pattern: mcpchecker-results-*
           path: mcpchecker-results/
+
+      - name: Download mcpchecker multicluster results
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: mcpchecker-multicluster-results
+          path: mcpchecker-multicluster-results/
 
       - name: Copy results to evals/results
         run: |
@@ -618,6 +634,14 @@ jobs:
             cp "$RESULTS_FILE" "evals/results/${RESULT_NAME}-latest.json"
             echo "Copied ${SUITE} results to evals/results/${RESULT_NAME}-latest.json"
           done
+
+          MC_RESULTS_FILE=$(ls -t mcpchecker-multicluster-results/mcpchecker-*-out.json 2>/dev/null | head -1)
+          if [ -n "$MC_RESULTS_FILE" ]; then
+            cp "$MC_RESULTS_FILE" "evals/results/openai-agent-multicluster-latest.json"
+            echo "Copied multicluster results to evals/results/openai-agent-multicluster-latest.json"
+          else
+            echo "No multicluster results artifact present (job skipped or failed); continuing"
+          fi
 
       - name: Create Pull Request
         env:
@@ -669,93 +693,6 @@ jobs:
             echo "Creating new PR"
             gh pr create \
               --title "chore: update mcpchecker evaluation results" \
-              --body "$PR_BODY" \
-              --base main \
-              --head "$BRANCH"
-          fi
-
-  # Kiali multicluster results only (suite=kiali scheduled runs)
-  commit-multicluster-results:
-    name: Commit Kiali Multicluster Results
-    needs: [check-trigger, run-evaluation-multicluster]
-    if: |
-      always() &&
-      github.event_name == 'schedule' &&
-      needs.check-trigger.outputs.label-selector == 'suite=kiali' &&
-      needs.run-evaluation-multicluster.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.0
-        with:
-          ref: main
-
-      - name: Download mcpchecker multicluster results
-        uses: actions/download-artifact@v8
-        with:
-          name: mcpchecker-multicluster-results
-          path: mcpchecker-multicluster-results/
-
-      - name: Copy multicluster results to evals/results
-        run: |
-          mkdir -p evals/results
-          MC_RESULTS_FILE=$(ls -t mcpchecker-multicluster-results/mcpchecker-*-out.json 2>/dev/null | head -1)
-          if [ -z "$MC_RESULTS_FILE" ]; then
-            echo "Error: No multicluster mcpchecker results file found"
-            exit 1
-          fi
-          cp "$MC_RESULTS_FILE" "evals/results/openai-agent-multicluster-latest.json"
-
-      - name: Create Pull Request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TRIGGER: ${{ github.event_name }}
-          COMMIT_SHA: ${{ needs.check-trigger.outputs.pr-sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          BRANCH="chore/update-eval-results"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git checkout -B "$BRANCH"
-          git add evals/results/openai-agent-multicluster-latest.json
-
-          if git diff --staged --quiet; then
-            echo "No multicluster result changes to commit"
-            exit 0
-          fi
-
-          git commit -m "chore(evals): update kiali multicluster mcpchecker results"
-          git push -f origin "$BRANCH"
-
-          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' || echo "")
-
-          PR_BODY=$(cat <<EOF
-          ## Automated Kiali Multicluster Evaluation Results Update
-
-          This PR updates the kiali multicluster mcpchecker results from the weekly scheduled run.
-
-          **Run details:**
-          - Trigger: $TRIGGER
-          - Commit: $COMMIT_SHA
-          - Workflow run: $RUN_URL
-
-          ---
-          This PR was automatically generated by the mcpchecker workflow.
-          EOF
-          )
-
-          if [ -n "$EXISTING_PR" ]; then
-            echo "Updating existing PR #$EXISTING_PR"
-            gh pr edit "$EXISTING_PR" --body "$PR_BODY"
-          else
-            echo "Creating new PR"
-            gh pr create \
-              --title "chore: update kiali multicluster mcpchecker results" \
               --body "$PR_BODY" \
               --base main \
               --head "$BRANCH"

--- a/build/kiali.mk
+++ b/build/kiali.mk
@@ -1,5 +1,7 @@
 ##@ Istio/Kiali
 
+SHELL := /bin/bash
+
 ISTIOCTL = $(shell pwd)/_output/tools/bin/istioctl
 ISTIO_ADDONS_DIR = $(shell pwd)/_output/istio-addons
 ISTIO_VERSION = 1.30.1

--- a/build/kiali.mk
+++ b/build/kiali.mk
@@ -6,6 +6,11 @@ ISTIOCTL = $(shell pwd)/_output/tools/bin/istioctl
 ISTIO_ADDONS_DIR = $(shell pwd)/_output/istio-addons
 ISTIO_VERSION = 1.30.1
 KIALI_VERSION = v2.27
+# Multicluster evals call Kiali MCP tools (e.g. list_clusters) that exist only on
+# Kiali master today. Upstream setup-kind-in-ci.sh also hardcodes -kudi true for
+# MC, so a released -kv (e.g. v2.27) still tries to push a local image without
+# building it unless KIALI_BUILD_DEV_IMAGE=true (set below when this is "dev").
+KIALI_MC_VERSION = dev
 # Release version without patch (e.g. 1.28.0 -> 1.28)
 
 # Download and install istioctl (also copies samples/addons for install-istio)
@@ -124,7 +129,7 @@ setup-kiali-multicluster: ## Setup primary-remote multicluster Kind + Istio/Kial
 		exit 1; \
 	fi; \
 	echo "Using Kiali hack scripts from: $${KIALI_HACK_DIR}"; \
-	if [ "$(KIALI_VERSION)" = "dev" ]; then \
+	if [ "$(KIALI_MC_VERSION)" = "dev" ]; then \
 		export KIALI_BUILD_DEV_IMAGE="$${KIALI_BUILD_DEV_IMAGE:-true}"; \
 		echo "KIALI_BUILD_DEV_IMAGE=$${KIALI_BUILD_DEV_IMAGE} (dev image requires build-ui + build before push)"; \
 	fi; \
@@ -135,7 +140,7 @@ setup-kiali-multicluster: ## Setup primary-remote multicluster Kind + Istio/Kial
 			--multicluster primary-remote \
 			--tempo false \
 			--auth-strategy anonymous \
-			-kv "$(KIALI_VERSION)" \
+			-kv "$(KIALI_MC_VERSION)" \
 			--istio-version "$(ISTIO_VERSION)" \
 			--deploy-kiali true; \
 	); \
@@ -160,7 +165,7 @@ setup-kiali-multicluster: ## Setup primary-remote multicluster Kind + Istio/Kial
 		-H 'Content-Type: application/json' -d '{"mcp_mode":true}'); \
 	if ! echo "$$list_clusters" | jq -e 'type == "array"' >/dev/null 2>&1; then \
 		echo "ERROR: Kiali MCP list_clusters unavailable: $$list_clusters" >&2; \
-		echo "Try a newer Kiali image or rebuild from source:" >&2; \
+		echo "Multicluster evals require Kiali master (KIALI_MC_VERSION=dev). Try:" >&2; \
 		echo "  KIALI_SRC=~/dev/kiali_sources/kiali make redeploy-kiali-multicluster-dev" >&2; \
 		exit 1; \
 	fi; \

--- a/build/kiali.mk
+++ b/build/kiali.mk
@@ -6,8 +6,6 @@ ISTIOCTL = $(shell pwd)/_output/tools/bin/istioctl
 ISTIO_ADDONS_DIR = $(shell pwd)/_output/istio-addons
 ISTIO_VERSION = 1.30.1
 KIALI_VERSION = v2.27
-# Multicluster evals call Kiali MCP tools (e.g. list_clusters) that exist only on Kiali master today.
-KIALI_MC_VERSION = dev
 # Release version without patch (e.g. 1.28.0 -> 1.28)
 
 # Download and install istioctl (also copies samples/addons for install-istio)
@@ -126,7 +124,7 @@ setup-kiali-multicluster: ## Setup primary-remote multicluster Kind + Istio/Kial
 		exit 1; \
 	fi; \
 	echo "Using Kiali hack scripts from: $${KIALI_HACK_DIR}"; \
-	if [ "$(KIALI_MC_VERSION)" = "dev" ]; then \
+	if [ "$(KIALI_VERSION)" = "dev" ]; then \
 		export KIALI_BUILD_DEV_IMAGE="$${KIALI_BUILD_DEV_IMAGE:-true}"; \
 		echo "KIALI_BUILD_DEV_IMAGE=$${KIALI_BUILD_DEV_IMAGE} (dev image requires build-ui + build before push)"; \
 	fi; \
@@ -137,7 +135,7 @@ setup-kiali-multicluster: ## Setup primary-remote multicluster Kind + Istio/Kial
 			--multicluster primary-remote \
 			--tempo false \
 			--auth-strategy anonymous \
-			-kv "$(KIALI_MC_VERSION)" \
+			-kv "$(KIALI_VERSION)" \
 			--istio-version "$(ISTIO_VERSION)" \
 			--deploy-kiali true; \
 	); \
@@ -162,7 +160,7 @@ setup-kiali-multicluster: ## Setup primary-remote multicluster Kind + Istio/Kial
 		-H 'Content-Type: application/json' -d '{"mcp_mode":true}'); \
 	if ! echo "$$list_clusters" | jq -e 'type == "array"' >/dev/null 2>&1; then \
 		echo "ERROR: Kiali MCP list_clusters unavailable: $$list_clusters" >&2; \
-		echo "Multicluster evals require Kiali master (KIALI_MC_VERSION=dev). Try:" >&2; \
+		echo "Try a newer Kiali image or rebuild from source:" >&2; \
 		echo "  KIALI_SRC=~/dev/kiali_sources/kiali make redeploy-kiali-multicluster-dev" >&2; \
 		exit 1; \
 	fi; \

--- a/build/kiali.mk
+++ b/build/kiali.mk
@@ -4,6 +4,8 @@ ISTIOCTL = $(shell pwd)/_output/tools/bin/istioctl
 ISTIO_ADDONS_DIR = $(shell pwd)/_output/istio-addons
 ISTIO_VERSION = 1.30.1
 KIALI_VERSION = v2.27
+# Multicluster evals call Kiali MCP tools (e.g. list_clusters) that exist only on Kiali master today.
+KIALI_MC_VERSION = dev
 # Release version without patch (e.g. 1.28.0 -> 1.28)
 
 # Download and install istioctl (also copies samples/addons for install-istio)
@@ -82,3 +84,178 @@ expose-kiali:
 
 .PHONY: setup-kiali
 setup-kiali: install-istio install-gateway-api-crds update-kiali-version install-bookinfo-demo expose-kiali expose-bookinfo-demo ## Setup Kiali
+
+# Optional local Kiali checkout for multicluster hack scripts (override: KIALI_SRC=/path/to/kiali).
+KIALI_REF ?= master
+KIALI_SRC ?=
+KIALI_HACK_DIR = $(if $(KIALI_SRC),$(KIALI_SRC),$(shell pwd)/_output/kiali-hack)
+KIALI_MC_CONFIG = dev/config/mcp-configs-multicluster/kiali.toml
+
+.PHONY: write-kiali-multicluster-mcp-config
+write-kiali-multicluster-mcp-config: ## Write MCP kiali.toml from Kiali LoadBalancer on kind-east
+	@set -euo pipefail; \
+	kubectl wait --for=jsonpath='{.status.loadBalancer.ingress[0]}' -n istio-system service/kiali \
+		--context kind-east --timeout=300s; \
+	KIALI_URL=$$(kubectl get svc kiali -n istio-system --context kind-east \
+		-o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali/'); \
+	if [ -z "$${KIALI_URL}" ] || [ "$${KIALI_URL}" = "http:///kiali/" ]; then \
+		echo "ERROR: failed to resolve Kiali LoadBalancer URL on kind-east" >&2; \
+		exit 1; \
+	fi; \
+	mkdir -p dev/config/mcp-configs-multicluster; \
+	printf '%s\n' "[toolset_configs.kiali]" "url = \"$${KIALI_URL}\"" "insecure = true" > "$(KIALI_MC_CONFIG)"; \
+	echo "Wrote $(KIALI_MC_CONFIG) (url=$${KIALI_URL})"
+
+.PHONY: setup-kiali-multicluster
+setup-kiali-multicluster: ## Setup primary-remote multicluster Kind + Istio/Kiali for MCP evals
+	@set -euo pipefail; \
+	ROOTDIR="$$(pwd)"; \
+	KIALI_HACK_DIR="$(KIALI_HACK_DIR)"; \
+	for cmd in git curl kubectl docker helm yq envsubst jq; do \
+		command -v "$$cmd" >/dev/null 2>&1 || { echo "ERROR: required command not found: $$cmd" >&2; exit 1; }; \
+	done; \
+	if [ ! -f "$${KIALI_HACK_DIR}/hack/setup-kind-in-ci.sh" ]; then \
+		echo "Cloning kiali/kiali ($(KIALI_REF)) into $${KIALI_HACK_DIR}..."; \
+		git clone --depth 1 --branch "$(KIALI_REF)" https://github.com/kiali/kiali.git "$${KIALI_HACK_DIR}"; \
+	fi; \
+	if ! grep -q 'kiali-version' "$${KIALI_HACK_DIR}/hack/setup-kind-in-ci.sh" 2>/dev/null; then \
+		echo "ERROR: $${KIALI_HACK_DIR} is too old for multicluster setup (missing --kiali-version support)." >&2; \
+		echo "Set KIALI_SRC to a newer checkout or remove stale clone: rm -rf $${KIALI_HACK_DIR}" >&2; \
+		exit 1; \
+	fi; \
+	echo "Using Kiali hack scripts from: $${KIALI_HACK_DIR}"; \
+	echo "Setting up primary-remote multicluster Kind clusters (east/west)..."; \
+	( \
+		cd "$${KIALI_HACK_DIR}"; \
+		./hack/setup-kind-in-ci.sh \
+			--multicluster primary-remote \
+			--tempo false \
+			--auth-strategy anonymous \
+			-kv "$(KIALI_MC_VERSION)" \
+			--istio-version "$(ISTIO_VERSION)" \
+			--deploy-kiali true; \
+	); \
+	echo "Waiting for Kiali on kind-east..."; \
+	kubectl rollout status deployment/kiali -n istio-system --context kind-east --timeout=300s; \
+	$(MAKE) write-kiali-multicluster-mcp-config; \
+	KIALI_URL=$$(kubectl get svc kiali -n istio-system --context kind-east \
+		-o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali/'); \
+	echo "Waiting for Kiali health at $${KIALI_URL}..."; \
+	start=$$(date +%s); \
+	while ! curl -sf "$${KIALI_URL}healthz" >/dev/null 2>&1; do \
+		elapsed=$$(( $$(date +%s) - start )); \
+		if [ "$$elapsed" -ge 120 ]; then \
+			echo "ERROR: timed out waiting for Kiali health at $${KIALI_URL}healthz" >&2; \
+			exit 1; \
+		fi; \
+		sleep 2; \
+	done; \
+	echo "Kiali is healthy"; \
+	echo "Verifying Kiali MCP list_clusters..."; \
+	list_clusters=$$(curl -sk -X POST "$${KIALI_URL}api/chat/mcp/list_clusters" \
+		-H 'Content-Type: application/json' -d '{"mcp_mode":true}'); \
+	if ! echo "$$list_clusters" | jq -e 'type == "array"' >/dev/null 2>&1; then \
+		echo "ERROR: Kiali MCP list_clusters unavailable: $$list_clusters" >&2; \
+		echo "Multicluster evals require Kiali master (KIALI_MC_VERSION=dev). Try:" >&2; \
+		echo "  KIALI_SRC=~/dev/kiali_sources/kiali make redeploy-kiali-multicluster-dev" >&2; \
+		exit 1; \
+	fi; \
+	echo "list_clusters OK ($$(echo "$$list_clusters" | jq -c 'map(.name)'))"; \
+	echo "Waiting for reviews traffic on west mesh cluster..."; \
+	start=$$(date +%s); \
+	while true; do \
+		elapsed=$$(( $$(date +%s) - start )); \
+		if [ "$$elapsed" -ge 300 ]; then \
+			echo "ERROR: timed out waiting for healthy reviews app on west cluster" >&2; \
+			exit 1; \
+		fi; \
+		response=$$(curl -sk "$${KIALI_URL}api/clusters/apps?namespaces=bookinfo&clusterName=west&health=true&istioResources=true&rateInterval=60s"); \
+		if [ "$$(echo "$$response" | jq '[.applications[]? | select(.name=="reviews" and .cluster=="west" and .health.requests.inbound.http."200" > 0)] | length > 0')" = "true" ]; then \
+			echo "reviews app on west cluster is healthy"; \
+			break; \
+		fi; \
+		sleep 10; \
+	done; \
+	echo "Waiting for traces on west mesh cluster..."; \
+	traces_date=$$(( ($$(date +%s) - 300) * 1000 )); \
+	trace_url="$${KIALI_URL}api/namespaces/bookinfo/workloads/reviews-v2/traces?startMicros=$${traces_date}&tags=&limit=100&clusterName=west"; \
+	start=$$(date +%s); \
+	while true; do \
+		elapsed=$$(( $$(date +%s) - start )); \
+		if [ "$$elapsed" -ge 120 ]; then \
+			echo "WARNING: timed out waiting for traces on west; continuing anyway" >&2; \
+			break; \
+		fi; \
+		result=$$(curl -sk "$$trace_url" | jq -r '.data // []'); \
+		if [ -n "$$result" ] && [ "$$result" != "[]" ]; then \
+			echo "Kiali has traces for reviews-v2 on west"; \
+			break; \
+		fi; \
+		sleep 10; \
+	done; \
+	echo "Multicluster setup complete."; \
+	echo "  Kiali URL: $${KIALI_URL}"; \
+	echo "  MCP config: $(KIALI_MC_CONFIG)"; \
+	echo "  Contexts: kind-east (primary), kind-west (remote)"; \
+	echo "  Mesh clusters: east, west"
+
+.PHONY: redeploy-kiali-multicluster-dev
+redeploy-kiali-multicluster-dev: ## Rebuild Kiali dev image from master and redeploy on kind-east
+	@set -euo pipefail; \
+	KIALI_REPO="$(KIALI_HACK_DIR)"; \
+	if [ ! -f "$${KIALI_REPO}/Makefile" ]; then \
+		echo "ERROR: Kiali repo not found at $${KIALI_REPO}. Set KIALI_SRC to a master checkout." >&2; \
+		exit 1; \
+	fi; \
+	if ! git -C "$${KIALI_REPO}" cat-file -e HEAD:ai/mcp/list_clusters/list_clusters.go 2>/dev/null; then \
+		echo "ERROR: Kiali checkout at $${KIALI_REPO} lacks list_clusters (need master)." >&2; \
+		exit 1; \
+	fi; \
+	echo "Building Kiali dev image from $${KIALI_REPO}..."; \
+	$(MAKE) -e -C "$${KIALI_REPO}" build-ui build; \
+	$(MAKE) -e -C "$${KIALI_REPO}" DORP=docker CLUSTER_TYPE=kind KIND_NAME=east cluster-push-kiali; \
+	kubectl rollout restart deployment/kiali -n istio-system --context kind-east; \
+	kubectl rollout status deployment/kiali -n istio-system --context kind-east --timeout=300s; \
+	$(MAKE) write-kiali-multicluster-mcp-config; \
+	KIALI_URL=$$(kubectl get svc kiali -n istio-system --context kind-east \
+		-o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali/'); \
+	start=$$(date +%s); \
+	while ! curl -sf "$${KIALI_URL}healthz" >/dev/null 2>&1; do \
+		elapsed=$$(( $$(date +%s) - start )); \
+		if [ "$$elapsed" -ge 120 ]; then \
+			echo "ERROR: timed out waiting for Kiali health at $${KIALI_URL}healthz" >&2; \
+			exit 1; \
+		fi; \
+		sleep 2; \
+	done; \
+	list_clusters=$$(curl -sk -X POST "$${KIALI_URL}api/chat/mcp/list_clusters" \
+		-H 'Content-Type: application/json' -d '{"mcp_mode":true}'); \
+	if ! echo "$$list_clusters" | jq -e 'type == "array"' >/dev/null 2>&1; then \
+		echo "ERROR: list_clusters still unavailable: $$list_clusters" >&2; \
+		exit 1; \
+	fi; \
+	echo "list_clusters OK: $$list_clusters"
+
+.PHONY: kind-delete-multicluster
+kind-delete-multicluster: ## Delete primary-remote multicluster Kind clusters (east/west)
+	@# Set KIND provider for podman on Linux
+	@if [ "$(shell uname -s)" != "Darwin" ] && echo "$(CONTAINER_ENGINE)" | grep -q "podman"; then \
+		export KIND_EXPERIMENTAL_PROVIDER=podman; \
+	fi; \
+	$(KIND) delete cluster --name east 2>/dev/null || true; \
+	$(KIND) delete cluster --name west 2>/dev/null || true
+
+KIALI_MC_EVAL_CONFIG ?= evals/tasks/kiali/multicluster/eval.yaml
+KIALI_MC_EVAL_RESULTS ?= evals/results/openai-agent-multicluster-latest.json
+
+.PHONY: run-evals-multicluster
+run-evals-multicluster: mcpchecker ## Run mcpchecker multicluster Kiali evaluations
+	$(MCPCHECKER) check $(KIALI_MC_EVAL_CONFIG) \
+		$(if $(EVAL_TASK_FILTER),--run "$(EVAL_TASK_FILTER)",) \
+		$(if $(filter true,$(EVAL_VERBOSE)),--verbose,) \
+		--default-task-timeout 15m \
+		--output json
+	@if [ -f mcpchecker-kiali-multicluster-out.json ]; then \
+		mkdir -p $(dir $(KIALI_MC_EVAL_RESULTS)); \
+		mv -f mcpchecker-kiali-multicluster-out.json $(KIALI_MC_EVAL_RESULTS); \
+	fi

--- a/build/kiali.mk
+++ b/build/kiali.mk
@@ -126,6 +126,10 @@ setup-kiali-multicluster: ## Setup primary-remote multicluster Kind + Istio/Kial
 		exit 1; \
 	fi; \
 	echo "Using Kiali hack scripts from: $${KIALI_HACK_DIR}"; \
+	if [ "$(KIALI_MC_VERSION)" = "dev" ]; then \
+		export KIALI_BUILD_DEV_IMAGE="$${KIALI_BUILD_DEV_IMAGE:-true}"; \
+		echo "KIALI_BUILD_DEV_IMAGE=$${KIALI_BUILD_DEV_IMAGE} (dev image requires build-ui + build before push)"; \
+	fi; \
 	echo "Setting up primary-remote multicluster Kind clusters (east/west)..."; \
 	( \
 		cd "$${KIALI_HACK_DIR}"; \

--- a/build/kiali.mk
+++ b/build/kiali.mk
@@ -4,6 +4,8 @@ ISTIOCTL = $(shell pwd)/_output/tools/bin/istioctl
 ISTIO_ADDONS_DIR = $(shell pwd)/_output/istio-addons
 ISTIO_VERSION = 1.30.1
 KIALI_VERSION = v2.27
+# Multicluster evals call Kiali MCP tools (e.g. list_clusters) that exist only on Kiali master today.
+KIALI_MC_VERSION = dev
 # Release version without patch (e.g. 1.28.0 -> 1.28)
 
 # Download and install istioctl (also copies samples/addons for install-istio)
@@ -82,3 +84,178 @@ expose-kiali: kubectl
 
 .PHONY: setup-kiali
 setup-kiali: install-istio install-gateway-api-crds update-kiali-version install-bookinfo-demo expose-kiali expose-bookinfo-demo ## Setup Kiali
+
+# Optional local Kiali checkout for multicluster hack scripts (override: KIALI_SRC=/path/to/kiali).
+KIALI_REF ?= master
+KIALI_SRC ?=
+KIALI_HACK_DIR = $(if $(KIALI_SRC),$(KIALI_SRC),$(shell pwd)/_output/kiali-hack)
+KIALI_MC_CONFIG = dev/config/mcp-configs-multicluster/kiali.toml
+
+.PHONY: write-kiali-multicluster-mcp-config
+write-kiali-multicluster-mcp-config: ## Write MCP kiali.toml from Kiali LoadBalancer on kind-east
+	@set -euo pipefail; \
+	kubectl wait --for=jsonpath='{.status.loadBalancer.ingress[0]}' -n istio-system service/kiali \
+		--context kind-east --timeout=300s; \
+	KIALI_URL=$$(kubectl get svc kiali -n istio-system --context kind-east \
+		-o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali/'); \
+	if [ -z "$${KIALI_URL}" ] || [ "$${KIALI_URL}" = "http:///kiali/" ]; then \
+		echo "ERROR: failed to resolve Kiali LoadBalancer URL on kind-east" >&2; \
+		exit 1; \
+	fi; \
+	mkdir -p dev/config/mcp-configs-multicluster; \
+	printf '%s\n' "[toolset_configs.kiali]" "url = \"$${KIALI_URL}\"" "insecure = true" > "$(KIALI_MC_CONFIG)"; \
+	echo "Wrote $(KIALI_MC_CONFIG) (url=$${KIALI_URL})"
+
+.PHONY: setup-kiali-multicluster
+setup-kiali-multicluster: ## Setup primary-remote multicluster Kind + Istio/Kiali for MCP evals
+	@set -euo pipefail; \
+	ROOTDIR="$$(pwd)"; \
+	KIALI_HACK_DIR="$(KIALI_HACK_DIR)"; \
+	for cmd in git curl kubectl docker helm yq envsubst jq; do \
+		command -v "$$cmd" >/dev/null 2>&1 || { echo "ERROR: required command not found: $$cmd" >&2; exit 1; }; \
+	done; \
+	if [ ! -f "$${KIALI_HACK_DIR}/hack/setup-kind-in-ci.sh" ]; then \
+		echo "Cloning kiali/kiali ($(KIALI_REF)) into $${KIALI_HACK_DIR}..."; \
+		git clone --depth 1 --branch "$(KIALI_REF)" https://github.com/kiali/kiali.git "$${KIALI_HACK_DIR}"; \
+	fi; \
+	if ! grep -q 'kiali-version' "$${KIALI_HACK_DIR}/hack/setup-kind-in-ci.sh" 2>/dev/null; then \
+		echo "ERROR: $${KIALI_HACK_DIR} is too old for multicluster setup (missing --kiali-version support)." >&2; \
+		echo "Set KIALI_SRC to a newer checkout or remove stale clone: rm -rf $${KIALI_HACK_DIR}" >&2; \
+		exit 1; \
+	fi; \
+	echo "Using Kiali hack scripts from: $${KIALI_HACK_DIR}"; \
+	echo "Setting up primary-remote multicluster Kind clusters (east/west)..."; \
+	( \
+		cd "$${KIALI_HACK_DIR}"; \
+		./hack/setup-kind-in-ci.sh \
+			--multicluster primary-remote \
+			--tempo false \
+			--auth-strategy anonymous \
+			-kv "$(KIALI_MC_VERSION)" \
+			--istio-version "$(ISTIO_VERSION)" \
+			--deploy-kiali true; \
+	); \
+	echo "Waiting for Kiali on kind-east..."; \
+	kubectl rollout status deployment/kiali -n istio-system --context kind-east --timeout=300s; \
+	$(MAKE) write-kiali-multicluster-mcp-config; \
+	KIALI_URL=$$(kubectl get svc kiali -n istio-system --context kind-east \
+		-o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali/'); \
+	echo "Waiting for Kiali health at $${KIALI_URL}..."; \
+	start=$$(date +%s); \
+	while ! curl -sf "$${KIALI_URL}healthz" >/dev/null 2>&1; do \
+		elapsed=$$(( $$(date +%s) - start )); \
+		if [ "$$elapsed" -ge 120 ]; then \
+			echo "ERROR: timed out waiting for Kiali health at $${KIALI_URL}healthz" >&2; \
+			exit 1; \
+		fi; \
+		sleep 2; \
+	done; \
+	echo "Kiali is healthy"; \
+	echo "Verifying Kiali MCP list_clusters..."; \
+	list_clusters=$$(curl -sk -X POST "$${KIALI_URL}api/chat/mcp/list_clusters" \
+		-H 'Content-Type: application/json' -d '{"mcp_mode":true}'); \
+	if ! echo "$$list_clusters" | jq -e 'type == "array"' >/dev/null 2>&1; then \
+		echo "ERROR: Kiali MCP list_clusters unavailable: $$list_clusters" >&2; \
+		echo "Multicluster evals require Kiali master (KIALI_MC_VERSION=dev). Try:" >&2; \
+		echo "  KIALI_SRC=~/dev/kiali_sources/kiali make redeploy-kiali-multicluster-dev" >&2; \
+		exit 1; \
+	fi; \
+	echo "list_clusters OK ($$(echo "$$list_clusters" | jq -c 'map(.name)'))"; \
+	echo "Waiting for reviews traffic on west mesh cluster..."; \
+	start=$$(date +%s); \
+	while true; do \
+		elapsed=$$(( $$(date +%s) - start )); \
+		if [ "$$elapsed" -ge 300 ]; then \
+			echo "ERROR: timed out waiting for healthy reviews app on west cluster" >&2; \
+			exit 1; \
+		fi; \
+		response=$$(curl -sk "$${KIALI_URL}api/clusters/apps?namespaces=bookinfo&clusterName=west&health=true&istioResources=true&rateInterval=60s"); \
+		if [ "$$(echo "$$response" | jq '[.applications[]? | select(.name=="reviews" and .cluster=="west" and .health.requests.inbound.http."200" > 0)] | length > 0')" = "true" ]; then \
+			echo "reviews app on west cluster is healthy"; \
+			break; \
+		fi; \
+		sleep 10; \
+	done; \
+	echo "Waiting for traces on west mesh cluster..."; \
+	traces_date=$$(( ($$(date +%s) - 300) * 1000 )); \
+	trace_url="$${KIALI_URL}api/namespaces/bookinfo/workloads/reviews-v2/traces?startMicros=$${traces_date}&tags=&limit=100&clusterName=west"; \
+	start=$$(date +%s); \
+	while true; do \
+		elapsed=$$(( $$(date +%s) - start )); \
+		if [ "$$elapsed" -ge 120 ]; then \
+			echo "WARNING: timed out waiting for traces on west; continuing anyway" >&2; \
+			break; \
+		fi; \
+		result=$$(curl -sk "$$trace_url" | jq -r '.data // []'); \
+		if [ -n "$$result" ] && [ "$$result" != "[]" ]; then \
+			echo "Kiali has traces for reviews-v2 on west"; \
+			break; \
+		fi; \
+		sleep 10; \
+	done; \
+	echo "Multicluster setup complete."; \
+	echo "  Kiali URL: $${KIALI_URL}"; \
+	echo "  MCP config: $(KIALI_MC_CONFIG)"; \
+	echo "  Contexts: kind-east (primary), kind-west (remote)"; \
+	echo "  Mesh clusters: east, west"
+
+.PHONY: redeploy-kiali-multicluster-dev
+redeploy-kiali-multicluster-dev: ## Rebuild Kiali dev image from master and redeploy on kind-east
+	@set -euo pipefail; \
+	KIALI_REPO="$(KIALI_HACK_DIR)"; \
+	if [ ! -f "$${KIALI_REPO}/Makefile" ]; then \
+		echo "ERROR: Kiali repo not found at $${KIALI_REPO}. Set KIALI_SRC to a master checkout." >&2; \
+		exit 1; \
+	fi; \
+	if ! git -C "$${KIALI_REPO}" cat-file -e HEAD:ai/mcp/list_clusters/list_clusters.go 2>/dev/null; then \
+		echo "ERROR: Kiali checkout at $${KIALI_REPO} lacks list_clusters (need master)." >&2; \
+		exit 1; \
+	fi; \
+	echo "Building Kiali dev image from $${KIALI_REPO}..."; \
+	$(MAKE) -e -C "$${KIALI_REPO}" build-ui build; \
+	$(MAKE) -e -C "$${KIALI_REPO}" DORP=docker CLUSTER_TYPE=kind KIND_NAME=east cluster-push-kiali; \
+	kubectl rollout restart deployment/kiali -n istio-system --context kind-east; \
+	kubectl rollout status deployment/kiali -n istio-system --context kind-east --timeout=300s; \
+	$(MAKE) write-kiali-multicluster-mcp-config; \
+	KIALI_URL=$$(kubectl get svc kiali -n istio-system --context kind-east \
+		-o=jsonpath='http://{.status.loadBalancer.ingress[0].ip}/kiali/'); \
+	start=$$(date +%s); \
+	while ! curl -sf "$${KIALI_URL}healthz" >/dev/null 2>&1; do \
+		elapsed=$$(( $$(date +%s) - start )); \
+		if [ "$$elapsed" -ge 120 ]; then \
+			echo "ERROR: timed out waiting for Kiali health at $${KIALI_URL}healthz" >&2; \
+			exit 1; \
+		fi; \
+		sleep 2; \
+	done; \
+	list_clusters=$$(curl -sk -X POST "$${KIALI_URL}api/chat/mcp/list_clusters" \
+		-H 'Content-Type: application/json' -d '{"mcp_mode":true}'); \
+	if ! echo "$$list_clusters" | jq -e 'type == "array"' >/dev/null 2>&1; then \
+		echo "ERROR: list_clusters still unavailable: $$list_clusters" >&2; \
+		exit 1; \
+	fi; \
+	echo "list_clusters OK: $$list_clusters"
+
+.PHONY: kind-delete-multicluster
+kind-delete-multicluster: ## Delete primary-remote multicluster Kind clusters (east/west)
+	@# Set KIND provider for podman on Linux
+	@if [ "$(shell uname -s)" != "Darwin" ] && echo "$(CONTAINER_ENGINE)" | grep -q "podman"; then \
+		export KIND_EXPERIMENTAL_PROVIDER=podman; \
+	fi; \
+	$(KIND) delete cluster --name east 2>/dev/null || true; \
+	$(KIND) delete cluster --name west 2>/dev/null || true
+
+KIALI_MC_EVAL_CONFIG ?= evals/tasks/kiali/multicluster/eval.yaml
+KIALI_MC_EVAL_RESULTS ?= evals/results/openai-agent-multicluster-latest.json
+
+.PHONY: run-evals-multicluster
+run-evals-multicluster: mcpchecker ## Run mcpchecker multicluster Kiali evaluations
+	$(MCPCHECKER) check $(KIALI_MC_EVAL_CONFIG) \
+		$(if $(EVAL_TASK_FILTER),--run "$(EVAL_TASK_FILTER)",) \
+		$(if $(filter true,$(EVAL_VERBOSE)),--verbose,) \
+		--default-task-timeout 15m \
+		--output json
+	@if [ -f mcpchecker-kiali-multicluster-out.json ]; then \
+		mkdir -p $(dir $(KIALI_MC_EVAL_RESULTS)); \
+		mv -f mcpchecker-kiali-multicluster-out.json $(KIALI_MC_EVAL_RESULTS); \
+	fi

--- a/docs/KIALI.md
+++ b/docs/KIALI.md
@@ -77,4 +77,4 @@ curl -sk -X POST "${KIALI_URL}api/chat/mcp/list_clusters" \
   - If `[toolset_configs.kiali].url` uses HTTPS and `[toolset_configs.kiali].insecure` is false, you must set `[toolset_configs.kiali].certificate_authority` with the path to the CA certificate file. Relative paths are resolved relative to the directory containing the config file.
   - For non-production environments you can set `[toolset_configs.kiali].insecure = true` to skip certificate verification.
 - Multicluster eval: `Tool 'list_clusters' not found` → Kiali too old; run `KIALI_SRC=~/path/to/kiali make redeploy-kiali-multicluster-dev`
-- Multicluster eval: agent returns empty output → check `MODEL_BASE_URL` / `MODEL_KEY` (same as `evals/openai-agent/agent.yaml`)
+- Multicluster eval: agent returns empty output → check `MODEL_BASE_URL` / `MODEL_KEY` (same credentials as other mcpchecker evals)

--- a/docs/KIALI.md
+++ b/docs/KIALI.md
@@ -33,6 +33,42 @@ Use `<toolset>_list_mesh_clusters` (e.g. `kiali_list_mesh_clusters`) to discover
 
 Kiali tools and prompts are not cluster-aware: the MCP server does not inject a `context` parameter on them. Use `meshCluster` to select mesh scope. Core Kubernetes tools still use `context` when multi-cluster is enabled.
 
+### Multicluster evaluations
+
+Multicluster mcpchecker tasks live under `evals/tasks/kiali/multicluster/`. They exercise Kiali tools against a primary-remote Kind setup (`east` home cluster, `west` remote cluster).
+
+**Requirements:** Kiali **master** (dev image) — MCP tools such as `list_clusters` are not yet in released Kiali tags. Use a local Kiali checkout on master with `ai/mcp/list_clusters/`.
+
+```bash
+# Setup (~15–30 min)
+KIALI_SRC=~/dev/kiali_sources/kiali make setup-kiali-multicluster
+
+# MCP server (terminal 1)
+TOOLSETS=core,config,kiali MCP_CONFIG_DIR=dev/config/mcp-configs-multicluster make run-server
+
+# Evals (terminal 2) — same model credentials as other mcpchecker evals
+export MODEL_BASE_URL="https://api.openai.com/v1"
+export MODEL_KEY="sk-..."
+make run-evals-multicluster
+```
+
+Useful targets (all in `build/kiali.mk`):
+
+| Target | Purpose |
+|--------|---------|
+| `setup-kiali-multicluster` | Create east/west Kind clusters, deploy Kiali, write `dev/config/mcp-configs-multicluster/kiali.toml` |
+| `redeploy-kiali-multicluster-dev` | Rebuild Kiali dev image when `list_clusters` is missing |
+| `run-evals-multicluster` | Run the 6 multicluster eval tasks |
+| `kind-delete-multicluster` | Tear down east/west clusters |
+
+Verify `list_clusters` before running evals:
+
+```bash
+KIALI_URL=$(grep url dev/config/mcp-configs-multicluster/kiali.toml | cut -d'"' -f2)
+curl -sk -X POST "${KIALI_URL}api/chat/mcp/list_clusters" \
+  -H 'Content-Type: application/json' -d '{"mcp_mode":true}' | jq .
+```
+
 ### Troubleshooting
 
 - Missing Kiali configuration when `kiali` toolset is enabled → set `[toolset_configs.kiali].url` in the config TOML.
@@ -40,4 +76,5 @@ Kiali tools and prompts are not cluster-aware: the MCP server does not inject a 
 - TLS certificate validation:
   - If `[toolset_configs.kiali].url` uses HTTPS and `[toolset_configs.kiali].insecure` is false, you must set `[toolset_configs.kiali].certificate_authority` with the path to the CA certificate file. Relative paths are resolved relative to the directory containing the config file.
   - For non-production environments you can set `[toolset_configs.kiali].insecure = true` to skip certificate verification.
-
+- Multicluster eval: `Tool 'list_clusters' not found` → Kiali too old; run `KIALI_SRC=~/path/to/kiali make redeploy-kiali-multicluster-dev`
+- Multicluster eval: agent returns empty output → check `MODEL_BASE_URL` / `MODEL_KEY` (same as `evals/openai-agent/agent.yaml`)

--- a/evals/tasks/kiali/multicluster/eval.yaml
+++ b/evals/tasks/kiali/multicluster/eval.yaml
@@ -7,15 +7,15 @@ config:
     cleanupTimeout: 2m
   agent:
     type: "file"
-    path: ../../../openai-agent/agent.yaml
+    path: ../../../core-eval-testing/builtin-openai/agent.yaml
   mcpConfigFile: ../../../mcp-config.yaml
   extensions:
     kubernetes:
       package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
   llmJudge:
     ref:
-      type: builtin.llm-agent
-      model: "openai:gpt-5"
+      type: file
+      path: ../../../core-eval-testing/builtin-openai/agent.yaml
   taskSets:
     - glob: "*/*.yaml"
       labelSelector:

--- a/evals/tasks/kiali/multicluster/eval.yaml
+++ b/evals/tasks/kiali/multicluster/eval.yaml
@@ -1,0 +1,29 @@
+kind: Eval
+metadata:
+  name: "kiali-multicluster"
+config:
+  defaultTaskLimits:
+    timeout: 15m
+    cleanupTimeout: 2m
+  agent:
+    type: "file"
+    path: ../../../openai-agent/agent.yaml
+  mcpConfigFile: ../../../mcp-config.yaml
+  extensions:
+    kubernetes:
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.4
+  llmJudge:
+    ref:
+      type: builtin.llm-agent
+      model: "openai:gpt-5"
+  taskSets:
+    - glob: "*/*.yaml"
+      labelSelector:
+        suite: kiali
+        multicluster: "true"
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/evals/tasks/kiali/multicluster/mesh-status-multicluster/mesh-status-multicluster.yaml
+++ b/evals/tasks/kiali/multicluster/mesh-status-multicluster/mesh-status-multicluster.yaml
@@ -1,0 +1,24 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    multicluster: "true"
+    suite: kiali
+  name: "Audit Multicluster Mesh Health"
+  category: "Mesh Health & Status"
+  description: "Audits mesh health across multiple clusters, including control plane connectivity."
+  difficulty: medium
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  verify:
+    - llmJudge:
+        contains: "east"
+    - llmJudge:
+        contains: "west"
+  prompt:
+    inline: |
+      Perform a mesh health audit for my multicluster Istio deployment.
+      Report control plane and data plane status for each mesh cluster Kiali can access.
+      Summarize overall mesh health.

--- a/evals/tasks/kiali/multicluster/metrics-west-reviews/metrics-west-reviews.yaml
+++ b/evals/tasks/kiali/multicluster/metrics-west-reviews/metrics-west-reviews.yaml
@@ -1,0 +1,24 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    multicluster: "true"
+    suite: kiali
+  name: "Analyze Remote Service Metrics"
+  category: "Performance Analysis"
+  description: "Retrieves request-rate metrics for a service on the remote mesh cluster using meshCluster."
+  difficulty: medium
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  verify:
+    - llmJudge:
+        contains: "reviews"
+    - llmJudge:
+        contains: "west"
+  prompt:
+    inline: |
+      Show me inbound request rate metrics for the reviews service in the bookinfo namespace on the remote mesh cluster (not Kiali's home cluster) for the last 10 minutes.
+      When querying service metrics, use direction inbound so request series are not empty.
+      Indicate which mesh cluster the metrics are from.

--- a/evals/tasks/kiali/multicluster/resource-list-clusters/resource-list-clusters.yaml
+++ b/evals/tasks/kiali/multicluster/resource-list-clusters/resource-list-clusters.yaml
@@ -1,0 +1,25 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    multicluster: "true"
+    suite: kiali
+  name: "Discover Accessible Mesh Clusters"
+  category: "Resource Inspection"
+  description: "Lists the Istio mesh clusters that Kiali can access and identifies the home cluster."
+  difficulty: easy
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  verify:
+    - llmJudge:
+        contains: "home"
+    - llmJudge:
+        contains: "east"
+    - llmJudge:
+        contains: "west"
+  prompt:
+    inline: |
+      Which Istio mesh clusters can Kiali access in my service mesh?
+      List each mesh cluster name and indicate which one is the home cluster where Kiali is running.

--- a/evals/tasks/kiali/multicluster/resource-remote-workload/resource-remote-workload.yaml
+++ b/evals/tasks/kiali/multicluster/resource-remote-workload/resource-remote-workload.yaml
@@ -1,0 +1,24 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    multicluster: "true"
+    suite: kiali
+  name: "Inspect Remote Cluster Workload"
+  category: "Resource Inspection"
+  description: "Retrieves workload details from a remote mesh cluster using the meshCluster parameter."
+  difficulty: medium
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  verify:
+    - llmJudge:
+        contains: "reviews-v2"
+    - llmJudge:
+        contains: "west"
+  prompt:
+    inline: |
+      Discover which mesh clusters Kiali can access.
+      Inspect the reviews-v2 workload in the bookinfo namespace on the remote mesh cluster (not Kiali's home cluster).
+      Summarize its status and health, and indicate which mesh cluster it is on.

--- a/evals/tasks/kiali/multicluster/topology-west-cluster-graph/topology-west-cluster-graph.yaml
+++ b/evals/tasks/kiali/multicluster/topology-west-cluster-graph/topology-west-cluster-graph.yaml
@@ -1,0 +1,23 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    multicluster: "true"
+    suite: kiali
+  name: "Visualize West Cluster Traffic"
+  category: "Traffic Observability"
+  description: "Generates a workload-level traffic graph scoped to the remote mesh cluster."
+  difficulty: medium
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  verify:
+    - llmJudge:
+        contains: "west"
+    - llmJudge:
+        contains: "bookinfo"
+  prompt:
+    inline: |
+      Show me a workload-level traffic graph for the bookinfo namespace on the remote mesh cluster (not Kiali's home cluster).
+      Summarize what the graph shows and indicate which mesh cluster it represents.

--- a/evals/tasks/kiali/multicluster/traces-west-reviews/traces-west-reviews.yaml
+++ b/evals/tasks/kiali/multicluster/traces-west-reviews/traces-west-reviews.yaml
@@ -1,0 +1,24 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    multicluster: "true"
+    suite: kiali
+  name: "List Remote Cluster Traces"
+  category: "Troubleshooting & Diagnostics"
+  description: "Lists distributed traces for a service on the remote mesh cluster using meshCluster."
+  difficulty: medium
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  verify:
+    - llmJudge:
+        contains: "reviews"
+    - llmJudge:
+        contains: "west"
+  prompt:
+    inline: |
+      List recent distributed traces for the reviews service in the bookinfo namespace on the remote mesh cluster (not Kiali's home cluster).
+      Summarize how many traces were found and mention any slow or error spans you see.
+      Indicate which mesh cluster the traces are from.


### PR DESCRIPTION
## Summary

Adds multicluster Kiali mcpchecker evals against a primary-remote Kind setup (`east` home cluster, `west` remote cluster).

- **Evals:** 6 tasks under `evals/tasks/kiali/multicluster/` covering mesh status, listing mesh clusters, remote metrics/workloads/topology, and traces (agent must identify the remote cluster; judge checks for `west`).
- **Makefile (`build/kiali.mk`):** `setup-kiali-multicluster`, `run-evals-multicluster`, `redeploy-kiali-multicluster-dev`, `kind-delete-multicluster`. Uses Kiali dev/master (`KIALI_MC_VERSION=dev`) for `list_clusters`. CI fix: `SHELL := /bin/bash` for `pipefail` recipes.
- **CI:** New `run-evaluation-multicluster` job when suite is `kiali`: spins up east/west Kind, starts MCP with multicluster config, runs the 6 tasks.
- **Docs:** `docs/KIALI.md` updated with setup/run instructions and troubleshooting.

** Requires the changes in https://github.com/containers/kubernetes-mcp-server/pull/1224 to work