### PR TITLE
Option to run /metrics on a different port

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,7 +133,7 @@ The server will:
 
 ### Limitations
 
-- **Requires restart**: `kubeconfig` or cluster-related settings
+- **Requires restart**: `kubeconfig`, cluster-related settings, `port`, `bind_address`, `metrics_port`, `tls_cert`, `tls_key`
 - **Not available on Windows**: Restart the server to reload configuration
 
 ## Configuration Reference
@@ -145,7 +145,8 @@ The server will:
 | `log_level` | integer | `0` | Logging verbosity level (0-9). Higher values produce more verbose output. Similar to [kubectl logging levels](https://kubernetes.io/docs/reference/kubectl/quick-reference/#kubectl-output-verbosity-and-debugging). |
 | `log_file` | string | `""` | Path to a server log file. Required for logging in stdio mode (where stdout is reserved for the MCP protocol); replaces stdout logging in HTTP mode. The file is created if it does not exist and opened in append mode (`O_APPEND`, `0o600`). Use the special value `stderr` to route logs to stderr without opening a file. |
 | `port` | string | `""` | When set, starts the MCP server in HTTP mode (Streamable HTTP at `/mcp`) on the specified port. |
-| `bind_address` | string | `"0.0.0.0"` | Address to bind the HTTP server to. Set to `127.0.0.1` to restrict to localhost. A warning is logged when listening on all interfaces (`0.0.0.0` or `::`) without TLS or OAuth. |
+| `bind_address` | string | `"0.0.0.0"` | Address to bind the HTTP server to. Set to `127.0.0.1` to restrict to localhost. A warning is logged when listening on all interfaces (`0.0.0.0` or `::`) without TLS or OAuth, and when a separate metrics port is bound to all interfaces (the metrics server never uses TLS or OAuth). |
+| `metrics_port` | string | `""` | When set (in HTTP mode), starts a separate HTTP server on this port serving only `/metrics`, `/stats`, and `/healthz` endpoints. Useful for Kubernetes deployments with network policies to separate metrics scraping from MCP protocol access. The metrics server uses the same `bind_address` but does not use TLS or OAuth. A warning is logged if `bind_address` is all interfaces (`0.0.0.0` or `::`). |
 | `list_output` | string | `"table"` | Output format for resource list operations. Valid values: `yaml`, `table`. |
 | `stateless` | boolean | `false` | When `true`, disables tool and prompt change notifications. Useful for container deployments, load balancing, and serverless environments. |
 | `tls_cert` | string | `""` | Path to TLS certificate file for HTTPS. When set along with `tls_key`, the server serves HTTPS instead of HTTP. |
@@ -159,6 +160,7 @@ The server will:
 log_level = 2
 log_file = "/var/log/kubernetes-mcp-server.log"
 port = "8080"
+metrics_port = "9090"  # Separate port for metrics/stats (e.g. for network policy isolation)
 list_output = "yaml"
 stateless = true
 
@@ -763,6 +765,7 @@ The following options can be set via command-line arguments. CLI arguments overr
 |--------|-------------|
 | `--port` | Start in HTTP mode on the specified port |
 | `--bind-address` | Address to bind the HTTP server to (default: `0.0.0.0`) |
+| `--metrics-port` | Start a separate metrics server on the specified port (only valid with `--port`) |
 | `--log-level` | Logging verbosity (0-9) |
 | `--log-file` | Path to a server log file. Required for logging in stdio mode; replaces stdout logging in HTTP mode. Use `stderr` to log to the standard error stream. |
 | `--config` | Path to main TOML configuration file |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -44,6 +45,7 @@ type StaticConfig struct {
 	LogFile     string `toml:"log_file,omitempty"`
 	Port        string `toml:"port,omitempty"`
 	BindAddress string `toml:"bind_address,omitempty"`
+	MetricsPort string `toml:"metrics_port,omitempty"`
 	KubeConfig  string `toml:"kubeconfig,omitempty"`
 	ListOutput  string `toml:"list_output,omitempty"`
 	// Stateless configures the MCP server to operate in stateless mode.
@@ -565,6 +567,18 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 	}
 	if err := toolsets.Validate(c.Toolsets); err != nil {
 		return err
+	}
+	if c.MetricsPort != "" && c.Port == "" {
+		return fmt.Errorf("metrics_port requires port to be set (metrics port is only supported in HTTP mode)")
+	}
+	if c.MetricsPort != "" && c.MetricsPort == c.Port {
+		return fmt.Errorf("metrics_port must be different from port")
+	}
+	if c.MetricsPort != "" {
+		p, err := strconv.Atoi(c.MetricsPort)
+		if err != nil || p < 1 || p > 65535 {
+			return fmt.Errorf("metrics_port must be a valid port number (1-65535), got %q", c.MetricsPort)
+		}
 	}
 	if c.ClusterProviderStrategy != "" && len(c.providerStrategies) > 0 {
 		if !slices.Contains(c.providerStrategies, c.ClusterProviderStrategy) {

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -739,6 +739,51 @@ func (s *ValidateSuite) TestClusterAuthMode() {
 	})
 }
 
+func (s *ValidateSuite) TestMetricsPort() {
+	s.Run("metrics_port without port is rejected", func() {
+		cfg := s.validConfig()
+		cfg.MetricsPort = "9090"
+		cfg.Port = ""
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "metrics_port requires port")
+	})
+
+	s.Run("metrics_port same as port is rejected", func() {
+		cfg := s.validConfig()
+		cfg.Port = "8080"
+		cfg.MetricsPort = "8080"
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "metrics_port must be different from port")
+	})
+
+	s.Run("metrics_port with different port is accepted", func() {
+		cfg := s.validConfig()
+		cfg.Port = "8080"
+		cfg.MetricsPort = "9090"
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("metrics_port with non-numeric value is rejected", func() {
+		cfg := s.validConfig()
+		cfg.Port = "8080"
+		cfg.MetricsPort = "abc"
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "metrics_port must be a valid port number")
+	})
+
+	s.Run("metrics_port with out-of-range value is rejected", func() {
+		cfg := s.validConfig()
+		cfg.Port = "8080"
+		cfg.MetricsPort = "99999"
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "metrics_port must be a valid port number")
+	})
+}
+
 func TestValidate(t *testing.T) {
 	suite.Run(t, new(ValidateSuite))
 }

