### PR TITLE
chore: expand run-server target to accept additional arguments

### DIFF
--- a/build/evals.mk
+++ b/build/evals.mk
@@ -78,7 +78,7 @@ diff-evals: mcpchecker ## Diff latest mcpchecker results against baseline
 .PHONY: run-server
 run-server: build ## Start MCP server in background and wait for health check
 	@echo "Starting MCP server on port $(MCP_PORT)..."
-	./$(BINARY_NAME) --port $(MCP_PORT) $(if $(TOOLSETS),--toolsets "$(TOOLSETS)") --config-dir $(MCP_CONFIG_DIR) & echo $$! > .mcp-server.pid
+	./$(BINARY_NAME) --port $(MCP_PORT) $(if $(TOOLSETS),--toolsets "$(TOOLSETS)") --config-dir $(MCP_CONFIG_DIR) $(MCP_SERVER_EXTRA_ARGS) & echo $$! > .mcp-server.pid
 	@echo "MCP server started with PID $$(cat .mcp-server.pid)"
 	@echo "Waiting for MCP server to be ready..."
 	@elapsed=0; \


### PR DESCRIPTION
provide the capability to pass additional arguments to run-server.  This allows us to neither mutate nor override the mcp-server config while still being able to adapt it to different runtime environments (for e.g. passing `--kubeconfig filename`). 
