### PR TITLE
feat(tekton): add filtered logs and pipeline context

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,7 +791,9 @@ Examples:
 - **tekton_pipelinerun_logs** - Get logs for all TaskRuns owned by a Tekton PipelineRun. Use this to inspect PipelineRun execution output without locating pods manually.
   - `name` (`string`) **(required)** - Name of the PipelineRun to get logs from
   - `namespace` (`string`) - Namespace of the PipelineRun
+  - `step` (`string`) - Step name to include within matching TaskRuns
   - `tail` (`integer`) - Number of lines to retrieve from the end of each container log (default: 100)
+  - `task` (`string`) - Pipeline task name to include
 
 - **tekton_task_start** - Start a Tekton Task by creating a TaskRun that references it
   - `name` (`string`) **(required)** - Name of the Task to start
@@ -805,6 +807,7 @@ Examples:
 - **tekton_taskrun_logs** - Get the logs from a Tekton TaskRun by resolving its underlying pod
   - `name` (`string`) **(required)** - Name of the TaskRun to get logs from
   - `namespace` (`string`) - Namespace of the TaskRun
+  - `step` (`string`) - Step name to include. If omitted, logs from all steps and sidecars are returned
   - `tail` (`integer`) - Number of lines to retrieve from the end of the logs (Optional, default: 100)
 
 </details>
@@ -886,7 +889,7 @@ Examples:
 
 <summary>tekton</summary>
 
-- **pipeline-troubleshoot** - Gather PipelineRun status, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting
+- **pipeline-troubleshoot** - Gather PipelineRun status, its Pipeline definition, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting
   - `namespace` (`string`) **(required)** - Namespace of the PipelineRun to troubleshoot
   - `name` (`string`) **(required)** - Name of the PipelineRun to troubleshoot
 

--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ Examples:
   - `namespace` (`string`) - Namespace of the PipelineRun
   - `step` (`string`) - Step name to include within matching TaskRuns
   - `tail` (`integer`) - Number of lines to retrieve from the end of each container log (default: 100)
-  - `task` (`string`) - Pipeline task name to include
+  - `task` (`string`) - Pipeline task name to filter by (tekton.dev/pipelineTask label)
 
 - **tekton_task_start** - Start a Tekton Task by creating a TaskRun that references it
   - `name` (`string`) **(required)** - Name of the Task to start

--- a/README.md
+++ b/README.md
@@ -889,7 +889,7 @@ Examples:
 
 <summary>tekton</summary>
 
-- **pipeline-troubleshoot** - Gather PipelineRun status, its Pipeline definition, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting
+- **pipeline-troubleshoot** - Gather PipelineRun status, its Pipeline definition, TaskRuns, failed or errored step logs, warning events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting
   - `namespace` (`string`) **(required)** - Namespace of the PipelineRun to troubleshoot
   - `name` (`string`) **(required)** - Name of the PipelineRun to troubleshoot
 

--- a/docs/tekton.md
+++ b/docs/tekton.md
@@ -38,4 +38,4 @@ These tools are read-only except the start and lifecycle operations.
 
 ## Troubleshooting prompt
 
-Use the `pipeline-troubleshoot` prompt with `namespace` and `name` to gather PipelineRun status, the exact resolved or embedded PipelineSpec when available, the referenced Pipeline otherwise, related TaskRuns, logs, events, Pipeline-as-Code repositories, and TektonConfig context into one diagnostic prompt. Missing definitions are reported without preventing the remaining data from being collected.
+Use the `pipeline-troubleshoot` prompt with `namespace` and `name` to gather PipelineRun status, the exact resolved or embedded PipelineSpec when available, the referenced Pipeline otherwise, related TaskRuns, failed or errored step logs, warning events, Pipeline-as-Code repositories, and TektonConfig context into one diagnostic prompt. Missing definitions are reported without preventing the remaining data from being collected. The guide structures the response as PipelineRun Status, TaskRun Status, Failed Step Logs, Events, Troubleshooting Analysis, and Fix Suggestions.

--- a/docs/tekton.md
+++ b/docs/tekton.md
@@ -12,13 +12,13 @@ kubernetes-mcp-server --toolsets core,config,tekton
 
 - `tekton_pipeline_start` starts a Pipeline by creating a PipelineRun.
 - `tekton_pipelinerun_lifecycle` restarts a PipelineRun from its existing spec or cancels it by setting `spec.status` to `Cancelled`.
-- `tekton_pipelinerun_logs` collects logs from TaskRuns owned by a PipelineRun.
+- `tekton_pipelinerun_logs` collects logs from TaskRuns owned by a PipelineRun. Use the optional `task` and `step` parameters to narrow the output.
 
 ## TaskRun operations
 
 - `tekton_task_start` starts a Task by creating a TaskRun.
 - `tekton_taskrun_restart` creates a new TaskRun from an existing TaskRun spec.
-- `tekton_taskrun_logs` resolves a TaskRun pod and returns step/sidecar logs.
+- `tekton_taskrun_logs` resolves a TaskRun pod and returns step/sidecar logs. Use the optional `step` parameter to return one step only.
 
 Pipeline-as-Code `Repository` and operator `TektonConfig` resources are ordinary Kubernetes resources; use `resources_list` and `resources_get` for those.
 
@@ -38,4 +38,4 @@ These tools are read-only except the start and lifecycle operations.
 
 ## Troubleshooting prompt
 
-Use the `pipeline-troubleshoot` prompt with `namespace` and `name` to gather PipelineRun status, related TaskRuns, logs, events, Pipeline-as-Code repositories, and TektonConfig context into one diagnostic prompt.
+Use the `pipeline-troubleshoot` prompt with `namespace` and `name` to gather PipelineRun status, the exact resolved or embedded PipelineSpec when available, the referenced Pipeline otherwise, related TaskRuns, logs, events, Pipeline-as-Code repositories, and TektonConfig context into one diagnostic prompt. Missing definitions are reported without preventing the remaining data from being collected.

--- a/evals/tasks/tekton/README.md
+++ b/evals/tasks/tekton/README.md
@@ -42,7 +42,7 @@ All tasks use the `tekton-eval` namespace and require Tekton Pipelines to be ins
   - **Prompt:** *Cancel the Tekton PipelineRun named cancel-me in the tekton-eval namespace.*
   - **Tests:** `tekton_pipelinerun_lifecycle` tool with `action=cancel`
 
