### PR TITLE
feat(helm): make install/uninstall wait and timeout configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -723,6 +723,9 @@ storage_driver = "configmap"
 |-------|------|-------------|
 | `allowed_registries` | string array | Optional list of permitted chart registry URL prefixes. Only `oci://` and `https://` schemes are accepted. |
 | `storage_driver` | string | Optional default storage driver for Helm operations. Supported values: `secret` (default) and `configmap`. |
+| `timeout` | string | Optional time to wait for resource readiness during blocking Helm operations, as a Go duration string (e.g. `4m`, `90s`). Equivalent to the Helm CLI `--timeout` flag. Defaults to `5m`. |
+| `wait` | bool | Optional. Whether `helm_install` blocks until the release's resources are ready. Equivalent to `helm install --wait`. Defaults to `true`. |
+| `uninstall_wait` | bool | Optional. Whether `helm_uninstall` blocks until the release's resources are deleted. Equivalent to `helm uninstall --wait`. Defaults to `true`. |
 
 The Helm toolset supports an optional `allowed_registries` allowlist to restrict which registries
 `helm_install` can fetch charts from.
@@ -734,6 +737,19 @@ The Helm toolset supports an optional `allowed_registries` allowlist to restrict
 - When `allowed_registries` **is configured**, chart references must be URL-based and prefix-match an entry in the list. Non-URL references (local paths, repo/chart names) are rejected.
 
 **Accepted risk:** bare filesystem paths (e.g. `/absolute/path`, `./relative/path`) are not blocked when no allowlist is configured, because they are indistinguishable from Helm repository references at the string level. When the server runs in a container, the blast radius is limited to the container filesystem. To fully restrict chart sources, configure `allowed_registries`.
+
+**Blocking behavior:** by default `helm_install` and `helm_uninstall` wait up to `timeout` for the
+release's resources to become ready or to be deleted, and return an error if they do not. Note that
+`wait` defaults to `true` here, whereas the Helm CLI's `--wait` defaults to `false`.
+
+Tune these when the MCP client enforces its own per-tool-call timeout. If the client's ceiling is
+below the server's `timeout`, the client gives up first and never sees the Helm error — lower
+`timeout` so the server reports the failure instead. Setting `wait = false` goes further:
+`helm_install` returns as soon as the resources are created, letting the caller poll readiness
+itself. `wait` and `uninstall_wait` are separate options, mirroring the separate `--wait` flags on
+`helm install` and `helm uninstall`, so that install can stop blocking while uninstall still
+sequences its deletes — a caller that reinstalls immediately after a non-blocking uninstall would
+otherwise race the deletions.
 
 Refer to individual toolset documentation for available options:
 - [Kiali Configuration](KIALI.md)

--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -5,16 +5,25 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 )
 
+const DefaultTimeout = 5 * time.Minute
+
 // Config holds Helm toolset configuration
 type Config struct {
 	AllowedRegistries []string `toml:"allowed_registries,omitempty"`
 	StorageDriver     string   `toml:"storage_driver,omitempty"`
+	// Equivalent to the helm CLI --timeout flag. Defaults to 5m when unset.
+	Timeout string `toml:"timeout,omitempty"`
+	// Equivalent to the helm CLI --wait flag on `helm install`. Defaults to true when unset
+	Wait *bool `toml:"wait,omitempty"`
+	// Equivalent to the helm CLI --wait flag on `helm uninstall`. Defaults to true when unset.
+	UninstallWait *bool `toml:"uninstall_wait,omitempty"`
 }
 
 var _ api.ExtendedConfig = (*Config)(nil)
@@ -46,8 +55,48 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("unsupported Helm storage driver %q: must be \"secret\" or \"configmap\"", c.StorageDriver)
 		}
 	}
