### PR TITLE
chore: always set disable-destructive to false in evals server

### DIFF
--- a/build/evals.mk
+++ b/build/evals.mk
@@ -79,9 +79,9 @@ diff-evals: mcpchecker ## Diff latest mcpchecker results against baseline
 run-server: build ## Start MCP server in background and wait for health check
 	@echo "Starting MCP server on port $(MCP_PORT)..."
 	@if [ -n "$(TOOLSETS)" ]; then \
-		./$(BINARY_NAME) --port $(MCP_PORT) --toolsets $(TOOLSETS) --config-dir $(MCP_CONFIG_DIR) --read-only=false & echo $$! > .mcp-server.pid; \
+		./$(BINARY_NAME) --port $(MCP_PORT) --toolsets $(TOOLSETS) --config-dir $(MCP_CONFIG_DIR) --read-only=false --disable-destructive=false & echo $$! > .mcp-server.pid; \
 	else \
-		./$(BINARY_NAME) --port $(MCP_PORT) --read-only=false & echo $$! > .mcp-server.pid; \
+		./$(BINARY_NAME) --port $(MCP_PORT) --read-only=false --disable-destructive=false & echo $$! > .mcp-server.pid; \
 	fi
 	@echo "MCP server started with PID $$(cat .mcp-server.pid)"
 	@echo "Waiting for MCP server to be ready..."


### PR DESCRIPTION
Follow up on #1310 to help keep the set of tools enabled in a eval run consistent in different envs