-- **[hard] troubleshoot-pipelinerun** – Gather PipelineRun status, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for diagnosis
+- **[hard] troubleshoot-pipelinerun** – Gather PipelineRun status, its Pipeline definition, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for diagnosis
   - **Prompt:** *The Tekton PipelineRun named failed-run in the tekton-eval namespace is failing. Diagnose the likely root cause, include any Pipeline-as-Code Repository and TektonConfig context that may be relevant, and recommend the next action.*
   - **Tests:** `pipeline-troubleshoot` prompt and PAC/TektonConfig visibility
 

--- a/evals/tasks/tekton/README.md
+++ b/evals/tasks/tekton/README.md
@@ -42,7 +42,7 @@ All tasks use the `tekton-eval` namespace and require Tekton Pipelines to be ins
   - **Prompt:** *Cancel the Tekton PipelineRun named cancel-me in the tekton-eval namespace.*
   - **Tests:** `tekton_pipelinerun_lifecycle` tool with `action=cancel`
 
-- **[hard] troubleshoot-pipelinerun** – Gather PipelineRun status, its Pipeline definition, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for diagnosis
+- **[hard] troubleshoot-pipelinerun** – Gather PipelineRun status, its Pipeline definition, TaskRuns, failed or errored step logs, warning events, Pipeline-as-Code Repository, and TektonConfig context for diagnosis
   - **Prompt:** *The Tekton PipelineRun named failed-run in the tekton-eval namespace is failing. Diagnose the likely root cause, include any Pipeline-as-Code Repository and TektonConfig context that may be relevant, and recommend the next action.*
   - **Tests:** `pipeline-troubleshoot` prompt and PAC/TektonConfig visibility
 

--- a/evals/tasks/tekton/troubleshoot-pipelinerun/task.yaml
+++ b/evals/tasks/tekton/troubleshoot-pipelinerun/task.yaml
@@ -125,6 +125,18 @@ spec:
 
   verify:
     - llmJudge:
+        contains: "PipelineRun Status"
+    - llmJudge:
+        contains: "TaskRun Status"
+    - llmJudge:
+        contains: "Failed Step Logs"
+    - llmJudge:
+        contains: "Events"
+    - llmJudge:
+        contains: "Troubleshooting Analysis"
+    - llmJudge:
+        contains: "Fix Suggestions"
+    - llmJudge:
         contains: "failed-run"
     - llmJudge:
         contains: "missing"

--- a/evals/tasks/tekton/troubleshoot-pipelinerun/task.yaml
+++ b/evals/tasks/tekton/troubleshoot-pipelinerun/task.yaml
@@ -66,19 +66,30 @@ spec:
           ensure_crd tektonconfigs.operator.tekton.dev operator.tekton.dev v1alpha1 tektonconfigs tektonconfig TektonConfig Cluster
     - k8s.create:
         apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: broken-pipeline
+          namespace: tekton-eval
+        spec:
+          tasks:
+            - name: missing-task-stage
+              taskRef:
+                name: missing-task
+    - k8s.create:
+        apiVersion: tekton.dev/v1
         kind: PipelineRun
         metadata:
           name: failed-run
           namespace: tekton-eval
         spec:
           pipelineRef:
-            name: missing-pipeline
+            name: broken-pipeline
         status:
           conditions:
             - type: Succeeded
               status: "False"
               reason: Failed
-              message: "Pipeline missing-pipeline was not found"
+              message: "Task missing-task was not found"
     - k8s.create:
         apiVersion: tekton.dev/v1
         kind: TaskRun
@@ -140,6 +151,13 @@ spec:
         kind: PipelineRun
         metadata:
           name: failed-run
+          namespace: tekton-eval
+        ignoreNotFound: true
+    - k8s.delete:
+        apiVersion: tekton.dev/v1
+        kind: Pipeline
+        metadata:
+          name: broken-pipeline
           namespace: tekton-eval
         ignoreNotFound: true
     - k8s.delete:

--- a/evals/tasks/tekton/troubleshoot-pipelinerun/task.yaml
+++ b/evals/tasks/tekton/troubleshoot-pipelinerun/task.yaml
@@ -129,6 +129,8 @@ spec:
     - llmJudge:
         contains: "missing"
     - llmJudge:
+        contains: "missing-task-stage"
+    - llmJudge:
         contains: "eval-repo"
     - llmJudge:
         contains: "tekton-eval-config"

--- a/pkg/mcp/tekton_test.go
+++ b/pkg/mcp/tekton_test.go
@@ -268,6 +268,64 @@ func (s *TektonMcpSuite) TestPipelineTroubleshootPrompt() {
 		s.Contains(text, "resolved-diagnostic-task")
 	})
 