+	if c.Timeout != "" {
+		d, err := time.ParseDuration(c.Timeout)
+		if err != nil {
+			return fmt.Errorf("invalid Helm timeout %q: %v", c.Timeout, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("invalid Helm timeout %q: must be positive", c.Timeout)
+		}
+	}
 
 	return nil
+}
+
+// TimeoutOrDefault returns the timeout to wait for resource readiness during
+// blocking helm operations, or DefaultTimeout when unset or invalid.
+func (c *Config) TimeoutOrDefault() time.Duration {
+	if c == nil || c.Timeout == "" {
+		return DefaultTimeout
+	}
+	d, err := time.ParseDuration(c.Timeout)
+	if err != nil || d <= 0 {
+		return DefaultTimeout
+	}
+	return d
+}
+
+// WaitOrDefault returns whether install waits for resource readiness, or true
+// when unset.
+func (c *Config) WaitOrDefault() bool {
+	if c == nil || c.Wait == nil {
+		return true
+	}
+	return *c.Wait
+}
+
+// UninstallWaitOrDefault returns whether uninstall waits for the release's
+// resources to be deleted, or true when unset.
+func (c *Config) UninstallWaitOrDefault() bool {
+	if c == nil || c.UninstallWait == nil {
+		return true
+	}
+	return *c.UninstallWait
 }
 
 func helmToolsetParser(_ context.Context, primitive toml.Primitive, md toml.MetaData) (api.ExtendedConfig, error) {

--- a/pkg/helm/config_test.go
+++ b/pkg/helm/config_test.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"testing"
+	"time"
 
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
@@ -102,6 +103,105 @@ func (s *ConfigSuite) TestValidate() {
 		s.Error(err)
 		s.Contains(err.Error(), "unsupported Helm storage driver")
 	})
