### PR TITLE
feat(kiali): API based filtering for Kiali

### DIFF
--- a/docs/KIALI.md
+++ b/docs/KIALI.md
@@ -10,6 +10,7 @@ Config (TOML):
 
 ```toml
 toolsets = ["core", "kiali"]
+experimental_enable_target_compatibility_tool_filters = true
 
 [toolset_configs.kiali]
 url = "https://kiali.example" # Endpoint/route to reach Kiali console
@@ -18,7 +19,14 @@ url = "https://kiali.example" # Endpoint/route to reach Kiali console
 # When url is https and insecure is false, certificate_authority is required.
 ```
 
-When the `kiali` toolset is enabled, a Kiali toolset configuration is required via `[toolset_configs.kiali]`. If missing or invalid, the server will refuse to start.
+Reachability checks and in-cluster URL discovery require `experimental_enable_target_compatibility_tool_filters = true` (default `false`). Without it, Kiali tools are always registered and no `/api/status` probe or CR-based discovery runs.
+
+When that flag is enabled:
+
+- If `url` is set, the server probes `GET {url}/api/status` and only exposes Kiali tools if that call succeeds.
+- If `url` is unset and a Kiali CR is present, the server tries to discover the in-cluster Service URL (`http://<instance>.<namespace>.svc:<port>[/web_root]`), probes `/api/status`, and injects a working URL into the live config.
+
+When the `kiali` toolset is enabled with an explicit HTTPS URL and `insecure = false`, `certificate_authority` is still required at config load time.
 
 ### How authentication works
 
@@ -35,8 +43,8 @@ Kiali tools and prompts are not cluster-aware: the MCP server does not inject a 
 
 ### Troubleshooting
 
-- Missing Kiali configuration when `kiali` toolset is enabled → set `[toolset_configs.kiali].url` in the config TOML.
-- Invalid URL → ensure `[toolset_configs.kiali].url` is a valid `http(s)://host` URL.
+- Kiali tools missing from `tools/list` → enable `experimental_enable_target_compatibility_tool_filters = true`, then set `[toolset_configs.kiali].url` or ensure a Kiali CR is installed so the in-cluster Service URL can be discovered.
+- Invalid or unreachable URL → ensure `[toolset_configs.kiali].url` is a valid `http(s)://host` URL and that `GET {url}/api/status` succeeds from the MCP server.
 - TLS certificate validation:
   - If `[toolset_configs.kiali].url` uses HTTPS and `[toolset_configs.kiali].insecure` is false, you must set `[toolset_configs.kiali].certificate_authority` with the path to the CA certificate file. Relative paths are resolved relative to the directory containing the config file.
   - For non-production environments you can set `[toolset_configs.kiali].insecure = true` to skip certificate verification.