+	s.Run("returns only failed step logs and warning events", func() {
+		s.createPipeline("failed-step-pipeline", "diagnostic-task")
+		s.createReferencedPipelineRun("failed-step-run", "failed-step-pipeline")
+		s.createLogTaskRunWithStepStates("failed-step-taskrun", "failed-step-run", "diagnostic-task", []interface{}{
+			map[string]interface{}{
+				"name":      "failed",
+				"container": "step-failed",
+				"terminated": map[string]interface{}{
+					"exitCode": int64(1),
+					"reason":   "Error",
+				},
+			},
+			map[string]interface{}{
+				"name":      "passed",
+				"container": "step-passed",
+				"terminated": map[string]interface{}{
+					"exitCode": int64(0),
+					"reason":   "Completed",
+				},
+			},
+			map[string]interface{}{
+				"name":      "errored",
+				"container": "step-errored",
+				"waiting": map[string]interface{}{
+					"reason": "ErrImagePull",
+				},
+			},
+			map[string]interface{}{
+				"name":      "starting",
+				"container": "step-starting",
+				"waiting": map[string]interface{}{
+					"reason": "ContainerCreating",
+				},
+			},
+		}, []string{"cache"})
+		s.createEvent("failed-step-warning", "PipelineRun", "failed-step-run", "WarningEvent")
+		s.createEventWithType("failed-step-normal", "PipelineRun", "failed-step-run", "NormalEvent", corev1.EventTypeNormal)
+
+		result, err := s.GetPrompt("pipeline-troubleshoot", map[string]string{
+			"namespace": s.namespace,
+			"name":      "failed-step-run",
+		})
+		s.Require().NoError(err)
+		text := result.Messages[0].Content.(*mcp.TextContent).Text
+		s.Contains(text, "## PipelineRun Status")
+		s.Contains(text, "## TaskRun Status")
+		s.Contains(text, "## Failed Step Logs")
+		s.Contains(text, "## Troubleshooting Analysis")
+		s.Contains(text, "## Fix Suggestions")
+		s.Contains(text, "[step: failed]")
+		s.Contains(text, "[step: errored]")
+		s.NotContains(text, "[step: passed]")
+		s.NotContains(text, "[step: starting]")
+		s.NotContains(text, "[sidecar: cache]")
+		s.Contains(text, "WarningEvent")
+		s.NotContains(text, "NormalEvent")
+	})
+
 	s.Run("requires namespace", func() {
 		result, err := s.GetPrompt("pipeline-troubleshoot", map[string]string{"name": "broken-run"})
 		s.Error(err)
@@ -385,6 +443,10 @@ func (s *TektonMcpSuite) createLogTaskRun(name, pipelineRun, pipelineTask string
 	for _, step := range steps {
 		stepStates = append(stepStates, map[string]interface{}{"name": step, "container": "step-" + step})
 	}
+	s.createLogTaskRunWithStepStates(name, pipelineRun, pipelineTask, stepStates, sidecars)
+}
+
+func (s *TektonMcpSuite) createLogTaskRunWithStepStates(name, pipelineRun, pipelineTask string, stepStates []interface{}, sidecars []string) {
 	sidecarStates := make([]interface{}, 0, len(sidecars))
 	for _, sidecar := range sidecars {
 		sidecarStates = append(sidecarStates, map[string]interface{}{"name": sidecar, "container": "sidecar-" + sidecar})
@@ -414,6 +476,10 @@ func (s *TektonMcpSuite) createLogTaskRun(name, pipelineRun, pipelineTask string
 }
 
 func (s *TektonMcpSuite) createEvent(name, involvedKind, involvedName, reason string) {
+	s.createEventWithType(name, involvedKind, involvedName, reason, corev1.EventTypeWarning)
+}
+
+func (s *TektonMcpSuite) createEventWithType(name, involvedKind, involvedName, reason, eventType string) {
 	now := metav1.Now()
 	_, err := kubernetes.NewForConfigOrDie(test.EnvTestRestConfig()).CoreV1().Events(s.namespace).Create(s.T().Context(), &corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
@@ -425,7 +491,7 @@ func (s *TektonMcpSuite) createEvent(name, involvedKind, involvedName, reason st
 			Name:      involvedName,
 			Namespace: s.namespace,
 		},
-		Type:           corev1.EventTypeWarning,
+		Type:           eventType,
 		Reason:         reason,
 		Message:        reason,
 		FirstTimestamp: now,

--- a/pkg/mcp/tekton_test.go
+++ b/pkg/mcp/tekton_test.go
@@ -27,6 +27,7 @@ var tektonTestAPIs = []schema.GroupVersionResource{
 }
 
 var (
+	tektonTestPipelineGVR    = schema.GroupVersionResource{Group: "tekton.dev", Version: "v1", Resource: "pipelines"}
 	tektonTestPipelineRunGVR = schema.GroupVersionResource{Group: "tekton.dev", Version: "v1", Resource: "pipelineruns"}
 	tektonTestTaskRunGVR     = schema.GroupVersionResource{Group: "tekton.dev", Version: "v1", Resource: "taskruns"}
 	tektonTestRepositoryGVR  = schema.GroupVersionResource{Group: "pipelinesascode.tekton.dev", Version: "v1alpha1", Resource: "repositories"}
@@ -123,8 +124,70 @@ func (s *TektonMcpSuite) TestPipelineRunLogsWithoutTaskRuns() {
 	s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "No TaskRuns found")
 }
 
+func (s *TektonMcpSuite) TestPipelineRunLogFilters() {
+	s.createPipelineRun("filtered-run")
+	s.createLogTaskRun("compile-run", "filtered-run", "compile", []string{"build", "test"}, []string{"cache"})
+	s.createLogTaskRun("deploy-run", "filtered-run", "deploy", []string{"release"}, nil)
+
+	toolResult, err := s.CallTool("tekton_pipelinerun_logs", map[string]interface{}{
+		"namespace": s.namespace,
+		"name":      "filtered-run",
+		"task":      "compile",
+		"step":      "build",
+	})
+	s.Require().NoError(err)
+	s.False(toolResult.IsError)
+	text := toolResult.Content[0].(*mcp.TextContent).Text
+	s.Contains(text, "# TaskRun: compile-run")
+	s.Contains(text, "[step: build]")
+	s.NotContains(text, "[step: test]")
+	s.NotContains(text, "[sidecar: cache]")
+	s.NotContains(text, "# TaskRun: deploy-run")
+}
+
+func (s *TektonMcpSuite) TestTaskRunLogStepFilter() {
+	s.createLogTaskRun("filtered-taskrun", "standalone-run", "compile", []string{"build", "test"}, []string{"cache"})
+
+	s.Run("returns only the selected step", func() {
+		toolResult, err := s.CallTool("tekton_taskrun_logs", map[string]interface{}{
+			"namespace": s.namespace,
+			"name":      "filtered-taskrun",
+			"step":      "test",
+		})
+		s.Require().NoError(err)
+		s.False(toolResult.IsError)
+		text := toolResult.Content[0].(*mcp.TextContent).Text
+		s.Contains(text, "[step: test]")
+		s.NotContains(text, "[step: build]")
+		s.NotContains(text, "[sidecar: cache]")
+	})
+
+	s.Run("returns no logs for an unknown step", func() {
+		toolResult, err := s.CallTool("tekton_taskrun_logs", map[string]interface{}{
+			"namespace": s.namespace,
+			"name":      "filtered-taskrun",
+			"step":      "unknown",
+		})
+		s.Require().NoError(err)
+		s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "No logs available")
+	})
+
+	s.Run("preserves all steps and sidecars when no filter is set", func() {
+		toolResult, err := s.CallTool("tekton_taskrun_logs", map[string]interface{}{
+			"namespace": s.namespace,
+			"name":      "filtered-taskrun",
+		})
+		s.Require().NoError(err)
+		text := toolResult.Content[0].(*mcp.TextContent).Text
+		s.Contains(text, "[step: build]")
+		s.Contains(text, "[step: test]")
+		s.Contains(text, "[sidecar: cache]")
+	})
+}
+
 func (s *TektonMcpSuite) TestPipelineTroubleshootPrompt() {
 	s.Run("returns gathered PipelineRun data", func() {
+		s.createPipeline("demo-pipeline", "diagnostic-task")
 		s.createPipelineRun("broken-run")
 		s.createTaskRun("broken-run-task", "broken-run")
 		s.createEvent("broken-run-event", "PipelineRun", "broken-run", "BrokenPipelineRun")
@@ -141,11 +204,51 @@ func (s *TektonMcpSuite) TestPipelineTroubleshootPrompt() {
 		s.Require().Len(result.Messages, 2)
 		text := result.Messages[0].Content.(*mcp.TextContent).Text
 		s.Contains(text, "PipelineRun: "+s.namespace+"/broken-run")
+		s.Contains(text, "diagnostic-task")
 		s.Contains(text, "broken-run-task")
 		s.Contains(text, "BrokenPipelineRun")
 		s.NotContains(text, "UnrelatedPipelineRun")
 		s.Contains(text, "eval-repo")
 		s.Contains(text, s.tektonConfigName)
+	})
+
+	s.Run("returns an embedded PipelineSpec", func() {
+		s.createEmbeddedPipelineRun("embedded-run", "embedded-diagnostic-task")
+
+		result, err := s.GetPrompt("pipeline-troubleshoot", map[string]string{
+			"namespace": s.namespace,
+			"name":      "embedded-run",
+		})
+		s.Require().NoError(err)
+		text := result.Messages[0].Content.(*mcp.TextContent).Text
+		s.Contains(text, "Embedded PipelineSpec")
+		s.Contains(text, "embedded-diagnostic-task")
+	})
+
+	s.Run("continues when a referenced Pipeline is missing", func() {
+		s.createReferencedPipelineRun("missing-pipeline-run", "does-not-exist")
+
+		result, err := s.GetPrompt("pipeline-troubleshoot", map[string]string{
+			"namespace": s.namespace,
+			"name":      "missing-pipeline-run",
+		})
+		s.Require().NoError(err)
+		text := result.Messages[0].Content.(*mcp.TextContent).Text
+		s.Contains(text, "Pipeline definition unavailable")
+		s.Contains(text, "does-not-exist")
+	})
+
+	s.Run("returns the resolved PipelineSpec for a resolver-based Pipeline", func() {
+		s.createResolverPipelineRun("resolver-pipeline-run", "resolved-diagnostic-task")
+
+		result, err := s.GetPrompt("pipeline-troubleshoot", map[string]string{
+			"namespace": s.namespace,
+			"name":      "resolver-pipeline-run",
+		})
+		s.Require().NoError(err)
+		text := result.Messages[0].Content.(*mcp.TextContent).Text
+		s.Contains(text, "Resolved PipelineSpec")
+		s.Contains(text, "resolved-diagnostic-task")
 	})
 
 	s.Run("requires namespace", func() {
@@ -155,7 +258,29 @@ func (s *TektonMcpSuite) TestPipelineTroubleshootPrompt() {
 	})
 }
 
+func (s *TektonMcpSuite) createPipeline(name, pipelineTaskName string) {
+	_, err := s.dynamic.Resource(tektonTestPipelineGVR).Namespace(s.namespace).Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "tekton.dev/v1",
+		"kind":       "Pipeline",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": s.namespace,
+		},
+		"spec": map[string]interface{}{
+			"tasks": []interface{}{map[string]interface{}{
+				"name":    pipelineTaskName,
+				"taskRef": map[string]interface{}{"name": "demo-task"},
+			}},
+		},
+	}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
 func (s *TektonMcpSuite) createPipelineRun(name string) {
+	s.createReferencedPipelineRun(name, "demo-pipeline")
+}
+
+func (s *TektonMcpSuite) createReferencedPipelineRun(name, pipelineName string) {
 	_, err := s.dynamic.Resource(tektonTestPipelineRunGVR).Namespace(s.namespace).Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "tekton.dev/v1",
 		"kind":       "PipelineRun",
@@ -164,7 +289,7 @@ func (s *TektonMcpSuite) createPipelineRun(name string) {
 			"namespace": s.namespace,
 		},
 		"spec": map[string]interface{}{
-			"pipelineRef": map[string]interface{}{"name": "demo-pipeline"},
+			"pipelineRef": map[string]interface{}{"name": pipelineName},
 		},
 		"status": map[string]interface{}{
 			"conditions": []interface{}{map[string]interface{}{
@@ -172,6 +297,49 @@ func (s *TektonMcpSuite) createPipelineRun(name string) {
 				"status": "False",
 				"reason": "Failed",
 			}},
+		},
+	}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+func (s *TektonMcpSuite) createResolverPipelineRun(name, pipelineTaskName string) {
+	_, err := s.dynamic.Resource(tektonTestPipelineRunGVR).Namespace(s.namespace).Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "tekton.dev/v1",
+		"kind":       "PipelineRun",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": s.namespace,
+		},
+		"spec": map[string]interface{}{
+			"pipelineRef": map[string]interface{}{"resolver": "git"},
+		},
+		"status": map[string]interface{}{
+			"pipelineSpec": map[string]interface{}{
+				"tasks": []interface{}{map[string]interface{}{
+					"name":    pipelineTaskName,
+					"taskRef": map[string]interface{}{"name": "demo-task"},
+				}},
+			},
+		},
+	}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+func (s *TektonMcpSuite) createEmbeddedPipelineRun(name, pipelineTaskName string) {
+	_, err := s.dynamic.Resource(tektonTestPipelineRunGVR).Namespace(s.namespace).Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "tekton.dev/v1",
+		"kind":       "PipelineRun",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": s.namespace,
+		},
+		"spec": map[string]interface{}{
+			"pipelineSpec": map[string]interface{}{
+				"tasks": []interface{}{map[string]interface{}{
+					"name":    pipelineTaskName,
+					"taskRef": map[string]interface{}{"name": "demo-task"},
+				}},
+			},
 		},
 	}}, metav1.CreateOptions{})
 	s.Require().NoError(err)
@@ -190,6 +358,39 @@ func (s *TektonMcpSuite) createTaskRun(name, pipelineRun string) {
 		},
 		"spec": map[string]interface{}{
 			"taskRef": map[string]interface{}{"name": "demo-task"},
+		},
+	}}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+func (s *TektonMcpSuite) createLogTaskRun(name, pipelineRun, pipelineTask string, steps, sidecars []string) {
+	stepStates := make([]interface{}, 0, len(steps))
+	for _, step := range steps {
+		stepStates = append(stepStates, map[string]interface{}{"name": step, "container": "step-" + step})
+	}
+	sidecarStates := make([]interface{}, 0, len(sidecars))
+	for _, sidecar := range sidecars {
+		sidecarStates = append(sidecarStates, map[string]interface{}{"name": sidecar, "container": "sidecar-" + sidecar})
+	}
+
+	_, err := s.dynamic.Resource(tektonTestTaskRunGVR).Namespace(s.namespace).Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "tekton.dev/v1",
+		"kind":       "TaskRun",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": s.namespace,
+			"labels": map[string]interface{}{
+				"tekton.dev/pipelineRun":  pipelineRun,
+				"tekton.dev/pipelineTask": pipelineTask,
+			},
+		},
+		"spec": map[string]interface{}{
+			"taskRef": map[string]interface{}{"name": "demo-task"},
+		},
+		"status": map[string]interface{}{
+			"podName":  "pod-" + name,
+			"steps":    stepStates,
+			"sidecars": sidecarStates,
 		},
 	}}, metav1.CreateOptions{})
 	s.Require().NoError(err)

