### PR TITLE
fix(nodes): fix file query paths and tailLines for nodes_log tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ In case multi-cluster support is enabled (default) and you have access to multip
 
 - **nodes_log** - Get logs from a Kubernetes node (kubelet, kube-proxy, or other system logs). This accesses node logs through the Kubernetes API proxy to the kubelet
   - `name` (`string`) **(required)** - Name of the node to get logs from
-  - `query` (`string`) **(required)** - query specifies services(s) or files from which to return logs (required). Example: "kubelet" to fetch kubelet logs, "/<log-file-name>" to fetch a specific log file from the node (e.g., "/var/log/kubelet.log" or "/var/log/kube-proxy.log")
+  - `query` (`string`) **(required)** - query specifies the service or file to fetch logs from. Service names (e.g. "kubelet", "kube-proxy") return service logs. File paths are relative to `/var/log` on the node (e.g. "/kubelet.log", not "/var/log/kubelet.log"). See https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#log-query
   - `tailLines` (`integer`) - Number of lines to retrieve from the end of the logs (Optional, 0 means all logs)
 
 - **nodes_stats_summary** - Get detailed resource usage statistics from a Kubernetes node via the kubelet's Summary API. Provides comprehensive metrics including CPU, memory, filesystem, and network usage at the node, pod, and container levels. On systems with cgroup v2 and kernel 4.20+, also includes PSI (Pressure Stall Information) metrics that show resource pressure for CPU, memory, and I/O. See https://kubernetes.io/docs/reference/instrumentation/understand-psi-metrics/ for details on PSI metrics

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,10 +15,11 @@ import (
 func (c *Core) NodesLog(ctx context.Context, name string, query string, tailLines int64) (string, error) {
 	// Use the node proxy API to access logs from the kubelet
 	// https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#log-query
-	// Common log paths:
-	// - /var/log/kubelet.log - kubelet logs
-	// - /var/log/kube-proxy.log - kube-proxy logs
-	// - /var/log/containers/ - container logs
+	// Query paths are relative to the kubelet's log directory (/var/log).
+	// The kubelet SecureJoin normalizes the query against that root, so:
+	//   - Service logs: use the service name (e.g. "kubelet", "kube-proxy")
+	//   - File logs:    use a path relative to /var/log (e.g. "/kubelet.log", not "/var/log/kubelet.log")
+	// See: https://github.com/kubernetes/kubernetes/blob/70d3cc9/pkg/kubelet/kubelet_server_journal.go#L231-L232
 
 	if _, err := c.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{}); err != nil {
 		return "", fmt.Errorf("failed to get node %s: %w", name, err)
@@ -27,8 +29,11 @@ func (c *Core) NodesLog(ctx context.Context, name string, query string, tailLine
 		Get().
 		AbsPath("api", "v1", "nodes", name, "proxy", "logs")
 	req.Param("query", query)
-	// Query parameters for tail
-	if tailLines > 0 {
+	// Only forward tailLines for service-style queries.
+	// The kubelet rejects options on file queries (see
+	// https://github.com/kubernetes/kubernetes/blob/70d3cc9/pkg/kubelet/kubelet_server_journal.go#L229-L230)
+	// because tailLines is only supported for service logs.
+	if tailLines > 0 && !strings.ContainsAny(query, `/\\`) {
 		req.Param("tailLines", fmt.Sprintf("%d", tailLines))
 	}
 

--- a/pkg/mcp/nodes_test.go
+++ b/pkg/mcp/nodes_test.go
@@ -53,7 +53,7 @@ func (s *NodesSuite) TestNodesLog() {
 			switch query {
 			case "/empty.log":
 				logContent = ""
-			case "/kubelet.log":
+			case "/kubelet.log", "kubelet":
 				logContent = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
 			default:
 				w.WriteHeader(http.StatusNotFound)
@@ -162,42 +162,44 @@ func (s *NodesSuite) TestNodesLog() {
 				"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 		})
 	})
-	for _, tailCase := range []interface{}{2, int64(2), float64(2)} {
+		for _, tailCase := range []interface{}{2, int64(2), float64(2)} {
+			s.Run("nodes_log(name=existing-node, query=kubelet, tailLines=2)", func() {
+				toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
+					"name":      "existing-node",
+					"query":     "kubelet",
+					"tailLines": tailCase,
+				})
+				s.Require().NotNil(toolResult, "toolResult should not be nil")
+				s.Run("no error", func() {
+					s.Falsef(toolResult.IsError, "call tool should succeed")
+					s.Nilf(err, "call tool should not return error object")
+				})
+				s.Run("returns tail log", func() {
+					expectedMessage := "Line 4\nLine 5\n"
+					s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
+						"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
+				})
+			})
+		}
+		// File queries should NOT forward tailLines to avoid kubelet 406 errors
 		s.Run("nodes_log(name=existing-node, query=/kubelet.log, tailLines=2)", func() {
 			toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
 				"name":      "existing-node",
 				"query":     "/kubelet.log",
-				"tailLines": tailCase,
+				"tailLines": 2,
 			})
 			s.Require().NotNil(toolResult, "toolResult should not be nil")
 			s.Run("no error", func() {
 				s.Falsef(toolResult.IsError, "call tool should succeed")
 				s.Nilf(err, "call tool should not return error object")
 			})
-			s.Run("returns tail log", func() {
-				expectedMessage := "Line 4\nLine 5\n"
-				s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
-					"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
-			})
-		})
-		s.Run("nodes_log(name=existing-node, query=/kubelet.log, tailLines=-1)", func() {
-			toolResult, err := s.CallTool("nodes_log", map[string]interface{}{
-				"name":  "existing-node",
-				"query": "/kubelet.log",
-				"tail":  -1,
-			})
-			s.Require().NotNil(toolResult, "toolResult should not be nil")
-			s.Run("no error", func() {
-				s.Falsef(toolResult.IsError, "call tool should succeed")
-				s.Nilf(err, "call tool should not return error object")
-			})
-			s.Run("returns full log", func() {
+			s.Run("returns full log (tailLines ignored for file queries)", func() {
+				// Since tailLines is not forwarded for file queries, we get the full log
 				expectedMessage := "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
 				s.Equalf(expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text,
 					"expected log content '%s', got %v", expectedMessage, toolResult.Content[0].(*mcp.TextContent).Text)
 			})
 		})
-	}
 }
 
 func (s *NodesSuite) TestNodesLogDenied() {


### PR DESCRIPTION
Fixes #1262

Two bugs in nodes_log:

**1. Double-prefix on file paths**
The docstring examples showed `/var/log/kubelet.log` but the kubelet SecureJoin normalizes the query against `/var/log`, so `/var/log/kubelet.log` resolves to `/var/log/var/log/kubelet.log` and returns 404. Correct form is the relative path `/kubelet.log`.

**2. tailLines forwarded on file queries**
The kubelet rejects options on file queries (validate() at https://github.com/kubernetes/kubernetes/blob/70d3cc9/pkg/kubelet/kubelet_server_journal.go#L229-L230). Our tool advertised `tailLines` with a default of 100, which caused a 406 on every file query. A caller must explicitly pass `tailLines: 0` for a file query to succeed.

## Fix

- Update comments/docs to use correct relative paths (e.g. `/kubelet.log` not `/var/log/kubelet.log`)
- Only forward `tailLines` for service-style queries (no `/` or `\` in query)
- Add test: service query `kubelet` with `tailLines=2` returns tail
- Add test: file query `/kubelet.log` with `tailLines=2` ignores tailLines and returns full log

## Verification

```bash
go test ./pkg/mcp/ -run TestNodes -v
# 69 passed
```