### PR TITLE
feat(dev): add compose + MCP Inspector support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ LD_FLAGS = -s -w \
 	-X '$(PACKAGE)/pkg/version.BinaryName=$(BINARY_NAME)' \
 	-X '$(PACKAGE)/pkg/version.WebsiteURL=$(WEBSITE_URL)'
 COMMON_BUILD_ARGS = -ldflags "$(LD_FLAGS)"
+CONTAINER_CLI ?= $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null || echo docker)
+KUBECONFIG ?= $(or $(wildcard _output/kubeconfig),$(HOME)/.kube/config)
 
 GOLANGCI_LINT = $(shell pwd)/_output/tools/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.11.4
@@ -193,6 +195,15 @@ local-env-setup-kuadrant: ## Setup complete local development environment with K
 .PHONY: local-env-teardown
 local-env-teardown: ## Tear down the local Kind cluster
 	$(MAKE) kind-delete-cluster
+
+.PHONY: inspect
+inspect: ## Start kubernetes-mcp-server + MCP Inspector via compose
+	@mkdir -p _output && \
+	sed -e 's|https://127\.0\.0\.1|https://host.docker.internal|g' \
+	    -e 's|https://localhost|https://host.docker.internal|g' \
+	    -e 's|certificate-authority-data:.*|insecure-skip-tls-verify: true|' \
+	    $(KUBECONFIG) > _output/compose-kubeconfig && \
+	$(CONTAINER_CLI) compose up --build
 
 .PHONY: print-git-tag-version
 print-git-tag-version: ## Print the GIT_TAG_VERSION

--- a/README.md
+++ b/README.md
@@ -934,9 +934,25 @@ Compile the project and run the Kubernetes MCP server with [mcp-inspector](https
 ```shell
 # Compile the project
 make build
-# Run the Kubernetes MCP server with mcp-inspector
+# Run the Kubernetes MCP server with mcp-inspector (stdio)
 npx @modelcontextprotocol/inspector@latest $(pwd)/kubernetes-mcp-server
 ```
+
+#### Via Docker/Podman Compose (HTTP transport)
+
+Run the server and Inspector as containers — no Node.js required on the host:
+
+```shell
+# Requires a kubeconfig (e.g. after: make kind-create-cluster)
+make inspect
+
+# With podman:
+CONTAINER_CLI=podman make inspect
+```
+
+Open the Inspector URL from the logs (`http://localhost:6274/?MCP_PROXY_AUTH_TOKEN=...`),
+then connect using **Streamable HTTP** to `http://kubernetes-mcp-server:8080/mcp`
+(the Inspector proxy resolves the compose service name internally).
 
 ---
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,20 @@
+services:
+  kubernetes-mcp-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      KUBECONFIG: /kube/config
+    volumes:
+      - ./_output/compose-kubeconfig:/kube/config:ro
+    ports:
+      - "8080:8080"
+
+  inspector:
+    image: ghcr.io/modelcontextprotocol/inspector:latest
+    environment:
+      - HOST=0.0.0.0
+      - MCP_AUTO_OPEN_ENABLED=false
+    ports:
+      - "6274:6274"
+      - "6277:6277"


### PR DESCRIPTION
Adds a compose.yaml and `make inspect` target to run the server and MCP Inspector as containers (Docker or Podman). The Makefile recipe auto-rewrites Kind kubeconfigs for container access (host.docker.internal + insecure-skip-tls-verify).

No Node.js/npx needed on the host useful for container-only setups.