--- a/pkg/mcp/tekton_test.go
+++ b/pkg/mcp/tekton_test.go
@@ -124,6 +124,23 @@ func (s *TektonMcpSuite) TestPipelineRunLogsWithoutTaskRuns() {
 	s.Contains(toolResult.Content[0].(*mcp.TextContent).Text, "No TaskRuns found")
 }
 
+func (s *TektonMcpSuite) TestPipelineRunLogsWithoutMatchingPipelineTask() {
+	s.createPipelineRun("filtered-run")
+	s.createLogTaskRun("compile-run", "filtered-run", "compile", []string{"build"}, nil)
+
+	toolResult, err := s.CallTool("tekton_pipelinerun_logs", map[string]interface{}{
+		"namespace": s.namespace,
+		"name":      "filtered-run",
+		"task":      "deploy",
+	})
+	s.Require().NoError(err)
+	s.False(toolResult.IsError)
+	s.Equal(
+		fmt.Sprintf("No TaskRuns found for PipelineRun 'filtered-run' in namespace '%s' matching pipeline task 'deploy'", s.namespace),
+		toolResult.Content[0].(*mcp.TextContent).Text,
+	)
+}
+
 func (s *TektonMcpSuite) TestPipelineRunLogFilters() {
 	s.createPipelineRun("filtered-run")
 	s.createLogTaskRun("compile-run", "filtered-run", "compile", []string{"build", "test"}, []string{"cache"})

--- a/pkg/mcp/testdata/toolsets-tekton-tools.json
+++ b/pkg/mcp/testdata/toolsets-tekton-tools.json
@@ -85,11 +85,19 @@
           "description": "Namespace of the PipelineRun",
           "type": "string"
         },
