### PR TITLE
fix(bugs): A few minor bugfixes

### DIFF
--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -218,9 +218,11 @@ func (c *JWTClaims) ValidateOffline(audience string) error {
 // ValidateWithProvider validates the JWT claims against the OIDC provider.
 func (c *JWTClaims) ValidateWithProvider(ctx context.Context, audience string, provider *oidc.Provider) error {
 	if provider != nil {
-		verifier := provider.Verifier(&oidc.Config{
-			ClientID: audience,
-		})
+		cfg := &oidc.Config{ClientID: audience}
+		if audience == "" {
+			cfg.SkipClientIDCheck = true
+		}
+		verifier := provider.Verifier(cfg)
 		_, err := verifier.Verify(ctx, c.Token)
 		if err != nil {
 			return fmt.Errorf("OIDC token validation error: %w", err)

--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -189,7 +189,7 @@ func (p *kcpClusterProvider) managerForWorkspace(ctx context.Context, workspace 
 	}
 
 	if _, exists := p.managers[workspace]; !exists {
-		return nil, fmt.Errorf("workspace %s not found", workspace)
+		return nil, fmt.Errorf("workspace %s not found: %w", workspace, kubernetes.ErrUnknownTarget)
 	}
 
 	// Create REST config for this workspace

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -2,11 +2,16 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 )
+
+// ErrUnknownTarget is returned by GetDerivedKubernetes when the requested
+// target (context, workspace, etc.) does not exist or cannot be used.
+var ErrUnknownTarget = errors.New("unknown target")
 
 // McpReload is a function type that defines a callback for reloading MCP toolsets (including tools, prompts, or other configurations)
 type McpReload func() error

--- a/pkg/kubernetes/provider_kubeconfig.go
+++ b/pkg/kubernetes/provider_kubeconfig.go
@@ -134,7 +134,7 @@ func (p *kubeConfigClusterProvider) managerForContext(ctx context.Context, kubeC
 
 	m, err := NewKubeconfigManager(ctx, baseManager.config, kubeContext)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrUnknownTarget, err)
 	}
 
 	p.managers[kubeContext] = m

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -89,7 +89,7 @@ func (p *singleClusterProvider) GetTargetManagers(_ context.Context) ([]*Manager
 
 func (p *singleClusterProvider) GetDerivedKubernetes(ctx context.Context, target string) (*Kubernetes, error) {
 	if target != "" {
-		return nil, fmt.Errorf("unable to get manager for other context/cluster with %s strategy", p.strategy)
+		return nil, fmt.Errorf("unable to get manager for other context/cluster with %s strategy: %w", p.strategy, ErrUnknownTarget)
 	}
 
 	return p.manager.Derived(ctx)

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -110,6 +110,7 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 		ClientID:           baseConfig.GetStsClientId(),
 		ClientSecret:       baseConfig.GetStsClientSecret(),
 		Audience:           baseConfig.GetStsAudience(),
+		SubjectTokenType:   tokenexchange.TokenTypeAccessToken,
 		Scopes:             scopes,
 		AuthStyle:          authStyle,
 		ClientCertFile:     baseConfig.GetStsClientCertFile(),

--- a/pkg/kubernetes/provider_token_exchange_test.go
+++ b/pkg/kubernetes/provider_token_exchange_test.go
@@ -27,10 +27,11 @@ type TokenExchangingProviderSuite struct {
 }
 
 type observedTokenRequest struct {
-	clientID     string
-	clientSecret string
-	audience     string
-	scope        string
+	clientID         string
+	clientSecret     string
+	audience         string
+	scope            string
+	subjectTokenType string
 }
 
 type exchangeTestOIDCServer struct {
@@ -104,16 +105,18 @@ func (s *TokenExchangingProviderSuite) TestGetDerivedKubernetes() {
 		requests := authServer.recordedRequests()
 		s.Require().Len(requests, 2)
 		s.Equal(observedTokenRequest{
-			clientID:     "old-client",
-			clientSecret: "old-secret",
-			audience:     "old-audience",
-			scope:        "old-scope",
+			clientID:         "old-client",
+			clientSecret:     "old-secret",
+			audience:         "old-audience",
+			scope:            "old-scope",
+			subjectTokenType: tokenexchange.TokenTypeAccessToken,
 		}, requests[0])
 		s.Equal(observedTokenRequest{
-			clientID:     "new-client",
-			clientSecret: "new-secret",
-			audience:     "new-audience",
-			scope:        "new-scope",
+			clientID:         "new-client",
+			clientSecret:     "new-secret",
+			audience:         "new-audience",
+			scope:            "new-scope",
+			subjectTokenType: tokenexchange.TokenTypeAccessToken,
 		}, requests[1])
 	})
 }
@@ -335,10 +338,11 @@ func (s *TokenExchangingProviderSuite) newExchangeTestOIDCServer() *exchangeTest
 		case "/token":
 			s.Require().NoError(r.ParseForm())
 			authServer.record(observedTokenRequest{
-				clientID:     r.PostForm.Get(tokenexchange.FormKeyClientID),
-				clientSecret: r.PostForm.Get(tokenexchange.FormKeyClientSecret),
-				audience:     r.PostForm.Get(tokenexchange.FormKeyAudience),
-				scope:        strings.TrimSpace(r.PostForm.Get(tokenexchange.FormKeyScope)),
+				clientID:         r.PostForm.Get(tokenexchange.FormKeyClientID),
+				clientSecret:     r.PostForm.Get(tokenexchange.FormKeyClientSecret),
+				audience:         r.PostForm.Get(tokenexchange.FormKeyAudience),
+				scope:            strings.TrimSpace(r.PostForm.Get(tokenexchange.FormKeyScope)),
+				subjectTokenType: r.PostForm.Get(tokenexchange.FormKeySubjectTokenType),
 			})
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"access_token":"exchanged-token","token_type":"Bearer","expires_in":3600}`))

--- a/pkg/kubernetes/sts.go
+++ b/pkg/kubernetes/sts.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/oauth2/google/externalaccount"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 )
 
 type staticSubjectTokenSupplier struct {
@@ -48,7 +49,7 @@ func (sts *SecurityTokenService) ExternalAccountTokenExchange(ctx context.Contex
 		ClientID:             sts.ClientId,
 		ClientSecret:         sts.ClientSecret,
 		Audience:             sts.ExternalAccountAudience,
-		SubjectTokenType:     "urn:ietf:params:oauth:token-type:access_token",
+		SubjectTokenType:     tokenexchange.TokenTypeAccessToken,
 		SubjectTokenSupplier: &staticSubjectTokenSupplier{token: originalToken.AccessToken},
 		Scopes:               sts.ExternalAccountScopes,
 	})

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -174,6 +174,7 @@ func strategyBasedTokenExchange(
 			ClientID:           baseConfig.GetStsClientId(),
 			ClientSecret:       baseConfig.GetStsClientSecret(),
 			Audience:           baseConfig.GetStsAudience(),
+			SubjectTokenType:   tokenexchange.TokenTypeAccessToken,
 			Scopes:             baseConfig.GetStsScopes(),
 			AuthStyle:          authStyle,
 			ClientCertFile:     baseConfig.GetStsClientCertFile(),

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/confirmation"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/mcplog" //nolint:staticcheck // MCP logging deprecated (SEP-2577)
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -79,6 +80,9 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 		cluster := toolCallRequest.GetString(s.p.GetTargetParameterName(), s.p.GetDefaultTarget())
 		k, err := s.p.GetDerivedKubernetes(ctx, cluster)
 		if err != nil {
+			if errors.Is(err, kubernetes.ErrUnknownTarget) {
+				return NewTextResult("", fmt.Errorf("target %q: %w", cluster, err)), nil
+			}
 			return nil, err
 		}
 

--- a/pkg/tokenexchange/keycloak_v1_exchanger.go
+++ b/pkg/tokenexchange/keycloak_v1_exchanger.go
@@ -21,10 +21,15 @@ func (e *keycloakV1Exchanger) Exchange(ctx context.Context, cfg *TargetTokenExch
 		return nil, fmt.Errorf("failed to acquire http client to talk to IdP for target: %w", err)
 	}
 
+	subjectTokenType := cfg.SubjectTokenType
+	if subjectTokenType == "" {
+		subjectTokenType = TokenTypeAccessToken
+	}
+
 	data := url.Values{}
 	data.Set(FormKeyGrantType, GrantTypeTokenExchange)
 	data.Set(FormKeySubjectToken, subjectToken)
-	data.Set(FormKeySubjectTokenType, cfg.SubjectTokenType)
+	data.Set(FormKeySubjectTokenType, subjectTokenType)
 	data.Set(FormKeyAudience, cfg.Audience)
 
 	if cfg.SubjectIssuer != "" {

--- a/pkg/tokenexchange/rfc8693_exchanger.go
+++ b/pkg/tokenexchange/rfc8693_exchanger.go
@@ -20,10 +20,15 @@ func (e *rfc8693Exchanger) Exchange(ctx context.Context, cfg *TargetTokenExchang
 		return nil, fmt.Errorf("failed to acquire http client to talk to IdP for target: %w", err)
 	}
 
+	subjectTokenType := cfg.SubjectTokenType
+	if subjectTokenType == "" {
+		subjectTokenType = TokenTypeAccessToken
+	}
+
 	data := url.Values{}
 	data.Set(FormKeyGrantType, GrantTypeTokenExchange)
 	data.Set(FormKeySubjectToken, subjectToken)
-	data.Set(FormKeySubjectTokenType, cfg.SubjectTokenType)
+	data.Set(FormKeySubjectTokenType, subjectTokenType)
 	data.Set(FormKeyAudience, cfg.Audience)
 	data.Set(FormKeyRequestedTokenType, TokenTypeAccessToken)
 


### PR DESCRIPTION
- Return tool result errors instead of protocol errors for invalid multi-cluster targets (tools_gosdk.go)
- Skip OIDC client ID check when oauth_audience is empty instead of passing empty string to the verifier (authorization.go)
- Default SubjectTokenType to access_token in token exchange config so keycloak accepts the subject token (provider_token_exchange.go, token_exchange.go)