### PR TITLE
feat(kubevirt): add vm_create_from_template tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ and only needed for the project-specific scenarios noted.
 | [Istio](https://istio.io) | `kiali` | 5 |
 | [Kiali](https://kiali.io) | `kiali` | 16 |
 | [Kubernetes](https://kubernetes.io) | - | 32 |
-| [KubeVirt](https://kubevirt.io) | `kubevirt`, `tekton` | 19 |
+| [KubeVirt](https://kubevirt.io) | `kubevirt`, `tekton` | 24 |
 | [NetObserv](https://netobserv.io) | `netobserv` | 4 |
 | [Tekton](https://tekton.dev) | `tekton` | 9 |
 
@@ -565,6 +565,11 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `action` (`string`) **(required)** - The lifecycle action to perform: 'start' (changes runStrategy to Always), 'stop' (changes runStrategy to Halted), or 'restart' (stops then starts the VM)
   - `name` (`string`) **(required)** - The name of the virtual machine
   - `namespace` (`string`) **(required)** - The namespace of the virtual machine
+
+- **vm_create_from_template** - Create a VirtualMachine from a VirtualMachineTemplate (virt-template) on KubeVirt. Processes the template server-side to substitute parameters (required values, defaults, and auto-generated values like passwords), then creates the resulting VirtualMachine in the same namespace. Cross-namespace template usage is not supported.
+  - `namespace` (`string`) **(required)** - The namespace of the VirtualMachineTemplate and the resulting VirtualMachine (must be the same)
+  - `parameters` (`object`) - Parameter values to substitute in the template. Keys are parameter names (e.g. VM_NAME), values are strings. Required parameters must be provided; optional parameters use their defaults if omitted; parameters with generate/from will be auto-generated if not provided.
+  - `template_name` (`string`) **(required)** - The name of the VirtualMachineTemplate to create the VM from
 
 - **vm_troubleshoot** - Diagnose KubeVirt VirtualMachine issues with automated root-cause detection. Collects VM status, VMI status, volumes, DataVolume/PVC state, cloud-init configuration, pod state, logs, and events, then runs heuristic checks to identify specific problems and suggest fixes. Returns a 'Detected Issues' section with CRITICAL/WARNING findings and actionable remediation steps, followed by raw diagnostic data. Use this tool FIRST whenever a user asks why a VM is not starting, stuck in Provisioning, crashlooping, failing to migrate, or exhibiting unexpected behavior. Automatically detects: missing StorageClasses, invalid PVC specs, dangerous cloud-init commands (shutdown/halt), nodeSelector migration blockers, failed migrations, and pod crashloops. If the user asks to fix or remediate the issue, use the Suggested Fixes from the report with vm_lifecycle (restart) or resources_create_or_update.
   - `name` (`string`) **(required)** - The name of the VirtualMachine to troubleshoot

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ and only needed for the project-specific scenarios noted.
 | [Istio](https://istio.io) | `kiali` | 5 |
 | [Kiali](https://kiali.io) | `kiali` | 16 |
 | [Kubernetes](https://kubernetes.io) | - | 32 |
-| [KubeVirt](https://kubevirt.io) | `kubevirt`, `tekton` | 19 |
+| [KubeVirt](https://kubevirt.io) | `kubevirt`, `tekton` | 24 |
 | [NetObserv](https://netobserv.io) | `netobserv` | 4 |
 | [Tekton](https://tekton.dev) | `tekton` | 9 |
 
@@ -565,6 +565,11 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `action` (`string`) **(required)** - The lifecycle action to perform: 'start' (changes runStrategy to Always), 'stop' (changes runStrategy to Halted), or 'restart' (stops then starts the VM)
   - `name` (`string`) **(required)** - The name of the virtual machine
   - `namespace` (`string`) **(required)** - The namespace of the virtual machine
+
+- **vm_create_from_template** - Create a VirtualMachine from a VirtualMachineTemplate (virt-template) on KubeVirt. Processes the template server-side to substitute parameters (required values, defaults, and auto-generated values like passwords), then creates the resulting VirtualMachine in the same namespace. Cross-namespace template usage is not supported.
+  - `namespace` (`string`) **(required)** - The namespace of the VirtualMachineTemplate and the resulting VirtualMachine (must be the same)
+  - `parameters` (`object`) - Parameter values to substitute in the template. Keys are parameter names (e.g. VM_NAME), values are strings. Required parameters must be provided; optional parameters use their defaults if omitted; parameters with generate/from will be auto-generated if not provided.
+  - `template_name` (`string`) **(required)** - The name of the VirtualMachineTemplate to create the VM from
 
 </details>
 

--- a/evals/tasks/kubevirt/create-template-from-vm/task.yaml
+++ b/evals/tasks/kubevirt/create-template-from-vm/task.yaml
@@ -1,0 +1,104 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    project: kubevirt
+    requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
+  name: "create-template-from-vm"
+  difficulty: medium
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-from-vm
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-from-vm
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: source-web-server
+          namespace: vmt-test-from-vm
+          labels:
+            app: web-server
+            tier: frontend
+        spec:
+          runStrategy: Halted
+          template:
+            metadata:
+              labels:
+                app: web-server
+            spec:
+              domain:
+                cpu:
+                  cores: 2
+                memory:
+                  guest: 2Gi
+                devices:
+                  disks:
+                    - name: containerdisk
+                      disk:
+                        bus: virtio
+              terminationGracePeriodSeconds: 180
+              volumes:
+                - name: containerdisk
+                  containerDisk:
+                    image: quay.io/containerdisks/fedora:latest
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          NS="vmt-test-from-vm"
+          VMT_API="template.kubevirt.io/v1beta1"
+
+          kubectl wait --for=jsonpath='{.metadata.name}'=web-server-vmtr \
+            virtualmachinetemplaterequest.${VMT_API}/web-server-vmtr -n "$NS" --timeout=30s
+
+          SOURCE_VM=$(kubectl get virtualmachinetemplaterequest.${VMT_API} web-server-vmtr -n "$NS" \
+            -o jsonpath='{.spec.virtualMachineRef.name}')
+          [ "$SOURCE_VM" = "source-web-server" ] || { echo "ERROR: source VM is '$SOURCE_VM', expected 'source-web-server'"; exit 1; }
+
+          TEMPLATE_NAME=$(kubectl get virtualmachinetemplaterequest.${VMT_API} web-server-vmtr -n "$NS" \
+            -o jsonpath='{.spec.templateName}')
+          [ "$TEMPLATE_NAME" = "web-server-template" ] || { echo "ERROR: templateName is '$TEMPLATE_NAME', expected 'web-server-template'"; exit 1; }
+
+          echo "All validations passed"
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl delete virtualmachinetemplaterequest.template.kubevirt.io/v1beta1 web-server-vmtr -n vmt-test-from-vm --ignore-not-found=true 2>/dev/null || true
+          kubectl delete virtualmachinetemplate.template.kubevirt.io/v1beta1 web-server-template -n vmt-test-from-vm --ignore-not-found=true 2>/dev/null || true
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: source-web-server
+          namespace: vmt-test-from-vm
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-from-vm
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      A VirtualMachine named source-web-server exists in the vmt-test-from-vm namespace.
+
+      Create a template from this VM so it can be reused.
+      Name the request web-server-vmtr and the resulting template web-server-template.

--- a/evals/tasks/kubevirt/create-template-from-vm/task.yaml
+++ b/evals/tasks/kubevirt/create-template-from-vm/task.yaml
@@ -1,0 +1,104 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    project: kubevirt
+    requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
+  name: "create-template-from-vm"
+  difficulty: medium
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-from-vm
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-from-vm
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: source-web-server
+          namespace: vmt-test-from-vm
+          labels:
+            app: web-server
+            tier: frontend
+        spec:
+          runStrategy: Halted
+          template:
+            metadata:
+              labels:
+                app: web-server
+            spec:
+              domain:
+                cpu:
+                  cores: 2
+                memory:
+                  guest: 2Gi
+                devices:
+                  disks:
+                    - name: containerdisk
+                      disk:
+                        bus: virtio
+              terminationGracePeriodSeconds: 180
+              volumes:
+                - name: containerdisk
+                  containerDisk:
+                    image: quay.io/containerdisks/fedora:latest
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          NS="vmt-test-from-vm"
+          VMT_API="template.kubevirt.io/v1beta1"
+
+          kubectl wait --for=jsonpath='{.metadata.name}'=web-server-vmtr \
+            virtualmachinetemplaterequest.${VMT_API}/web-server-vmtr -n "$NS" --timeout=30s
+
+          SOURCE_VM=$(kubectl get virtualmachinetemplaterequest.${VMT_API} web-server-vmtr -n "$NS" \
+            -o jsonpath='{.spec.virtualMachineRef.name}')
+          [ "$SOURCE_VM" = "source-web-server" ] || { echo "ERROR: source VM is '$SOURCE_VM', expected 'source-web-server'"; exit 1; }
+
+          TEMPLATE_NAME=$(kubectl get virtualmachinetemplaterequest.${VMT_API} web-server-vmtr -n "$NS" \
+            -o jsonpath='{.spec.templateName}')
+          [ "$TEMPLATE_NAME" = "web-server-template" ] || { echo "ERROR: templateName is '$TEMPLATE_NAME', expected 'web-server-template'"; exit 1; }
+
+          echo "All validations passed"
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl delete virtualmachinetemplaterequest.template.kubevirt.io/v1beta1 web-server-vmtr -n vmt-test-from-vm --ignore-not-found=true 2>/dev/null || true
+          kubectl delete virtualmachinetemplate.template.kubevirt.io/v1beta1 web-server-template -n vmt-test-from-vm --ignore-not-found=true 2>/dev/null || true
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: source-web-server
+          namespace: vmt-test-from-vm
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-from-vm
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      A VirtualMachine named source-web-server exists in the vmt-test-from-vm namespace.
+
+      Create a VirtualMachineTemplateRequest to convert this VM into a reusable template.
+      Use the name web-server-vmtr for the template request, and set the template name to web-server-template.

--- a/evals/tasks/kubevirt/create-vm-from-template/task.yaml
+++ b/evals/tasks/kubevirt/create-vm-from-template/task.yaml
@@ -1,0 +1,130 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    project: kubevirt
+    requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
+  name: "create-vm-from-template"
+  difficulty: hard
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-create-vm
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-create-vm
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: template.kubevirt.io/v1beta1
+          kind: VirtualMachineTemplate
+          metadata:
+            name: app-server-template
+            namespace: vmt-test-create-vm
+          spec:
+            parameters:
+              - name: VM_NAME
+                displayName: "Virtual Machine Name"
+                description: "Name of the virtual machine to create"
+                required: true
+              - name: MEMORY
+                displayName: "Memory Size"
+                description: "Amount of memory for the VM"
+                value: "2Gi"
+              - name: CPU_CORES
+                displayName: "CPU Cores"
+                description: "Number of CPU cores"
+                value: "1"
+            virtualMachine:
+              metadata:
+                name: ${VM_NAME}
+              spec:
+                runStrategy: Halted
+                template:
+                  spec:
+                    domain:
+                      cpu:
+                        cores: ${CPU_CORES}
+                      memory:
+                        guest: ${MEMORY}
+                      devices:
+                        disks:
+                          - name: containerdisk
+                            disk:
+                              bus: virtio
+                    volumes:
+                      - name: containerdisk
+                        containerDisk:
+                          image: quay.io/containerdisks/fedora:latest
+          EOF
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          source ../helpers/verify-vm.sh
+          NS="vmt-test-create-vm"
+
+          verify_vm_exists "my-app-server" "$NS" || exit 1
+          verify_container_disk "my-app-server" "$NS" "fedora" || exit 1
+
+          # Verify memory was set to 4Gi (the overridden value)
+          MEMORY=$(kubectl get virtualmachine my-app-server -n "$NS" -o jsonpath='{.spec.template.spec.domain.memory.guest}')
+          if [ "$MEMORY" != "4Gi" ]; then
+            echo "ERROR: Expected memory '4Gi', got '$MEMORY'"
+            exit 1
+          fi
+          echo "Memory correctly set to 4Gi"
+
+          # Verify CPU was set to 1 (the default)
+          CPU=$(kubectl get virtualmachine my-app-server -n "$NS" -o jsonpath='{.spec.template.spec.domain.cpu.cores}')
+          if [ "$CPU" != "1" ]; then
+            echo "ERROR: Expected 1 CPU core (default), got '$CPU'"
+            exit 1
+          fi
+          echo "CPU cores correctly set to 1 (default)"
+
+          verify_no_unresolved_placeholders "my-app-server" "$NS" || exit 1
+
+          echo "All validations passed"
+          exit 0
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: my-app-server
+          namespace: vmt-test-create-vm
+        ignoreNotFound: true
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl delete virtualmachinetemplate.template.kubevirt.io/v1beta1 app-server-template -n vmt-test-create-vm --ignore-not-found=true 2>/dev/null || true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-create-vm
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      A VirtualMachineTemplate named app-server-template exists in the vmt-test-create-vm namespace.
+
+      Please create a new VirtualMachine from this template with the following parameter values:
+      - VM_NAME: my-app-server
+      - MEMORY: 4Gi
+
+      Use the default value for CPU_CORES. The VM should be created in the vmt-test-create-vm namespace.

--- a/evals/tasks/kubevirt/helpers/verify-vm.sh
+++ b/evals/tasks/kubevirt/helpers/verify-vm.sh
@@ -253,6 +253,23 @@ verify_memory_increased() {
     fi
 }
 
+# verify_no_unresolved_placeholders: Verifies that no ${PARAM} placeholders remain in a VM
+# Usage: verify_no_unresolved_placeholders <vm-name> <namespace>
+verify_no_unresolved_placeholders() {
+    local vm_name="$1"
+    local namespace="$2"
+
+    local vm_yaml
+    vm_yaml=$(kubectl get virtualmachine "$vm_name" -n "$namespace" -o yaml)
+    if echo "$vm_yaml" | grep -q '${'; then
+        echo "✗ VM still contains unresolved parameter placeholders"
+        echo "$vm_yaml" | grep '${' || true
+        return 1
+    fi
+    echo "✓ No unresolved placeholders found"
+    return 0
+}
+
 # verify_multus_secondary_network: Verifies that a VM has a secondary network interface with Multus
 # Usage: verify_multus_secondary_network <vm-name> <namespace> <network-name>
 # Example: verify_multus_secondary_network test-vm vm-test vlan-network

--- a/evals/tasks/kubevirt/inspect-vm-template/task.yaml
+++ b/evals/tasks/kubevirt/inspect-vm-template/task.yaml
@@ -1,0 +1,129 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    project: kubevirt
+    requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
+  name: "inspect-vm-template"
+  difficulty: medium
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-inspect
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-inspect
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: template.kubevirt.io/v1beta1
+          kind: VirtualMachineTemplate
+          metadata:
+            name: web-server-template
+            namespace: vmt-test-inspect
+          spec:
+            parameters:
+              - name: VM_NAME
+                displayName: "Virtual Machine Name"
+                description: "Name of the virtual machine to create"
+                required: true
+              - name: MEMORY
+                displayName: "Memory Size"
+                description: "Amount of memory for the VM"
+                value: "4Gi"
+              - name: CPU_CORES
+                displayName: "CPU Cores"
+                description: "Number of CPU cores"
+                value: "2"
+              - name: ROOT_PASSWORD
+                displayName: "Root Password"
+                description: "Root password for the VM (auto-generated if not provided)"
+                generate: "expression"
+                from: "[a-zA-Z0-9]{16}"
+            virtualMachine:
+              metadata:
+                name: ${VM_NAME}
+              spec:
+                runStrategy: Halted
+                template:
+                  spec:
+                    domain:
+                      cpu:
+                        cores: ${CPU_CORES}
+                      memory:
+                        guest: ${MEMORY}
+                      devices:
+                        disks:
+                          - name: containerdisk
+                            disk:
+                              bus: virtio
+                          - name: cloudinitdisk
+                            disk:
+                              bus: virtio
+                    volumes:
+                      - name: containerdisk
+                        containerDisk:
+                          image: quay.io/containerdisks/fedora:latest
+                      - name: cloudinitdisk
+                        cloudInitNoCloud:
+                          userData: |
+                            #cloud-config
+                            password: ${ROOT_PASSWORD}
+                            chpasswd:
+                              expire: false
+          EOF
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          NS="vmt-test-inspect"
+          VMT_API="template.kubevirt.io/v1beta1"
+
+          kubectl wait --for=jsonpath='{.metadata.name}'=web-server-template \
+            virtualmachinetemplate.${VMT_API}/web-server-template -n "$NS" --timeout=30s
+
+          PARAMS=$(kubectl get virtualmachinetemplate.${VMT_API} web-server-template -n "$NS" -o json | jq -r '.spec.parameters[].name')
+          for p in VM_NAME MEMORY CPU_CORES ROOT_PASSWORD; do
+            echo "$PARAMS" | grep -qx "$p" || { echo "ERROR: parameter $p not found"; exit 1; }
+          done
+
+          COUNT=$(kubectl get virtualmachinetemplate.${VMT_API} web-server-template -n "$NS" -o json | jq '.spec.parameters | length')
+          [ "$COUNT" -eq 4 ] || { echo "ERROR: expected 4 parameters, got $COUNT"; exit 1; }
+
+          VM_SPEC=$(kubectl get virtualmachinetemplate.${VMT_API} web-server-template -n "$NS" -o jsonpath='{.spec.virtualMachine}')
+          [ -n "$VM_SPEC" ] || { echo "ERROR: missing spec.virtualMachine"; exit 1; }
+
+          echo "All validations passed"
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl delete virtualmachinetemplate.template.kubevirt.io/v1beta1 web-server-template -n vmt-test-inspect --ignore-not-found=true 2>/dev/null || true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-inspect
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      Get the VirtualMachineTemplate named web-server-template in the vmt-test-inspect namespace.
+      Examine its parameters and tell me:
+      1. Which parameters are required?
+      2. Which parameters have default values, and what are those defaults?
+      3. Which parameters use auto-generation?

--- a/evals/tasks/kubevirt/list-vm-templates/task.yaml
+++ b/evals/tasks/kubevirt/list-vm-templates/task.yaml
@@ -1,0 +1,157 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    project: kubevirt
+    requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
+  name: "list-vm-templates"
+  difficulty: easy
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-list
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-list
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: template.kubevirt.io/v1beta1
+          kind: VirtualMachineTemplate
+          metadata:
+            name: fedora-server
+            namespace: vmt-test-list
+          spec:
+            parameters:
+              - name: VM_NAME
+                displayName: "Virtual Machine Name"
+                required: true
+              - name: MEMORY
+                displayName: "Memory Size"
+                value: "2Gi"
+            virtualMachine:
+              metadata:
+                name: ${VM_NAME}
+              spec:
+                runStrategy: Halted
+                template:
+                  spec:
+                    domain:
+                      memory:
+                        guest: ${MEMORY}
+                      devices:
+                        disks:
+                          - name: containerdisk
+                            disk:
+                              bus: virtio
+                    volumes:
+                      - name: containerdisk
+                        containerDisk:
+                          image: quay.io/containerdisks/fedora:latest
+          ---
+          apiVersion: template.kubevirt.io/v1beta1
+          kind: VirtualMachineTemplate
+          metadata:
+            name: ubuntu-desktop
+            namespace: vmt-test-list
+          spec:
+            parameters:
+              - name: VM_NAME
+                displayName: "Virtual Machine Name"
+                required: true
+              - name: CPU_CORES
+                displayName: "CPU Cores"
+                value: "2"
+            virtualMachine:
+              metadata:
+                name: ${VM_NAME}
+              spec:
+                runStrategy: Halted
+                template:
+                  spec:
+                    domain:
+                      cpu:
+                        cores: ${CPU_CORES}
+                      memory:
+                        guest: 4Gi
+                      devices:
+                        disks:
+                          - name: containerdisk
+                            disk:
+                              bus: virtio
+                    volumes:
+                      - name: containerdisk
+                        containerDisk:
+                          image: quay.io/containerdisks/ubuntu:24.04
+          ---
+          apiVersion: template.kubevirt.io/v1beta1
+          kind: VirtualMachineTemplate
+          metadata:
+            name: centos-minimal
+            namespace: vmt-test-list
+          spec:
+            parameters:
+              - name: VM_NAME
+                displayName: "Virtual Machine Name"
+                required: true
+            virtualMachine:
+              metadata:
+                name: ${VM_NAME}
+              spec:
+                runStrategy: Halted
+                template:
+                  spec:
+                    domain:
+                      memory:
+                        guest: 1Gi
+                      devices:
+                        disks:
+                          - name: containerdisk
+                            disk:
+                              bus: virtio
+                    volumes:
+                      - name: containerdisk
+                        containerDisk:
+                          image: quay.io/containerdisks/centos-stream:9
+          EOF
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          NS="vmt-test-list"
+
+          COUNT=$(kubectl get virtualmachinetemplate.template.kubevirt.io/v1beta1 -n "$NS" --no-headers 2>/dev/null | wc -l)
+          if [ "$COUNT" -ne 3 ]; then
+            echo "ERROR: Expected 3 VirtualMachineTemplates, found $COUNT"
+            exit 1
+          fi
+          echo "All 3 VirtualMachineTemplates exist in namespace"
+          exit 0
+  cleanup:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl delete virtualmachinetemplate.template.kubevirt.io/v1beta1 --all -n vmt-test-list --ignore-not-found=true 2>/dev/null || true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-list
+        ignoreNotFound: true
+  prompt:
+    inline: List all VirtualMachineTemplates in the vmt-test-list namespace. Tell me how many templates are available and what their names are.

--- a/evals/tasks/kubevirt/template-required-params/task.yaml
+++ b/evals/tasks/kubevirt/template-required-params/task.yaml
@@ -1,0 +1,147 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    project: kubevirt
+    requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
+  name: "template-required-params"
+  difficulty: hard
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-params
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-params
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: template.kubevirt.io/v1beta1
+          kind: VirtualMachineTemplate
+          metadata:
+            name: secure-vm-template
+            namespace: vmt-test-params
+          spec:
+            parameters:
+              - name: VM_NAME
+                displayName: "Virtual Machine Name"
+                description: "Name of the virtual machine to create"
+                required: true
+              - name: SSH_KEY
+                displayName: "SSH Public Key"
+                description: "SSH public key for VM access"
+                required: true
+              - name: MEMORY
+                displayName: "Memory Size"
+                description: "Amount of memory for the VM"
+                value: "2Gi"
+              - name: ROOT_PASSWORD
+                displayName: "Root Password"
+                description: "Root password (auto-generated if not provided)"
+                generate: "expression"
+                from: "[a-zA-Z0-9]{12}"
+            virtualMachine:
+              metadata:
+                name: ${VM_NAME}
+              spec:
+                runStrategy: Halted
+                template:
+                  spec:
+                    domain:
+                      memory:
+                        guest: ${MEMORY}
+                      devices:
+                        disks:
+                          - name: containerdisk
+                            disk:
+                              bus: virtio
+                          - name: cloudinitdisk
+                            disk:
+                              bus: virtio
+                    volumes:
+                      - name: containerdisk
+                        containerDisk:
+                          image: quay.io/containerdisks/fedora:latest
+                      - name: cloudinitdisk
+                        cloudInitNoCloud:
+                          userData: |
+                            #cloud-config
+                            password: ${ROOT_PASSWORD}
+                            chpasswd:
+                              expire: false
+                            ssh_authorized_keys:
+                              - ${SSH_KEY}
+          EOF
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          source ../helpers/verify-vm.sh
+          NS="vmt-test-params"
+
+          verify_vm_exists "secure-server" "$NS" || exit 1
+          verify_container_disk "secure-server" "$NS" "fedora" || exit 1
+
+          # Verify memory is 2Gi (the default)
+          MEMORY=$(kubectl get virtualmachine secure-server -n "$NS" -o jsonpath='{.spec.template.spec.domain.memory.guest}')
+          if [ "$MEMORY" != "2Gi" ]; then
+            echo "ERROR: Expected memory '2Gi' (default), got '$MEMORY'"
+            exit 1
+          fi
+          echo "Memory correctly set to 2Gi (default)"
+
+          verify_no_unresolved_placeholders "secure-server" "$NS" || exit 1
+
+          # Verify the SSH key was substituted into cloud-init
+          VM_YAML=$(kubectl get virtualmachine secure-server -n "$NS" -o yaml)
+          if echo "$VM_YAML" | grep -q "ssh-rsa"; then
+            echo "SSH key was correctly substituted"
+          else
+            echo "ERROR: SSH key not found in VM spec"
+            exit 1
+          fi
+
+          echo "All validations passed"
+          exit 0
+  cleanup:
+    - k8s.delete:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: secure-server
+          namespace: vmt-test-params
+        ignoreNotFound: true
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          kubectl delete virtualmachinetemplate.template.kubevirt.io/v1beta1 secure-vm-template -n vmt-test-params --ignore-not-found=true 2>/dev/null || true
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vmt-test-params
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      A VirtualMachineTemplate named secure-vm-template exists in the vmt-test-params namespace.
+
+      Create a VirtualMachine from this template with the following values:
+      - VM_NAME: secure-server
+      - SSH_KEY: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7example test@example.com
+
+      Use default values for all other parameters. For any auto-generated parameters, generate an appropriate value.
+      The VM should be created in the vmt-test-params namespace.

--- a/internal/test/envtest.go
+++ b/internal/test/envtest.go
@@ -102,6 +102,8 @@ func EnvTest() *envtest.Environment {
 				CRD("tekton.dev", "v1", "taskruns", "TaskRun", "taskrun", true),
 				CRD("pipelinesascode.tekton.dev", "v1alpha1", "repositories", "Repository", "repository", true),
 				CRD("operator.tekton.dev", "v1alpha1", "tektonconfigs", "TektonConfig", "tektonconfig", false),
+				// virt-template
+				CRD("template.kubevirt.io", "v1beta1", "virtualmachinetemplates", "VirtualMachineTemplate", "virtualmachinetemplate", true),
 			},
 		}
 

--- a/internal/test/envtest.go
+++ b/internal/test/envtest.go
@@ -102,6 +102,9 @@ func EnvTest() *envtest.Environment {
 				CRD("tekton.dev", "v1", "taskruns", "TaskRun", "taskrun", true),
 				CRD("pipelinesascode.tekton.dev", "v1alpha1", "repositories", "Repository", "repository", true),
 				CRD("operator.tekton.dev", "v1alpha1", "tektonconfigs", "TektonConfig", "tektonconfig", false),
+				// virt-template
+				CRD("template.kubevirt.io", "v1beta1", "virtualmachinetemplates", "VirtualMachineTemplate", "virtualmachinetemplate", true),
+				CRD("template.kubevirt.io", "v1beta1", "virtualmachinetemplaterequests", "VirtualMachineTemplateRequest", "virtualmachinetemplaterequest", true),
 			},
 		}
 

--- a/pkg/kubevirt/guestagent.go
+++ b/pkg/kubevirt/guestagent.go
@@ -6,7 +6,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
 )
 
@@ -16,13 +15,6 @@ const (
 	subresourceFilesystemList = "filesystemlist"
 	subresourceUserList       = "userlist"
 	subresourceInterfaceList  = "interfacelist"
-)
-
-var (
-	// subresourcesScheme is the scheme for subresources API
-	subresourcesScheme = Scheme
-	// subresourcesCodec is the codec for encoding/decoding subresources
-	subresourcesCodec = serializer.NewCodecFactory(subresourcesScheme)
 )
 
 // AllGuestInfo holds all guest agent information with error tracking

--- a/pkg/kubevirt/gvr.go
+++ b/pkg/kubevirt/gvr.go
@@ -6,10 +6,14 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
 // Scheme is the runtime scheme for KubeVirt resources
 var Scheme = runtime.NewScheme()
+
+// subresourcesCodec is the codec for encoding/decoding subresources
+var subresourcesCodec = serializer.NewCodecFactory(Scheme)
 
 // KubeVirt core resources
 var (
@@ -112,6 +116,24 @@ var (
 		Resource: "virtualmachineinstancemigrations",
 	}
 )
+
+// virt-template resources
+var (
+	// VirtualMachineTemplateGVK is the GroupVersionKind for VirtualMachineTemplate resources
+	VirtualMachineTemplateGVK = schema.GroupVersionKind{
+		Group:   "template.kubevirt.io",
+		Version: "v1beta1",
+		Kind:    "VirtualMachineTemplate",
+	}
+)
+
+// HasVirtualMachineTemplate returns a TargetCompatibilityFilter that checks whether any
+// target cluster has the VirtualMachineTemplate GVK registered.
+func HasVirtualMachineTemplate(p api.FilteringProvider) func() bool {
+	return func() bool {
+		return p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{VirtualMachineTemplateGVK})
+	}
+}
 
 // HasVirtualMachine returns a TargetCompatibilityFilter that checks whether any
 // target cluster has the VirtualMachine GVK registered.

--- a/pkg/kubevirt/gvr.go
+++ b/pkg/kubevirt/gvr.go
@@ -103,6 +103,24 @@ var (
 	}
 )
 
+// virt-template resources
+var (
+	// VirtualMachineTemplateGVK is the GroupVersionKind for VirtualMachineTemplate resources
+	VirtualMachineTemplateGVK = schema.GroupVersionKind{
+		Group:   "template.kubevirt.io",
+		Version: "v1beta1",
+		Kind:    "VirtualMachineTemplate",
+	}
+)
+
+// HasVirtualMachineTemplate returns a TargetCompatibilityFilter that checks whether any
+// target cluster has the VirtualMachineTemplate GVK registered.
+func HasVirtualMachineTemplate(p api.FilteringProvider) func() bool {
+	return func() bool {
+		return p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{VirtualMachineTemplateGVK})
+	}
+}
+
 // HasVirtualMachine returns a TargetCompatibilityFilter that checks whether any
 // target cluster has the VirtualMachine GVK registered.
 func HasVirtualMachine(p api.FilteringProvider) func() bool {

--- a/pkg/kubevirt/gvr_test.go
+++ b/pkg/kubevirt/gvr_test.go
@@ -19,6 +19,35 @@ func (f *fakeFilteringProvider) AnyTargetHasGVKs(_ context.Context, gvks []schem
 
 func (f *fakeFilteringProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return true }
 
+func TestHasVirtualMachineTemplate(t *testing.T) {
+	t.Run("queries for VirtualMachineTemplate GVK", func(t *testing.T) {
+		p := &fakeFilteringProvider{hasGVKs: true}
+		filter := HasVirtualMachineTemplate(p)
+		filter()
+
+		if len(p.queriedGVKs) != 1 {
+			t.Fatalf("expected 1 GVK query, got %d", len(p.queriedGVKs))
+		}
+		if p.queriedGVKs[0] != VirtualMachineTemplateGVK {
+			t.Errorf("expected query for %v, got %v", VirtualMachineTemplateGVK, p.queriedGVKs[0])
+		}
+	})
+
+	t.Run("returns true when provider has VirtualMachineTemplate GVK", func(t *testing.T) {
+		filter := HasVirtualMachineTemplate(&fakeFilteringProvider{hasGVKs: true})
+		if !filter() {
+			t.Error("expected HasVirtualMachineTemplate to return true")
+		}
+	})
+
+	t.Run("returns false when provider does not have VirtualMachineTemplate GVK", func(t *testing.T) {
+		filter := HasVirtualMachineTemplate(&fakeFilteringProvider{hasGVKs: false})
+		if filter() {
+			t.Error("expected HasVirtualMachineTemplate to return false")
+		}
+	})
+}
+
 func TestHasVirtualMachine(t *testing.T) {
 	t.Run("queries for VirtualMachine GVK", func(t *testing.T) {
 		p := &fakeFilteringProvider{hasGVKs: true}

--- a/pkg/kubevirt/template.go
+++ b/pkg/kubevirt/template.go
@@ -1,0 +1,57 @@
+package kubevirt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+// CreateVMFromTemplate calls the create subresource on a VirtualMachineTemplate
+// to perform server-side parameter substitution and create the resulting
+// VirtualMachine in a single atomic operation.
+func CreateVMFromTemplate(ctx context.Context, restConfig *rest.Config, namespace, templateName string, parameters map[string]string) (map[string]any, error) {
+	config := rest.CopyConfig(restConfig)
+
+	gv := schema.GroupVersion{Group: "subresources.template.kubevirt.io", Version: "v1beta1"}
+	config.GroupVersion = &gv
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = subresourcesCodec.WithoutConversion()
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create REST client for template subresources: %w", err)
+	}
+
+	createOptions := map[string]any{
+		"apiVersion": "subresources.template.kubevirt.io/v1beta1",
+		"kind":       "CreateOptions",
+	}
+	if len(parameters) > 0 {
+		createOptions["parameters"] = parameters
+	}
+
+	body, err := json.Marshal(createOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal CreateOptions: %w", err)
+	}
+
+	result := &unstructured.Unstructured{}
+	err = restClient.Post().
+		Namespace(namespace).
+		Resource("virtualmachinetemplates").
+		Name(templateName).
+		SubResource("create").
+		Body(body).
+		Do(ctx).
+		Into(result)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VM from template %s/%s: %w", namespace, templateName, err)
+	}
+
+	return result.Object, nil
+}

--- a/pkg/kubevirt/template_test.go
+++ b/pkg/kubevirt/template_test.go
@@ -1,0 +1,162 @@
+package kubevirt
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateVMFromTemplate(t *testing.T) {
+	tests := []struct {
+		name          string
+		namespace     string
+		templateName  string
+		parameters    map[string]string
+		setupServer   func() *httptest.Server
+		wantError     bool
+		errorContains string
+		wantKeys      []string
+	}{
+		{
+			name:         "successfully creates VM from template",
+			namespace:    "default",
+			templateName: "test-template",
+			parameters:   map[string]string{"VM_NAME": "my-vm"},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					expectedPath := "/apis/subresources.template.kubevirt.io/v1beta1/namespaces/default/virtualmachinetemplates/test-template/create"
+					if r.URL.Path != expectedPath {
+						t.Errorf("unexpected path: got %s, want %s", r.URL.Path, expectedPath)
+						http.NotFound(w, r)
+						return
+					}
+					if r.Method != http.MethodPost {
+						t.Errorf("unexpected method: got %s, want POST", r.Method)
+						http.NotFound(w, r)
+						return
+					}
+
+					var body map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Errorf("failed to decode request body: %v", err)
+						http.Error(w, "bad request", http.StatusBadRequest)
+						return
+					}
+					if body["kind"] != "CreateOptions" {
+						t.Errorf("unexpected kind: got %v, want CreateOptions", body["kind"])
+					}
+
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"apiVersion": "kubevirt.io/v1",
+						"kind":       "VirtualMachine",
+						"metadata": map[string]any{
+							"name":      "my-vm",
+							"namespace": "default",
+						},
+						"spec": map[string]any{
+							"runStrategy": "Halted",
+						},
+					})
+				}))
+			},
+			wantError: false,
+			wantKeys:  []string{"apiVersion", "kind", "metadata", "spec"},
+		},
+		{
+			name:         "successfully creates VM without parameters",
+			namespace:    "default",
+			templateName: "test-template",
+			parameters:   nil,
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					var body map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						http.Error(w, "bad request", http.StatusBadRequest)
+						return
+					}
+					if _, hasParams := body["parameters"]; hasParams {
+						t.Error("expected no parameters in request body")
+					}
+
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"apiVersion": "kubevirt.io/v1",
+						"kind":       "VirtualMachine",
+						"metadata": map[string]any{
+							"name":      "generated-vm",
+							"namespace": "default",
+						},
+					})
+				}))
+			},
+			wantError: false,
+			wantKeys:  []string{"apiVersion", "kind", "metadata"},
+		},
+		{
+			name:         "returns error when template not found",
+			namespace:    "default",
+			templateName: "nonexistent",
+			parameters:   nil,
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.NotFound(w, r)
+				}))
+			},
+			wantError:     true,
+			errorContains: "failed to create VM from template",
+		},
+		{
+			name:         "returns error on server error",
+			namespace:    "default",
+			templateName: "test-template",
+			parameters:   map[string]string{"VM_NAME": "my-vm"},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+				}))
+			},
+			wantError:     true,
+			errorContains: "failed to create VM from template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.setupServer()
+			defer server.Close()
+
+			config := createTestRESTConfig(server)
+			result, err := CreateVMFromTemplate(context.Background(), config, tt.namespace, tt.templateName, tt.parameters)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("Expected error, got nil")
+					return
+				}
+				if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
+					t.Errorf("Error = %v, want to contain %q", err, tt.errorContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if result == nil {
+				t.Error("Expected non-nil result, got nil")
+				return
+			}
+
+			for _, key := range tt.wantKeys {
+				if _, ok := result[key]; !ok {
+					t.Errorf("Result missing expected key %q", key)
+				}
+			}
+		})
+	}
+}