--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -57,14 +57,15 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger := klogutil.FromContext(r.Context())
-			// Skip auth for infrastructure endpoints (health, metrics) and well-known endpoints
-			if slices.Contains(infraPaths, r.URL.Path) || isWellKnownPath(r.URL.EscapedPath()) {
-				next.ServeHTTP(w, r)
-				return
-			}
 			// Load the latest config snapshot on every request so that
 			// SIGHUP-reloaded auth settings take effect immediately.
 			staticConfig := cfgState.Load()
+			// Skip auth for infrastructure endpoints (health, metrics) and well-known endpoints.
+			// When metrics are on a separate port, only /healthz is exempt on the main port.
+			if slices.Contains(infraPaths(staticConfig.MetricsPort != ""), r.URL.Path) || isWellKnownPath(r.URL.EscapedPath()) {
+				next.ServeHTTP(w, r)
+				return
+			}
 			if !staticConfig.RequireOAuth {
 				next.ServeHTTP(w, r)
 				return

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -51,9 +51,16 @@ const (
 )
 
 var (
-	// infraPaths contains infrastructure endpoints which should not have oauth applied
-	infraPaths = []string{healthEndpoint, metricsEndpoint, statsEndpoint}
+	infraPathsMetricsSeparate = []string{healthEndpoint}
+	infraPathsMetricsTogether = []string{healthEndpoint, metricsEndpoint, statsEndpoint}
 )
+
+func infraPaths(metricsOnSeparatePort bool) []string {
+	if metricsOnSeparatePort {
+		return infraPathsMetricsSeparate
+	}
+	return infraPathsMetricsTogether
+}
 
 // metricsMiddleware wraps an HTTP handler to record metrics for all requests
 func metricsMiddleware(next http.Handler, metrics *mcp.Server) http.Handler {
@@ -152,9 +159,30 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 	mux.HandleFunc(healthEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	mux.HandleFunc(statsEndpoint, statsHandler(mcpServer))
-	mux.Handle(metricsEndpoint, mcpServer.GetMetrics().PrometheusHandler())
 	mux.Handle("/.well-known/", WellKnownHandler(cfgState, oauthState))
+
+	metricsOnSeparatePort := staticConfig.MetricsPort != ""
+
+	if !metricsOnSeparatePort {
+		mux.HandleFunc(statsEndpoint, statsHandler(mcpServer))
+		mux.Handle(metricsEndpoint, mcpServer.GetMetrics().PrometheusHandler())
+	}
+
+	var metricsServer *http.Server
+	if metricsOnSeparatePort {
+		metricsMux := http.NewServeMux()
+		metricsMux.HandleFunc(healthEndpoint, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		metricsMux.HandleFunc(statsEndpoint, statsHandler(mcpServer))
+		metricsMux.Handle(metricsEndpoint, mcpServer.GetMetrics().PrometheusHandler())
+		metricsServer = &http.Server{
+			Addr:              net.JoinHostPort(staticConfig.BindAddress, staticConfig.MetricsPort),
+			Handler:           metricsMux,
+			ReadHeaderTimeout: staticConfig.HTTP.ReadHeaderTimeout.Duration(),
+			BaseContext:       func(_ net.Listener) context.Context { return ctx },
+		}
+	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -171,27 +199,44 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 	signal.Notify(sigHupChan, syscall.SIGHUP)
 	defer signal.Stop(sigHupChan)
 
-	if (staticConfig.BindAddress == "0.0.0.0" || staticConfig.BindAddress == "::") && staticConfig.TLSCert == "" && !staticConfig.RequireOAuth {
+	listeningOnAllInterfaces := staticConfig.BindAddress == "0.0.0.0" || staticConfig.BindAddress == "::"
+	if listeningOnAllInterfaces && staticConfig.TLSCert == "" && !staticConfig.RequireOAuth {
 		klogutil.LogWarn(logger,
 			"HTTP server is listening on all interfaces without TLS or authentication, "+
 				"consider setting bind_address to 127.0.0.1, enabling TLS, or enabling OAuth",
 			klogutil.Field("bind_address", staticConfig.BindAddress),
 		)
 	}
+	// The metrics server never uses TLS or OAuth, so the branch above is not
+	// sufficient: TLS/OAuth on the main server would otherwise suppress the
+	// warning while /metrics and /stats remain exposed on all interfaces.
+	if listeningOnAllInterfaces && metricsOnSeparatePort {
+		klogutil.LogWarn(logger,
+			"Metrics server is listening on all interfaces without TLS or authentication, "+
+				"exposing /metrics and /stats; TLS and OAuth on the main server do not apply. "+
+				"Consider setting bind_address to 127.0.0.1 or restricting access with a network policy",
+			klogutil.Field("bind_address", staticConfig.BindAddress),
+			klogutil.Field("metrics_port", staticConfig.MetricsPort),
+		)
+	}
 
-	serverErr := make(chan error, 1)
+	serverErr := make(chan error, 2)
 	go func() {
 		var err error
+		endpoints := "/mcp, /healthz, /stats, /metrics"
+		if metricsOnSeparatePort {
+			endpoints = "/mcp, /healthz"
+		}
 		if staticConfig.TLSCert != "" && staticConfig.TLSKey != "" {
 			logger.Info("HTTPS server starting",
 				"server.addr", httpServer.Addr,
-				"endpoints", "/mcp, /healthz, /stats, /metrics",
+				"endpoints", endpoints,
 			)
 			err = httpServer.ListenAndServeTLS(staticConfig.TLSCert, staticConfig.TLSKey)
 		} else {
 			logger.Info("HTTP server starting",
 				"server.addr", httpServer.Addr,
-				"endpoints", "/mcp, /healthz, /stats, /metrics",
+				"endpoints", endpoints,
 			)
 			err = httpServer.ListenAndServe()
 		}
@@ -200,6 +245,19 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 		}
 	}()
 
+	if metricsServer != nil {
+		go func() {
+			logger.Info("Metrics server starting",
+				"server.addr", metricsServer.Addr,
+				"endpoints", "/metrics, /stats, /healthz",
+			)
+			if err := metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				serverErr <- err
+			}
+		}()
+	}
+
+	var serveErr error
 	select {
 	case sig := <-sigChan:
 		logger.Info("Received signal, initiating graceful shutdown", "signal", sig.String())
@@ -208,7 +266,7 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 		logger.Info("Context cancelled, initiating graceful shutdown")
 	case err := <-serverErr:
 		logger.Error(err, "HTTP server error")
-		return err
+		serveErr = err
 	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -221,6 +279,12 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 		logger.Error(err, "HTTP server shutdown error")
 	}
 
+	if metricsServer != nil {
+		if err := metricsServer.Shutdown(shutdownCtx); err != nil {
+			logger.Error(err, "Metrics server shutdown error")
+		}
+	}
+
 	// Always attempt MCP server shutdown (flushes metrics) even if HTTP shutdown failed
 	if err := mcpServer.Shutdown(shutdownCtx); err != nil {
 		// Don't fail Run() for errors during shutdown
@@ -228,5 +292,5 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, cfgState *config.StaticCo
 	}
 
 	logger.Info("HTTP server shutdown complete")
-	return nil
+	return serveErr
 }

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -354,6 +354,66 @@ func TestBindAddress(t *testing.T) {
 			}
 		})
 	})