+        "step": {
+          "description": "Step name to include within matching TaskRuns",
+          "type": "string"
+        },
         "tail": {
           "default": 100,
           "description": "Number of lines to retrieve from the end of each container log (default: 100)",
           "minimum": 0,
           "type": "integer"
+        },
+        "task": {
+          "description": "Pipeline task name to include",
+          "type": "string"
         }
       },
       "required": [
@@ -149,6 +157,10 @@
         },
         "namespace": {
           "description": "Namespace of the TaskRun",
+          "type": "string"
+        },
+        "step": {
+          "description": "Step name to include. If omitted, logs from all steps and sidecars are returned",
           "type": "string"
         },
         "tail": {

--- a/pkg/mcp/testdata/toolsets-tekton-tools.json
+++ b/pkg/mcp/testdata/toolsets-tekton-tools.json
@@ -96,7 +96,7 @@
           "type": "integer"
         },
         "task": {
-          "description": "Pipeline task name to include",
+          "description": "Pipeline task name to filter by (tekton.dev/pipelineTask label)",
           "type": "string"
         }
       },

--- a/pkg/toolsets/tekton/pipeline_troubleshoot.go
+++ b/pkg/toolsets/tekton/pipeline_troubleshoot.go
@@ -22,7 +22,7 @@ func pipelineTroubleshootPrompts() []api.ServerPrompt {
 			Prompt: api.Prompt{
 				Name:        "pipeline-troubleshoot",
 				Title:       "Tekton PipelineRun Troubleshoot",
-				Description: "Gather PipelineRun status, its Pipeline definition, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting",
+				Description: "Gather PipelineRun status, its Pipeline definition, TaskRuns, failed or errored step logs, warning events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting",
 				Arguments: []api.PromptArgument{
 					{
 						Name:        "namespace",
@@ -179,13 +179,18 @@ func fetchPipelineRunTaskRunsForPrompt(params api.PromptHandlerParams, namespace
 
 func fetchPipelineRunLogsForPrompt(params api.PromptHandlerParams, namespace string, taskRuns []tektonv1.TaskRun) string {
 	if len(taskRuns) == 0 {
-		return "*No TaskRuns found, so no logs are available*"
+		return "*No TaskRuns found, so no failed or errored step logs are available*"
 	}
 
 	var sb strings.Builder
 	for _, taskRun := range taskRuns {
 		var taskLogs strings.Builder
-		collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, &taskLogs, namespace, &taskRun, "", kubernetes.DefaultTailLines)
+		for _, step := range taskRun.Status.Steps {
+			if step.Name == "" || !failedOrErroredStep(step) {
+				continue
+			}
+			collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, &taskLogs, namespace, &taskRun, step.Name, kubernetes.DefaultTailLines)
+		}
 		taskLogsText := taskLogs.String()
 		if strings.TrimSpace(taskLogsText) == "" {
 			continue
@@ -198,9 +203,19 @@ func fetchPipelineRunLogsForPrompt(params api.PromptHandlerParams, namespace str
 		sb.WriteString("\n")
 	}
 	if sb.Len() == 0 {
-		return "*No logs available for this PipelineRun*"
+		return "*No failed or errored step logs available for this PipelineRun*"
 	}
 	return sb.String()
+}
+
+func failedOrErroredStep(step tektonv1.StepState) bool {
+	if step.Terminated != nil {
+		return step.Terminated.ExitCode != 0 || (step.Terminated.Reason != "" && step.Terminated.Reason != "Completed")
+	}
+	if step.Waiting != nil {
+		return step.Waiting.Reason != "" && step.Waiting.Reason != "PodInitializing" && step.Waiting.Reason != "ContainerCreating"
+	}
+	return false
 }
 
 type pipelineEventTarget struct {
@@ -234,6 +249,9 @@ func fetchPipelineRunEventsForPrompt(params api.PromptHandlerParams, namespace, 
 			continue
 		}
 		for _, event := range events.Items {
+			if event.Type != corev1.EventTypeWarning {
+				continue
+			}
 			key := string(event.GetUID())
 			if key == "" {
 				key = event.GetNamespace() + "/" + event.GetName()
@@ -246,7 +264,7 @@ func fetchPipelineRunEventsForPrompt(params api.PromptHandlerParams, namespace, 
 		}
 	}
 	if len(matched) == 0 {
-		return "*No related events found*"
+		return "*No related warning events found*"
 	}
 	yaml, err := output.MarshalYaml(matched)
 	if err != nil {
@@ -302,18 +320,17 @@ func buildPipelineTroubleshootPrompt(data pipelineTroubleshootData) string {
 **Collected:** %s
 **Current status hint:** %s
 
-Analyze the collected data and report:
-1. Overall PipelineRun state
-2. Pipeline definition and expected task flow
-3. Failed or blocked TaskRuns
-4. Relevant log errors
-5. Pipeline-as-Code Repository or TektonConfig context that may affect this run
-6. Warning events
-7. Recommended next action
+Analyze the collected data and use these exact section headings in the response:
+1. PipelineRun Status - overall status, conditions, and timing
+2. TaskRun Status - per-task pass, failure, or blocked state
+3. Failed Step Logs - errors from failed or errored steps
+4. Events - related warnings and errors
+5. Troubleshooting Analysis - diagnosis based on the Pipeline definition and collected context
+6. Fix Suggestions - concrete next actions for the identified failure pattern
 
 ---
 
-## PipelineRun
+## PipelineRun Status
 
 %s
 
@@ -325,13 +342,13 @@ Analyze the collected data and report:
 
 ---
 
-## TaskRuns
+## TaskRun Status
 
 %s
 
 ---
 
-## Logs
+## Failed Step Logs
 
 %s
 
@@ -352,6 +369,23 @@ Analyze the collected data and report:
 ## Events
 
 %s
+
+---
+
+## Troubleshooting Analysis
+
+Use the collected data to identify:
+1. The first failed or blocked PipelineTask
+2. The failed step and its relevant log error
+3. Pipeline definition, parameter, workspace, dependency, or scheduling problems
+4. Warning events that confirm the failure path
+5. Pipeline-as-Code or TektonConfig settings that contributed to the failure
+
+---
+
+## Fix Suggestions
+
+Recommend only fixes supported by the collected evidence. Common actions include correcting missing Pipeline or Task references, invalid parameters or workspaces, image pull failures, insufficient permissions or resources, and timeout or cancellation settings.
 `, data.namespace, data.name, time.Now().Format(time.RFC3339), statusHint, data.pipelineRunText, data.pipelineText, data.taskRunsText, data.logsText, data.pacText, data.tektonConfigText, data.eventsText)
 }
 

--- a/pkg/toolsets/tekton/pipeline_troubleshoot.go
+++ b/pkg/toolsets/tekton/pipeline_troubleshoot.go
@@ -22,7 +22,7 @@ func pipelineTroubleshootPrompts() []api.ServerPrompt {
 			Prompt: api.Prompt{
 				Name:        "pipeline-troubleshoot",
 				Title:       "Tekton PipelineRun Troubleshoot",
-				Description: "Gather PipelineRun status, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting",
+				Description: "Gather PipelineRun status, its Pipeline definition, TaskRuns, logs, events, Pipeline-as-Code Repository, and TektonConfig context for Tekton troubleshooting",
 				Arguments: []api.PromptArgument{
 					{
 						Name:        "namespace",
@@ -46,6 +46,7 @@ type pipelineTroubleshootData struct {
 	name             string
 	pipelineRun      *unstructured.Unstructured
 	pipelineRunText  string
+	pipelineText     string
 	taskRunsText     string
 	logsText         string
 	eventsText       string
@@ -71,6 +72,7 @@ func pipelineTroubleshootHandler(params api.PromptHandlerParams) (*api.PromptCal
 		name:             name,
 		pipelineRun:      pipelineRun,
 		pipelineRunText:  pipelineRunText,
+		pipelineText:     fetchPipelineDefinitionForPrompt(params, namespace, pipelineRun),
 		taskRunsText:     taskRunsText,
 		logsText:         fetchPipelineRunLogsForPrompt(params, namespace, taskRuns),
 		eventsText:       fetchPipelineRunEventsForPrompt(params, namespace, name, taskRuns),
@@ -109,8 +111,52 @@ func fetchPipelineRunForPrompt(params api.PromptHandlerParams, namespace, name s
 	return pipelineRun, yamlBlock("PipelineRun", pipelineRun)
 }
 
+func fetchPipelineDefinitionForPrompt(params api.PromptHandlerParams, namespace string, pipelineRun *unstructured.Unstructured) string {
+	if pipelineRun == nil {
+		return "*Pipeline definition unavailable because the PipelineRun could not be fetched*"
+	}
+
+	pipelineSpec, found, err := unstructured.NestedMap(pipelineRun.Object, "spec", "pipelineSpec")
+	if err != nil {
+		return fmt.Sprintf("*Pipeline definition unavailable: invalid embedded PipelineSpec: %v*", err)
+	}
+	if found {
+		return pipelineSpecBlock("Embedded", pipelineSpec)
+	}
+
+	pipelineSpec, found, err = unstructured.NestedMap(pipelineRun.Object, "status", "pipelineSpec")
+	if err != nil {
+		return fmt.Sprintf("*Pipeline definition unavailable: invalid resolved PipelineSpec: %v*", err)
+	}
+	if found {
+		return pipelineSpecBlock("Resolved", pipelineSpec)
+	}
+
+	pipelineName, found, err := unstructured.NestedString(pipelineRun.Object, "spec", "pipelineRef", "name")
+	if err != nil {
+		return fmt.Sprintf("*Pipeline definition unavailable: invalid Pipeline reference: %v*", err)
+	}
+	if !found || pipelineName == "" {
+		return "*Pipeline definition unavailable because the PipelineRun has no named Pipeline reference or embedded PipelineSpec*"
+	}
+
+	pipeline, err := params.DynamicClient().Resource(pipelineGVR).Namespace(namespace).Get(params.Context, pipelineName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("*Pipeline definition unavailable: failed to fetch Pipeline %q: %v*", pipelineName, err)
+	}
+	return yamlBlock("Pipeline", pipeline)
+}
+
+func pipelineSpecBlock(source string, pipelineSpec map[string]interface{}) string {
+	yaml, err := output.MarshalYaml(pipelineSpec)
+	if err != nil {
+		return fmt.Sprintf("*Error formatting %s PipelineSpec: %v*", strings.ToLower(source), err)
+	}
+	return fmt.Sprintf("**%s PipelineSpec**\n\n```yaml\n%s```", source, yaml)
+}
+
 func fetchPipelineRunTaskRunsForPrompt(params api.PromptHandlerParams, namespace, pipelineRunName string) ([]tektonv1.TaskRun, string) {
-	taskRuns, err := pipelineRunTaskRuns(params.Context, params.DynamicClient(), namespace, pipelineRunName)
+	taskRuns, err := pipelineRunTaskRuns(params.Context, params.DynamicClient(), namespace, pipelineRunName, "")
 	if err != nil {
 		return nil, fmt.Sprintf("*Error listing TaskRuns: %v*", err)
 	}
@@ -139,7 +185,7 @@ func fetchPipelineRunLogsForPrompt(params api.PromptHandlerParams, namespace str
 	var sb strings.Builder
 	for _, taskRun := range taskRuns {
 		var taskLogs strings.Builder
-		collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, &taskLogs, namespace, &taskRun, kubernetes.DefaultTailLines)
+		collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, &taskLogs, namespace, &taskRun, "", kubernetes.DefaultTailLines)
 		taskLogsText := taskLogs.String()
 		if strings.TrimSpace(taskLogsText) == "" {
 			continue
@@ -258,15 +304,22 @@ func buildPipelineTroubleshootPrompt(data pipelineTroubleshootData) string {
 
 Analyze the collected data and report:
 1. Overall PipelineRun state
-2. Failed or blocked TaskRuns
-3. Relevant log errors
-4. Pipeline-as-Code Repository or TektonConfig context that may affect this run
-5. Warning events
-6. Recommended next action
+2. Pipeline definition and expected task flow
+3. Failed or blocked TaskRuns
+4. Relevant log errors
+5. Pipeline-as-Code Repository or TektonConfig context that may affect this run
+6. Warning events
+7. Recommended next action
 
 ---
 
 ## PipelineRun
+
+%s
+
+---
+
+## Pipeline Definition
 
 %s
 
@@ -299,7 +352,7 @@ Analyze the collected data and report:
 ## Events
 
 %s
-`, data.namespace, data.name, time.Now().Format(time.RFC3339), statusHint, data.pipelineRunText, data.taskRunsText, data.logsText, data.pacText, data.tektonConfigText, data.eventsText)
+`, data.namespace, data.name, time.Now().Format(time.RFC3339), statusHint, data.pipelineRunText, data.pipelineText, data.taskRunsText, data.logsText, data.pacText, data.tektonConfigText, data.eventsText)
 }
 
 func yamlBlock(title string, obj *unstructured.Unstructured) string {

--- a/pkg/toolsets/tekton/pipelinerun.go
+++ b/pkg/toolsets/tekton/pipelinerun.go
@@ -60,7 +60,7 @@ func pipelineRunTools() []api.ServerTool {
 						},
 						"task": {
 							Type:        "string",
-							Description: "Pipeline task name to include",
+							Description: "Pipeline task name to filter by (tekton.dev/pipelineTask label)",
 						},
 						"step": {
 							Type:        "string",
@@ -196,6 +196,9 @@ func getPipelineRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 		return api.NewToolCallResult("", fmt.Errorf("failed to list TaskRuns for PipelineRun %s/%s: %w", namespace, name, err)), nil
 	}
 	if len(taskRuns) == 0 {
+		if pipelineTaskName != "" {
+			return api.NewToolCallResult(fmt.Sprintf("No TaskRuns found for PipelineRun '%s' in namespace '%s' matching pipeline task '%s'", name, namespace, pipelineTaskName), nil), nil
+		}
 		return api.NewToolCallResult(fmt.Sprintf("No TaskRuns found for PipelineRun '%s' in namespace '%s'", name, namespace), nil), nil
 	}
 

--- a/pkg/toolsets/tekton/pipelinerun.go
+++ b/pkg/toolsets/tekton/pipelinerun.go
@@ -8,9 +8,11 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/google/jsonschema-go/jsonschema"
+	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
@@ -55,6 +57,14 @@ func pipelineRunTools() []api.ServerTool {
 						"namespace": {
 							Type:        "string",
 							Description: "Namespace of the PipelineRun",
+						},
+						"task": {
+							Type:        "string",
+							Description: "Pipeline task name to include",
+						},
+						"step": {
+							Type:        "string",
+							Description: "Step name to include within matching TaskRuns",
 						},
 						"tail": {
 							Type:        "integer",
@@ -170,6 +180,8 @@ func getPipelineRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 	p := api.WrapParams(params)
 	name := p.RequiredString("name")
 	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	pipelineTaskName := p.OptionalString("task", "")
+	stepName := p.OptionalString("step", "")
 	tailLines := p.OptionalInt64("tail", kubernetes.DefaultTailLines)
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get pipeline run logs: %w", err)), nil
@@ -179,7 +191,7 @@ func getPipelineRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 		return api.NewToolCallResult("", fmt.Errorf("failed to get PipelineRun %s/%s: %w", namespace, name, err)), nil
 	}
 
-	taskRuns, err := pipelineRunTaskRuns(params.Context, params.DynamicClient(), namespace, name)
+	taskRuns, err := pipelineRunTaskRuns(params.Context, params.DynamicClient(), namespace, name, pipelineTaskName)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to list TaskRuns for PipelineRun %s/%s: %w", namespace, name, err)), nil
 	}
@@ -190,7 +202,7 @@ func getPipelineRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 	var sb strings.Builder
 	for _, taskRun := range taskRuns {
 		var taskLogs strings.Builder
-		collectTaskRunLogs(params, &taskLogs, namespace, &taskRun, tailLines)
+		collectTaskRunLogs(params, &taskLogs, namespace, &taskRun, stepName, tailLines)
 		taskLogsText := taskLogs.String()
 		if strings.TrimSpace(taskLogsText) == "" {
 			continue
@@ -207,9 +219,17 @@ func getPipelineRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, erro
 	return api.NewToolCallResult(sb.String(), nil), nil
 }
 
-func pipelineRunTaskRuns(ctx context.Context, dynamicClient dynamic.Interface, namespace, pipelineRunName string) ([]tektonv1.TaskRun, error) {
+func pipelineRunTaskRuns(ctx context.Context, dynamicClient dynamic.Interface, namespace, pipelineRunName, pipelineTaskName string) ([]tektonv1.TaskRun, error) {
+	matchLabels := labels.Set{pipeline.PipelineRunLabelKey: pipelineRunName}
+	if pipelineTaskName != "" {
+		matchLabels[pipeline.PipelineTaskLabelKey] = pipelineTaskName
+	}
+	selector, err := labels.ValidatedSelectorFromSet(matchLabels)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TaskRun label filter: %w", err)
+	}
 	list, err := dynamicClient.Resource(taskRunGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName,
+		LabelSelector: selector.String(),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/toolsets/tekton/taskrun.go
+++ b/pkg/toolsets/tekton/taskrun.go
@@ -64,6 +64,10 @@ func taskRunTools() []api.ServerTool {
 							Type:        "string",
 							Description: "Namespace of the TaskRun",
 						},
+						"step": {
+							Type:        "string",
+							Description: "Step name to include. If omitted, logs from all steps and sidecars are returned",
+						},
 						"tail": {
 							Type:        "integer",
 							Description: "Number of lines to retrieve from the end of the logs (Optional, default: 100)",
@@ -142,6 +146,7 @@ func getTaskRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	p := api.WrapParams(params)
 	name := p.RequiredString("name")
 	namespace := p.OptionalString("namespace", params.NamespaceOrDefault(""))
+	stepName := p.OptionalString("step", "")
 	tailInt := p.OptionalInt64("tail", kubernetes.DefaultTailLines)
 	if err := p.Err(); err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to get task run logs: %w", err)), nil
@@ -161,7 +166,7 @@ func getTaskRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	}
 
 	var sb strings.Builder
-	collectTaskRunLogs(params, &sb, namespace, &tr, tailInt)
+	collectTaskRunLogs(params, &sb, namespace, &tr, stepName, tailInt)
 
 	if sb.Len() == 0 {
 		return api.NewToolCallResult(fmt.Sprintf("No logs available for TaskRun '%s' in namespace '%s'", name, namespace), nil), nil
@@ -170,20 +175,34 @@ func getTaskRunLogs(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	return api.NewToolCallResult(sb.String(), nil), nil
 }
 
-func collectTaskRunLogs(params api.ToolHandlerParams, sb *strings.Builder, namespace string, tr *tektonv1.TaskRun, tailLines int64) {
-	collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, sb, namespace, tr, tailLines)
+func collectTaskRunLogs(params api.ToolHandlerParams, sb *strings.Builder, namespace string, tr *tektonv1.TaskRun, stepName string, tailLines int64) {
+	collectTaskRunLogsWithClient(params.Context, params.KubernetesClient, sb, namespace, tr, stepName, tailLines)
 }
 
-func collectTaskRunLogsWithClient(ctx context.Context, client api.KubernetesClient, sb *strings.Builder, namespace string, tr *tektonv1.TaskRun, tailLines int64) {
+func collectTaskRunLogsWithClient(ctx context.Context, client api.KubernetesClient, sb *strings.Builder, namespace string, tr *tektonv1.TaskRun, stepName string, tailLines int64) {
+	hasStep := stepName == ""
+	for _, step := range tr.Status.Steps {
+		if step.Name == stepName {
+			hasStep = true
+			break
+		}
+	}
+	if !hasStep {
+		return
+	}
 	if tr.Status.PodName == "" {
 		fmt.Fprintf(sb, "TaskRun '%s' in namespace '%s' has not started a pod yet\n", tr.Name, namespace)
 		return
 	}
 	for _, step := range tr.Status.Steps {
-		collectContainerLogs(ctx, client, sb, tr.Status.PodName, namespace, "step", step.Name, step.Container, tailLines)
+		if stepName == "" || step.Name == stepName {
+			collectContainerLogs(ctx, client, sb, tr.Status.PodName, namespace, "step", step.Name, step.Container, tailLines)
+		}
 	}
-	for _, sidecar := range tr.Status.Sidecars {
-		collectContainerLogs(ctx, client, sb, tr.Status.PodName, namespace, "sidecar", sidecar.Name, sidecar.Container, tailLines)
+	if stepName == "" {
+		for _, sidecar := range tr.Status.Sidecars {
+			collectContainerLogs(ctx, client, sb, tr.Status.PodName, namespace, "sidecar", sidecar.Name, sidecar.Container, tailLines)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

- Add optional Pipeline task and step filters to PipelineRun log collection.
- Add optional step filtering to TaskRun log collection. Sidecar logs remain included when no step filter is set.
- Limit troubleshooting context to failed or errored step logs and warning events, and structure the response as PipelineRun Status, TaskRun Status, Failed Step Logs, Events, Troubleshooting Analysis, and Fix Suggestions.
- Include the embedded or resolved PipelineSpec in the troubleshooting prompt, falling back to the referenced Pipeline when needed.
- Keep missing Pipeline definitions nonfatal so the remaining diagnostic context is still collected.
- Update behavior tests, the troubleshooting evaluation, generated tool metadata, and user documentation.

## Why

Pipeline troubleshooting currently returns every TaskRun container log and omits the Pipeline definition that describes the expected task flow. Narrow filters reduce noisy output, while including the effective Pipeline definition gives the model enough context to relate failures to the intended execution graph.

## Testing

- `go test -count=1 ./pkg/toolsets/tekton`
- `go test -count=1 -v ./pkg/mcp -run '^TestTektonMcp$'`
- `go test -race -count=1 ./pkg/toolsets/tekton`
- `go test -race -count=1 ./pkg/mcp -run '^(TestTektonMcp|TestToolsets)$'`
- `make test-update-snapshots`
- `make update-readme-tools`