--- a/pkg/mcp/kubevirt_test.go
+++ b/pkg/mcp/kubevirt_test.go
@@ -30,6 +30,7 @@ var kubevirtApis = []schema.GroupVersionResource{
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachineinstancetypes"},
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachineclusterpreferences"},
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinepreferences"},
+	{Group: "template.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinetemplates"},
 }
 
 type KubevirtSuite struct {
@@ -1239,6 +1240,62 @@ func (s *KubevirtSuite) TestVMGuestInfo() {
 			Version:  "v1",
 			Resource: "virtualmachineinstances",
 		}).Namespace("default").Delete(s.T().Context(), "default-info-vm", metav1.DeleteOptions{})
+	})
+}
+
+func (s *KubevirtSuite) TestCreateFromTemplate() {
+	s.Run("vm_create_from_template missing required params", func() {
+		testCases := []string{"namespace", "template_name"}
+		for _, param := range testCases {
+			s.Run("missing "+param, func() {
+				params := map[string]interface{}{
+					"namespace":     "default",
+					"template_name": "test-template",
+				}
+				delete(params, param)
+				toolResult, err := s.CallTool("vm_create_from_template", params)
+				s.Require().Nilf(err, "call tool failed %v", err)
+				s.Truef(toolResult.IsError, "expected call tool to fail due to missing %s", param)
+				s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, param+" parameter required")
+			})
+		}
+	})
+
+	s.Run("vm_create_from_template with non-existent template", func() {
+		toolResult, err := s.CallTool("vm_create_from_template", map[string]interface{}{
+			"namespace":     "default",
+			"template_name": "non-existent-template",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected call tool to fail for non-existent template")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "failed to create VM from template")
+	})
+
+	s.Run("vm_create_from_template with parameters", func() {
+		toolResult, err := s.CallTool("vm_create_from_template", map[string]interface{}{
+			"namespace":     "default",
+			"template_name": "test-template",
+			"parameters": map[string]interface{}{
+				"VM_NAME": "my-vm",
+				"MEMORY":  "4Gi",
+			},
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected call tool to fail without virt-template API server")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "failed to create VM from template")
+	})
+
+	s.Run("vm_create_from_template with invalid parameter types", func() {
+		toolResult, err := s.CallTool("vm_create_from_template", map[string]interface{}{
+			"namespace":     "default",
+			"template_name": "test-template",
+			"parameters": map[string]interface{}{
+				"VM_NAME": 123,
+			},
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected call tool to fail for invalid parameter types")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "must be a string")
 	})
 }
 

--- a/pkg/mcp/kubevirt_test.go
+++ b/pkg/mcp/kubevirt_test.go
@@ -30,6 +30,8 @@ var kubevirtApis = []schema.GroupVersionResource{
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachineinstancetypes"},
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachineclusterpreferences"},
 	{Group: "instancetype.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinepreferences"},
+	{Group: "template.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinetemplates"},
+	{Group: "template.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinetemplaterequests"},
 }
 
 type KubevirtSuite struct {
@@ -1040,6 +1042,62 @@ func (s *KubevirtSuite) TestVMGuestInfo() {
 			Version:  "v1",
 			Resource: "virtualmachineinstances",
 		}).Namespace("default").Delete(s.T().Context(), "default-info-vm", metav1.DeleteOptions{})
+	})
+}
+
+func (s *KubevirtSuite) TestCreateFromTemplate() {
+	s.Run("vm_create_from_template missing required params", func() {
+		testCases := []string{"namespace", "template_name"}
+		for _, param := range testCases {
+			s.Run("missing "+param, func() {
+				params := map[string]interface{}{
+					"namespace":     "default",
+					"template_name": "test-template",
+				}
+				delete(params, param)
+				toolResult, err := s.CallTool("vm_create_from_template", params)
+				s.Require().Nilf(err, "call tool failed %v", err)
+				s.Truef(toolResult.IsError, "expected call tool to fail due to missing %s", param)
+				s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, param+" parameter required")
+			})
+		}
+	})
+
+	s.Run("vm_create_from_template with non-existent template", func() {
+		toolResult, err := s.CallTool("vm_create_from_template", map[string]interface{}{
+			"namespace":     "default",
+			"template_name": "non-existent-template",
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected call tool to fail for non-existent template")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "failed to create VM from template")
+	})
+
+	s.Run("vm_create_from_template with parameters", func() {
+		toolResult, err := s.CallTool("vm_create_from_template", map[string]interface{}{
+			"namespace":     "default",
+			"template_name": "test-template",
+			"parameters": map[string]interface{}{
+				"VM_NAME": "my-vm",
+				"MEMORY":  "4Gi",
+			},
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected call tool to fail without virt-template API server")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "failed to create VM from template")
+	})
+
+	s.Run("vm_create_from_template with invalid parameter types", func() {
+		toolResult, err := s.CallTool("vm_create_from_template", map[string]interface{}{
+			"namespace":     "default",
+			"template_name": "test-template",
+			"parameters": map[string]interface{}{
+				"VM_NAME": 123,
+			},
+		})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected call tool to fail for invalid parameter types")
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "must be a string")
 	})
 }
 

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -160,6 +160,42 @@
   },
   {
     "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "openWorldHint": false,
+      "readOnlyHint": false,
+      "title": "Virtual Machine: Create from Template"
+    },
+    "description": "Create a VirtualMachine from a VirtualMachineTemplate (virt-template) on KubeVirt. Processes the template server-side to substitute parameters (required values, defaults, and auto-generated values like passwords), then creates the resulting VirtualMachine in the same namespace. Cross-namespace template usage is not supported.",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "The namespace of the VirtualMachineTemplate and the resulting VirtualMachine (must be the same)",
+          "type": "string"
+        },
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Parameter values to substitute in the template. Keys are parameter names (e.g. VM_NAME), values are strings. Required parameters must be provided; optional parameters use their defaults if omitted; parameters with generate/from will be auto-generated if not provided.",
+          "type": "object"
+        },
+        "template_name": {
+          "description": "The name of the VirtualMachineTemplate to create the VM from",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "template_name"
+      ],
+      "type": "object"
+    },
+    "name": "vm_create_from_template",
+    "title": "Virtual Machine: Create from Template"
+  },
+  {
+    "annotations": {
       "destructiveHint": false,
       "idempotentHint": true,
       "openWorldHint": false,

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -158,6 +158,40 @@
   },
   {
     "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": false,
+      "title": "Virtual Machine: Create from Template"
+    },
+    "description": "Create a VirtualMachine from a VirtualMachineTemplate (virt-template) on KubeVirt. Processes the template server-side to substitute parameters (required values, defaults, and auto-generated values like passwords), then creates the resulting VirtualMachine in the same namespace. Cross-namespace template usage is not supported.",
+    "inputSchema": {
+      "properties": {
+        "namespace": {
+          "description": "The namespace of the VirtualMachineTemplate and the resulting VirtualMachine (must be the same)",
+          "type": "string"
+        },
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Parameter values to substitute in the template. Keys are parameter names (e.g. VM_NAME), values are strings. Required parameters must be provided; optional parameters use their defaults if omitted; parameters with generate/from will be auto-generated if not provided.",
+          "type": "object"
+        },
+        "template_name": {
+          "description": "The name of the VirtualMachineTemplate to create the VM from",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "template_name"
+      ],
+      "type": "object"
+    },
+    "name": "vm_create_from_template",
+    "title": "Virtual Machine: Create from Template"
+  },
+  {
+    "annotations": {
       "destructiveHint": false,
       "idempotentHint": true,
       "openWorldHint": false,

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -137,7 +137,7 @@ func (s *ToolsetsSuite) TestKubevirtToolsFilteredWithoutCRDs() {
 			s.NoError(err, "Expected no error from ListTools")
 		})
 		s.Run("kubevirt tools are not present", func() {
-			kubevirtTools := []string{"vm_create", "vm_lifecycle", "vm_clone", "vm_guest_info"}
+			kubevirtTools := []string{"vm_create", "vm_create_from_template", "vm_lifecycle", "vm_clone", "vm_guest_info"}
 			for _, tool := range tools.Tools {
 				for _, kvTool := range kubevirtTools {
 					s.Require().NotEqual(kvTool, tool.Name, "Expected %s to not be present when filtering enabled on cluster without KubeVirt", kvTool)

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -10,6 +10,7 @@ import (
 	vm_create "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/create"
 	vm_guestagent "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/guestagent"
 	vm_lifecycle "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/lifecycle"
+	vm_template "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/template"
 	vm_troubleshoot "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/troubleshoot"
 )
 
@@ -31,6 +32,7 @@ func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
 		vm_create.Tools(p),
 		vm_guestagent.Tools(p),
 		vm_lifecycle.Tools(p),
+		vm_template.Tools(p),
 		vm_troubleshoot.Tools(p),
 	)
 }

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -10,6 +10,7 @@ import (
 	vm_create "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/create"
 	vm_guestagent "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/guestagent"
 	vm_lifecycle "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/lifecycle"
+	vm_template "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/template"
 )
 
 type Toolset struct{}
@@ -30,6 +31,7 @@ func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
 		vm_create.Tools(p),
 		vm_guestagent.Tools(p),
 		vm_lifecycle.Tools(p),
+		vm_template.Tools(p),
 	)
 }
 

--- a/pkg/toolsets/kubevirt/vm/template/tool.go
+++ b/pkg/toolsets/kubevirt/vm/template/tool.go
@@ -1,0 +1,115 @@
+package template
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	"github.com/containers/kubernetes-mcp-server/pkg/output"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
+	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/utils/ptr"
+)
+
+func Tools(p api.FilteringProvider) []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "vm_create_from_template",
+				Description: fmt.Sprintf("Create a VirtualMachine from a VirtualMachineTemplate (virt-template) on %s. Processes the template server-side to substitute parameters (required values, defaults, and auto-generated values like passwords), then creates the resulting VirtualMachine in the same namespace. Cross-namespace template usage is not supported.", defaults.ProductName()),
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "The namespace of the VirtualMachineTemplate and the resulting VirtualMachine (must be the same)",
+						},
+						"template_name": {
+							Type:        "string",
+							Description: "The name of the VirtualMachineTemplate to create the VM from",
+						},
+						"parameters": {
+							Type:        "object",
+							Description: "Parameter values to substitute in the template. Keys are parameter names (e.g. VM_NAME), values are strings. Required parameters must be provided; optional parameters use their defaults if omitted; parameters with generate/from will be auto-generated if not provided.",
+							AdditionalProperties: &jsonschema.Schema{
+								Type: "string",
+							},
+						},
+					},
+					Required: []string{"namespace", "template_name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Virtual Machine: Create from Template",
+					ReadOnlyHint:    ptr.To(false),
+					DestructiveHint: ptr.To(true),
+					IdempotentHint:  ptr.To(false),
+					OpenWorldHint:   ptr.To(false),
+				},
+			},
+			Handler: createFromTemplate,
+			TargetCompatibilityFilters: []func() bool{
+				kubevirt.HasVirtualMachineTemplate(p),
+			},
+		},
+	}
+}
+
+func createFromTemplate(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	namespace := p.RequiredString("namespace")
+	templateName := p.RequiredString("template_name")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	templateParams, err := extractParameters(params)
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	result, err := kubevirt.CreateVMFromTemplate(params.Context, params.RESTConfig(), namespace, templateName, templateParams)
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	marshalledYaml, err := output.MarshalYaml(result)
+	if err != nil {
+		return api.NewToolCallResult("", fmt.Errorf("failed to marshal created VirtualMachine: %w", err)), nil
+	}
+
+	return api.NewToolCallResult("# VirtualMachine created from template successfully\n"+marshalledYaml, nil), nil
+}
+
+func extractParameters(params api.ToolHandlerParams) (map[string]string, error) {
+	args := params.GetArguments()
+	raw, ok := args["parameters"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+
+	switch v := raw.(type) {
+	case map[string]any:
+		result := make(map[string]string, len(v))
+		for key, val := range v {
+			s, ok := val.(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter %q value must be a string, got %T", key, val)
+			}
+			result[key] = s
+		}
+		return result, nil
+	case map[string]string:
+		return v, nil
+	default:
+		b, err := json.Marshal(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parameters must be an object mapping parameter names to string values")
+		}
+		var result map[string]string
+		if err := json.Unmarshal(b, &result); err != nil {
+			return nil, fmt.Errorf("parameters must be an object mapping parameter names to string values")
+		}
+		return result, nil
+	}
+}


### PR DESCRIPTION
Add MCP tool to create VirtualMachines from
VirtualMachineTemplates via the virt-template
process subresource API, with eval tasks
and tests.