+	t.Run("warns when metrics_port is on 0.0.0.0 even with TLS", func(t *testing.T) {
+		metricsAddr, err := test.RandomPortAddress()
+		if err != nil {
+			t.Fatalf("Failed to find random port for metrics server: %v", err)
+		}
+		testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{
+			BindAddress: "0.0.0.0",
+			TLSCert:     "/dummy-cert.pem",
+			MetricsPort: strconv.Itoa(metricsAddr.Port),
+		}}, func(ctx *httpContext) {
+			ctx.StopServer()
+			_ = ctx.WaitForShutdown()
+			logStr := ctx.LogBuffer.String()
+			if !strings.Contains(logStr, "Metrics server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected warning about metrics server listening on all interfaces, got: %s", logStr)
+			}
+			if strings.Contains(logStr, "HTTP server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected no main-server warning when TLS cert is configured, got: %s", logStr)
+			}
+		})
+	})
+	t.Run("warns when metrics_port is on 0.0.0.0 even with OAuth", func(t *testing.T) {
+		metricsAddr, err := test.RandomPortAddress()
+		if err != nil {
+			t.Fatalf("Failed to find random port for metrics server: %v", err)
+		}
+		testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{
+			BindAddress:             "0.0.0.0",
+			RequireOAuth:            true,
+			ClusterProviderStrategy: api.ClusterProviderKubeConfig,
+			MetricsPort:             strconv.Itoa(metricsAddr.Port),
+		}}, func(ctx *httpContext) {
+			ctx.StopServer()
+			_ = ctx.WaitForShutdown()
+			logStr := ctx.LogBuffer.String()
+			if !strings.Contains(logStr, "Metrics server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected warning about metrics server listening on all interfaces, got: %s", logStr)
+			}
+			if strings.Contains(logStr, "HTTP server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected no main-server warning when OAuth is enabled, got: %s", logStr)
+			}
+		})
+	})
+	t.Run("no metrics warning when metrics_port is on 127.0.0.1", func(t *testing.T) {
+		metricsAddr, err := test.RandomPortAddress()
+		if err != nil {
+			t.Fatalf("Failed to find random port for metrics server: %v", err)
+		}
+		testCaseWithContext(t, &httpContext{StaticConfig: &config.StaticConfig{
+			BindAddress: "127.0.0.1",
+			MetricsPort: strconv.Itoa(metricsAddr.Port),
+		}}, func(ctx *httpContext) {
+			ctx.StopServer()
+			_ = ctx.WaitForShutdown()
+			logStr := ctx.LogBuffer.String()
+			if strings.Contains(logStr, "Metrics server is listening on all interfaces without TLS or authentication") {
+				t.Errorf("Expected no metrics warning for 127.0.0.1, got: %s", logStr)
+			}
+		})
+	})
 }
 
 func TestMiddlewareLogging(t *testing.T) {
@@ -383,6 +443,84 @@ func TestMiddlewareLogging(t *testing.T) {
 			}
 			if duration < 0 {
 				t.Errorf("Expected duration to be non-negative, got %v", duration)
+			}
+		})
+	})
+}
+
+func TestMetricsPort(t *testing.T) {
+	t.Run("metrics and stats served on separate port when metrics_port is set", func(t *testing.T) {
+		metricsAddr, err := test.RandomPortAddress()
+		if err != nil {
+			t.Fatalf("Failed to find random port for metrics server: %v", err)
+		}
+
+		testCaseWithContext(t, &httpContext{
+			StaticConfig: &config.StaticConfig{
+				MetricsPort:             strconv.Itoa(metricsAddr.Port),
+				ClusterProviderStrategy: api.ClusterProviderKubeConfig,
+			},
+		}, func(ctx *httpContext) {
+			if err := test.WaitForServer(metricsAddr); err != nil {
+				t.Fatalf("Metrics server did not start in time: %v", err)
+			}
+
+			assertEndpoint := func(addr, path string, wantStatus int) {
+				t.Helper()
+				resp, err := http.Get(fmt.Sprintf("http://%s%s", addr, path))
+				if err != nil {
+					t.Fatalf("Failed to get %s from %s: %v", path, addr, err)
+				}
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode != wantStatus {
+					t.Errorf("GET %s on %s: expected %d, got %d", path, addr, wantStatus, resp.StatusCode)
+				}
+			}
+
+			assertEndpoint(metricsAddr.String(), "/metrics", http.StatusOK)
+			assertEndpoint(metricsAddr.String(), "/stats", http.StatusOK)
+			assertEndpoint(metricsAddr.String(), "/healthz", http.StatusOK)
+			assertEndpoint(ctx.HttpAddress, "/metrics", http.StatusNotFound)
+			assertEndpoint(ctx.HttpAddress, "/stats", http.StatusNotFound)
+			assertEndpoint(ctx.HttpAddress, "/healthz", http.StatusOK)
+		})
+	})
+
+	t.Run("all endpoints on main port when metrics_port is not set", func(t *testing.T) {
+		testCase(t, func(ctx *httpContext) {
+			assertEndpoint := func(addr, path string, wantStatus int) {
+				t.Helper()
+				resp, err := http.Get(fmt.Sprintf("http://%s%s", addr, path))
+				if err != nil {
+					t.Fatalf("Failed to get %s from %s: %v", path, addr, err)
+				}
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode != wantStatus {
+					t.Errorf("GET %s on %s: expected %d, got %d", path, addr, wantStatus, resp.StatusCode)
+				}
+			}
+
+			assertEndpoint(ctx.HttpAddress, "/metrics", http.StatusOK)
+			assertEndpoint(ctx.HttpAddress, "/stats", http.StatusOK)
+		})
+	})
+
+	t.Run("graceful shutdown stops both servers", func(t *testing.T) {
+		metricsAddr, err := test.RandomPortAddress()
+		if err != nil {
+			t.Fatalf("Failed to find random port for metrics server: %v", err)
+		}
+
+		testCaseWithContext(t, &httpContext{
+			StaticConfig: &config.StaticConfig{
+				MetricsPort:             strconv.Itoa(metricsAddr.Port),
+				ClusterProviderStrategy: api.ClusterProviderKubeConfig,
+			},
+		}, func(ctx *httpContext) {
+			ctx.StopServer()
+			err := ctx.WaitForShutdown()
+			if err != nil {
+				t.Errorf("Expected graceful shutdown, but got error: %v", err)
 			}
 		})
 	})

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -70,6 +70,7 @@ const (
 	flagConfigDir            = "config-dir"
 	flagPort                 = "port"
 	flagBindAddress          = "bind-address"
+	flagMetricsPort          = "metrics-port"
 	flagKubeconfig           = "kubeconfig"
 	flagToolsets             = "toolsets"
 	flagListOutput           = "list-output"
@@ -95,6 +96,7 @@ type MCPServerOptions struct {
 	LogFile              string
 	Port                 string
 	BindAddress          string
+	MetricsPort          string
 	Kubeconfig           string
 	Toolsets             []string
 	ListOutput           string
@@ -171,6 +173,7 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&o.ConfigDir, flagConfigDir, o.ConfigDir, "Path to drop-in configuration directory (files loaded in lexical order). Defaults to "+config.DefaultDropInConfigDir+" relative to the config file if --config is set.")
 	cmd.Flags().StringVar(&o.Port, flagPort, o.Port, "Start a streamable HTTP server on the specified port (e.g. 8080)")
 	cmd.Flags().StringVar(&o.BindAddress, flagBindAddress, o.BindAddress, "Address to bind the HTTP server to (e.g. 127.0.0.1). Defaults to 0.0.0.0 (all interfaces)")
+	cmd.Flags().StringVar(&o.MetricsPort, flagMetricsPort, o.MetricsPort, "Start a separate metrics server on the specified port (e.g. 9090) serving /metrics, /stats, and /healthz endpoints. Only valid with --port.")
 	cmd.Flags().StringVar(&o.Kubeconfig, flagKubeconfig, o.Kubeconfig, "Path to the kubeconfig file to use for authentication")
 	cmd.Flags().StringSliceVar(&o.Toolsets, flagToolsets, o.Toolsets, "Comma-separated list of MCP toolsets to use (available toolsets: "+strings.Join(toolsets.ToolsetNames(), ", ")+"). Defaults to "+strings.Join(o.StaticConfig.Toolsets, ", ")+".")
 	cmd.Flags().StringVar(&o.ListOutput, flagListOutput, o.ListOutput, "Output format for resource list operations (one of: "+strings.Join(output.Names, ", ")+"). Defaults to "+o.StaticConfig.ListOutput+".")
@@ -259,6 +262,9 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 	if cmd.Flag(flagBindAddress).Changed {
 		m.StaticConfig.BindAddress = m.BindAddress
+	}
+	if cmd.Flag(flagMetricsPort).Changed {
+		m.StaticConfig.MetricsPort = m.MetricsPort
 	}
 	if cmd.Flag(flagKubeconfig).Changed {
 		m.StaticConfig.KubeConfig = m.Kubeconfig
@@ -440,6 +446,10 @@ func (m *MCPServerOptions) setupSIGHUPHandler(
 				continue
 			}
 
+			// MetricsPort is fixed at startup (TOML, then CLI if set).
+			// TODO: Similar logic for other non-reloadable config values.
+			pinMetricsPortOnReload(ctx, originalMetricsPort(m, cfgState), newConfig)
+
 			// Apply the new configuration to the MCP server first — if this fails,
 			// we skip the OAuth state and config state updates to avoid inconsistent state.
 			if err := mcpServer.ReloadConfiguration(ctx, newConfig); err != nil {
@@ -492,4 +502,35 @@ func (m *MCPServerOptions) setupSIGHUPHandler(
 		close(sigHupCh)
 		<-done // Wait for goroutine to finish
 	}
+}
+
+// originalMetricsPort returns the MetricsPort loaded at process start (TOML
+// then CLI). MCPServerOptions.StaticConfig is that snapshot and is never
+// replaced on reload; cfgState is the fallback for tests that omit it.
+func originalMetricsPort(m *MCPServerOptions, cfgState *config.StaticConfigState) string {
+	if m != nil && m.StaticConfig != nil {
+		return m.StaticConfig.MetricsPort
+	}
+	if cfgState != nil {
+		if current := cfgState.Load(); current != nil {
+			return current.MetricsPort
+		}
+	}
+	return ""
+}
+
+// pinMetricsPortOnReload keeps MetricsPort at its originally-loaded value.
+// The metrics HTTP listener is bound once at startup; a SIGHUP-changed
+// metrics_port cannot move it, but AuthorizationMiddleware reads MetricsPort
+// per request.
+func pinMetricsPortOnReload(ctx context.Context, original string, newConfig *config.StaticConfig) {
+	if newConfig == nil || newConfig.MetricsPort == original {
+		return
+	}
+	klogutil.LogWarn(klogutil.FromContext(ctx),
+		"Ignoring metrics_port change on config reload; the metrics listener is fixed at startup. Restart the process to apply a new metrics_port",
+		klogutil.Field("metrics_port", original),
+		klogutil.Field("ignored_metrics_port", newConfig.MetricsPort),
+	)
+	newConfig.MetricsPort = original
 }

--- a/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_sighup_test.go
@@ -68,6 +68,7 @@ type SIGHUPSuite struct {
 	dropInConfigDir string
 	server          *mcp.Server
 	stopSIGHUP      func()
+	cfgState        *config.StaticConfigState
 }
 
 func (s *SIGHUPSuite) SetupTest() {
@@ -100,8 +101,9 @@ func (s *SIGHUPSuite) InitServer(configPath, configDir string) *MCPServerOptions
 	s.Require().NoError(err)
 
 	opts := &MCPServerOptions{
-		ConfigPath: configPath,
-		ConfigDir:  configDir,
+		ConfigPath:   configPath,
+		ConfigDir:    configDir,
+		StaticConfig: cfg,
 		IOStreams: genericiooptions.IOStreams{
 			Out:    s.logBuffer,
 			ErrOut: s.logBuffer,
@@ -109,8 +111,8 @@ func (s *SIGHUPSuite) InitServer(configPath, configDir string) *MCPServerOptions
 	}
 	oauthState := oauth.NewState(&oauth.Snapshot{})
 
-	cfgState := config.NewStaticConfigState(cfg)
-	s.stopSIGHUP = opts.setupSIGHUPHandler(s.T().Context(), s.server, oauthState, cfgState)
+	s.cfgState = config.NewStaticConfigState(cfg)
+	s.stopSIGHUP = opts.setupSIGHUPHandler(s.T().Context(), s.server, oauthState, s.cfgState)
 	return opts
 }
 
@@ -249,6 +251,95 @@ func (s *SIGHUPSuite) TestSIGHUPWithConfigDirOnly() {
 	})
 }
 
+func (s *SIGHUPSuite) TestSIGHUPPreservesMetricsPort() {
+	configPath := filepath.Join(s.tempDir, "config.toml")
+	s.Require().NoError(os.WriteFile(configPath, []byte(`
+		port = "18080"
+		metrics_port = "9090"
+		toolsets = ["core", "config"]
+	`), 0o644))
+	_ = s.InitServer(configPath, "")
+
+	s.Run("metrics_port is set at startup", func() {
+		s.Equal("9090", s.cfgState.Load().MetricsPort)
+	})
+
+	s.Require().NoError(os.WriteFile(configPath, []byte(`
+		port = "18080"
+		metrics_port = "9090"
+		toolsets = ["core", "config", "helm"]
+	`), 0o644))
+	s.Require().NoError(syscall.Kill(syscall.Getpid(), syscall.SIGHUP))
+
+	s.Run("unchanged metrics_port reloads other fields without warning", func() {
+		s.Require().Eventually(func() bool {
+			return slices.Contains(s.server.GetEnabledTools(), "helm_list")
+		}, 2*time.Second, 50*time.Millisecond)
+		s.Equal("9090", s.cfgState.Load().MetricsPort)
+		s.NotContains(s.logBuffer.String(), "Ignoring metrics_port change on config reload")
+	})
+
+	s.Require().NoError(os.WriteFile(configPath, []byte(`
+		port = "18080"
+		metrics_port = "9091"
+		toolsets = ["core", "config", "helm"]
+	`), 0o644))
+	s.Require().NoError(syscall.Kill(syscall.Getpid(), syscall.SIGHUP))
+
+	s.Run("changed metrics_port is kept at the original value and warned", func() {
+		s.Require().Eventually(func() bool {
+			klog.Flush()
+			return strings.Contains(s.logBuffer.String(), "Ignoring metrics_port change on config reload")
+		}, 2*time.Second, 50*time.Millisecond)
+		s.Equal("9090", s.cfgState.Load().MetricsPort, "SIGHUP must not change MetricsPort used for OAuth skip paths")
+	})
+
+	s.logBuffer.Reset()
+	s.Require().NoError(os.WriteFile(configPath, []byte(`
+		port = "18080"
+		toolsets = ["core", "config", "helm"]
+	`), 0o644))
+	s.Require().NoError(syscall.Kill(syscall.Getpid(), syscall.SIGHUP))
+
+	s.Run("cleared metrics_port is kept at the original value and warned", func() {
+		s.Require().Eventually(func() bool {
+			klog.Flush()
+			return strings.Contains(s.logBuffer.String(), "Ignoring metrics_port change on config reload")
+		}, 2*time.Second, 50*time.Millisecond)
+		s.Equal("9090", s.cfgState.Load().MetricsPort)
+	})
+}
+
+func (s *SIGHUPSuite) TestSIGHUPPreservesCLIMetricsPort() {
+	configPath := filepath.Join(s.tempDir, "config.toml")
+	s.Require().NoError(os.WriteFile(configPath, []byte(`
+		port = "18080"
+		metrics_port = "9090"
+		toolsets = ["core", "config"]
+	`), 0o644))
+	opts := s.InitServer(configPath, "")
+	// Simulate --metrics-port winning over TOML at startup. StaticConfig is
+	// the same pointer stored in cfgState until the first successful reload.
+	opts.StaticConfig.MetricsPort = "9092"
+	s.Equal("9092", s.cfgState.Load().MetricsPort)
+
+	s.Require().NoError(os.WriteFile(configPath, []byte(`
+		port = "18080"
+		metrics_port = "9090"
+		toolsets = ["core", "config", "helm"]
+	`), 0o644))
+	s.Require().NoError(syscall.Kill(syscall.Getpid(), syscall.SIGHUP))
+
+	s.Run("CLI-overlaid metrics_port is kept when TOML would revert it", func() {
+		s.Require().Eventually(func() bool {
+			return slices.Contains(s.server.GetEnabledTools(), "helm_list")
+		}, 2*time.Second, 50*time.Millisecond)
+		s.Equal("9092", s.cfgState.Load().MetricsPort)
+		klog.Flush()
+		s.Contains(s.logBuffer.String(), "Ignoring metrics_port change on config reload")
+	})
+}
+
 func (s *SIGHUPSuite) TestSIGHUPReloadsPrompts() {
 	// Create initial config with one prompt
 	configPath := filepath.Join(s.tempDir, "config.toml")
@@ -345,7 +436,8 @@ func TestSIGHUPInvokesLogSinkReload(t *testing.T) {
 	t.Cleanup(mcpServer.Close)
 
 	opts := &MCPServerOptions{
-		ConfigPath: configPath,
+		ConfigPath:   configPath,
+		StaticConfig: cfg,
 		IOStreams: genericiooptions.IOStreams{
 			Out:    logBuffer,
 			ErrOut: logBuffer,

--- a/pkg/kubernetes-mcp-server/cmd/root_test.go
+++ b/pkg/kubernetes-mcp-server/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/textlogger"
 )
 
 func captureOutput(f func() error) (string, error) {
@@ -837,5 +839,62 @@ func TestTLSValidation(t *testing.T) {
 		err := rootCmd.Execute()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--tls-cert and --tls-key require --port to be set")
+	})
+}
+
+func TestOriginalMetricsPort(t *testing.T) {
+	t.Run("prefers StaticConfig over cfgState", func(t *testing.T) {
+		m := &MCPServerOptions{StaticConfig: &config.StaticConfig{MetricsPort: "9092"}}
+		state := config.NewStaticConfigState(&config.StaticConfig{MetricsPort: "9090"})
+		assert.Equal(t, "9092", originalMetricsPort(m, state))
+	})
+	t.Run("falls back to cfgState when StaticConfig is unset", func(t *testing.T) {
+		m := &MCPServerOptions{}
+		state := config.NewStaticConfigState(&config.StaticConfig{MetricsPort: "9090"})
+		assert.Equal(t, "9090", originalMetricsPort(m, state))
+	})
+	t.Run("empty when neither is set", func(t *testing.T) {
+		assert.Equal(t, "", originalMetricsPort(nil, nil))
+	})
+}
+
+func TestPinMetricsPortOnReload(t *testing.T) {
+	klogState := klog.CaptureState()
+	t.Cleanup(klogState.Restore)
+	buf := &bytes.Buffer{}
+	klog.SetLoggerWithOptions(textlogger.NewLogger(textlogger.NewConfig(textlogger.Output(buf))))
+	ctx := context.Background()
+
+	t.Run("unchanged value is a no-op", func(t *testing.T) {
+		buf.Reset()
+		cfg := &config.StaticConfig{MetricsPort: "9090"}
+		pinMetricsPortOnReload(ctx, "9090", cfg)
+		assert.Equal(t, "9090", cfg.MetricsPort)
+		assert.NotContains(t, buf.String(), "Ignoring metrics_port change on config reload")
+	})
+	t.Run("changed value is restored and warned", func(t *testing.T) {
+		buf.Reset()
+		cfg := &config.StaticConfig{MetricsPort: "9091"}
+		pinMetricsPortOnReload(ctx, "9090", cfg)
+		assert.Equal(t, "9090", cfg.MetricsPort)
+		assert.Contains(t, buf.String(), "Ignoring metrics_port change on config reload")
+		assert.Contains(t, buf.String(), "9091")
+	})
+	t.Run("cleared value is restored and warned", func(t *testing.T) {
+		buf.Reset()
+		cfg := &config.StaticConfig{MetricsPort: ""}
+		pinMetricsPortOnReload(ctx, "9090", cfg)
+		assert.Equal(t, "9090", cfg.MetricsPort)
+		assert.Contains(t, buf.String(), "Ignoring metrics_port change on config reload")
+	})
+	t.Run("newly set value is cleared back to original empty", func(t *testing.T) {
+		buf.Reset()
+		cfg := &config.StaticConfig{MetricsPort: "9090"}
+		pinMetricsPortOnReload(ctx, "", cfg)
+		assert.Equal(t, "", cfg.MetricsPort)
+		assert.Contains(t, buf.String(), "Ignoring metrics_port change on config reload")
+	})
+	t.Run("nil config is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() { pinMetricsPortOnReload(ctx, "9090", nil) })
 	})
 }


### PR DESCRIPTION
To facilitate simpler network policies, add an option `--metrics-port`/`metrics_port`, which may only be provided in http mode (i.e. with `--port`), which causes the `/metrics`, `/stats`, and a separate `/healthz` endpoint to run in a separate server on the specified port (which must differ from `--port`).

Note that this configuration setting is in the subset that *cannot* be reloaded via SIGHUP. A full restart is required.

Almost-Exclusively-Authored-By: claude

Closes: #1364