--- a/pkg/kiali/config.go
+++ b/pkg/kiali/config.go
@@ -27,8 +27,15 @@ func (c *Config) Validate() error {
 	if c == nil {
 		return errors.New("kiali config is nil")
 	}
-	if c.Url == "" {
-		return errors.New("url is required")
+	// URL is optional: when empty, HasKiali may discover an in-cluster Service URL
+	// from a Kiali CR and inject it into this config at runtime.
+	if strings.TrimSpace(c.Url) == "" {
+		if caValue := strings.TrimSpace(c.CertificateAuthority); caValue != "" {
+			if _, err := os.Stat(caValue); err != nil {
+				return fmt.Errorf("certificate_authority must be a valid file path: %w", err)
+			}
+		}
+		return nil
 	}
 	if u, err := url.Parse(c.Url); err != nil || u.Scheme == "" || u.Host == "" {
 		return errors.New("url must be a valid URL")
@@ -61,8 +68,9 @@ func kialiToolsetParser(ctx context.Context, primitive toml.Primitive, md toml.M
 		// If it's already absolute or configDir is empty, use as-is
 	}
 
-	// Validate TLS settings when require_tls is enabled
-	if config.RequireTLSFromContext(ctx) {
+	// Validate TLS settings when require_tls is enabled (only when a URL is set;
+	// auto-discovered in-cluster URLs use http and are validated at filter time).
+	if config.RequireTLSFromContext(ctx) && strings.TrimSpace(cfg.Url) != "" {
 		if err := config.ValidateURLRequiresTLS(cfg.Url, "Kiali URL"); err != nil {
 			return nil, err
 		}

--- a/pkg/kiali/config.go
+++ b/pkg/kiali/config.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 )
 
 // Config holds Kiali toolset configuration
@@ -80,6 +82,34 @@ func kialiToolsetParser(ctx context.Context, primitive toml.Primitive, md toml.M
 	}
 
 	return &cfg, nil
+}
+
+var warnEmptyURLWithoutDiscoveryOnce sync.Once
+
+// WarnIfEmptyURLWithoutDiscovery logs once when Kiali has no configured URL and
+// target-compatibility filtering is disabled, so in-cluster auto-discovery will not run.
+func WarnIfEmptyURLWithoutDiscovery(p api.FilteringProvider) {
+	if p == nil || p.IsTargetCompatibilityToolFiltersEnabled() {
+		return
+	}
+	cfgProvider, ok := p.(api.ExtendedConfigProvider)
+	if !ok || cfgProvider == nil {
+		return
+	}
+	ext, ok := cfgProvider.GetToolsetConfig("kiali")
+	if !ok {
+		return
+	}
+	kc, ok := ext.(*Config)
+	if !ok || kc == nil || strings.TrimSpace(kc.Url) != "" {
+		return
+	}
+	warnEmptyURLWithoutDiscoveryOnce.Do(func() {
+		klogutil.LogWarn(
+			klogutil.FromContext(context.Background()),
+			"Kiali url is empty and experimental_enable_target_compatibility_tool_filters is disabled; Kiali tools will not auto-discover an in-cluster URL",
+		)
+	})
 }
 
 func init() {

--- a/pkg/kiali/config.go
+++ b/pkg/kiali/config.go
@@ -8,12 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
-	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 )
 
 // Config holds Kiali toolset configuration
@@ -82,34 +80,6 @@ func kialiToolsetParser(ctx context.Context, primitive toml.Primitive, md toml.M
 	}
 
 	return &cfg, nil
-}
-
-var warnEmptyURLWithoutDiscoveryOnce sync.Once
-
-// WarnIfEmptyURLWithoutDiscovery logs once when Kiali has no configured URL and
-// target-compatibility filtering is disabled, so in-cluster auto-discovery will not run.
-func WarnIfEmptyURLWithoutDiscovery(p api.FilteringProvider) {
-	if p == nil || p.IsTargetCompatibilityToolFiltersEnabled() {
-		return
-	}
-	cfgProvider, ok := p.(api.ExtendedConfigProvider)
-	if !ok || cfgProvider == nil {
-		return
-	}
-	ext, ok := cfgProvider.GetToolsetConfig("kiali")
-	if !ok {
-		return
-	}
-	kc, ok := ext.(*Config)
-	if !ok || kc == nil || strings.TrimSpace(kc.Url) != "" {
-		return
-	}
-	warnEmptyURLWithoutDiscoveryOnce.Do(func() {
-		klogutil.LogWarn(
-			klogutil.FromContext(context.Background()),
-			"Kiali url is empty and experimental_enable_target_compatibility_tool_filters is disabled; Kiali tools will not auto-discover an in-cluster URL",
-		)
-	})
 }
 
 func init() {

--- a/pkg/kiali/config_test.go
+++ b/pkg/kiali/config_test.go
@@ -122,11 +122,10 @@ func (s *ConfigSuite) TestValidate() {
 		s.Error(err, "Expected error for nil config")
 		s.ErrorContains(err, "kiali config is nil")
 	})
-	s.Run("empty URL returns error", func() {
+	s.Run("empty URL is allowed for auto-discovery", func() {
 		cfg := &Config{}
 		err := cfg.Validate()
-		s.Error(err, "Expected error for empty URL")
-		s.ErrorContains(err, "url is required")
+		s.NoError(err, "empty URL should be allowed so discovery can fill it in")
 	})
 	s.Run("invalid URL returns error", func() {
 		cfg := &Config{Url: "://bad-url"}

--- a/pkg/kiali/crd_types.go
+++ b/pkg/kiali/crd_types.go
@@ -1,0 +1,36 @@
+package kiali
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// KialiCR mirrors kiali.io/v1alpha1 fields used for in-cluster URL discovery.
+type KialiCR struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   KialiSpec   `json:"spec,omitempty"`
+	Status KialiStatus `json:"status,omitempty"`
+}
+
+type KialiSpec struct {
+	Deployment KialiDeploymentSpec `json:"deployment,omitempty"`
+	Server     KialiServerSpec     `json:"server,omitempty"`
+}
+
+type KialiDeploymentSpec struct {
+	InstanceName string `json:"instance_name,omitempty"`
+	Namespace    string `json:"namespace,omitempty"`
+}
+
+type KialiServerSpec struct {
+	Port    int64  `json:"port,omitempty"`
+	WebRoot string `json:"web_root,omitempty"`
+}
+
+type KialiStatus struct {
+	Deployment KialiDeploymentStatus `json:"deployment,omitempty"`
+}
+
+type KialiDeploymentStatus struct {
+	InstanceName string `json:"instanceName,omitempty"`
+	Namespace    string `json:"namespace,omitempty"`
+}

--- a/pkg/kiali/discover.go
+++ b/pkg/kiali/discover.go
@@ -1,0 +1,124 @@
+package kiali
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+)
+
+// KialiGVR is the GroupVersionResource for Kiali CRs.
+var KialiGVR = schema.GroupVersionResource{
+	Group:    KialiGVK.Group,
+	Version:  KialiGVK.Version,
+	Resource: "kialis",
+}
+
+const defaultKialiPort int64 = 20001
+
+// internalServiceURLs builds candidate in-cluster Service base URLs for a Kiali CR.
+// Prefer values from status/spec; fall back to CR metadata and Kiali defaults.
+func internalServiceURLs(cr *unstructured.Unstructured) []string {
+	if cr == nil {
+		return nil
+	}
+	instanceName := nestedString(cr.Object, "status", "deployment", "instanceName")
+	if instanceName == "" {
+		instanceName = nestedString(cr.Object, "spec", "deployment", "instance_name")
+	}
+	if instanceName == "" {
+		instanceName = cr.GetName()
+	}
+	if instanceName == "" {
+		instanceName = "kiali"
+	}
+
+	ns := nestedString(cr.Object, "status", "deployment", "namespace")
+	if ns == "" {
+		ns = nestedString(cr.Object, "spec", "deployment", "namespace")
+	}
+	if ns == "" {
+		ns = cr.GetNamespace()
+	}
+	if ns == "" {
+		return nil
+	}
+
+	port := nestedInt64(cr.Object, "spec", "server", "port")
+	if port <= 0 {
+		port = defaultKialiPort
+	}
+
+	webRoot := nestedString(cr.Object, "spec", "server", "web_root")
+	base := fmt.Sprintf("http://%s.%s.svc:%d", instanceName, ns, port)
+
+	switch webRoot {
+	case "", "/":
+		// Operator defaults: "/" on OpenShift, "/kiali" elsewhere. Try both.
+		return []string{base, base + "/kiali"}
+	default:
+		return []string{base + strings.TrimSuffix(webRoot, "/")}
+	}
+}
+
+func nestedString(obj map[string]any, fields ...string) string {
+	v, found, err := unstructured.NestedString(obj, fields...)
+	if !found || err != nil {
+		return ""
+	}
+	return strings.TrimSpace(v)
+}
+
+func nestedInt64(obj map[string]any, fields ...string) int64 {
+	v, found, err := unstructured.NestedInt64(obj, fields...)
+	if !found || err != nil {
+		return 0
+	}
+	return v
+}
+
+// listKialiCRs returns all Kiali CRs across namespaces. Returns nil when none exist or on error.
+func listKialiCRs(ctx context.Context, dc dynamic.Interface) []*unstructured.Unstructured {
+	if dc == nil {
+		return nil
+	}
+	list, err := dc.Resource(KialiGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klogutil.FromContext(ctx).V(2).Info("failed to list Kiali CRs", "error", err)
+		return nil
+	}
+	if list == nil || len(list.Items) == 0 {
+		return nil
+	}
+	out := make([]*unstructured.Unstructured, 0, len(list.Items))
+	for i := range list.Items {
+		out = append(out, &list.Items[i])
+	}
+	return out
+}
+
+// discoverAndValidateInternalURL finds a Kiali CR, builds in-cluster Service URL candidates,
+// and returns the first base URL that responds successfully to GET /api/status.
+func discoverAndValidateInternalURL(ctx context.Context, dc dynamic.Interface, cfg *Config, bearerToken string) (string, bool) {
+	crs := listKialiCRs(ctx, dc)
+	if len(crs) == 0 {
+		return "", false
+	}
+	for _, cr := range crs {
+		for _, candidate := range internalServiceURLs(cr) {
+			if probeStatusURL(ctx, candidate, cfg, bearerToken) {
+				klogutil.FromContext(ctx).V(1).Info("discovered reachable Kiali URL from CR",
+					"url", candidate, "kiali_cr", cr.GetNamespace()+"/"+cr.GetName())
+				return candidate, true
+			}
+		}
+	}
+	klogutil.FromContext(ctx).V(1).Info("Kiali CR(s) found but no reachable in-cluster URL")
+	return "", false
+}

--- a/pkg/kiali/discover.go
+++ b/pkg/kiali/discover.go
@@ -7,6 +7,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
@@ -24,13 +25,13 @@ const defaultKialiPort int64 = 20001
 
 // internalServiceURLs builds candidate in-cluster Service base URLs for a Kiali CR.
 // Prefer values from status/spec; fall back to CR metadata and Kiali defaults.
-func internalServiceURLs(cr *unstructured.Unstructured) []string {
+func internalServiceURLs(cr *KialiCR) []string {
 	if cr == nil {
 		return nil
 	}
-	instanceName := nestedString(cr.Object, "status", "deployment", "instanceName")
+	instanceName := cr.Status.Deployment.InstanceName
 	if instanceName == "" {
-		instanceName = nestedString(cr.Object, "spec", "deployment", "instance_name")
+		instanceName = cr.Spec.Deployment.InstanceName
 	}
 	if instanceName == "" {
 		instanceName = cr.GetName()
@@ -39,9 +40,9 @@ func internalServiceURLs(cr *unstructured.Unstructured) []string {
 		instanceName = "kiali"
 	}
 
-	ns := nestedString(cr.Object, "status", "deployment", "namespace")
+	ns := cr.Status.Deployment.Namespace
 	if ns == "" {
-		ns = nestedString(cr.Object, "spec", "deployment", "namespace")
+		ns = cr.Spec.Deployment.Namespace
 	}
 	if ns == "" {
 		ns = cr.GetNamespace()
@@ -50,12 +51,12 @@ func internalServiceURLs(cr *unstructured.Unstructured) []string {
 		return nil
 	}
 
-	port := nestedInt64(cr.Object, "spec", "server", "port")
+	port := cr.Spec.Server.Port
 	if port <= 0 {
 		port = defaultKialiPort
 	}
 
-	webRoot := nestedString(cr.Object, "spec", "server", "web_root")
+	webRoot := cr.Spec.Server.WebRoot
 	base := fmt.Sprintf("http://%s.%s.svc:%d", instanceName, ns, port)
 
 	switch webRoot {
@@ -67,24 +68,19 @@ func internalServiceURLs(cr *unstructured.Unstructured) []string {
 	}
 }
 
-func nestedString(obj map[string]any, fields ...string) string {
-	v, found, err := unstructured.NestedString(obj, fields...)
-	if !found || err != nil {
-		return ""
+func kialiFromUnstructured(obj *unstructured.Unstructured) (*KialiCR, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("kiali CR is nil")
 	}
-	return strings.TrimSpace(v)
-}
-
-func nestedInt64(obj map[string]any, fields ...string) int64 {
-	v, found, err := unstructured.NestedInt64(obj, fields...)
-	if !found || err != nil {
-		return 0
+	var cr KialiCR
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &cr); err != nil {
+		return nil, err
 	}
-	return v
+	return &cr, nil
 }
 
 // listKialiCRs returns all Kiali CRs across namespaces. Returns nil when none exist or on error.
-func listKialiCRs(ctx context.Context, dc dynamic.Interface) []*unstructured.Unstructured {
+func listKialiCRs(ctx context.Context, dc dynamic.Interface) []*KialiCR {
 	if dc == nil {
 		return nil
 	}
@@ -96,9 +92,14 @@ func listKialiCRs(ctx context.Context, dc dynamic.Interface) []*unstructured.Uns
 	if list == nil || len(list.Items) == 0 {
 		return nil
 	}
-	out := make([]*unstructured.Unstructured, 0, len(list.Items))
+	out := make([]*KialiCR, 0, len(list.Items))
 	for i := range list.Items {
-		out = append(out, &list.Items[i])
+		cr, err := kialiFromUnstructured(&list.Items[i])
+		if err != nil {
+			klogutil.FromContext(ctx).V(2).Info("failed to decode Kiali CR", "error", err)
+			continue
+		}
+		out = append(out, cr)
 	}
 	return out
 }
@@ -110,14 +111,15 @@ func discoverAndValidateInternalURL(ctx context.Context, dc dynamic.Interface, c
 	if len(crs) == 0 {
 		return "", false
 	}
+
+	candidates := make([]string, 0, len(crs)*2)
 	for _, cr := range crs {
-		for _, candidate := range internalServiceURLs(cr) {
-			if probeStatusURL(ctx, candidate, cfg, bearerToken) {
-				klogutil.FromContext(ctx).V(1).Info("discovered reachable Kiali URL from CR",
-					"url", candidate, "kiali_cr", cr.GetNamespace()+"/"+cr.GetName())
-				return candidate, true
-			}
-		}
+		candidates = append(candidates, internalServiceURLs(cr)...)
+	}
+	url, ok := probeCandidateURLs(ctx, candidates, cfg, bearerToken)
+	if ok {
+		klogutil.FromContext(ctx).V(1).Info("discovered reachable Kiali URL from CR", "url", url)
+		return url, true
 	}
 	klogutil.FromContext(ctx).V(1).Info("Kiali CR(s) found but no reachable in-cluster URL")
 	return "", false

--- a/pkg/kiali/gvr.go
+++ b/pkg/kiali/gvr.go
@@ -1,0 +1,25 @@
+package kiali
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+)
+
+// KialiGVK is the GroupVersionKind for the Kiali custom resource installed by
+// the Kiali Operator (kialis.kiali.io CRD).
+var KialiGVK = schema.GroupVersionKind{
+	Group:   "kiali.io",
+	Version: "v1alpha1",
+	Kind:    "Kiali",
+}
+
+// HasKiali returns a TargetCompatibilityFilter that checks whether any
+// target cluster has the Kiali GVK registered.
+func HasKiali(p api.FilteringProvider) func() bool {
+	return func() bool {
+		return p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{KialiGVK})
+	}
+}

--- a/pkg/kiali/gvr.go
+++ b/pkg/kiali/gvr.go
@@ -2,6 +2,7 @@ package kiali
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -10,16 +11,44 @@ import (
 
 // KialiGVK is the GroupVersionKind for the Kiali custom resource installed by
 // the Kiali Operator (kialis.kiali.io CRD).
+//
+// Target-compatibility filtering treats either of these as "Kiali available":
+//   - the Operator CRD is registered on a target cluster (OSSM / operator installs)
+//   - [toolset_configs.kiali].url is set (Helm / standalone installs that talk to
+//     the Kiali HTTP API without that CRD)
+//
+// The URL check uses an optional api.ExtendedConfigProvider on the same value
+// passed as FilteringProvider (the MCP server wraps the provider with live
+// config before calling Toolset.GetTools).
 var KialiGVK = schema.GroupVersionKind{
 	Group:   "kiali.io",
 	Version: "v1alpha1",
 	Kind:    "Kiali",
 }
 
-// HasKiali returns a TargetCompatibilityFilter that checks whether any
-// target cluster has the Kiali GVK registered.
+// HasKiali returns a TargetCompatibilityFilter that is true when any target
+// cluster has the Kiali Operator GVK registered, or when a Kiali URL is
+// configured via toolset_configs.
 func HasKiali(p api.FilteringProvider) func() bool {
 	return func() bool {
+		if cfg, ok := p.(api.ExtendedConfigProvider); ok && hasConfiguredURL(cfg) {
+			return true
+		}
+		if p == nil {
+			return false
+		}
 		return p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{KialiGVK})
 	}
+}
+
+func hasConfiguredURL(cfg api.ExtendedConfigProvider) bool {
+	if cfg == nil {
+		return false
+	}
+	ext, ok := cfg.GetToolsetConfig("kiali")
+	if !ok {
+		return false
+	}
+	kc, ok := ext.(*Config)
+	return ok && kc != nil && strings.TrimSpace(kc.Url) != ""
 }

--- a/pkg/kiali/gvr.go
+++ b/pkg/kiali/gvr.go
@@ -3,52 +3,190 @@ package kiali
 import (
 	"context"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 )
 
 // KialiGVK is the GroupVersionKind for the Kiali custom resource installed by
 // the Kiali Operator (kialis.kiali.io CRD).
 //
-// Target-compatibility filtering treats either of these as "Kiali available":
-//   - the Operator CRD is registered on a target cluster (OSSM / operator installs)
-//   - [toolset_configs.kiali].url is set (Helm / standalone installs that talk to
-//     the Kiali HTTP API without that CRD)
+// Target-compatibility filtering enables Kiali tools when:
+//   - [toolset_configs.kiali].url is set and GET {url}/api/status succeeds, or
+//   - no URL is set, a Kiali CRD/CR path can discover a working in-cluster
+//     Service URL (via kubernetes.Provider when available, otherwise well-known
+//     Service DNS candidates after the Kiali GVK is detected).
 //
-// The URL check uses an optional api.ExtendedConfigProvider on the same value
-// passed as FilteringProvider (the MCP server wraps the provider with live
-// config before calling Toolset.GetTools).
+// URL / config checks use api.ExtendedConfigProvider on the FilteringProvider
+// value (the MCP server wraps it with live toolset_configs). Cluster listing
+// for CRs is optional and only used when the provider also implements
+// kubernetes.Provider — no generic MCP changes are required for the URL-probe path.
 var KialiGVK = schema.GroupVersionKind{
 	Group:   "kiali.io",
 	Version: "v1alpha1",
 	Kind:    "Kiali",
 }
 
-// HasKiali returns a TargetCompatibilityFilter that is true when any target
-// cluster has the Kiali Operator GVK registered, or when a Kiali URL is
-// configured via toolset_configs.
+// discoveredURL holds an in-cluster URL found when toolset_configs.kiali.url
+// is empty. NewKiali reads it when the parsed config has no URL.
+var discoveredURL atomic.Pointer[string]
+
+func setDiscoveredURL(url string) {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		discoveredURL.Store(nil)
+		return
+	}
+	discoveredURL.Store(&url)
+}
+
+func getDiscoveredURL() string {
+	if p := discoveredURL.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// HasKiali returns a TargetCompatibilityFilter that is true when Kiali is
+// reachable: either a configured URL passes GET /api/status, or an in-cluster
+// Service URL can be discovered and probed.
+//
+// The returned closure memoizes the result (sync.Once). Callers that register
+// the filter on many tools should share one closure (see Toolset.GetTools).
 func HasKiali(p api.FilteringProvider) func() bool {
+	var once sync.Once
+	var available bool
 	return func() bool {
-		if cfg, ok := p.(api.ExtendedConfigProvider); ok && hasConfiguredURL(cfg) {
-			return true
-		}
-		if p == nil {
-			return false
-		}
-		return p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{KialiGVK})
+		once.Do(func() {
+			available = evaluateKialiAvailability(context.TODO(), p)
+		})
+		return available
 	}
 }
 
-func hasConfiguredURL(cfg api.ExtendedConfigProvider) bool {
-	if cfg == nil {
+func evaluateKialiAvailability(ctx context.Context, p api.FilteringProvider) bool {
+	cfg, cfgOK := kialiConfigFromProvider(p)
+	if cfgOK && strings.TrimSpace(cfg.Url) != "" {
+		setDiscoveredURL("")
+		token := bearerTokenFromProvider(ctx, p)
+		ok := probeStatusURL(ctx, cfg.Url, cfg, token)
+		if !ok {
+			klogutil.FromContext(ctx).V(1).Info("configured Kiali URL failed /api/status probe; disabling Kiali tools",
+				"url", cfg.Url)
+		}
+		return ok
+	}
+
+	// No configured URL: discover + probe an in-cluster Service URL.
+	if kp, ok := p.(kubernetes.Provider); ok {
+		return discoverInjectAndProbe(ctx, cfg, cfgOK, kp)
+	}
+
+	// FilteringProvider wrappers may not expose kubernetes.Provider. Fall back to
+	// GVK presence + well-known Service DNS candidates (no generic MCP API change).
+	if p == nil || !p.AnyTargetHasGVKs(ctx, []schema.GroupVersionKind{KialiGVK}) {
+		setDiscoveredURL("")
 		return false
 	}
-	ext, ok := cfg.GetToolsetConfig("kiali")
+	token := bearerTokenFromProvider(ctx, p)
+	url, ok := probeCandidateURLs(ctx, wellKnownInternalURLs(), cfg, token)
 	if !ok {
+		klogutil.FromContext(ctx).V(1).Info("Kiali GVK present but no reachable well-known in-cluster URL")
+		setDiscoveredURL("")
 		return false
+	}
+	injectDiscoveredURL(cfg, cfgOK, url)
+	return true
+}
+
+func discoverInjectAndProbe(ctx context.Context, cfg *Config, cfgOK bool, kp kubernetes.Provider) bool {
+	k8s, err := kp.GetDerivedKubernetes(ctx, kp.GetDefaultTarget())
+	if err != nil || k8s == nil {
+		klogutil.FromContext(ctx).V(2).Info("Kiali discovery skipped: cannot derive Kubernetes client", "error", err)
+		setDiscoveredURL("")
+		return false
+	}
+	token := ""
+	if rc := k8s.RESTConfig(); rc != nil {
+		token = rc.BearerToken
+	}
+	url, ok := discoverAndValidateInternalURL(ctx, k8s.DynamicClient(), cfg, token)
+	if !ok {
+		// CR list failed or unreachable — still try well-known Service DNS.
+		url, ok = probeCandidateURLs(ctx, wellKnownInternalURLs(), cfg, token)
+	}
+	if !ok {
+		setDiscoveredURL("")
+		return false
+	}
+	injectDiscoveredURL(cfg, cfgOK, url)
+	return true
+}
+
+func injectDiscoveredURL(cfg *Config, cfgOK bool, url string) {
+	setDiscoveredURL(url)
+	if cfgOK && cfg != nil {
+		cfg.Url = url
+		klogutil.FromContext(context.TODO()).V(1).Info("injected discovered Kiali URL into toolset config", "url", url)
+		return
+	}
+	klogutil.FromContext(context.TODO()).V(1).Info("stored discovered Kiali URL for client use", "url", url)
+}
+
+func kialiConfigFromProvider(p api.FilteringProvider) (*Config, bool) {
+	cfgProvider, ok := p.(api.ExtendedConfigProvider)
+	if !ok || cfgProvider == nil {
+		return nil, false
+	}
+	ext, ok := cfgProvider.GetToolsetConfig("kiali")
+	if !ok {
+		return nil, false
 	}
 	kc, ok := ext.(*Config)
-	return ok && kc != nil && strings.TrimSpace(kc.Url) != ""
+	if !ok || kc == nil {
+		return nil, false
+	}
+	return kc, true
+}
+
+func bearerTokenFromProvider(ctx context.Context, p api.FilteringProvider) string {
+	kp, ok := p.(kubernetes.Provider)
+	if !ok {
+		return ""
+	}
+	k8s, err := kp.GetDerivedKubernetes(ctx, kp.GetDefaultTarget())
+	if err != nil || k8s == nil || k8s.RESTConfig() == nil {
+		return ""
+	}
+	return k8s.RESTConfig().BearerToken
+}
+
+// wellKnownInternalURLs are tried when a Kiali CR cannot be listed through the
+// FilteringProvider (typical MCP wrapper) but the Kiali GVK is present.
+func wellKnownInternalURLs() []string {
+	hosts := []string{
+		"kiali.istio-system.svc",
+		"kiali.kiali.svc",
+		"kiali.openshift-operators.svc",
+	}
+	out := make([]string, 0, len(hosts)*2)
+	for _, host := range hosts {
+		base := "http://" + host + ":20001"
+		out = append(out, base, base+"/kiali")
+	}
+	return out
+}
+
+func probeCandidateURLs(ctx context.Context, candidates []string, cfg *Config, bearerToken string) (string, bool) {
+	for _, candidate := range candidates {
+		if probeStatusURL(ctx, candidate, cfg, bearerToken) {
+			return candidate, true
+		}
+	}
+	return "", false
 }

--- a/pkg/kiali/gvr.go
+++ b/pkg/kiali/gvr.go
@@ -23,8 +23,8 @@ import (
 //     Service DNS candidates after the Kiali GVK is detected).
 //
 // URL / config checks use api.ExtendedConfigProvider on the FilteringProvider
-// value (the MCP server wraps it with live toolset_configs). Cluster listing
-// for CRs is optional and only used when the provider also implements
+// (kubernetes.Provider embeds api.BaseConfig). Cluster listing for CRs is
+// optional and only used when the provider also implements
 // kubernetes.Provider — no generic MCP changes are required for the URL-probe path.
 var KialiGVK = schema.GroupVersionKind{
 	Group:   "kiali.io",

--- a/pkg/kiali/gvr.go
+++ b/pkg/kiali/gvr.go
@@ -3,7 +3,6 @@ package kiali
 import (
 	"context"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -19,13 +18,8 @@ import (
 // Target-compatibility filtering enables Kiali tools when:
 //   - [toolset_configs.kiali].url is set and GET {url}/api/status succeeds, or
 //   - no URL is set, a Kiali CRD/CR path can discover a working in-cluster
-//     Service URL (via kubernetes.Provider when available, otherwise well-known
-//     Service DNS candidates after the Kiali GVK is detected).
-//
-// URL / config checks use api.ExtendedConfigProvider on the FilteringProvider
-// (kubernetes.Provider embeds api.BaseConfig). Cluster listing for CRs is
-// optional and only used when the provider also implements
-// kubernetes.Provider — no generic MCP changes are required for the URL-probe path.
+//     Service URL via kubernetes.Provider (or well-known Service DNS when the
+//     Kiali GVK is present but no cluster client is available).
 var KialiGVK = schema.GroupVersionKind{
 	Group:   "kiali.io",
 	Version: "v1alpha1",
@@ -52,28 +46,20 @@ func getDiscoveredURL() string {
 	return ""
 }
 
-// HasKiali returns a TargetCompatibilityFilter that is true when Kiali is
-// reachable: either a configured URL passes GET /api/status, or an in-cluster
-// Service URL can be discovered and probed.
+// HasKiali reports whether Kiali is reachable: either a configured URL passes
+// GET /api/status, or an in-cluster Service URL can be discovered and probed.
 //
-// The returned closure memoizes the result (sync.Once). Callers that register
-// the filter on many tools should share one closure (see Toolset.GetTools).
-func HasKiali(p api.FilteringProvider) func() bool {
-	var once sync.Once
-	var available bool
-	return func() bool {
-		once.Do(func() {
-			available = evaluateKialiAvailability(context.TODO(), p)
-		})
-		return available
-	}
+// fp supplies config and optional GVK discovery; kp is the Kubernetes provider
+// used for CR listing and bearer tokens (may be nil in tests).
+func HasKiali(ctx context.Context, fp api.FilteringProvider, kp kubernetes.Provider) bool {
+	return evaluateKialiAvailability(ctx, fp, kp)
 }
 
-func evaluateKialiAvailability(ctx context.Context, p api.FilteringProvider) bool {
-	cfg, cfgOK := kialiConfigFromProvider(p)
+func evaluateKialiAvailability(ctx context.Context, fp api.FilteringProvider, kp kubernetes.Provider) bool {
+	cfg, cfgOK := kialiConfigFromProvider(fp)
 	if cfgOK && strings.TrimSpace(cfg.Url) != "" {
 		setDiscoveredURL("")
-		token := bearerTokenFromProvider(ctx, p)
+		token := bearerTokenFromProvider(ctx, kp)
 		ok := probeStatusURL(ctx, cfg.Url, cfg, token)
 		if !ok {
 			klogutil.FromContext(ctx).V(1).Info("configured Kiali URL failed /api/status probe; disabling Kiali tools",
@@ -83,28 +69,28 @@ func evaluateKialiAvailability(ctx context.Context, p api.FilteringProvider) boo
 	}
 
 	// No configured URL: discover + probe an in-cluster Service URL.
-	if kp, ok := p.(kubernetes.Provider); ok {
-		return discoverInjectAndProbe(ctx, cfg, cfgOK, kp)
+	if kp != nil {
+		return discoverInjectAndProbe(ctx, cfg, kp)
 	}
 
-	// FilteringProvider wrappers may not expose kubernetes.Provider. Fall back to
-	// GVK presence + well-known Service DNS candidates (no generic MCP API change).
-	if p == nil || !p.AnyTargetHasGVKs(ctx, []schema.GroupVersionKind{KialiGVK}) {
+	// No kubernetes provider (typical in unit tests): fall back to GVK presence +
+	// well-known Service DNS candidates.
+	if fp == nil || !fp.AnyTargetHasGVKs(ctx, []schema.GroupVersionKind{KialiGVK}) {
 		setDiscoveredURL("")
 		return false
 	}
-	token := bearerTokenFromProvider(ctx, p)
+	token := bearerTokenFromProvider(ctx, nil)
 	url, ok := probeCandidateURLs(ctx, wellKnownInternalURLs(), cfg, token)
 	if !ok {
 		klogutil.FromContext(ctx).V(1).Info("Kiali GVK present but no reachable well-known in-cluster URL")
 		setDiscoveredURL("")
 		return false
 	}
-	injectDiscoveredURL(cfg, cfgOK, url)
+	storeDiscoveredURL(ctx, url)
 	return true
 }
 
-func discoverInjectAndProbe(ctx context.Context, cfg *Config, cfgOK bool, kp kubernetes.Provider) bool {
+func discoverInjectAndProbe(ctx context.Context, cfg *Config, kp kubernetes.Provider) bool {
 	k8s, err := kp.GetDerivedKubernetes(ctx, kp.GetDefaultTarget())
 	if err != nil || k8s == nil {
 		klogutil.FromContext(ctx).V(2).Info("Kiali discovery skipped: cannot derive Kubernetes client", "error", err)
@@ -124,22 +110,17 @@ func discoverInjectAndProbe(ctx context.Context, cfg *Config, cfgOK bool, kp kub
 		setDiscoveredURL("")
 		return false
 	}
-	injectDiscoveredURL(cfg, cfgOK, url)
+	storeDiscoveredURL(ctx, url)
 	return true
 }
 
-func injectDiscoveredURL(cfg *Config, cfgOK bool, url string) {
+func storeDiscoveredURL(ctx context.Context, url string) {
 	setDiscoveredURL(url)
-	if cfgOK && cfg != nil {
-		cfg.Url = url
-		klogutil.FromContext(context.TODO()).V(1).Info("injected discovered Kiali URL into toolset config", "url", url)
-		return
-	}
-	klogutil.FromContext(context.TODO()).V(1).Info("stored discovered Kiali URL for client use", "url", url)
+	klogutil.FromContext(ctx).V(1).Info("stored discovered Kiali URL for client use", "url", url)
 }
 
-func kialiConfigFromProvider(p api.FilteringProvider) (*Config, bool) {
-	cfgProvider, ok := p.(api.ExtendedConfigProvider)
+func kialiConfigFromProvider(fp api.FilteringProvider) (*Config, bool) {
+	cfgProvider, ok := fp.(api.ExtendedConfigProvider)
 	if !ok || cfgProvider == nil {
 		return nil, false
 	}
@@ -154,9 +135,8 @@ func kialiConfigFromProvider(p api.FilteringProvider) (*Config, bool) {
 	return kc, true
 }
 
-func bearerTokenFromProvider(ctx context.Context, p api.FilteringProvider) string {
-	kp, ok := p.(kubernetes.Provider)
-	if !ok {
+func bearerTokenFromProvider(ctx context.Context, kp kubernetes.Provider) string {
+	if kp == nil {
 		return ""
 	}
 	k8s, err := kp.GetDerivedKubernetes(ctx, kp.GetDefaultTarget())
@@ -167,7 +147,7 @@ func bearerTokenFromProvider(ctx context.Context, p api.FilteringProvider) strin
 }
 
 // wellKnownInternalURLs are tried when a Kiali CR cannot be listed through the
-// FilteringProvider (typical MCP wrapper) but the Kiali GVK is present.
+// kubernetes provider but the Kiali GVK is present.
 func wellKnownInternalURLs() []string {
 	hosts := []string{
 		"kiali.istio-system.svc",
@@ -180,13 +160,4 @@ func wellKnownInternalURLs() []string {
 		out = append(out, base, base+"/kiali")
 	}
 	return out
-}
-
-func probeCandidateURLs(ctx context.Context, candidates []string, cfg *Config, bearerToken string) (string, bool) {
-	for _, candidate := range candidates {
-		if probeStatusURL(ctx, candidate, cfg, bearerToken) {
-			return candidate, true
-		}
-	}
-	return "", false
 }

--- a/pkg/kiali/gvr_test.go
+++ b/pkg/kiali/gvr_test.go
@@ -1,0 +1,49 @@
+package kiali
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type fakeFilteringProvider struct {
+	hasGVKs     bool
+	queriedGVKs []schema.GroupVersionKind
+}
+
+func (f *fakeFilteringProvider) AnyTargetHasGVKs(_ context.Context, gvks []schema.GroupVersionKind) bool {
+	f.queriedGVKs = gvks
+	return f.hasGVKs
+}
+
+func (f *fakeFilteringProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return true }
+
+func TestHasKiali(t *testing.T) {
+	t.Run("queries for Kiali GVK", func(t *testing.T) {
+		p := &fakeFilteringProvider{hasGVKs: true}
+		filter := HasKiali(p)
+		filter()
+
+		if len(p.queriedGVKs) != 1 {
+			t.Fatalf("expected 1 GVK query, got %d", len(p.queriedGVKs))
+		}
+		if p.queriedGVKs[0] != KialiGVK {
+			t.Errorf("expected query for %v, got %v", KialiGVK, p.queriedGVKs[0])
+		}
+	})
+
+	t.Run("returns true when provider has Kiali GVK", func(t *testing.T) {
+		filter := HasKiali(&fakeFilteringProvider{hasGVKs: true})
+		if !filter() {
+			t.Error("expected HasKiali to return true")
+		}
+	})
+
+	t.Run("returns false when provider does not have Kiali GVK", func(t *testing.T) {
+		filter := HasKiali(&fakeFilteringProvider{hasGVKs: false})
+		if filter() {
+			t.Error("expected HasKiali to return false")
+		}
+	})
+}

--- a/pkg/kiali/gvr_test.go
+++ b/pkg/kiali/gvr_test.go
@@ -2,9 +2,16 @@ package kiali
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 )
@@ -36,60 +43,149 @@ func (f *fakeFilteringProviderWithConfig) GetToolsetConfig(name string) (api.Ext
 	return cfg, ok
 }
 
-func TestHasKiali(t *testing.T) {
-	t.Run("queries for Kiali GVK", func(t *testing.T) {
-		p := &fakeFilteringProvider{hasGVKs: true}
-		filter := HasKiali(p)
-		filter()
-
-		if len(p.queriedGVKs) != 1 {
-			t.Fatalf("expected 1 GVK query, got %d", len(p.queriedGVKs))
+func TestInternalServiceURLs(t *testing.T) {
+	t.Run("uses status deployment fields and tries web_root defaults", func(t *testing.T) {
+		cr := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "kiali", "namespace": "istio-system"},
+			"status": map[string]any{
+				"deployment": map[string]any{
+					"instanceName": "kiali",
+					"namespace":    "istio-system",
+				},
+			},
+		}}
+		urls := internalServiceURLs(cr)
+		if len(urls) != 2 {
+			t.Fatalf("expected 2 candidates, got %v", urls)
 		}
-		if p.queriedGVKs[0] != KialiGVK {
-			t.Errorf("expected query for %v, got %v", KialiGVK, p.queriedGVKs[0])
+		if urls[0] != "http://kiali.istio-system.svc:20001" {
+			t.Errorf("unexpected first URL: %s", urls[0])
 		}
-	})
-
-	t.Run("returns true when provider has Kiali GVK", func(t *testing.T) {
-		filter := HasKiali(&fakeFilteringProvider{hasGVKs: true})
-		if !filter() {
-			t.Error("expected HasKiali to return true")
-		}
-	})
-
-	t.Run("returns false when provider does not have Kiali GVK and URL is unset", func(t *testing.T) {
-		filter := HasKiali(&fakeFilteringProvider{hasGVKs: false})
-		if filter() {
-			t.Error("expected HasKiali to return false")
+		if urls[1] != "http://kiali.istio-system.svc:20001/kiali" {
+			t.Errorf("unexpected second URL: %s", urls[1])
 		}
 	})
 
-	t.Run("returns true when URL is configured even without Kiali GVK", func(t *testing.T) {
+	t.Run("honors explicit web_root and port", func(t *testing.T) {
+		cr := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-kiali", "namespace": "mesh"},
+			"spec": map[string]any{
+				"deployment": map[string]any{"instance_name": "my-kiali", "namespace": "mesh"},
+				"server":     map[string]any{"port": int64(20001), "web_root": "/kiali"},
+			},
+		}}
+		urls := internalServiceURLs(cr)
+		if len(urls) != 1 || urls[0] != "http://my-kiali.mesh.svc:20001/kiali" {
+			t.Fatalf("unexpected URLs: %v", urls)
+		}
+	})
+}
+
+func TestProbeStatusURL(t *testing.T) {
+	t.Run("returns true for valid status payload", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/status" {
+				http.NotFound(w, r)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": map[string]any{"Kiali state": "running"},
+			})
+		}))
+		defer srv.Close()
+
+		if !probeStatusURL(context.Background(), srv.URL, &Config{Url: srv.URL}, "") {
+			t.Fatal("expected probe to succeed")
+		}
+	})
+
+	t.Run("returns false for missing status object", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"externalServices":[]}`))
+		}))
+		defer srv.Close()
+		if probeStatusURL(context.Background(), srv.URL, nil, "") {
+			t.Fatal("expected probe to fail")
+		}
+	})
+
+	t.Run("returns false on connection error", func(t *testing.T) {
+		if probeStatusURL(context.Background(), "http://127.0.0.1:1", nil, "") {
+			t.Fatal("expected probe to fail for unreachable URL")
+		}
+	})
+}
+
+func TestHasKiali_ConfiguredURL(t *testing.T) {
+	t.Run("enables when configured URL passes status probe", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": map[string]any{"Kiali state": "running"},
+			})
+		}))
+		defer srv.Close()
+
 		p := &fakeFilteringProviderWithConfig{
 			fakeFilteringProvider: fakeFilteringProvider{hasGVKs: false},
 			configs: map[string]api.ExtendedConfig{
-				"kiali": &Config{Url: "https://kiali.example"},
+				"kiali": &Config{Url: srv.URL},
 			},
 		}
-		filter := HasKiali(p)
-		if !filter() {
-			t.Error("expected HasKiali to return true when URL is configured")
-		}
-		if len(p.queriedGVKs) != 0 {
-			t.Errorf("expected no GVK query when URL short-circuits, got %v", p.queriedGVKs)
+		if !HasKiali(p)() {
+			t.Fatal("expected HasKiali true for reachable configured URL")
 		}
 	})
 
-	t.Run("returns false when URL config is empty", func(t *testing.T) {
+	t.Run("disables when configured URL fails status probe", func(t *testing.T) {
 		p := &fakeFilteringProviderWithConfig{
-			fakeFilteringProvider: fakeFilteringProvider{hasGVKs: false},
+			fakeFilteringProvider: fakeFilteringProvider{hasGVKs: true},
 			configs: map[string]api.ExtendedConfig{
-				"kiali": &Config{Url: "   "},
+				"kiali": &Config{Url: "http://127.0.0.1:1"},
 			},
 		}
-		filter := HasKiali(p)
-		if filter() {
-			t.Error("expected HasKiali to return false for blank URL")
+		if HasKiali(p)() {
+			t.Fatal("expected HasKiali false for unreachable configured URL")
 		}
 	})
+}
+
+func TestHasKiali_DiscoverFromCR(t *testing.T) {
+	t.Run("returns false when no URL and provider cannot access cluster", func(t *testing.T) {
+		p := &fakeFilteringProviderWithConfig{
+			fakeFilteringProvider: fakeFilteringProvider{hasGVKs: true},
+			configs: map[string]api.ExtendedConfig{
+				"kiali": &Config{},
+			},
+		}
+		if HasKiali(p)() {
+			t.Fatal("expected false without cluster access for discovery")
+		}
+	})
+
+	t.Run("discoverAndValidate finds CR but fails when service unreachable", func(t *testing.T) {
+		cr := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kiali.io/v1alpha1",
+			"kind":       "Kiali",
+			"metadata":   map[string]any{"name": "kiali", "namespace": "istio-system"},
+		}}
+		scheme := runtime.NewScheme()
+		dc := fake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{KialiGVR: "KialiList"},
+			cr,
+		)
+		dc.PrependReactor("list", "kialis", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &unstructured.UnstructuredList{Items: []unstructured.Unstructured{*cr}}, nil
+		})
+		url, ok := discoverAndValidateInternalURL(context.Background(), dc, &Config{}, "")
+		if ok || url != "" {
+			t.Fatalf("expected discovery to fail for unreachable in-cluster URL, got %q", url)
+		}
+	})
+}
+
+func TestHasKiali_NoURLNoCR(t *testing.T) {
+	filter := HasKiali(&fakeFilteringProvider{hasGVKs: false})
+	if filter() {
+		t.Fatal("expected false when no URL and no cluster access")
+	}
 }

--- a/pkg/kiali/gvr_test.go
+++ b/pkg/kiali/gvr_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
 )
 
 type fakeFilteringProvider struct {
@@ -18,6 +20,21 @@ func (f *fakeFilteringProvider) AnyTargetHasGVKs(_ context.Context, gvks []schem
 }
 
 func (f *fakeFilteringProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return true }
+
+// fakeFilteringProviderWithConfig implements both FilteringProvider and ExtendedConfigProvider.
+type fakeFilteringProviderWithConfig struct {
+	fakeFilteringProvider
+	configs map[string]api.ExtendedConfig
+}
+
+func (f *fakeFilteringProviderWithConfig) GetProviderConfig(string) (api.ExtendedConfig, bool) {
+	return nil, false
+}
+
+func (f *fakeFilteringProviderWithConfig) GetToolsetConfig(name string) (api.ExtendedConfig, bool) {
+	cfg, ok := f.configs[name]
+	return cfg, ok
+}
 
 func TestHasKiali(t *testing.T) {
 	t.Run("queries for Kiali GVK", func(t *testing.T) {
@@ -40,10 +57,39 @@ func TestHasKiali(t *testing.T) {
 		}
 	})
 
-	t.Run("returns false when provider does not have Kiali GVK", func(t *testing.T) {
+	t.Run("returns false when provider does not have Kiali GVK and URL is unset", func(t *testing.T) {
 		filter := HasKiali(&fakeFilteringProvider{hasGVKs: false})
 		if filter() {
 			t.Error("expected HasKiali to return false")
+		}
+	})
+
+	t.Run("returns true when URL is configured even without Kiali GVK", func(t *testing.T) {
+		p := &fakeFilteringProviderWithConfig{
+			fakeFilteringProvider: fakeFilteringProvider{hasGVKs: false},
+			configs: map[string]api.ExtendedConfig{
+				"kiali": &Config{Url: "https://kiali.example"},
+			},
+		}
+		filter := HasKiali(p)
+		if !filter() {
+			t.Error("expected HasKiali to return true when URL is configured")
+		}
+		if len(p.queriedGVKs) != 0 {
+			t.Errorf("expected no GVK query when URL short-circuits, got %v", p.queriedGVKs)
+		}
+	})
+
+	t.Run("returns false when URL config is empty", func(t *testing.T) {
+		p := &fakeFilteringProviderWithConfig{
+			fakeFilteringProvider: fakeFilteringProvider{hasGVKs: false},
+			configs: map[string]api.ExtendedConfig{
+				"kiali": &Config{Url: "   "},
+			},
+		}
+		filter := HasKiali(p)
+		if filter() {
+			t.Error("expected HasKiali to return false for blank URL")
 		}
 	})
 }

--- a/pkg/kiali/gvr_test.go
+++ b/pkg/kiali/gvr_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -45,15 +46,15 @@ func (f *fakeFilteringProviderWithConfig) GetToolsetConfig(name string) (api.Ext
 
 func TestInternalServiceURLs(t *testing.T) {
 	t.Run("uses status deployment fields and tries web_root defaults", func(t *testing.T) {
-		cr := &unstructured.Unstructured{Object: map[string]any{
-			"metadata": map[string]any{"name": "kiali", "namespace": "istio-system"},
-			"status": map[string]any{
-				"deployment": map[string]any{
-					"instanceName": "kiali",
-					"namespace":    "istio-system",
+		cr := &KialiCR{
+			ObjectMeta: metav1.ObjectMeta{Name: "kiali", Namespace: "istio-system"},
+			Status: KialiStatus{
+				Deployment: KialiDeploymentStatus{
+					InstanceName: "kiali",
+					Namespace:    "istio-system",
 				},
 			},
-		}}
+		}
 		urls := internalServiceURLs(cr)
 		if len(urls) != 2 {
 			t.Fatalf("expected 2 candidates, got %v", urls)
@@ -67,13 +68,19 @@ func TestInternalServiceURLs(t *testing.T) {
 	})
 
 	t.Run("honors explicit web_root and port", func(t *testing.T) {
-		cr := &unstructured.Unstructured{Object: map[string]any{
-			"metadata": map[string]any{"name": "my-kiali", "namespace": "mesh"},
-			"spec": map[string]any{
-				"deployment": map[string]any{"instance_name": "my-kiali", "namespace": "mesh"},
-				"server":     map[string]any{"port": int64(20001), "web_root": "/kiali"},
+		cr := &KialiCR{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-kiali", Namespace: "mesh"},
+			Spec: KialiSpec{
+				Deployment: KialiDeploymentSpec{
+					InstanceName: "my-kiali",
+					Namespace:    "mesh",
+				},
+				Server: KialiServerSpec{
+					Port:    20001,
+					WebRoot: "/kiali",
+				},
 			},
-		}}
+		}
 		urls := internalServiceURLs(cr)
 		if len(urls) != 1 || urls[0] != "http://my-kiali.mesh.svc:20001/kiali" {
 			t.Fatalf("unexpected URLs: %v", urls)
@@ -131,7 +138,7 @@ func TestHasKiali_ConfiguredURL(t *testing.T) {
 				"kiali": &Config{Url: srv.URL},
 			},
 		}
-		if !HasKiali(p)() {
+		if !HasKiali(context.Background(), p, nil) {
 			t.Fatal("expected HasKiali true for reachable configured URL")
 		}
 	})
@@ -143,7 +150,7 @@ func TestHasKiali_ConfiguredURL(t *testing.T) {
 				"kiali": &Config{Url: "http://127.0.0.1:1"},
 			},
 		}
-		if HasKiali(p)() {
+		if HasKiali(context.Background(), p, nil) {
 			t.Fatal("expected HasKiali false for unreachable configured URL")
 		}
 	})
@@ -157,7 +164,7 @@ func TestHasKiali_DiscoverFromCR(t *testing.T) {
 				"kiali": &Config{},
 			},
 		}
-		if HasKiali(p)() {
+		if HasKiali(context.Background(), p, nil) {
 			t.Fatal("expected false without cluster access for discovery")
 		}
 	})
@@ -184,8 +191,27 @@ func TestHasKiali_DiscoverFromCR(t *testing.T) {
 }
 
 func TestHasKiali_NoURLNoCR(t *testing.T) {
-	filter := HasKiali(&fakeFilteringProvider{hasGVKs: false})
-	if filter() {
+	if HasKiali(context.Background(), &fakeFilteringProvider{hasGVKs: false}, nil) {
 		t.Fatal("expected false when no URL and no cluster access")
 	}
+}
+
+func TestProbeCandidateURLs(t *testing.T) {
+	t.Run("returns first reachable URL", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": map[string]any{"Kiali state": "running"},
+			})
+		}))
+		defer srv.Close()
+
+		url, ok := probeCandidateURLs(context.Background(), []string{
+			"http://127.0.0.1:1",
+			srv.URL,
+			"http://127.0.0.1:2",
+		}, nil, "")
+		if !ok || url != srv.URL {
+			t.Fatalf("expected reachable URL %q, got %q ok=%v", srv.URL, url, ok)
+		}
+	})
 }

--- a/pkg/kiali/kiali.go
+++ b/pkg/kiali/kiali.go
@@ -44,6 +44,9 @@ func NewKiali(configProvider api.BaseConfig, kubernetes *rest.Config) *Kiali {
 			kiali.certificateAuthority = kc.CertificateAuthority
 		}
 	}
+	if strings.TrimSpace(kiali.kialiURL) == "" {
+		kiali.kialiURL = getDiscoveredURL()
+	}
 	return kiali
 }
 

--- a/pkg/kiali/status.go
+++ b/pkg/kiali/status.go
@@ -1,0 +1,96 @@
+package kiali
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+)
+
+const (
+	statusPath         = "/api/status"
+	statusProbeTimeout = 3 * time.Second
+)
+
+// statusResponse is the subset of Kiali GET /api/status used for reachability checks.
+type statusResponse struct {
+	Status map[string]any `json:"status"`
+}
+
+// probeStatusURL GETs {baseURL}/api/status and returns true when the response
+// is HTTP 2xx and contains a non-empty status object (Kiali is reachable).
+func probeStatusURL(ctx context.Context, baseURL string, cfg *Config, bearerToken string) bool {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return false
+	}
+	statusURL := baseURL + statusPath
+
+	probeCfg := cfg
+	if probeCfg == nil {
+		probeCfg = &Config{Url: baseURL}
+	} else if strings.TrimSpace(probeCfg.Url) == "" {
+		// Use a shallow copy so TLS options are preserved without mutating Url.
+		cp := *probeCfg
+		cp.Url = baseURL
+		probeCfg = &cp
+	}
+
+	k := &Kiali{
+		bearerToken:          bearerToken,
+		kialiURL:             probeCfg.Url,
+		kialiInsecure:        probeCfg.Insecure,
+		certificateAuthority: probeCfg.CertificateAuthority,
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, statusProbeTimeout)
+	defer cancel()
+
+	client, err := k.createHTTPClient(probeCtx)
+	if err != nil {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe: failed to create HTTP client", "error", err)
+		return false
+	}
+	client.Timeout = statusProbeTimeout
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, statusURL, nil)
+	if err != nil {
+		return false
+	}
+	if auth := k.authorizationHeader(); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe failed", "url", statusURL, "error", err)
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize+1))
+	if err != nil {
+		return false
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe non-success",
+			"url", statusURL, "status_code", resp.StatusCode)
+		return false
+	}
+
+	var parsed statusResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe: invalid JSON", "error", err)
+		return false
+	}
+	if len(parsed.Status) == 0 {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe: missing status object", "url", statusURL)
+		return false
+	}
+	klogutil.FromContext(ctx).V(2).Info("kiali status probe succeeded", "url", statusURL)
+	return true
+}

--- a/pkg/kiali/status.go
+++ b/pkg/kiali/status.go
@@ -6,14 +6,17 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 )
 
 const (
 	statusPath         = "/api/status"
-	statusProbeTimeout = 3 * time.Second
+	statusProbeTimeout = time.Second
 )
 
 // statusResponse is the subset of Kiali GET /api/status used for reachability checks.
@@ -55,7 +58,6 @@ func probeStatusURL(ctx context.Context, baseURL string, cfg *Config, bearerToke
 		klogutil.FromContext(ctx).V(2).Info("kiali status probe: failed to create HTTP client", "error", err)
 		return false
 	}
-	client.Timeout = statusProbeTimeout
 
 	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, statusURL, nil)
 	if err != nil {
@@ -93,4 +95,40 @@ func probeStatusURL(ctx context.Context, baseURL string, cfg *Config, bearerToke
 	}
 	klogutil.FromContext(ctx).V(2).Info("kiali status probe succeeded", "url", statusURL)
 	return true
+}
+
+func probeCandidateURLs(ctx context.Context, candidates []string, cfg *Config, bearerToken string) (string, bool) {
+	if len(candidates) == 0 {
+		return "", false
+	}
+	if len(candidates) == 1 {
+		if probeStatusURL(ctx, candidates[0], cfg, bearerToken) {
+			return candidates[0], true
+		}
+		return "", false
+	}
+
+	probeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		mu    sync.Mutex
+		found string
+	)
+	g, gctx := errgroup.WithContext(probeCtx)
+	for _, candidate := range candidates {
+		g.Go(func() error {
+			if probeStatusURL(gctx, candidate, cfg, bearerToken) {
+				mu.Lock()
+				if found == "" {
+					found = candidate
+					cancel()
+				}
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+	return found, found != ""
 }

--- a/pkg/mcp/kiali_test.go
+++ b/pkg/mcp/kiali_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"sync"
@@ -672,6 +673,79 @@ func (s *KialiSuite) TestKialiToolsNotClusterAware() {
 			s.Require().True(ok, "expected properties map for tool %s", tool.Name)
 			s.NotContains(properties, "context", "kiali tool %s must not expose context parameter", tool.Name)
 		})
+	}
+}
+
+func (s *KialiSuite) TestToolsFilteredByStatusProbe() {
+	s.Run("tools visible when configured URL passes /api/status", func() {
+		statusSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"status":{"Kiali state":"running"}}`))
+		}))
+		defer statusSrv.Close()
+
+		kubeConfig := s.Cfg.KubeConfig
+		cfg, err := config.ReadToml([]byte(fmt.Sprintf(`
+			toolsets = ["%s"]
+			experimental_enable_target_compatibility_tool_filters = true
+			[toolset_configs.kiali]
+			url = "%s"
+			insecure = true
+		`, s.toolsetName, statusSrv.URL)))
+		s.Require().NoError(err)
+		s.Cfg = cfg
+		s.Cfg.KubeConfig = kubeConfig
+		s.InitMcpClient()
+
+		tools, err := s.ListTools()
+		s.Require().NoError(err)
+		s.Require().NotNil(tools)
+		present := make(map[string]bool, len(tools.Tools))
+		for _, tool := range tools.Tools {
+			present[tool.Name] = true
+		}
+		for _, name := range s.kialiToolNames() {
+			s.Truef(present[name], "expected %s when status probe succeeds", name)
+		}
+	})
+
+	s.Run("tools hidden when configured URL fails /api/status", func() {
+		kubeConfig := s.Cfg.KubeConfig
+		cfg, err := config.ReadToml([]byte(fmt.Sprintf(`
+			toolsets = ["%s"]
+			experimental_enable_target_compatibility_tool_filters = true
+			[toolset_configs.kiali]
+			url = "http://127.0.0.1:1"
+			insecure = true
+		`, s.toolsetName)))
+		s.Require().NoError(err)
+		s.Cfg = cfg
+		s.Cfg.KubeConfig = kubeConfig
+		s.InitMcpClient()
+
+		tools, err := s.ListTools()
+		s.Require().NoError(err)
+		s.Require().NotNil(tools)
+		for _, tool := range tools.Tools {
+			for _, name := range s.kialiToolNames() {
+				s.Require().NotEqual(name, tool.Name, "expected %s hidden when status probe fails", name)
+			}
+		}
+	})
+}
+
+func (s *KialiSuite) kialiToolNames() []string {
+	return []string{
+		s.toolsetName + "_get_logs",
+		s.toolsetName + "_get_mesh_status",
+		s.toolsetName + "_get_mesh_traffic_graph",
+		s.toolsetName + "_get_metrics",
+		s.toolsetName + "_get_pod_performance",
+		s.toolsetName + "_get_resource_details",
+		s.toolsetName + "_get_trace_details",
+		s.toolsetName + "_list_mesh_clusters",
+		s.toolsetName + "_list_traces",
+		s.toolsetName + "_manage_istio_config",
+		s.toolsetName + "_manage_istio_config_read",
 	}
 }
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -395,9 +395,13 @@ func (s *Server) collectApplicableTools(cfg *Configuration) []api.ServerTool {
 		WithToolOverrides(cfg.ToolOverrides),
 	)
 
+	// Wrap the filtering provider with live config so toolsets that optionally
+	// type-assert to ExtendedConfigProvider (e.g. Kiali URL checks) see the
+	// current toolset_configs without changing the Toolset.GetTools signature.
+	provider := filteringProviderWithConfig{FilteringProvider: s.p, cfg: cfg.StaticConfig}
 	tools := make([]api.ServerTool, 0)
 	for _, toolset := range cfg.Toolsets() {
-		for _, tool := range toolset.GetTools(s.p) {
+		for _, tool := range toolset.GetTools(provider) {
 			tool = mutator(tool)
 			if filter(tool) {
 				tools = append(tools, tool)
@@ -405,6 +409,27 @@ func (s *Server) collectApplicableTools(cfg *Configuration) []api.ServerTool {
 		}
 	}
 	return tools
+}
+
+// filteringProviderWithConfig embeds FilteringProvider and exposes the live
+// ExtendedConfigProvider so target-compatibility filters can inspect toolset_configs.
+type filteringProviderWithConfig struct {
+	api.FilteringProvider
+	cfg api.ExtendedConfigProvider
+}
+
+func (f filteringProviderWithConfig) GetProviderConfig(strategy string) (api.ExtendedConfig, bool) {
+	if f.cfg == nil {
+		return nil, false
+	}
+	return f.cfg.GetProviderConfig(strategy)
+}
+
+func (f filteringProviderWithConfig) GetToolsetConfig(name string) (api.ExtendedConfig, bool) {
+	if f.cfg == nil {
+		return nil, false
+	}
+	return f.cfg.GetToolsetConfig(name)
 }
 
 // collectApplicablePrompts returns prompts after applying mutation and merging toolset and config prompts

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -395,13 +395,9 @@ func (s *Server) collectApplicableTools(cfg *Configuration) []api.ServerTool {
 		WithToolOverrides(cfg.ToolOverrides),
 	)
 
-	// Wrap the filtering provider with live config so toolsets that optionally
-	// type-assert to ExtendedConfigProvider (e.g. Kiali URL checks) see the
-	// current toolset_configs without changing the Toolset.GetTools signature.
-	provider := filteringProviderWithConfig{FilteringProvider: s.p, cfg: cfg.StaticConfig}
 	tools := make([]api.ServerTool, 0)
 	for _, toolset := range cfg.Toolsets() {
-		for _, tool := range toolset.GetTools(provider) {
+		for _, tool := range toolset.GetTools(s.p) {
 			tool = mutator(tool)
 			if filter(tool) {
 				tools = append(tools, tool)
@@ -409,27 +405,6 @@ func (s *Server) collectApplicableTools(cfg *Configuration) []api.ServerTool {
 		}
 	}
 	return tools
-}
-
-// filteringProviderWithConfig embeds FilteringProvider and exposes the live
-// ExtendedConfigProvider so target-compatibility filters can inspect toolset_configs.
-type filteringProviderWithConfig struct {
-	api.FilteringProvider
-	cfg api.ExtendedConfigProvider
-}
-
-func (f filteringProviderWithConfig) GetProviderConfig(strategy string) (api.ExtendedConfig, bool) {
-	if f.cfg == nil {
-		return nil, false
-	}
-	return f.cfg.GetProviderConfig(strategy)
-}
-
-func (f filteringProviderWithConfig) GetToolsetConfig(name string) (api.ExtendedConfig, bool) {
-	if f.cfg == nil {
-		return nil, false
-	}
-	return f.cfg.GetToolsetConfig(name)
 }
 
 // collectApplicablePrompts returns prompts after applying mutation and merging toolset and config prompts

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -166,34 +165,6 @@ func (s *ToolsetsSuite) TestKialiToolsFilteredWithoutCRDs() {
 				}
 			}
 		})
-	})
-}
-
-func (s *ToolsetsSuite) TestKialiToolsVisibleWithConfiguredURL() {
-	s.Run("Kiali tools remain visible when URL is set even without Kiali GVK", func() {
-		toolsetName := (&kiali.Toolset{}).GetName()
-		kubeConfig := s.Cfg.KubeConfig
-		cfg, err := configuration.ReadToml([]byte(fmt.Sprintf(`
-			toolsets = ["%s"]
-			experimental_enable_target_compatibility_tool_filters = true
-			[toolset_configs.kiali]
-			url = "https://kiali.example"
-			insecure = true
-		`, toolsetName)))
-		s.Require().NoError(err, "failed to parse kiali toolset config")
-		s.Cfg = cfg
-		s.Cfg.KubeConfig = kubeConfig
-		s.InitMcpClient()
-		tools, err := s.ListTools()
-		s.Require().NoError(err, "Expected no error from ListTools")
-		s.Require().NotNil(tools, "Expected tools from ListTools")
-		present := make(map[string]bool, len(tools.Tools))
-		for _, tool := range tools.Tools {
-			present[tool.Name] = true
-		}
-		for _, kialiTool := range s.kialiToolNames(toolsetName) {
-			s.Truef(present[kialiTool], "Expected %s to be present when URL is configured", kialiTool)
-		}
 	})
 }
 

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -145,6 +146,71 @@ func (s *ToolsetsSuite) TestKubevirtToolsFilteredWithoutCRDs() {
 			}
 		})
 	})
+}
+
+func (s *ToolsetsSuite) TestKialiToolsFilteredWithoutCRDs() {
+	s.Run("Kiali tools are filtered out when Kiali GVK is not present and URL is unset", func() {
+		toolsetName := (&kiali.Toolset{}).GetName()
+		s.Cfg.Toolsets = []string{toolsetName}
+		s.Cfg.EnableTargetCompatibilityToolFilters = true
+		s.InitMcpClient()
+		tools, err := s.ListTools()
+		s.Run("ListTools returns tools", func() {
+			s.NotNil(tools, "Expected tools from ListTools")
+			s.NoError(err, "Expected no error from ListTools")
+		})
+		s.Run("kiali tools are not present", func() {
+			for _, tool := range tools.Tools {
+				for _, kialiTool := range s.kialiToolNames(toolsetName) {
+					s.Require().NotEqual(kialiTool, tool.Name, "Expected %s to not be present when filtering enabled on cluster without Kiali CRD or URL", kialiTool)
+				}
+			}
+		})
+	})
+}
+
+func (s *ToolsetsSuite) TestKialiToolsVisibleWithConfiguredURL() {
+	s.Run("Kiali tools remain visible when URL is set even without Kiali GVK", func() {
+		toolsetName := (&kiali.Toolset{}).GetName()
+		kubeConfig := s.Cfg.KubeConfig
+		cfg, err := configuration.ReadToml([]byte(fmt.Sprintf(`
+			toolsets = ["%s"]
+			experimental_enable_target_compatibility_tool_filters = true
+			[toolset_configs.kiali]
+			url = "https://kiali.example"
+			insecure = true
+		`, toolsetName)))
+		s.Require().NoError(err, "failed to parse kiali toolset config")
+		s.Cfg = cfg
+		s.Cfg.KubeConfig = kubeConfig
+		s.InitMcpClient()
+		tools, err := s.ListTools()
+		s.Require().NoError(err, "Expected no error from ListTools")
+		s.Require().NotNil(tools, "Expected tools from ListTools")
+		present := make(map[string]bool, len(tools.Tools))
+		for _, tool := range tools.Tools {
+			present[tool.Name] = true
+		}
+		for _, kialiTool := range s.kialiToolNames(toolsetName) {
+			s.Truef(present[kialiTool], "Expected %s to be present when URL is configured", kialiTool)
+		}
+	})
+}
+
+func (s *ToolsetsSuite) kialiToolNames(toolsetName string) []string {
+	return []string{
+		toolsetName + "_get_logs",
+		toolsetName + "_get_mesh_status",
+		toolsetName + "_get_mesh_traffic_graph",
+		toolsetName + "_get_metrics",
+		toolsetName + "_get_pod_performance",
+		toolsetName + "_get_resource_details",
+		toolsetName + "_get_trace_details",
+		toolsetName + "_list_mesh_clusters",
+		toolsetName + "_list_traces",
+		toolsetName + "_manage_istio_config",
+		toolsetName + "_manage_istio_config_read",
+	}
 }
 
 func (s *ToolsetsSuite) TestDefaultToolsetsToolsInMultiCluster() {

--- a/pkg/toolsets/kiali/tools/all.go
+++ b/pkg/toolsets/kiali/tools/all.go
@@ -1,0 +1,35 @@
+package tools
+
+import (
+	"slices"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+)
+
+// All returns every Kiali tool with a shared reachability filter.
+func All(p api.FilteringProvider) []api.ServerTool {
+	hasKiali := kialiclient.HasKiali(p)
+	tools := slices.Concat(
+		InitGetMeshTrafficGraph(),
+		InitGetMeshStatus(),
+		InitManageIstioConfigRead(),
+		InitManageIstioConfig(),
+		InitListMeshClusters(),
+		InitListOrGetResources(),
+		InitListTraces(),
+		InitGetTraceDetails(),
+		InitGetPodPerformance(),
+		InitGetLogs(),
+		InitGetMetrics(),
+	)
+	// Kiali calls a single configured endpoint; mesh scope is selected via meshCluster,
+	// not the provider-level context parameter injected for core Kubernetes tools.
+	for i := range tools {
+		tools[i].ClusterAware = ptr.To(false)
+		tools[i].TargetCompatibilityFilters = []func() bool{hasKiali}
+	}
+	return tools
+}

--- a/pkg/toolsets/kiali/tools/all.go
+++ b/pkg/toolsets/kiali/tools/all.go
@@ -3,16 +3,12 @@ package tools
 import (
 	"slices"
 
-	"k8s.io/utils/ptr"
-
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
-	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
 )
 
-// All returns every Kiali tool with a shared reachability filter.
-func All(p api.FilteringProvider) []api.ServerTool {
-	hasKiali := kialiclient.HasKiali(p)
-	tools := slices.Concat(
+// All returns every Kiali tool. Reachability filtering is handled by the toolset.
+func All() []api.ServerTool {
+	return slices.Concat(
 		InitGetMeshTrafficGraph(),
 		InitGetMeshStatus(),
 		InitManageIstioConfigRead(),
@@ -25,11 +21,4 @@ func All(p api.FilteringProvider) []api.ServerTool {
 		InitGetLogs(),
 		InitGetMetrics(),
 	)
-	// Kiali calls a single configured endpoint; mesh scope is selected via meshCluster,
-	// not the provider-level context parameter injected for core Kubernetes tools.
-	for i := range tools {
-		tools[i].ClusterAware = ptr.To(false)
-		tools[i].TargetCompatibilityFilters = []func() bool{hasKiali}
-	}
-	return tools
 }

--- a/pkg/toolsets/kiali/tools/get_logs.go
+++ b/pkg/toolsets/kiali/tools/get_logs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetLogs() []api.ServerTool {
+func InitGetLogs(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_logs"
 	// Workload logs tool
@@ -71,7 +71,11 @@ func InitGetLogs() []api.ServerTool {
 				IdempotentHint:  ptr.To(false),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: workloadLogsHandler,
+		},
+		Handler: workloadLogsHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/get_logs.go
+++ b/pkg/toolsets/kiali/tools/get_logs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetLogs(p api.FilteringProvider) []api.ServerTool {
+func InitGetLogs() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_logs"
 	// Workload logs tool
@@ -73,9 +73,6 @@ func InitGetLogs(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: workloadLogsHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/get_mesh_status.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_status.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetMeshStatus() []api.ServerTool {
+func InitGetMeshStatus(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_mesh_status"
 	ret = append(ret, api.ServerTool{
@@ -29,7 +29,11 @@ func InitGetMeshStatus() []api.ServerTool {
 				IdempotentHint:  ptr.To(false),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: getMeshStatusHandler,
+		},
+		Handler: getMeshStatusHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/tools/get_mesh_status.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_status.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetMeshStatus(p api.FilteringProvider) []api.ServerTool {
+func InitGetMeshStatus() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_mesh_status"
 	ret = append(ret, api.ServerTool{
@@ -31,9 +31,6 @@ func InitGetMeshStatus(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: getMeshStatusHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/tools/get_mesh_status_test.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_status_test.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -51,7 +53,8 @@ func (s *MeshStatusToolSuite) TestToolRegistration() {
 		s.NotNil(tools[0].Tool.InputSchema)
 		s.NotNil(tools[0].Handler)
 		s.Require().Len(tools[0].TargetCompatibilityFilters, 1, "Expected 1 TargetCompatibilityFilter")
-		s.True(tools[0].TargetCompatibilityFilters[0](), "Filter should return true when Kiali GVK is present")
+		// Init* still attaches a filter; without a reachable URL/cluster it is false.
+		s.False(tools[0].TargetCompatibilityFilters[0](), "Filter should return false without reachable Kiali URL")
 	})
 
 	s.Run("filter returns false when Kiali GVK is absent and URL is unset", func() {
@@ -61,14 +64,28 @@ func (s *MeshStatusToolSuite) TestToolRegistration() {
 		s.False(tools[0].TargetCompatibilityFilters[0](), "Filter should return false when Kiali GVK is absent")
 	})
 
-	s.Run("filter returns true when URL is configured without Kiali GVK", func() {
+	s.Run("filter returns true when configured URL passes /api/status", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"status":{"Kiali state":"running"}}`))
+		}))
+		defer srv.Close()
 		tools := InitGetMeshStatus(&fakeProviderWithConfig{
 			fakeProvider: fakeProvider{hasGVKs: false},
-			url:          "https://kiali.example",
+			url:          srv.URL,
 		})
 		s.Require().Len(tools, 1)
 		s.Require().Len(tools[0].TargetCompatibilityFilters, 1)
-		s.True(tools[0].TargetCompatibilityFilters[0](), "Filter should return true when URL is configured")
+		s.True(tools[0].TargetCompatibilityFilters[0](), "Filter should return true when URL status probe succeeds")
+	})
+
+	s.Run("filter returns false when configured URL fails /api/status", func() {
+		tools := InitGetMeshStatus(&fakeProviderWithConfig{
+			fakeProvider: fakeProvider{hasGVKs: true},
+			url:          "http://127.0.0.1:1",
+		})
+		s.Require().Len(tools, 1)
+		s.Require().Len(tools[0].TargetCompatibilityFilters, 1)
+		s.False(tools[0].TargetCompatibilityFilters[0](), "Filter should return false when URL status probe fails")
 	})
 }
 

--- a/pkg/toolsets/kiali/tools/get_mesh_status_test.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_status_test.go
@@ -1,0 +1,49 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
+)
+
+type fakeProvider struct {
+	hasGVKs bool
+}
+
+func (f *fakeProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVersionKind) bool {
+	return f.hasGVKs
+}
+
+func (f *fakeProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return true }
+
+type MeshStatusToolSuite struct {
+	suite.Suite
+}
+
+func (s *MeshStatusToolSuite) TestToolRegistration() {
+	s.Run("tool is registered with TargetCompatibilityFilters", func() {
+		tools := InitGetMeshStatus(&fakeProvider{hasGVKs: true})
+		s.Require().Len(tools, 1, "Expected 1 mesh status tool")
+		s.Equal(defaults.ToolsetName()+"_get_mesh_status", tools[0].Tool.Name)
+		s.Equal("Get Mesh Status", tools[0].Tool.Annotations.Title)
+		s.NotNil(tools[0].Tool.InputSchema)
+		s.NotNil(tools[0].Handler)
+		s.Require().Len(tools[0].TargetCompatibilityFilters, 1, "Expected 1 TargetCompatibilityFilter")
+		s.True(tools[0].TargetCompatibilityFilters[0](), "Filter should return true when Kiali GVK is present")
+	})
+
+	s.Run("filter returns false when Kiali GVK is absent", func() {
+		tools := InitGetMeshStatus(&fakeProvider{hasGVKs: false})
+		s.Require().Len(tools, 1)
+		s.Require().Len(tools[0].TargetCompatibilityFilters, 1)
+		s.False(tools[0].TargetCompatibilityFilters[0](), "Filter should return false when Kiali GVK is absent")
+	})
+}
+
+func TestMeshStatusToolSuite(t *testing.T) {
+	suite.Run(t, new(MeshStatusToolSuite))
+}

--- a/pkg/toolsets/kiali/tools/get_mesh_status_test.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_status_test.go
@@ -1,91 +1,26 @@
 package tools
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/containers/kubernetes-mcp-server/pkg/api"
-	"github.com/containers/kubernetes-mcp-server/pkg/kiali"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
-
-type fakeProvider struct {
-	hasGVKs bool
-}
-
-func (f *fakeProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVersionKind) bool {
-	return f.hasGVKs
-}
-
-func (f *fakeProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return true }
-
-type fakeProviderWithConfig struct {
-	fakeProvider
-	url string
-}
-
-func (f *fakeProviderWithConfig) GetProviderConfig(string) (api.ExtendedConfig, bool) {
-	return nil, false
-}
-
-func (f *fakeProviderWithConfig) GetToolsetConfig(name string) (api.ExtendedConfig, bool) {
-	if name != "kiali" || f.url == "" {
-		return nil, false
-	}
-	return &kiali.Config{Url: f.url}, true
-}
 
 type MeshStatusToolSuite struct {
 	suite.Suite
 }
 
 func (s *MeshStatusToolSuite) TestToolRegistration() {
-	s.Run("tool is registered with TargetCompatibilityFilters", func() {
-		tools := InitGetMeshStatus(&fakeProvider{hasGVKs: true})
+	s.Run("tool is registered with expected metadata", func() {
+		tools := InitGetMeshStatus()
 		s.Require().Len(tools, 1, "Expected 1 mesh status tool")
 		s.Equal(defaults.ToolsetName()+"_get_mesh_status", tools[0].Tool.Name)
 		s.Equal("Get Mesh Status", tools[0].Tool.Annotations.Title)
 		s.NotNil(tools[0].Tool.InputSchema)
 		s.NotNil(tools[0].Handler)
-		s.Require().Len(tools[0].TargetCompatibilityFilters, 1, "Expected 1 TargetCompatibilityFilter")
-		// Init* still attaches a filter; without a reachable URL/cluster it is false.
-		s.False(tools[0].TargetCompatibilityFilters[0](), "Filter should return false without reachable Kiali URL")
-	})
-
-	s.Run("filter returns false when Kiali GVK is absent and URL is unset", func() {
-		tools := InitGetMeshStatus(&fakeProvider{hasGVKs: false})
-		s.Require().Len(tools, 1)
-		s.Require().Len(tools[0].TargetCompatibilityFilters, 1)
-		s.False(tools[0].TargetCompatibilityFilters[0](), "Filter should return false when Kiali GVK is absent")
-	})
-
-	s.Run("filter returns true when configured URL passes /api/status", func() {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{"status":{"Kiali state":"running"}}`))
-		}))
-		defer srv.Close()
-		tools := InitGetMeshStatus(&fakeProviderWithConfig{
-			fakeProvider: fakeProvider{hasGVKs: false},
-			url:          srv.URL,
-		})
-		s.Require().Len(tools, 1)
-		s.Require().Len(tools[0].TargetCompatibilityFilters, 1)
-		s.True(tools[0].TargetCompatibilityFilters[0](), "Filter should return true when URL status probe succeeds")
-	})
-
-	s.Run("filter returns false when configured URL fails /api/status", func() {
-		tools := InitGetMeshStatus(&fakeProviderWithConfig{
-			fakeProvider: fakeProvider{hasGVKs: true},
-			url:          "http://127.0.0.1:1",
-		})
-		s.Require().Len(tools, 1)
-		s.Require().Len(tools[0].TargetCompatibilityFilters, 1)
-		s.False(tools[0].TargetCompatibilityFilters[0](), "Filter should return false when URL status probe fails")
+		s.Empty(tools[0].TargetCompatibilityFilters, "Filters are applied by the toolset, not Init*")
 	})
 }
 

--- a/pkg/toolsets/kiali/tools/get_mesh_status_test.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_status_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kiali"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
@@ -19,6 +21,22 @@ func (f *fakeProvider) AnyTargetHasGVKs(_ context.Context, _ []schema.GroupVersi
 }
 
 func (f *fakeProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return true }
+
+type fakeProviderWithConfig struct {
+	fakeProvider
+	url string
+}
+
+func (f *fakeProviderWithConfig) GetProviderConfig(string) (api.ExtendedConfig, bool) {
+	return nil, false
+}
+
+func (f *fakeProviderWithConfig) GetToolsetConfig(name string) (api.ExtendedConfig, bool) {
+	if name != "kiali" || f.url == "" {
+		return nil, false
+	}
+	return &kiali.Config{Url: f.url}, true
+}
 
 type MeshStatusToolSuite struct {
 	suite.Suite
@@ -36,11 +54,21 @@ func (s *MeshStatusToolSuite) TestToolRegistration() {
 		s.True(tools[0].TargetCompatibilityFilters[0](), "Filter should return true when Kiali GVK is present")
 	})
 
-	s.Run("filter returns false when Kiali GVK is absent", func() {
+	s.Run("filter returns false when Kiali GVK is absent and URL is unset", func() {
 		tools := InitGetMeshStatus(&fakeProvider{hasGVKs: false})
 		s.Require().Len(tools, 1)
 		s.Require().Len(tools[0].TargetCompatibilityFilters, 1)
 		s.False(tools[0].TargetCompatibilityFilters[0](), "Filter should return false when Kiali GVK is absent")
+	})
+
+	s.Run("filter returns true when URL is configured without Kiali GVK", func() {
+		tools := InitGetMeshStatus(&fakeProviderWithConfig{
+			fakeProvider: fakeProvider{hasGVKs: false},
+			url:          "https://kiali.example",
+		})
+		s.Require().Len(tools, 1)
+		s.Require().Len(tools[0].TargetCompatibilityFilters, 1)
+		s.True(tools[0].TargetCompatibilityFilters[0](), "Filter should return true when URL is configured")
 	})
 }
 

--- a/pkg/toolsets/kiali/tools/get_mesh_status_test.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_status_test.go
@@ -20,7 +20,7 @@ func (s *MeshStatusToolSuite) TestToolRegistration() {
 		s.Equal("Get Mesh Status", tools[0].Tool.Annotations.Title)
 		s.NotNil(tools[0].Tool.InputSchema)
 		s.NotNil(tools[0].Handler)
-		s.Empty(tools[0].TargetCompatibilityFilters, "Filters are applied by the toolset, not Init*")
+		s.Empty(tools[0].TargetCompatibilityFilters, "Reachability filtering is handled by the toolset GetTools")
 	})
 }
 

--- a/pkg/toolsets/kiali/tools/get_mesh_traffic_graph.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_traffic_graph.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetMeshTrafficGraph() []api.ServerTool {
+func InitGetMeshTrafficGraph(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_mesh_traffic_graph"
 	ret = append(ret, api.ServerTool{
@@ -45,7 +45,11 @@ func InitGetMeshTrafficGraph() []api.ServerTool {
 				IdempotentHint:  ptr.To(false),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: getMeshGraphHandler,
+		},
+		Handler: getMeshGraphHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/tools/get_mesh_traffic_graph.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_traffic_graph.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetMeshTrafficGraph(p api.FilteringProvider) []api.ServerTool {
+func InitGetMeshTrafficGraph() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_mesh_traffic_graph"
 	ret = append(ret, api.ServerTool{
@@ -47,9 +47,6 @@ func InitGetMeshTrafficGraph(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: getMeshGraphHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/tools/get_metrics.go
+++ b/pkg/toolsets/kiali/tools/get_metrics.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetMetrics(p api.FilteringProvider) []api.ServerTool {
+func InitGetMetrics() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_metrics"
 	ret = append(ret, api.ServerTool{
@@ -84,9 +84,6 @@ func InitGetMetrics(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: resourceMetricsHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/get_metrics.go
+++ b/pkg/toolsets/kiali/tools/get_metrics.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetMetrics() []api.ServerTool {
+func InitGetMetrics(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_metrics"
 	ret = append(ret, api.ServerTool{
@@ -82,7 +82,11 @@ func InitGetMetrics() []api.ServerTool {
 				IdempotentHint:  ptr.To(true),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: resourceMetricsHandler,
+		},
+		Handler: resourceMetricsHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/get_pod_performance.go
+++ b/pkg/toolsets/kiali/tools/get_pod_performance.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetPodPerformance() []api.ServerTool {
+func InitGetPodPerformance(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_pod_performance"
 	ret = append(ret, api.ServerTool{
@@ -56,7 +56,11 @@ func InitGetPodPerformance() []api.ServerTool {
 				IdempotentHint:  ptr.To(true),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: getPodPerformanceHandler,
+		},
+		Handler: getPodPerformanceHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/get_pod_performance.go
+++ b/pkg/toolsets/kiali/tools/get_pod_performance.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetPodPerformance(p api.FilteringProvider) []api.ServerTool {
+func InitGetPodPerformance() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_pod_performance"
 	ret = append(ret, api.ServerTool{
@@ -58,9 +58,6 @@ func InitGetPodPerformance(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: getPodPerformanceHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/get_traces_details.go
+++ b/pkg/toolsets/kiali/tools/get_traces_details.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetTraceDetails(p api.FilteringProvider) []api.ServerTool {
+func InitGetTraceDetails() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_trace_details"
 	ret = append(ret, api.ServerTool{
@@ -37,9 +37,6 @@ func InitGetTraceDetails(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: tracesHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/get_traces_details.go
+++ b/pkg/toolsets/kiali/tools/get_traces_details.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitGetTraceDetails() []api.ServerTool {
+func InitGetTraceDetails(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_trace_details"
 	ret = append(ret, api.ServerTool{
@@ -35,7 +35,11 @@ func InitGetTraceDetails() []api.ServerTool {
 				IdempotentHint:  ptr.To(true),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: tracesHandler,
+		},
+		Handler: tracesHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/list_clusters.go
+++ b/pkg/toolsets/kiali/tools/list_clusters.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitListMeshClusters(p api.FilteringProvider) []api.ServerTool {
+func InitListMeshClusters() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_list_mesh_clusters"
 	ret = append(ret, api.ServerTool{
@@ -31,9 +31,6 @@ func InitListMeshClusters(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: listMeshClustersHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/tools/list_clusters.go
+++ b/pkg/toolsets/kiali/tools/list_clusters.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitListMeshClusters() []api.ServerTool {
+func InitListMeshClusters(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_list_mesh_clusters"
 	ret = append(ret, api.ServerTool{
@@ -29,7 +29,11 @@ func InitListMeshClusters() []api.ServerTool {
 				IdempotentHint:  ptr.To(true),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: listMeshClustersHandler,
+		},
+		Handler: listMeshClustersHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/tools/list_or_get_resources.go
+++ b/pkg/toolsets/kiali/tools/list_or_get_resources.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitListOrGetResources(p api.FilteringProvider) []api.ServerTool {
+func InitListOrGetResources() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_resource_details"
 	ret = append(ret, api.ServerTool{
@@ -53,9 +53,6 @@ func InitListOrGetResources(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: listOrGetResourcesHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/list_or_get_resources.go
+++ b/pkg/toolsets/kiali/tools/list_or_get_resources.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitListOrGetResources() []api.ServerTool {
+func InitListOrGetResources(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_get_resource_details"
 	ret = append(ret, api.ServerTool{
@@ -51,7 +51,11 @@ func InitListOrGetResources() []api.ServerTool {
 				IdempotentHint:  ptr.To(true),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: listOrGetResourcesHandler,
+		},
+		Handler: listOrGetResourcesHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/list_traces.go
+++ b/pkg/toolsets/kiali/tools/list_traces.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitListTraces(p api.FilteringProvider) []api.ServerTool {
+func InitListTraces() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_list_traces"
 	ret = append(ret, api.ServerTool{
@@ -60,9 +60,6 @@ func InitListTraces(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: listTracesHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/list_traces.go
+++ b/pkg/toolsets/kiali/tools/list_traces.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitListTraces() []api.ServerTool {
+func InitListTraces(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_list_traces"
 	ret = append(ret, api.ServerTool{
@@ -58,7 +58,11 @@ func InitListTraces() []api.ServerTool {
 				IdempotentHint:  ptr.To(true),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: listTracesHandler,
+		},
+		Handler: listTracesHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 
 	return ret

--- a/pkg/toolsets/kiali/tools/manage_istio_config.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitManageIstioConfig() []api.ServerTool {
+func InitManageIstioConfig(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_manage_istio_config"
 	ret = append(ret, api.ServerTool{
@@ -66,7 +66,11 @@ func InitManageIstioConfig() []api.ServerTool {
 				IdempotentHint:  ptr.To(true),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: istioConfigHandler,
+		},
+		Handler: istioConfigHandler,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/tools/manage_istio_config.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitManageIstioConfig(p api.FilteringProvider) []api.ServerTool {
+func InitManageIstioConfig() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_manage_istio_config"
 	ret = append(ret, api.ServerTool{
@@ -68,9 +68,6 @@ func InitManageIstioConfig(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: istioConfigHandler,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/tools/manage_istio_config_read.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config_read.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitManageIstioConfigRead() []api.ServerTool {
+func InitManageIstioConfigRead(p api.FilteringProvider) []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_manage_istio_config_read"
 	ret = append(ret, api.ServerTool{
@@ -72,7 +72,11 @@ func InitManageIstioConfigRead() []api.ServerTool {
 				IdempotentHint:  ptr.To(true),
 				OpenWorldHint:   ptr.To(true),
 			},
-		}, Handler: istioConfigHandlerRead,
+		},
+		Handler: istioConfigHandlerRead,
+		TargetCompatibilityFilters: []func() bool{
+			kialiclient.HasKiali(p),
+		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/tools/manage_istio_config_read.go
+++ b/pkg/toolsets/kiali/tools/manage_istio_config_read.go
@@ -11,7 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 )
 
-func InitManageIstioConfigRead(p api.FilteringProvider) []api.ServerTool {
+func InitManageIstioConfigRead() []api.ServerTool {
 	ret := make([]api.ServerTool, 0)
 	name := defaults.ToolsetName() + "_manage_istio_config_read"
 	ret = append(ret, api.ServerTool{
@@ -74,9 +74,6 @@ func InitManageIstioConfigRead(p api.FilteringProvider) []api.ServerTool {
 			},
 		},
 		Handler: istioConfigHandlerRead,
-		TargetCompatibilityFilters: []func() bool{
-			kialiclient.HasKiali(p),
-		},
 	})
 	return ret
 }

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
-	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 	kialiPrompts "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/prompts"
@@ -26,28 +25,7 @@ func (t *Toolset) GetDescription() string {
 }
 
 func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
-	// Evaluate reachability once and share the filter across all Kiali tools.
-	hasKiali := kialiclient.HasKiali(p)
-	tools := slices.Concat(
-		kialiTools.InitGetMeshTrafficGraph(p),
-		kialiTools.InitGetMeshStatus(p),
-		kialiTools.InitManageIstioConfigRead(p),
-		kialiTools.InitManageIstioConfig(p),
-		kialiTools.InitListMeshClusters(p),
-		kialiTools.InitListOrGetResources(p),
-		kialiTools.InitListTraces(p),
-		kialiTools.InitGetTraceDetails(p),
-		kialiTools.InitGetPodPerformance(p),
-		kialiTools.InitGetLogs(p),
-		kialiTools.InitGetMetrics(p),
-	)
-	// Kiali calls a single configured endpoint; mesh scope is selected via meshCluster,
-	// not the provider-level context parameter injected for core Kubernetes tools.
-	for i := range tools {
-		tools[i].ClusterAware = ptr.To(false)
-		tools[i].TargetCompatibilityFilters = []func() bool{hasKiali}
-	}
-	return tools
+	return kialiTools.All(p)
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -24,19 +24,19 @@ func (t *Toolset) GetDescription() string {
 	return defaults.ToolsetDescription()
 }
 
-func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
+func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
 	tools := slices.Concat(
-		kialiTools.InitGetMeshTrafficGraph(),
-		kialiTools.InitGetMeshStatus(),
-		kialiTools.InitManageIstioConfigRead(),
-		kialiTools.InitManageIstioConfig(),
-		kialiTools.InitListMeshClusters(),
-		kialiTools.InitListOrGetResources(),
-		kialiTools.InitListTraces(),
-		kialiTools.InitGetTraceDetails(),
-		kialiTools.InitGetPodPerformance(),
-		kialiTools.InitGetLogs(),
-		kialiTools.InitGetMetrics(),
+		kialiTools.InitGetMeshTrafficGraph(p),
+		kialiTools.InitGetMeshStatus(p),
+		kialiTools.InitManageIstioConfigRead(p),
+		kialiTools.InitManageIstioConfig(p),
+		kialiTools.InitListMeshClusters(p),
+		kialiTools.InitListOrGetResources(p),
+		kialiTools.InitListTraces(p),
+		kialiTools.InitGetTraceDetails(p),
+		kialiTools.InitGetPodPerformance(p),
+		kialiTools.InitGetLogs(p),
+		kialiTools.InitGetMetrics(p),
 	)
 	// Kiali calls a single configured endpoint; mesh scope is selected via meshCluster,
 	// not the provider-level context parameter injected for core Kubernetes tools.

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 	kialiPrompts "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/prompts"
@@ -25,6 +26,8 @@ func (t *Toolset) GetDescription() string {
 }
 
 func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
+	// Evaluate reachability once and share the filter across all Kiali tools.
+	hasKiali := kialiclient.HasKiali(p)
 	tools := slices.Concat(
 		kialiTools.InitGetMeshTrafficGraph(p),
 		kialiTools.InitGetMeshStatus(p),
@@ -42,6 +45,7 @@ func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
 	// not the provider-level context parameter injected for core Kubernetes tools.
 	for i := range tools {
 		tools[i].ClusterAware = ptr.To(false)
+		tools[i].TargetCompatibilityFilters = []func() bool{hasKiali}
 	}
 	return tools
 }

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -1,11 +1,14 @@
 package kiali
 
 import (
+	"context"
 	"slices"
 
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 	kialiPrompts "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/prompts"
@@ -25,7 +28,24 @@ func (t *Toolset) GetDescription() string {
 }
 
 func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
-	return kialiTools.All(p)
+	kialiclient.WarnIfEmptyURLWithoutDiscovery(p)
+	if p.IsTargetCompatibilityToolFiltersEnabled() && !kialiAvailable(p) {
+		return nil
+	}
+
+	tools := kialiTools.All()
+	for i := range tools {
+		tools[i].ClusterAware = ptr.To(false)
+	}
+	return tools
+}
+
+func kialiAvailable(p api.FilteringProvider) bool {
+	var kp kubernetes.Provider
+	if provider, ok := p.(kubernetes.Provider); ok {
+		kp = provider
+	}
+	return kialiclient.HasKiali(context.Background(), p, kp)
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -3,17 +3,21 @@ package kiali
 import (
 	"context"
 	"slices"
+	"sync"
 
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 	kialiPrompts "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/prompts"
 	kialiTools "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
 )
+
+var warnKialiValidationDisabledOnce sync.Once
 
 type Toolset struct{}
 
@@ -28,8 +32,14 @@ func (t *Toolset) GetDescription() string {
 }
 
 func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
-	kialiclient.WarnIfEmptyURLWithoutDiscovery(p)
-	if p.IsTargetCompatibilityToolFiltersEnabled() && !kialiAvailable(p) {
+	if p != nil && !p.IsTargetCompatibilityToolFiltersEnabled() {
+		warnKialiValidationDisabledOnce.Do(func() {
+			klogutil.LogWarn(
+				klogutil.FromContext(context.Background()),
+				"experimental_enable_target_compatibility_tool_filters is disabled; Kiali URL reachability and in-cluster discovery are not validated",
+			)
+		})
+	} else if p != nil && p.IsTargetCompatibilityToolFiltersEnabled() && !kialiAvailable(p) {
 		return nil
 	}
 


### PR DESCRIPTION
- URL probe: If [toolset_configs.kiali].url is set, Kiali tools are registered only when GET {url}/api/status succeeds.
- Auto-discovery: If url is empty, the server discovers the in-cluster Kiali Service URL from the Kiali CR (with well-known DNS fallback), probes /api/status, and uses the working URL for tool calls.
- Opt-in: Probe and discovery run only when experimental_enable_target_compatibility_tool_filters = true. With the flag off (default), Kiali tools are always registered (unchanged behavior).
- Tool registration: All Kiali tools share a single HasKiali reachability filter via tools.All(p).

Tests: 
-  `go test ./pkg/kiali/... ./pkg/toolsets/kiali/...`
- Tools hidden without `kialis.kiali.io` (with `experimental_enable_target_compatibility_tool_filters = true`)
- Tools visible when the Kiali CRD is present

To test the url auto discovery, the mcp must be deployed inside the cluster: 

**Prerequisites**

- Kiali Operator installed and a Kiali CR (kialis.kiali.io) in Running state.
- Kiali Service reachable from inside the cluster (GET http://<kiali-svc>:<port>/api/status returns {"status":...}).
- A local image built from this branch (the published chart image may not include these changes).

**Deploy MCP server in-cluster**

```
make build
docker build -t kubernetes-mcp-server:dev .
```
 
load into your cluster if using Kind:
```
kind load docker-image kubernetes-mcp-server:dev --name <cluster-name>
helm upgrade -i kubernetes-mcp-server charts/kubernetes-mcp-server \
  -n mcp-system --create-namespace \
  -f charts/kubernetes-mcp-server/examples/values-kiali-discovery.yaml \
  --set openshift=false \
  --set ingress.enabled=false \
  --set image.registry=docker.io/library \
  --set image.repository=kubernetes-mcp-server \
  --set image.version=dev \
  --set image.pullPolicy=Never
```

where values-kiali-discovery.yaml:

```
ingress:
  enabled: false

serviceAccount:
  create: true
  automountToken: true

rbac:
  create: true
  extraClusterRoles:
    - name: kiali-discovery
      rules:
        - apiGroups: ["kiali.io"]
          resources: ["kialis"]
          verbs: ["get", "list", "watch"]
  extraClusterRoleBindings:
    - name: view
      roleRef:
        name: view
        external: true
    - name: kiali-discovery
      roleRef:
        name: kiali-discovery

config:
  toolsets:
    - core
    - kiali
  experimental_enable_target_compatibility_tool_filters: true
  cluster_auth_mode: kubeconfig

  toolset_configs:
    kiali:
      insecure: true
      # Omit url to enable in-cluster discovery from the Kiali CR.
```

Key config (already in the example values):

- experimental_enable_target_compatibility_tool_filters: true
- toolsets: [core, kiali]
- No [toolset_configs.kiali].url — discovery uses the Kiali CR
- RBAC to list/get/watch kialis.kiali.io

**Verify**
```
kubectl -n mcp-system rollout status deployment/kubernetes-mcp-server
kubectl -n mcp-system port-forward svc/kubernetes-mcp-server 18080:8080
```
In MCP Inspector (http://localhost:18080/mcp) or via API:

- tools/list → all 11 kiali_* tools should appear.
- kiali_get_mesh_status → should return mesh status from the discovered Kiali URL.

Negative checks
- No Kiali CR → kiali_* tools should not appear in tools/list.
- Flag disabled (experimental_enable_target_compatibility_tool_filters: false) → tools always listed, no probe/discovery.

**Troubleshooting**
- Confirm the Kiali CR exists: kubectl get kiali -A
- Confirm MCP can list CRs: kubectl auth can-i list kialis.kiali.io --as=system:serviceaccount:mcp-system:<sa-name> -n <kiali-namespace>
- Discovery logs are at verbosity 1–2: check pod logs with -v=2 if tools are missing.