+	s.Run("accepts valid timeout", func() {
+		cfg := &Config{
+			Timeout: "4m",
+		}
+		s.NoError(cfg.Validate())
+	})
+	s.Run("rejects malformed timeout", func() {
+		cfg := &Config{
+			Timeout: "four minutes",
+		}
+		err := cfg.Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "invalid Helm timeout")
+	})
+	s.Run("rejects negative timeout", func() {
+		cfg := &Config{
+			Timeout: "-1m",
+		}
+		err := cfg.Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "must be positive")
+	})
+	s.Run("rejects zero timeout", func() {
+		cfg := &Config{
+			Timeout: "0s",
+		}
+		err := cfg.Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "must be positive")
+	})
+}
+
+func (s *ConfigSuite) TestTimeoutOrDefault() {
+	s.Run("returns default on nil config", func() {
+		var cfg *Config
+		s.Equal(DefaultTimeout, cfg.TimeoutOrDefault())
+	})
+	s.Run("returns default when unset", func() {
+		cfg := &Config{}
+		s.Equal(DefaultTimeout, cfg.TimeoutOrDefault())
+	})
+	s.Run("returns configured timeout", func() {
+		cfg := &Config{Timeout: "4m"}
+		s.Equal(4*time.Minute, cfg.TimeoutOrDefault())
+	})
+}
+
+func (s *ConfigSuite) TestWaitOrDefault() {
+	s.Run("returns true on nil config", func() {
+		var cfg *Config
+		s.True(cfg.WaitOrDefault())
+	})
+	s.Run("returns true when unset", func() {
+		cfg := &Config{}
+		s.True(cfg.WaitOrDefault())
+	})
+	s.Run("returns configured false", func() {
+		wait := false
+		cfg := &Config{Wait: &wait}
+		s.False(cfg.WaitOrDefault())
+	})
+	s.Run("returns configured true", func() {
+		wait := true
+		cfg := &Config{Wait: &wait}
+		s.True(cfg.WaitOrDefault())
+	})
+	s.Run("is independent of uninstall_wait", func() {
+		wait := false
+		cfg := &Config{Wait: &wait}
+		s.False(cfg.WaitOrDefault())
+		s.True(cfg.UninstallWaitOrDefault())
+	})
+}
+
+func (s *ConfigSuite) TestUninstallWaitOrDefault() {
+	s.Run("returns true on nil config", func() {
+		var cfg *Config
+		s.True(cfg.UninstallWaitOrDefault())
+	})
+	s.Run("returns true when unset", func() {
+		cfg := &Config{}
+		s.True(cfg.UninstallWaitOrDefault())
+	})
+	s.Run("returns configured false", func() {
+		wait := false
+		cfg := &Config{UninstallWait: &wait}
+		s.False(cfg.UninstallWaitOrDefault())
+	})
+	s.Run("returns configured true", func() {
+		wait := true
+		cfg := &Config{UninstallWait: &wait}
+		s.True(cfg.UninstallWaitOrDefault())
+	})
+	s.Run("is independent of wait", func() {
+		wait := false
+		cfg := &Config{UninstallWait: &wait}
+		s.False(cfg.UninstallWaitOrDefault())
+		s.True(cfg.WaitOrDefault())
+	})
 }
 
 func (s *ConfigSuite) TestParser() {
@@ -160,6 +260,94 @@ func (s *ConfigSuite) TestParser() {
 		`))
 		s.Error(err)
 		s.Contains(err.Error(), "unsupported Helm storage driver")
+	})
+	s.Run("parses timeout from TOML", func() {
+		cfg := test.Must(config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			timeout = "4m"
+		`)))
+		helmCfg, ok := cfg.GetToolsetConfig("helm")
+		s.Require().True(ok)
+		hc, ok := helmCfg.(*Config)
+		s.Require().True(ok)
+		s.Equal("4m", hc.Timeout)
+		s.Equal(4*time.Minute, hc.TimeoutOrDefault())
+	})
+	s.Run("parses wait from TOML", func() {
+		cfg := test.Must(config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			wait = false
+		`)))
+		helmCfg, ok := cfg.GetToolsetConfig("helm")
+		s.Require().True(ok)
+		hc, ok := helmCfg.(*Config)
+		s.Require().True(ok)
+		s.Require().NotNil(hc.Wait)
+		s.False(*hc.Wait)
+		s.False(hc.WaitOrDefault())
+	})
+	s.Run("wait defaults to true when absent from TOML", func() {
+		cfg := test.Must(config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			timeout = "4m"
+		`)))
+		helmCfg, ok := cfg.GetToolsetConfig("helm")
+		s.Require().True(ok)
+		hc, ok := helmCfg.(*Config)
+		s.Require().True(ok)
+		s.Nil(hc.Wait)
+		s.True(hc.WaitOrDefault())
+	})
+	s.Run("parses uninstall_wait from TOML", func() {
+		cfg := test.Must(config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			uninstall_wait = false
+		`)))
+		helmCfg, ok := cfg.GetToolsetConfig("helm")
+		s.Require().True(ok)
+		hc, ok := helmCfg.(*Config)
+		s.Require().True(ok)
+		s.Require().NotNil(hc.UninstallWait)
+		s.False(*hc.UninstallWait)
+		s.False(hc.UninstallWaitOrDefault())
+	})
+	s.Run("wait = false leaves uninstall waiting", func() {
+		// The deployed configuration: install returns as soon as resources
+		// are created, uninstall still sequences its deletes.
+		cfg := test.Must(config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			wait = false
+			timeout = "4m"
+		`)))
+		helmCfg, ok := cfg.GetToolsetConfig("helm")
+		s.Require().True(ok)
+		hc, ok := helmCfg.(*Config)
+		s.Require().True(ok)
+		s.False(hc.WaitOrDefault())
+		s.True(hc.UninstallWaitOrDefault())
+		s.Equal(4*time.Minute, hc.TimeoutOrDefault())
+	})
+	s.Run("rejects non-boolean uninstall_wait in TOML", func() {
+		_, err := config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			uninstall_wait = "no"
+		`))
+		s.Error(err)
+	})
+	s.Run("rejects non-boolean wait in TOML", func() {
+		_, err := config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			wait = "no"
+		`))
+		s.Error(err)
+	})
+	s.Run("rejects invalid timeout in TOML", func() {
+		_, err := config.ReadToml([]byte(`
+			[toolset_configs.helm]
+			timeout = "later"
+		`))
+		s.Error(err)
+		s.Contains(err.Error(), "invalid Helm timeout")
 	})
 }
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -42,7 +42,7 @@ func (h *Helm) Install(ctx context.Context, chart string, values map[string]inte
 	if err != nil {
 		return "", err
 	}
-	install := action.NewInstall(cfg)
+	install := h.newInstall(cfg)
 	if name == "" {
 		install.GenerateName = true
 		install.ReleaseName, _, _ = install.NameAndChart([]string{chart})
@@ -50,9 +50,6 @@ func (h *Helm) Install(ctx context.Context, chart string, values map[string]inte
 		install.ReleaseName = name
 	}
 	install.Namespace = h.kubernetes.NamespaceOrDefault(namespace)
-	install.Wait = true
-	install.Timeout = 5 * time.Minute
-	install.DryRun = false
 
 	chartRequested, err := install.LocateChart(chart, cli.New())
 	if err != nil {
@@ -100,10 +97,7 @@ func (h *Helm) Uninstall(ctx context.Context, name string, namespace string) (st
 	if err != nil {
 		return "", err
 	}
-	uninstall := action.NewUninstall(cfg)
-	uninstall.IgnoreNotFound = true
-	uninstall.Wait = true
-	uninstall.Timeout = 5 * time.Minute
+	uninstall := h.newUninstall(cfg)
 	uninstalledRelease, err := uninstall.Run(name)
 	if uninstalledRelease == nil && err == nil {
 		return fmt.Sprintf("Release %s not found", name), nil
@@ -111,6 +105,27 @@ func (h *Helm) Uninstall(ctx context.Context, name string, namespace string) (st
 		return "", err
 	}
 	return fmt.Sprintf("Uninstalled release %s %s", uninstalledRelease.Release.Name, uninstalledRelease.Info), nil
+}
+
+// newInstall builds the install action with the configured blocking behavior
+// applied. Callers set the release name and namespace on the result.
+func (h *Helm) newInstall(cfg *action.Configuration) *action.Install {
+	install := action.NewInstall(cfg)
+	install.Wait = h.config.WaitOrDefault()
+	install.Timeout = h.config.TimeoutOrDefault()
+	install.DryRun = false
+	return install
+}
+
+// newUninstall builds the uninstall action with the configured blocking
+// behavior applied. Note that uninstall waiting is configured separately from
+// install waiting, so this reads UninstallWait rather than Wait.
+func (h *Helm) newUninstall(cfg *action.Configuration) *action.Uninstall {
+	uninstall := action.NewUninstall(cfg)
+	uninstall.IgnoreNotFound = true
+	uninstall.Wait = h.config.UninstallWaitOrDefault()
+	uninstall.Timeout = h.config.TimeoutOrDefault()
+	return uninstall
 }
 
 func (h *Helm) newAction(ctx context.Context, namespace string, allNamespaces bool) (*action.Configuration, error) {

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -5,9 +5,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
 	helmtime "helm.sh/helm/v3/pkg/time"
+	"k8s.io/utils/ptr"
 )
 
 type HelmSuite struct {
@@ -213,6 +215,95 @@ func (s *HelmSuite) TestValidateChartReference() {
 			s.Error(err)
 			s.Contains(err.Error(), "http:// scheme is blocked")
 		})
+	})
+}
+
+func (s *HelmSuite) TestNewInstall() {
+	s.Run("with nil config", func() {
+		install := (&Helm{}).newInstall(&action.Configuration{})
+		s.Run("waits for resource readiness", func() {
+			s.True(install.Wait)
+		})
+		s.Run("uses the default timeout", func() {
+			s.Equal(DefaultTimeout, install.Timeout)
+		})
+	})
+	s.Run("with empty config", func() {
+		install := (&Helm{config: &Config{}}).newInstall(&action.Configuration{})
+		s.Run("waits for resource readiness", func() {
+			s.True(install.Wait)
+		})
+		s.Run("uses the default timeout", func() {
+			s.Equal(DefaultTimeout, install.Timeout)
+		})
+	})
+	s.Run("applies configured wait = false", func() {
+		install := (&Helm{config: &Config{Wait: ptr.To(false)}}).newInstall(&action.Configuration{})
+		s.False(install.Wait)
+	})
+	s.Run("applies configured wait = true", func() {
+		install := (&Helm{config: &Config{Wait: ptr.To(true)}}).newInstall(&action.Configuration{})
+		s.True(install.Wait)
+	})
+	s.Run("applies configured timeout", func() {
+		install := (&Helm{config: &Config{Timeout: "4m"}}).newInstall(&action.Configuration{})
+		s.Equal(4*time.Minute, install.Timeout)
+	})
+	s.Run("falls back to the default timeout when malformed", func() {
+		install := (&Helm{config: &Config{Timeout: "four minutes"}}).newInstall(&action.Configuration{})
+		s.Equal(DefaultTimeout, install.Timeout)
+	})
+	s.Run("reads wait, not uninstall_wait", func() {
+		// Disabling only uninstall waiting must leave install waiting.
+		install := (&Helm{config: &Config{UninstallWait: ptr.To(false)}}).newInstall(&action.Configuration{})
+		s.True(install.Wait)
+	})
+	s.Run("never dry runs", func() {
+		install := (&Helm{config: &Config{}}).newInstall(&action.Configuration{})
+		s.False(install.DryRun)
+	})
+}
+
+func (s *HelmSuite) TestNewUninstall() {
+	s.Run("with nil config", func() {
+		uninstall := (&Helm{}).newUninstall(&action.Configuration{})
+		s.Run("waits for resource deletion", func() {
+			s.True(uninstall.Wait)
+		})
+		s.Run("uses the default timeout", func() {
+			s.Equal(DefaultTimeout, uninstall.Timeout)
+		})
+	})
+	s.Run("with empty config", func() {
+		uninstall := (&Helm{config: &Config{}}).newUninstall(&action.Configuration{})
+		s.Run("waits for resource deletion", func() {
+			s.True(uninstall.Wait)
+		})
+		s.Run("uses the default timeout", func() {
+			s.Equal(DefaultTimeout, uninstall.Timeout)
+		})
+	})
+	s.Run("applies configured uninstall_wait = false", func() {
+		uninstall := (&Helm{config: &Config{UninstallWait: ptr.To(false)}}).newUninstall(&action.Configuration{})
+		s.False(uninstall.Wait)
+	})
+	s.Run("applies configured uninstall_wait = true", func() {
+		uninstall := (&Helm{config: &Config{UninstallWait: ptr.To(true)}}).newUninstall(&action.Configuration{})
+		s.True(uninstall.Wait)
+	})
+	s.Run("applies configured timeout", func() {
+		uninstall := (&Helm{config: &Config{Timeout: "4m"}}).newUninstall(&action.Configuration{})
+		s.Equal(4*time.Minute, uninstall.Timeout)
+	})
+	s.Run("reads uninstall_wait, not wait", func() {
+		// Disabling install waiting must leave uninstall sequencing its deletes,
+		// otherwise a caller that reinstalls immediately races the deletions.
+		uninstall := (&Helm{config: &Config{Wait: ptr.To(false)}}).newUninstall(&action.Configuration{})
+		s.True(uninstall.Wait)
+	})
+	s.Run("ignores a missing release", func() {
+		uninstall := (&Helm{config: &Config{}}).newUninstall(&action.Configuration{})
+		s.True(uninstall.IgnoreNotFound)
 	})
 }
 


### PR DESCRIPTION
## What

Makes the blocking behavior of `helm_install` and `helm_uninstall` configurable via three new options in `[toolset_configs.helm]`, each mirroring a Helm CLI flag. All defaults preserve today's behavior, so this is a no-op for existing users.

| Option | Type | Default | Equivalent to |
|---|---|---|---|
| `timeout` | string (Go duration) | `5m` | `--timeout` |
| `wait` | bool | `true` | `helm install --wait` |
| `uninstall_wait` | bool | `true` | `helm uninstall --wait` |

## Why

`pkg/helm/helm.go` hardcoded `Wait = true` and `Timeout = 5 * time.Minute` on both install and uninstall, with no way to override them.

This is a problem when the MCP client enforces its own per-tool-call timeout that is lower than the server's 5 minutes. The client then always gives up before the server does, so the caller never receives the Helm error explaining what actually went wrong — it sees only a transport-level timeout. In our case the client's ceiling is 300s and is not configurable, and its reconnect path is not re-entrant, so a single not-ready release left MCP unusable for the rest of the session.

### Reproducing

1. Configure a client with a per-tool-call timeout under 5 minutes.
2. `helm_install` a chart that cannot become ready (e.g. an image that will not pull, or a pod that cannot be scheduled).
3. The server blocks for the full hardcoded 5 minutes. The client times out first and surfaces a transport error instead of Helm's failure detail.

With `timeout = "4m"` the server loses the race deliberately and the client receives a normal Helm error. With `wait = false`, `helm_install` returns as soon as the resources are created, and the agent polls pod readiness and events itself — which also lets it uninstall and fix a broken release immediately rather than sitting blocked. An agent loop is strictly sequential, so there is no way to observe progress *during* a blocking call.

### Why `wait` and `uninstall_wait` are separate

The Helm CLI's `--wait` flags on `helm install` and `helm uninstall` are separate flags, and the useful configuration needs them to differ. Turning off install waiting is valuable because readiness can take minutes; turning off uninstall waiting is not, because teardown takes seconds and a caller that reinstalls immediately would otherwise race the deletions and fail with "resource already exists". A single option would force that tradeoff.

## Notes for reviewers

- **`wait` defaults to `true`, unlike the Helm CLI**, whose `--wait` defaults to `false`. This preserves the server's historical behavior rather than matching the CLI; documented in `docs/configuration.md`. Happy to flip it if you would rather match the CLI, but that would be a behavior change for existing users.
- **Only `timeout` is validated.** It is a string that has to be parsed, so it can be well-formed TOML but meaningless (`"four minutes"`) or nonsensical (`"-1m"`, `"0s"`). The two booleans need no validation: every state of a `*bool` is valid, and a non-boolean value is rejected by the TOML decoder before `Validate()` runs (covered by tests).
- **`*bool` rather than `bool`** so that "unset" is distinguishable from "explicitly false", which is what allows the default to be `true`.
- **`timeout` is not dead config when `wait = false`** — Helm also applies it to pre/post-install and pre/post-delete hooks, and to the atomic-rollback uninstall.
- **Small refactor:** the action construction moved into `newInstall`/`newUninstall`. The option-to-action wiring was four inline assignments with no test coverage; extracting them makes it testable without a cluster.

## Tests

- `pkg/helm/config_test.go` — parsing, defaulting, and `Validate()` for all three options, including malformed/negative/zero timeouts and non-boolean booleans.
- `pkg/helm/helm_test.go` — new `TestNewInstall`/`TestNewUninstall` assert the options reach the Helm action, including guards against reading `wait` where `uninstall_wait` is meant and vice versa.

Verified against a mutation run: reverting the wiring to the hardcoded values, or swapping uninstall to read `Wait`, fails 5 subtests.

`gofmt`, `go vet ./pkg/helm/...`, `go build ./...` and `go test ./pkg/helm/...` all clean; `go mod tidy` leaves `go.mod`/`go.sum` unchanged.

## Docs

`docs/configuration.md` — the three options added to the Helm Configuration table, plus a "Blocking behavior" section covering the defaults, the divergence from the CLI default, and when to tune them.
