### PR TITLE
chore:narrow kubeconfig injection option

### DIFF
--- a/build/evals.mk
+++ b/build/evals.mk
@@ -78,7 +78,7 @@ diff-evals: mcpchecker ## Diff latest mcpchecker results against baseline
 .PHONY: run-server
 run-server: build ## Start MCP server in background and wait for health check
 	@echo "Starting MCP server on port $(MCP_PORT)..."
-	./$(BINARY_NAME) --port $(MCP_PORT) $(if $(TOOLSETS),--toolsets "$(TOOLSETS)") --config-dir $(MCP_CONFIG_DIR) $(MCP_SERVER_EXTRA_ARGS) & echo $$! > .mcp-server.pid
+	./$(BINARY_NAME) --port $(MCP_PORT) $(if $(TOOLSETS),--toolsets "$(TOOLSETS)") --config-dir $(MCP_CONFIG_DIR) $(if $(MCP_EVAL_KUBECONFIG),--kubeconfig "$(MCP_EVAL_KUBECONFIG)") & echo $$! > .mcp-server.pid
 	@echo "MCP server started with PID $$(cat .mcp-server.pid)"
 	@echo "Waiting for MCP server to be ready..."
 	@elapsed=0; \


### PR DESCRIPTION
#1348 attempts to widen the mcp-server `run-server` make target options to allow for specification of a kubeconfig or cluster provider.  
This may be wider than desired.  
As a counter-proposal, this PR will inject the value of the special variable `MCP_EVAL_KUBECONFIG` as `--kubeconfig "$(MCP_EVAL_KUBECONFIG)"` option for mcp-server IFF the environment variable `MCP_EVAL_KUBECONFIG` is non-empty.
