### PR TITLE
Evals: Clean up `make` rules & toolset selection

### DIFF
--- a/build/evals.mk
+++ b/build/evals.mk
@@ -78,11 +78,7 @@ diff-evals: mcpchecker ## Diff latest mcpchecker results against baseline
 .PHONY: run-server
 run-server: build ## Start MCP server in background and wait for health check
 	@echo "Starting MCP server on port $(MCP_PORT)..."
-	@if [ -n "$(TOOLSETS)" ]; then \
-		./$(BINARY_NAME) --port $(MCP_PORT) --toolsets $(TOOLSETS) --config-dir $(MCP_CONFIG_DIR) --read-only=false & echo $$! > .mcp-server.pid; \
-	else \
-		./$(BINARY_NAME) --port $(MCP_PORT) --read-only=false & echo $$! > .mcp-server.pid; \
-	fi
+	./$(BINARY_NAME) --port $(MCP_PORT) $(if $(TOOLSETS),--toolsets "$(TOOLSETS)") --config-dir $(MCP_CONFIG_DIR) & echo $$! > .mcp-server.pid
 	@echo "MCP server started with PID $$(cat .mcp-server.pid)"
 	@echo "Waiting for MCP server to be ready..."
 	@elapsed=0; \

--- a/dev/config/mcp-configs/000-config-defaults.toml
+++ b/dev/config/mcp-configs/000-config-defaults.toml
@@ -1,0 +1,3 @@
+# !CAUTION! Destructive mode enabled by default for development.
+read_only = false
+disable_destructive = false

--- a/dev/config/mcp-configs/netobserv.toml
+++ b/dev/config/mcp-configs/netobserv.toml
@@ -1,5 +1,3 @@
-toolsets = ["core", "config", "netobserv"]
-
 [toolset_configs.netobserv]
 # Mock / local port-forward:
 url = "http://127.0.0.1:9001"


### PR DESCRIPTION
- Destructive config defaults (`read_only`/`disable_destructive` set to `false`) added to early-loading TOML in dev/config/mcp-configs. These will be picked up by evals.
- `$TOOLSETS` var is honored if specified, otherwise defaulting properly (rather than being set by netobserv.toml).
- Invocation in `run-server` consolidated to one line for maintainability.