### PR TITLE
Allow env var to specify config file path

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,7 @@ This reference focuses on TOML file configuration. For CLI arguments, see the [C
 Configuration values are loaded and merged in the following order (later sources override earlier ones):
 
 1. **Internal Defaults** - Built-in default values
-2. **Main Configuration File** - Loaded via `--config` flag
+2. **Main Configuration File** - Loaded via `--config` flag or `$K8S_MCP_CONFIG_PATH` (the flag takes precedence)
 3. **Drop-in Files** - Loaded from `--config-dir` in lexical (alphabetical) order
 
 ### Usage
@@ -57,6 +57,8 @@ Configuration values are loaded and merged in the following order (later sources
 ```bash
 # Use a main configuration file
 kubernetes-mcp-server --config /etc/kubernetes-mcp-server/config.toml
+# or
+K8S_MCP_CONFIG_PATH=/etc/kubernetes-mcp-server/config.toml kubernetes-mcp-server
 
 # Use only drop-in configuration files (no main config)
 kubernetes-mcp-server --config-dir /etc/kubernetes-mcp-server/conf.d/

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -58,6 +58,11 @@ kubernetes-mcp-server --cluster-provider kubeconfig
 # start with kcp cluster provider for multi-workspace support
 kubernetes-mcp-server --cluster-provider kcp
 `))
+
+	// config_path_env_var is the name of an environment variable whose value
+	// is the path to the main configuration TOML file. It is ignored if
+	// `--config` is provided on the command line.
+	config_path_env_var = "K8S_MCP_CONFIG_PATH"
 )
 
 const (
@@ -129,6 +134,8 @@ func NewMCPServerOptions(streams genericiooptions.IOStreams) *MCPServerOptions {
 }
 
 func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
+	// Allow downstreams to customize variable values
+	varOverrides()
 	o := NewMCPServerOptions(streams)
 	cmd := &cobra.Command{
 		Use:     "kubernetes-mcp-server [command] [options]",
@@ -198,6 +205,11 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 }
 
 func (m *MCPServerOptions) Complete(ctx context.Context, cmd *cobra.Command) error {
+	// If ConfigPath was not provided on the CLI, allow an env var to specify it.
+	if cp := os.Getenv(config_path_env_var); m.ConfigPath == "" && cp != "" {
+		m.ConfigPath = cp
+	}
+
 	if m.ConfigPath != "" || m.ConfigDir != "" {
 		cnf, err := config.Read(ctx, m.ConfigPath, m.ConfigDir)
 		if err != nil {

--- a/pkg/kubernetes-mcp-server/cmd/root_var_overrides.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_var_overrides.go
@@ -1,0 +1,9 @@
+package cmd
+
+// IMPORTANT: this file is used to override default variable values in downstream builds.
+
+// varOverrides is invoked early in the command bootstrapping process, allowing
+// downstreams to rename things like env var keys.
+func varOverrides() {
+	// Intentionally left blank upstream.
+}


### PR DESCRIPTION
With this change, if `--config` is not given on the CLI, we will look for an environment variable specifying a path to the main config file.

The variable is spelled `$K8S_MCP_CONFIG_PATH` here, but this change includes an override mechanism so downstreams can choose their own spelling.