### PR TITLE
fix: handle TLS version format from MCPLO

### DIFF
--- a/pkg/tlsutil/tlsutil.go
+++ b/pkg/tlsutil/tlsutil.go
@@ -14,10 +14,14 @@ import (
 
 // tlsVersionMap maps version strings to tls.Version constants
 var tlsVersionMap = map[string]uint16{
-	"1.0": tls.VersionTLS10,
-	"1.1": tls.VersionTLS11,
-	"1.2": tls.VersionTLS12,
-	"1.3": tls.VersionTLS13,
+	"1.0":          tls.VersionTLS10,
+	"1.1":          tls.VersionTLS11,
+	"1.2":          tls.VersionTLS12,
+	"1.3":          tls.VersionTLS13,
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
 }
 
 // tlsCipherSuiteMap maps cipher suite names to their IDs.

--- a/pkg/tlsutil/tlsutil_test.go
+++ b/pkg/tlsutil/tlsutil_test.go
@@ -53,6 +53,30 @@ func (s *TLSUtilSuite) TestParseTLSVersion() {
 		s.Equal(tls.VersionTLS13, int(v))
 	})
 
+	s.Run("parses VersionTLS10 format", func() {
+		v, err := ParseTLSVersion("VersionTLS10")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS10, int(v))
+	})
+
+	s.Run("parses VersionTLS11 format", func() {
+		v, err := ParseTLSVersion("VersionTLS11")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS11, int(v))
+	})
+
+	s.Run("parses VersionTLS12 format", func() {
+		v, err := ParseTLSVersion("VersionTLS12")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS12, int(v))
+	})
+
+	s.Run("parses VersionTLS13 format", func() {
+		v, err := ParseTLSVersion("VersionTLS13")
+		s.Require().NoError(err)
+		s.Equal(tls.VersionTLS13, int(v))
+	})
+
 	s.Run("returns error for invalid version", func() {
 		_, err := ParseTLSVersion("1.4")
 		s.Error(err)
@@ -117,6 +141,22 @@ func (s *TLSUtilSuite) TestParseTLSCipherSuites() {
 		s.Error(err)
 		s.Contains(err.Error(), "INVALID_1")
 		s.Contains(err.Error(), "INVALID_2")
+	})
+
+	s.Run("parses list of many valid ciphers", func() {
+		result, err := ParseTLSCipherSuites([]string{
+			"TLS_AES_128_GCM_SHA256",
+			"TLS_AES_256_GCM_SHA384",
+			"TLS_CHACHA20_POLY1305_SHA256",
+			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+			"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+		})
+		s.Require().NoError(err)
+		s.Len(result, 9)
 	})
 }
 


### PR DESCRIPTION
In #1270 we added support for configuring tls min version and cipher suites through env vars. This was done in large part to work with https://github.com/kubernetes-sigs/mcp-lifecycle-operator/pull/257, which will allow for setting tls properties across all MCP servers in a k8s cluster.

However, we did not actually support env vars for the tls min version set with the format provided by the MCPLO. This PR adds support for those, while keeping support for the simpler "1.0"-"1.3" strings, as that is likely easier for non MCPLO users to configure
