### PR TITLE
fix(http): reject unknown wellknown paths in proxy

### DIFF
--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -59,12 +59,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger := klogutil.FromContext(r.Context())
 			// Skip auth for infrastructure endpoints (health, metrics) and well-known endpoints
-			// Use prefix matching per endpoint to handle sub-paths like /.well-known/oauth-protected-resource/sse
-			requestPath := r.URL.EscapedPath()
-			isWellKnown := !strings.Contains(requestPath, "..") && slices.ContainsFunc(WellKnownEndpoints, func(ep string) bool {
-				return requestPath == ep || strings.HasPrefix(requestPath, ep+"/")
-			})
-			if slices.Contains(infraPaths, r.URL.Path) || isWellKnown {
+			if slices.Contains(infraPaths, r.URL.Path) || isWellKnownPath(r.URL.EscapedPath()) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -593,6 +593,28 @@ func (s *AuthorizationSuite) TestAuthorizationPassthroughRejectedWithoutSkipFlag
 	s.stopRunningServer()
 }
 
+func (s *AuthorizationSuite) TestAuthorizationUnknownWellKnownPathRequiresAuth() {
+	s.StartServer()
+
+	unknownPaths := []string{
+		"/.well-known/unknown-endpoint",
+		"/.well-known/jwks.json",
+		"/.well-known/admin",
+		"/.well-known/",
+	}
+	for _, path := range unknownPaths {
+		s.Run(fmt.Sprintf("%s requires auth", path), func() {
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%s%s", s.StaticConfig.Port, path), nil)
+			s.Require().NoError(err)
+			resp, err := http.DefaultClient.Do(req)
+			s.Require().NoError(err)
+			s.T().Cleanup(func() { _ = resp.Body.Close() })
+			s.Equal(http.StatusUnauthorized, resp.StatusCode, "Unknown well-known path should require auth")
+		})
+	}
+	s.stopRunningServer()
+}
+
 func (s *AuthorizationSuite) TestAuthorizationExemptEndpointsFromOAuth() {
 	// https://github.com/containers/kubernetes-mcp-server/issues/932
 	// https://github.com/containers/kubernetes-mcp-server/issues/964

--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -157,8 +157,8 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 
 	// Validate that the request targets a known well-known endpoint to prevent
 	// proxying arbitrary paths to the upstream authorization server.
-	if !isKnownWellKnownPath(requestPath) {
-		http.Error(writer, "Unknown well-known endpoint", http.StatusNotFound)
+	if !isWellKnownPath(requestPath) {
+		http.Error(writer, "Not a well-known endpoint", http.StatusNotFound)
 		return
 	}
 
@@ -415,9 +415,13 @@ func copyMap(src map[string]interface{}) map[string]interface{} {
 	return dst
 }
 
-// isKnownWellKnownPath reports whether path matches one of the known
+// isWellKnownPath reports whether path matches one of the known
 // well-known endpoints (exact match or sub-path, e.g. /sse suffix).
-func isKnownWellKnownPath(path string) bool {
+// Paths containing ".." are rejected to prevent path traversal bypasses.
+func isWellKnownPath(path string) bool {
+	if strings.Contains(path, "..") {
+		return false
+	}
 	for _, ep := range WellKnownEndpoints {
 		if path == ep || strings.HasPrefix(path, ep+"/") {
 			return true

--- a/pkg/http/wellknown.go
+++ b/pkg/http/wellknown.go
@@ -155,6 +155,13 @@ func (w *WellKnown) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 
 	requestPath := request.URL.EscapedPath()
 
+	// Validate that the request targets a known well-known endpoint to prevent
+	// proxying arbitrary paths to the upstream authorization server.
+	if !isKnownWellKnownPath(requestPath) {
+		http.Error(writer, "Unknown well-known endpoint", http.StatusNotFound)
+		return
+	}
+
 	// Validate the URL path to prevent path traversal
 	upstreamURL, err := url.JoinPath(authURL, requestPath)
 	if err != nil || !strings.HasPrefix(upstreamURL, authURL+"/") {
@@ -406,6 +413,17 @@ func copyMap(src map[string]interface{}) map[string]interface{} {
 		dst[k] = v
 	}
 	return dst
+}
+
+// isKnownWellKnownPath reports whether path matches one of the known
+// well-known endpoints (exact match or sub-path, e.g. /sse suffix).
+func isKnownWellKnownPath(path string) bool {
+	for _, ep := range WellKnownEndpoints {
+		if path == ep || strings.HasPrefix(path, ep+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func withCORSHeaders(writer http.ResponseWriter) {

--- a/pkg/http/wellknown_test.go
+++ b/pkg/http/wellknown_test.go
@@ -257,44 +257,26 @@ func (s *WellknownSuite) TestOAuthScopesOverride() {
 	})
 }
 
-func (s *WellknownSuite) TestUnknownWellKnownPath() {
-	s.StaticConfig.RequireOAuth = true
-	s.StartServer()
-
-	unknownPaths := []string{
-		".well-known/unknown-endpoint",
-		".well-known/jwks.json",
-		".well-known/admin",
-		".well-known/",
-	}
-	for _, path := range unknownPaths {
-		s.Run("does not proxy unknown well-known path "+path, func() {
-			s.ReceivedRequest = nil
-			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s/%s", s.StaticConfig.Port, path))
-			s.Require().NoError(err)
-			s.T().Cleanup(func() { _ = resp.Body.Close() })
-			s.NotEqual(http.StatusOK, resp.StatusCode, "Unknown well-known path should not succeed")
-			s.Nil(s.ReceivedRequest, "Unknown well-known path should not be proxied to upstream")
-		})
-	}
-}
-
-func (s *WellknownSuite) TestIsKnownWellKnownPath() {
+func (s *WellknownSuite) TestIsWellKnownPath() {
 	s.Run("accepts known endpoints", func() {
-		s.True(isKnownWellKnownPath("/.well-known/oauth-authorization-server"))
-		s.True(isKnownWellKnownPath("/.well-known/oauth-protected-resource"))
-		s.True(isKnownWellKnownPath("/.well-known/openid-configuration"))
+		s.True(isWellKnownPath("/.well-known/oauth-authorization-server"))
+		s.True(isWellKnownPath("/.well-known/oauth-protected-resource"))
+		s.True(isWellKnownPath("/.well-known/openid-configuration"))
 	})
 	s.Run("accepts known endpoints with sub-paths", func() {
-		s.True(isKnownWellKnownPath("/.well-known/oauth-protected-resource/sse"))
-		s.True(isKnownWellKnownPath("/.well-known/oauth-authorization-server/extra"))
+		s.True(isWellKnownPath("/.well-known/oauth-protected-resource/sse"))
+		s.True(isWellKnownPath("/.well-known/oauth-authorization-server/extra"))
 	})
 	s.Run("rejects unknown endpoints", func() {
-		s.False(isKnownWellKnownPath("/.well-known/unknown"))
-		s.False(isKnownWellKnownPath("/.well-known/jwks.json"))
-		s.False(isKnownWellKnownPath("/.well-known/"))
-		s.False(isKnownWellKnownPath("/.well-known/admin"))
-		s.False(isKnownWellKnownPath("/other-path"))
+		s.False(isWellKnownPath("/.well-known/unknown"))
+		s.False(isWellKnownPath("/.well-known/jwks.json"))
+		s.False(isWellKnownPath("/.well-known/"))
+		s.False(isWellKnownPath("/.well-known/admin"))
+		s.False(isWellKnownPath("/other-path"))
+	})
+	s.Run("rejects paths with path traversal", func() {
+		s.False(isWellKnownPath("/.well-known/oauth-authorization-server/../../admin"))
+		s.False(isWellKnownPath("/.well-known/../secrets"))
 	})
 }
 

--- a/pkg/http/wellknown_test.go
+++ b/pkg/http/wellknown_test.go
@@ -257,6 +257,47 @@ func (s *WellknownSuite) TestOAuthScopesOverride() {
 	})
 }
 
+func (s *WellknownSuite) TestUnknownWellKnownPath() {
+	s.StaticConfig.RequireOAuth = true
+	s.StartServer()
+
+	unknownPaths := []string{
+		".well-known/unknown-endpoint",
+		".well-known/jwks.json",
+		".well-known/admin",
+		".well-known/",
+	}
+	for _, path := range unknownPaths {
+		s.Run("does not proxy unknown well-known path "+path, func() {
+			s.ReceivedRequest = nil
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s/%s", s.StaticConfig.Port, path))
+			s.Require().NoError(err)
+			s.T().Cleanup(func() { _ = resp.Body.Close() })
+			s.NotEqual(http.StatusOK, resp.StatusCode, "Unknown well-known path should not succeed")
+			s.Nil(s.ReceivedRequest, "Unknown well-known path should not be proxied to upstream")
+		})
+	}
+}
+
+func (s *WellknownSuite) TestIsKnownWellKnownPath() {
+	s.Run("accepts known endpoints", func() {
+		s.True(isKnownWellKnownPath("/.well-known/oauth-authorization-server"))
+		s.True(isKnownWellKnownPath("/.well-known/oauth-protected-resource"))
+		s.True(isKnownWellKnownPath("/.well-known/openid-configuration"))
+	})
+	s.Run("accepts known endpoints with sub-paths", func() {
+		s.True(isKnownWellKnownPath("/.well-known/oauth-protected-resource/sse"))
+		s.True(isKnownWellKnownPath("/.well-known/oauth-authorization-server/extra"))
+	})
+	s.Run("rejects unknown endpoints", func() {
+		s.False(isKnownWellKnownPath("/.well-known/unknown"))
+		s.False(isKnownWellKnownPath("/.well-known/jwks.json"))
+		s.False(isKnownWellKnownPath("/.well-known/"))
+		s.False(isKnownWellKnownPath("/.well-known/admin"))
+		s.False(isKnownWellKnownPath("/other-path"))
+	})
+}
+
 func (s *WellknownSuite) TestPathTraversal() {
 	s.StaticConfig.RequireOAuth = true
 	s.StartServer()


### PR DESCRIPTION
This is a defense in depth hardening improvement, that makes the handler for the wellknown proxy reject urls that are not on the allowlist.

Note that when require oauth is enabled, these requests would get rejected earlier anyways.