### PR TITLE
chore: cleanup readme generator to reuse mcp imports

### DIFF
--- a/internal/tools/update-readme/main.go
+++ b/internal/tools/update-readme/main.go
@@ -13,16 +13,9 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	_ "github.com/containers/kubernetes-mcp-server/pkg/mcp"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 
-	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/config"
-	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/core"
-	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/helm"
-	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kcp"
-	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali"
-	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt"
-	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/netobserv"
-	_ "github.com/containers/kubernetes-mcp-server/pkg/toolsets/tekton"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 


### PR DESCRIPTION
Currently whenever adding new toolsets we need to add an import for the toolset into both pkg/mcp and internal/tools/update-readme

This is error prone and overly complex.

This PR moves to just importing pkg/mcp, which then in turn imports each toolset, leading to init functions running as expected