### PR TITLE
fix(kubernetes): roundtripper handles subresources/resources without Kind set

### DIFF
--- a/pkg/kubernetes/accesscontrol_round_tripper.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper.go
@@ -24,6 +24,7 @@ type AccessControlRoundTripper struct {
 	delegate                http.RoundTripper
 	deniedResourcesProvider api.DeniedResourcesProvider
 	restMapperProvider      func() meta.RESTMapper
+	discoveryProvider       func() discovery.DiscoveryInterface
 	apiPathPrefix           string
 	validators              []api.HTTPValidator
 }
@@ -58,6 +59,7 @@ func NewAccessControlRoundTripper(ctx context.Context, cfg AccessControlRoundTri
 		delegate:                cfg.Delegate,
 		deniedResourcesProvider: cfg.DeniedResourcesProvider,
 		restMapperProvider:      cfg.RestMapperProvider,
+		discoveryProvider:       cfg.DiscoveryProvider,
 		apiPathPrefix:           apiPathPrefix,
 	}
 
@@ -92,24 +94,12 @@ func (rt *AccessControlRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 		return rt.delegate.RoundTrip(req)
 	}
 
-	// Get restMapper at request time (lazy evaluation)
-	// This ensures we get the initialized restMapper even if the wrapper
-	// was created before restMapper was set (fixes issue #688)
-	restMapper := rt.restMapperProvider()
-	if restMapper == nil {
-		return nil, fmt.Errorf("failed to make request: AccessControlRoundTripper restMapper not initialized")
+	subresource := parseSubresource(kubernetesPath)
+	gvk, err := rt.getGVK(gvr, subresource)
+	if err != nil {
+		return nil, err
 	}
 
-	gvk, err := restMapper.KindFor(gvr)
-	if err != nil {
-		if meta.IsNoMatchError(err) {
-			return nil, &api.ValidationError{
-				Code:    api.ErrorCodeResourceNotFound,
-				Message: fmt.Sprintf("Resource %s does not exist in the cluster", api.FormatResourceName(&gvr)),
-			}
-		}
-		return nil, fmt.Errorf("failed to make request: AccessControlRoundTripper failed to get kind for gvr %v: %w", gvr, err)
-	}
 	if !rt.isAllowed(gvk) {
 		return nil, fmt.Errorf("resource not allowed: %s", gvk.String())
 	}
@@ -155,6 +145,53 @@ func (rt *AccessControlRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	return rt.delegate.RoundTrip(req)
 }
 
+func (rt *AccessControlRoundTripper) getGVK(
+	gvr schema.GroupVersionResource,
+	subresource string,
+) (schema.GroupVersionKind, error) {
+	// Get restMapper at request time (lazy evaluation)
+	// This ensures we get the initialized restMapper even if the wrapper
+	// was created before restMapper was set (fixes issue #688)
+	restMapper := rt.restMapperProvider()
+	if restMapper == nil {
+		return schema.GroupVersionKind{},
+			fmt.Errorf("failed to make request: AccessControlRoundTripper restMapper not initialized")
+	}
+
+	gvk, err := restMapper.KindFor(gvr)
+	if err == nil {
+		return gvk, nil
+
+	}
+	if meta.IsNoMatchError(err) {
+		// Fallback: check if the group/version exists in discovery and
+		// contains the resource (or resource/subresource pair).
+		// This handles aggregated APIs like subresources.kubevirt.io that
+		// only expose subresource endpoints with empty Kind.
+		if rt.resourceExistsInDiscovery(gvr, subresource) {
+			// No GVK is available for subresource-only API groups,
+			// but we still check the group/version against the denied
+			// resources list (the Kind="" wildcard entries).
+			return schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version}, nil
+		}
+
+		return schema.GroupVersionKind{}, &api.ValidationError{
+			Code: api.ErrorCodeResourceNotFound,
+			Message: fmt.Sprintf(
+				"Resource %s does not exist in the cluster",
+				api.FormatResourceName(&gvr),
+			),
+		}
+	}
+
+	return schema.GroupVersionKind{},
+		fmt.Errorf(
+			"failed to make request: AccessControlRoundTripper failed to get kind for gvr %v: %w",
+			gvr,
+			err,
+		)
+}
+
 // isAllowed checks the resource is in denied list or not.
 // If it is in denied list, this function returns false.
 func (rt *AccessControlRoundTripper) isAllowed(
@@ -179,6 +216,53 @@ func (rt *AccessControlRoundTripper) isAllowed(
 	}
 
 	return true
+}
+
+// resourceExistsInDiscovery checks whether the given GVR (and optional
+// subresource) corresponds to a resource advertised by the API server's
+// discovery endpoint. This handles aggregated APIs like
+// subresources.kubevirt.io that only expose subresource entries with empty
+// Kind, which prevents the REST mapper from building GVR→GVK mappings.
+//
+// When subresource is non-empty, the method requires an exact match for the
+// "resource/subresource" entry. When subresource is empty, any discovery entry
+// that matches the resource name (either as a top-level resource or as a parent
+// prefix of a subresource entry) is accepted.
+func (rt *AccessControlRoundTripper) resourceExistsInDiscovery(gvr schema.GroupVersionResource, subresource string) bool {
+	if rt.discoveryProvider == nil {
+		return false
+	}
+	disc := rt.discoveryProvider()
+	if disc == nil {
+		return false
+	}
+	groupVersion := gvr.Group + "/" + gvr.Version
+	if gvr.Group == "" {
+		groupVersion = gvr.Version
+	}
+	resources, err := disc.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil || resources == nil {
+		return false
+	}
+	// When a subresource is specified, look for an exact
+	// "resource/subresource" entry (e.g. "virtualmachineinstances/pause").
+	if subresource != "" {
+		fullName := gvr.Resource + "/" + subresource
+		for _, r := range resources.APIResources {
+			if r.Name == fullName {
+				return true
+			}
+		}
+		return false
+	}
+	// No subresource — match the resource as a top-level resource or as a
+	// parent of any subresource entry.
+	for _, r := range resources.APIResources {
+		if r.Name == gvr.Resource || strings.HasPrefix(r.Name, gvr.Resource+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func parseURLToGVR(path string) (gvr schema.GroupVersionResource, ok bool) {
@@ -249,6 +333,20 @@ func parseURLToNamespaceAndName(path string) (namespace, name string) {
 	}
 
 	return namespace, name
+}
+
+// parseSubresource extracts the subresource segment from a Kubernetes API path.
+// For example, given /apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/pause
+// it returns "pause". Returns "" if the path has no subresource segment.
+func parseSubresource(path string) string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	resourceIdx := findResourceTypeIndex(parts)
+	// A subresource exists when the path has segments beyond
+	// resource type (resourceIdx) + resource name (resourceIdx+1).
+	if resourceIdx >= 0 && resourceIdx+2 < len(parts) {
+		return parts[resourceIdx+2]
+	}
+	return ""
 }
 
 func findResourceTypeIndex(parts []string) int {

--- a/pkg/kubernetes/accesscontrol_round_tripper.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	authv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
@@ -24,7 +26,7 @@ type AccessControlRoundTripper struct {
 	delegate                http.RoundTripper
 	deniedResourcesProvider api.DeniedResourcesProvider
 	restMapperProvider      func() meta.RESTMapper
-	discoveryProvider       func() discovery.DiscoveryInterface
+	rawDiscovery            *rawDiscoveryCache
 	apiPathPrefix           string
 	validators              []api.HTTPValidator
 }
@@ -36,6 +38,7 @@ type AccessControlRoundTripperConfig struct {
 	RestMapperProvider        func() meta.RESTMapper
 	HostURL                   string
 	DiscoveryProvider         func() discovery.DiscoveryInterface
+	RawDiscoveryProvider      func() discovery.DiscoveryInterface
 	AuthClientProvider        func() authv1client.AuthorizationV1Interface
 	ValidationEnabled         bool
 	ConfirmationRulesProvider api.ConfirmationRulesProvider
@@ -55,11 +58,17 @@ func NewAccessControlRoundTripper(ctx context.Context, cfg AccessControlRoundTri
 			apiPathPrefix = hostURL.Path
 		}
 	}
+	var rawDisc *rawDiscoveryCache
+	if cfg.RawDiscoveryProvider != nil {
+		if disc := cfg.RawDiscoveryProvider(); disc != nil {
+			rawDisc = newRawDiscoveryCache(disc)
+		}
+	}
 	rt := &AccessControlRoundTripper{
 		delegate:                cfg.Delegate,
 		deniedResourcesProvider: cfg.DeniedResourcesProvider,
 		restMapperProvider:      cfg.RestMapperProvider,
-		discoveryProvider:       cfg.DiscoveryProvider,
+		rawDiscovery:            rawDisc,
 		apiPathPrefix:           apiPathPrefix,
 	}
 
@@ -161,8 +170,8 @@ func (rt *AccessControlRoundTripper) getGVK(
 	gvk, err := restMapper.KindFor(gvr)
 	if err == nil {
 		return gvk, nil
-
 	}
+
 	if meta.IsNoMatchError(err) {
 		// Fallback: check if the group/version exists in discovery and
 		// contains the resource (or resource/subresource pair).
@@ -229,18 +238,14 @@ func (rt *AccessControlRoundTripper) isAllowed(
 // that matches the resource name (either as a top-level resource or as a parent
 // prefix of a subresource entry) is accepted.
 func (rt *AccessControlRoundTripper) resourceExistsInDiscovery(gvr schema.GroupVersionResource, subresource string) bool {
-	if rt.discoveryProvider == nil {
-		return false
-	}
-	disc := rt.discoveryProvider()
-	if disc == nil {
+	if rt.rawDiscovery == nil {
 		return false
 	}
 	groupVersion := gvr.Group + "/" + gvr.Version
 	if gvr.Group == "" {
 		groupVersion = gvr.Version
 	}
-	resources, err := disc.ServerResourcesForGroupVersion(groupVersion)
+	resources, err := rt.rawDiscovery.ServerResourcesForGroupVersion(groupVersion)
 	if err != nil || resources == nil {
 		return false
 	}
@@ -405,4 +410,47 @@ func isCollectionPath(path string) bool {
 		return false
 	}
 	return resourceIdx == len(parts)-1
+}
+
+// rawDiscoveryCache caches per-group/version resource lists fetched from the
+// raw (non-aggregated) discovery endpoint. This is needed because the
+// aggregated discovery API filters out resources with empty Kind (e.g.
+// subresources.kubevirt.io), causing the memory-cached discovery client to
+// return empty results for those groups.
+//
+// Only successful lookups are cached. Errors (e.g. group not found) are not
+// cached so that newly installed API groups are discovered on the next request.
+// Cached entries are held indefinitely — if an API group is later removed, the
+// API server will reject the request regardless.
+type rawDiscoveryCache struct {
+	delegate discovery.DiscoveryInterface
+
+	mu    sync.RWMutex
+	cache map[string]*metav1.APIResourceList
+}
+
+func newRawDiscoveryCache(delegate discovery.DiscoveryInterface) *rawDiscoveryCache {
+	return &rawDiscoveryCache{
+		delegate: delegate,
+		cache:    make(map[string]*metav1.APIResourceList),
+	}
+}
+
+func (c *rawDiscoveryCache) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	c.mu.RLock()
+	if rl, ok := c.cache[groupVersion]; ok {
+		c.mu.RUnlock()
+		return rl, nil
+	}
+	c.mu.RUnlock()
+
+	rl, err := c.delegate.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		return rl, err
+	}
+
+	c.mu.Lock()
+	c.cache[groupVersion] = rl
+	c.mu.Unlock()
+	return rl, nil
 }

--- a/pkg/kubernetes/accesscontrol_round_tripper_test.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper_test.go
@@ -542,9 +542,9 @@ func (s *SubresourceOnlyAPIGroupSuite) TestRoundTripForSubresourceOnlyAPIGroups(
 	}
 
 	rt := NewAccessControlRoundTripper(s.T().Context(), AccessControlRoundTripperConfig{
-		Delegate:           mockDelegate,
-		RestMapperProvider: func() meta.RESTMapper { return s.restMapper },
-		DiscoveryProvider:  func() discovery.DiscoveryInterface { return s.discoveryClient },
+		Delegate:             mockDelegate,
+		RestMapperProvider:   func() meta.RESTMapper { return s.restMapper },
+		RawDiscoveryProvider: func() discovery.DiscoveryInterface { return s.discoveryClient },
 	})
 
 	s.Run("subresource-only API group passes through for pause action", func() {
@@ -607,7 +607,7 @@ func (s *SubresourceOnlyAPIGroupSuite) TestRoundTripForSubresourceOnlyAPIGroups(
 			Delegate:                mockDelegate,
 			DeniedResourcesProvider: &mockDeniedResourcesProvider{resources: []api.GroupVersionKind{{Group: "subresources.kubevirt.io", Version: "v1"}}},
 			RestMapperProvider:      func() meta.RESTMapper { return s.restMapper },
-			DiscoveryProvider:       func() discovery.DiscoveryInterface { return s.discoveryClient },
+			RawDiscoveryProvider:    func() discovery.DiscoveryInterface { return s.discoveryClient },
 		})
 		req := httptest.NewRequest("PUT", "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/pause", nil)
 		resp, err := deniedRT.RoundTrip(req)

--- a/pkg/kubernetes/accesscontrol_round_tripper_test.go
+++ b/pkg/kubernetes/accesscontrol_round_tripper_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
@@ -34,6 +35,14 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	rec := httptest.NewRecorder()
 	m.onRequest(rec, req)
 	return rec.Result(), nil
+}
+
+type mockDeniedResourcesProvider struct {
+	resources []api.GroupVersionKind
+}
+
+func (m *mockDeniedResourcesProvider) GetDeniedResources() []api.GroupVersionKind {
+	return m.resources
 }
 
 type AccessControlRoundTripperTestSuite struct {
@@ -475,4 +484,140 @@ func TestAccessControlRoundTripper(t *testing.T) {
 
 func TestStripAPIPathPrefix(t *testing.T) {
 	suite.Run(t, new(StripAPIPathPrefixTestSuite))
+}
+
+// SubresourceOnlyAPIGroupSuite tests the AccessControlRoundTripper behavior
+// with API groups that only expose subresource entries (all with empty Kind).
+// This reproduces the problem where subresources.kubevirt.io/v1 is rejected
+// with RESOURCE_NOT_FOUND because the REST mapper cannot build GVR→GVK
+// mappings from entries that have no Kind set.
+type SubresourceOnlyAPIGroupSuite struct {
+	suite.Suite
+	mockServer       *test.MockServer
+	discoveryHandler *test.DiscoveryClientHandler
+	restMapper       *restmapper.DeferredDiscoveryRESTMapper
+	discoveryClient  discovery.DiscoveryInterface
+}
+
+func (s *SubresourceOnlyAPIGroupSuite) SetupTest() {
+	s.mockServer = test.NewMockServer()
+	// Register subresources.kubevirt.io/v1 with subresource-only entries.
+	// All entries have zero-value Kind ("") and nil Verbs — this matches
+	// what KubeVirt actually advertises for its subresource API group.
+	// The REST mapper will see these during discovery but cannot build
+	// GVR→GVK mappings, so KindFor() returns NoMatchError.
+	s.discoveryHandler = test.NewDiscoveryClientHandler(metav1.APIResourceList{
+		GroupVersion: "subresources.kubevirt.io/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "virtualmachineinstances/pause", Namespaced: true},
+			{Name: "virtualmachineinstances/unpause", Namespaced: true},
+			{Name: "virtualmachineinstances/guestosinfo", Namespaced: true},
+			{Name: "virtualmachineinstances/userlist", Namespaced: true},
+			{Name: "virtualmachineinstances/filesystemlist", Namespaced: true},
+			{Name: "virtualmachines/start", Namespaced: true},
+			{Name: "virtualmachines/stop", Namespaced: true},
+			{Name: "virtualmachines/restart", Namespaced: true},
+		},
+	})
+	s.mockServer.Handle(s.discoveryHandler)
+
+	clientSet, err := kubernetes.NewForConfig(s.mockServer.Config())
+	s.Require().NoError(err, "Expected no error creating clientset")
+
+	s.discoveryClient = clientSet.Discovery()
+	s.restMapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(s.discoveryClient))
+}
+
+func (s *SubresourceOnlyAPIGroupSuite) TearDownTest() {
+	s.mockServer.Close()
+}
+
+func (s *SubresourceOnlyAPIGroupSuite) TestRoundTripForSubresourceOnlyAPIGroups() {
+	delegateCalled := false
+	mockDelegate := &mockRoundTripper{
+		called: &delegateCalled,
+		onRequest: func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	}
+
+	rt := NewAccessControlRoundTripper(s.T().Context(), AccessControlRoundTripperConfig{
+		Delegate:           mockDelegate,
+		RestMapperProvider: func() meta.RESTMapper { return s.restMapper },
+		DiscoveryProvider:  func() discovery.DiscoveryInterface { return s.discoveryClient },
+	})
+
+	s.Run("subresource-only API group passes through for pause action", func() {
+		delegateCalled = false
+		req := httptest.NewRequest("PUT", "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/pause", nil)
+		resp, err := rt.RoundTrip(req)
+		s.NoError(err, "Expected request to subresources.kubevirt.io to pass through")
+		s.NotNil(resp)
+		s.True(delegateCalled, "Expected delegate to be called for subresource-only API group")
+	})
+
+	s.Run("subresource-only API group passes through for guest agent query", func() {
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/guestosinfo", nil)
+		resp, err := rt.RoundTrip(req)
+		s.NoError(err, "Expected request to subresources.kubevirt.io guest agent subresource to pass through")
+		s.NotNil(resp)
+		s.True(delegateCalled, "Expected delegate to be called for guest agent subresource")
+	})
+
+	s.Run("non-existent API group is still rejected", func() {
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/apis/totally.fake.io/v1/namespaces/default/things", nil)
+		resp, err := rt.RoundTrip(req)
+		s.Error(err, "Expected error for non-existent API group")
+		s.Nil(resp)
+		s.False(delegateCalled, "Expected delegate not to be called for non-existent API group")
+		var ve *api.ValidationError
+		s.ErrorAs(err, &ve)
+		s.Equal(api.ErrorCodeResourceNotFound, ve.Code)
+	})
+
+	s.Run("non-existent resource in discoverable group is still rejected", func() {
+		delegateCalled = false
+		req := httptest.NewRequest("GET", "/apis/subresources.kubevirt.io/v1/namespaces/default/totallynotreal/foo", nil)
+		resp, err := rt.RoundTrip(req)
+		s.Error(err, "Expected error for non-existent resource in discoverable group")
+		s.Nil(resp)
+		s.False(delegateCalled, "Expected delegate not to be called for non-existent resource in discoverable group")
+		var ve *api.ValidationError
+		s.ErrorAs(err, &ve)
+		s.Equal(api.ErrorCodeResourceNotFound, ve.Code)
+	})
+
+	s.Run("non-existent subresource on valid resource is still rejected", func() {
+		delegateCalled = false
+		req := httptest.NewRequest("PUT", "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/bogusaction", nil)
+		resp, err := rt.RoundTrip(req)
+		s.Error(err, "Expected error for non-existent subresource")
+		s.Nil(resp)
+		s.False(delegateCalled, "Expected delegate not to be called for non-existent subresource")
+		var ve *api.ValidationError
+		s.ErrorAs(err, &ve)
+		s.Equal(api.ErrorCodeResourceNotFound, ve.Code)
+	})
+
+	s.Run("denied group/version is blocked even for discoverable subresource-only API groups", func() {
+		delegateCalled = false
+		deniedRT := NewAccessControlRoundTripper(s.T().Context(), AccessControlRoundTripperConfig{
+			Delegate:                mockDelegate,
+			DeniedResourcesProvider: &mockDeniedResourcesProvider{resources: []api.GroupVersionKind{{Group: "subresources.kubevirt.io", Version: "v1"}}},
+			RestMapperProvider:      func() meta.RESTMapper { return s.restMapper },
+			DiscoveryProvider:       func() discovery.DiscoveryInterface { return s.discoveryClient },
+		})
+		req := httptest.NewRequest("PUT", "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/test-vm/pause", nil)
+		resp, err := deniedRT.RoundTrip(req)
+		s.Error(err, "Expected error for denied group/version in discovery fallback path")
+		s.Nil(resp)
+		s.False(delegateCalled, "Expected delegate not to be called for denied group/version")
+		s.Contains(err.Error(), "resource not allowed")
+	})
+}
+
+func TestSubresourceOnlyAPIGroup(t *testing.T) {
+	suite.Run(t, new(SubresourceOnlyAPIGroupSuite))
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -44,14 +44,15 @@ var ParameterCodec = runtime.NewParameterCodec(Scheme)
 // apiVersion and kinds are checked for allowed access
 type Kubernetes struct {
 	kubernetes.Interface
-	config          api.BaseConfig
-	clientCmdConfig clientcmd.ClientConfig
-	restConfig      *rest.Config
-	httpClient      *http.Client
-	restMapper      meta.ResettableRESTMapper
-	discoveryClient discovery.CachedDiscoveryInterface
-	dynamicClient   dynamic.Interface
-	metricsV1beta1  *metricsv1beta1.MetricsV1beta1Client
+	config             api.BaseConfig
+	clientCmdConfig    clientcmd.ClientConfig
+	restConfig         *rest.Config
+	httpClient         *http.Client
+	restMapper         meta.ResettableRESTMapper
+	discoveryClient    discovery.CachedDiscoveryInterface
+	rawDiscoveryClient discovery.DiscoveryInterface
+	dynamicClient      dynamic.Interface
+	metricsV1beta1     *metricsv1beta1.MetricsV1beta1Client
 }
 
 var _ api.KubernetesClient = (*Kubernetes)(nil)
@@ -78,6 +79,7 @@ func NewKubernetes(
 			RestMapperProvider:        func() meta.RESTMapper { return k.restMapper },
 			HostURL:                   k.restConfig.Host,
 			DiscoveryProvider:         func() discovery.DiscoveryInterface { return k.discoveryClient },
+			RawDiscoveryProvider:      func() discovery.DiscoveryInterface { return k.rawDiscoveryClient },
 			AuthClientProvider:        func() authv1client.AuthorizationV1Interface { return k.AuthorizationV1() },
 			ValidationEnabled:         baseConfig.IsValidationEnabled(),
 			ConfirmationRulesProvider: baseConfig,
@@ -101,6 +103,7 @@ func NewKubernetes(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discovery client: %w", err)
 	}
+	k.rawDiscoveryClient = discoveryClient
 	k.discoveryClient = memory.NewMemCacheClient(discoveryClient)
 	k.restMapper = restmapper.NewDeferredDiscoveryRESTMapper(k.discoveryClient)
 	k.Interface, err = kubernetes.NewForConfigAndClient(k.restConfig, k.httpClient)


### PR DESCRIPTION
This is another attempt at solving the root cause of #1308 

The problem there is that kubevirt subresources do not have a `Kind` field set, so the rest mapper errors when trying to find the matching GVK.

This moves to see if the resource can be matched through the discovery interface as a fallback. From the unit tests added, this seems to work for the kubevirt resources.

I also tested the raw go code against a cluster with kubevirt installed and was able to have the discovery client approach work to find kubevirt subresources