### PR TITLE
fix(jwt): mint fresh assertions every time

### DIFF
--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -17,9 +17,11 @@ type tokenExchangingProvider struct {
 	provider           Provider
 	baseConfigProvider func() api.BaseConfig
 	oauthState         *oauth.State
-	// stsConfig is cached and reused across calls so that assertion caching
-	// in TargetTokenExchangeConfig is effective. Rebuilt when the token URL or
-	// any STS/TLS config field changes after a reload.
+	// stsConfig is cached and reused across calls so the memoized HTTP client in
+	// TargetTokenExchangeConfig (and its keep-alive connections to the IdP) is
+	// reused. Rebuilt when the token URL or any STS/TLS config field changes after
+	// a reload. Client assertions themselves are never cached — a fresh, single-use
+	// jti is minted per exchange (see TargetTokenExchangeConfig.BuildAssertion).
 	stsConfig    *tokenexchange.TargetTokenExchangeConfig
 	stsConfigMu  sync.Mutex
 	stsConfigKey stsConfigCacheKey

--- a/pkg/tokenexchange/assertion.go
+++ b/pkg/tokenexchange/assertion.go
@@ -33,9 +33,6 @@ const (
 
 	// DefaultAssertionLifetime is the default validity period for assertions
 	DefaultAssertionLifetime = 5 * time.Minute
-
-	// AssertionRefreshMargin is how early to refresh before expiry
-	AssertionRefreshMargin = 30 * time.Second
 )
 
 // loadCertificateAndKey reads the certificate and private key from PEM files
@@ -151,6 +148,7 @@ func BuildClientAssertion(
 		Subject:   clientID,
 		Audience:  jwt.Audience{tokenURL},
 		ID:        uuid.New().String(),
+		IssuedAt:  jwt.NewNumericDate(now),
 		NotBefore: jwt.NewNumericDate(now),
 		Expiry:    jwt.NewNumericDate(expiry),
 	}
@@ -183,28 +181,20 @@ func BuildClientAssertion(
 	return signedJWT, expiry, nil
 }
 
-// GetOrBuildAssertion returns a cached assertion or builds a new one
-func (c *TargetTokenExchangeConfig) GetOrBuildAssertion(ctx context.Context) (string, error) {
-	c.assertionMutex.Lock()
-	defer c.assertionMutex.Unlock()
-
-	logger := klogutil.FromContext(ctx)
-
-	// Check if cached assertion is still valid (with margin)
-	if c.cachedAssertion != "" && time.Now().Add(AssertionRefreshMargin).Before(c.cachedAssertionExpiry) {
-		logger.V(4).Info("Using cached JWT client assertion",
-			"jwt.client_assertion.expires", c.cachedAssertionExpiry.Format(time.RFC3339),
-		)
-		return c.cachedAssertion, nil
-	}
-
-	logger.V(4).Info("Building new JWT client assertion",
+// BuildAssertion mints a fresh signed JWT client assertion for a single exchange.
+// A new assertion (with a unique jti) is generated on every call and never cached:
+// OIDC private_key_jwt requires the jti to be single-use, and strict providers
+// (e.g. Keycloak) reject a reused assertion with "Token reuse detected". Signing is
+// cheap relative to the token-exchange round trip it accompanies, so there is no
+// caching to trade correctness against.
+func (c *TargetTokenExchangeConfig) BuildAssertion(ctx context.Context) (string, error) {
+	klogutil.FromContext(ctx).V(4).Info("Building JWT client assertion",
 		"jwt.client_assertion.client_id", c.ClientID,
 		"jwt.client_assertion.token_url", c.TokenURL,
 		"jwt.client_assertion.cert_file", c.ClientCertFile,
 	)
 
-	assertion, expiry, err := BuildClientAssertion(
+	assertion, _, err := BuildClientAssertion(
 		ctx,
 		c.ClientID,
 		c.TokenURL,
@@ -215,9 +205,6 @@ func (c *TargetTokenExchangeConfig) GetOrBuildAssertion(ctx context.Context) (st
 	if err != nil {
 		return "", err
 	}
-
-	c.cachedAssertion = assertion
-	c.cachedAssertionExpiry = expiry
 
 	return assertion, nil
 }

--- a/pkg/tokenexchange/assertion_test.go
+++ b/pkg/tokenexchange/assertion_test.go
@@ -86,6 +86,11 @@ func (s *AssertionTestSuite) TestBuildClientAssertion() {
 		s.Equal(clientID, claims.Subject)
 		s.True(claims.Audience.Contains(tokenURL))
 		s.NotEmpty(claims.ID)
+		// iat must be present: strict validators (e.g. Keycloak's client-jwt
+		// authenticator) reject an assertion without it, since they cannot bound
+		// the token's age and refuse the expiry as "too far in the future".
+		s.Require().NotNil(claims.IssuedAt, "iat claim must be set")
+		s.InDelta(time.Now().Unix(), claims.IssuedAt.Time().Unix(), 5)
 	})
 
 	s.Run("includes x5t#S256 header", func() {
@@ -140,8 +145,8 @@ func (s *AssertionTestSuite) TestBuildClientAssertion() {
 	})
 }
 
-func (s *AssertionTestSuite) TestGetOrBuildAssertion() {
-	s.Run("caches assertion", func() {
+func (s *AssertionTestSuite) TestBuildAssertion() {
+	s.Run("mints a fresh assertion with a unique jti each call", func() {
 		cfg := &TargetTokenExchangeConfig{
 			TokenURL:       "https://token.url",
 			ClientID:       "test-client",
@@ -149,13 +154,26 @@ func (s *AssertionTestSuite) TestGetOrBuildAssertion() {
 			ClientKeyFile:  s.keyFile,
 		}
 
-		assertion1, err := cfg.GetOrBuildAssertion(s.T().Context())
+		assertion1, err := cfg.BuildAssertion(s.T().Context())
 		s.Require().NoError(err)
 
-		assertion2, err := cfg.GetOrBuildAssertion(s.T().Context())
+		assertion2, err := cfg.BuildAssertion(s.T().Context())
 		s.Require().NoError(err)
 
-		s.Equal(assertion1, assertion2, "should return cached assertion")
+		// Assertions must not be cached/reused: OIDC private_key_jwt requires a
+		// single-use jti, and strict providers (e.g. Keycloak) reject a reused
+		// assertion with "Token reuse detected".
+		s.NotEqual(assertion1, assertion2, "each call must mint a fresh assertion")
+
+		var claims1, claims2 jwt.Claims
+		token1, err := jwt.ParseSigned(assertion1, []jose.SignatureAlgorithm{jose.RS256})
+		s.Require().NoError(err)
+		s.Require().NoError(token1.UnsafeClaimsWithoutVerification(&claims1))
+		token2, err := jwt.ParseSigned(assertion2, []jose.SignatureAlgorithm{jose.RS256})
+		s.Require().NoError(err)
+		s.Require().NoError(token2.UnsafeClaimsWithoutVerification(&claims2))
+		s.NotEmpty(claims1.ID)
+		s.NotEqual(claims1.ID, claims2.ID, "jti must differ between assertions")
 	})
 
 	s.Run("returns error for missing files", func() {
@@ -166,7 +184,7 @@ func (s *AssertionTestSuite) TestGetOrBuildAssertion() {
 			ClientKeyFile:  "/nonexistent/key.pem",
 		}
 
-		_, err := cfg.GetOrBuildAssertion(s.T().Context())
+		_, err := cfg.BuildAssertion(s.T().Context())
 		s.Error(err)
 	})
 }

--- a/pkg/tokenexchange/config.go
+++ b/pkg/tokenexchange/config.go
@@ -80,12 +80,6 @@ type TargetTokenExchangeConfig struct {
 	clientTLSMinVersion string `toml:"-"`
 	// clientTLSCipherSuites tracks the TLS cipher suites used to build the cached client
 	clientTLSCipherSuites []string `toml:"-"`
-	// cachedAssertion stores the most recently generated JWT assertion
-	cachedAssertion string `toml:"-"`
-	// cachedAssertionExpiry is when the cached assertion expires
-	cachedAssertionExpiry time.Time `toml:"-"`
-	// assertionMutex protects assertion caching from race conditions
-	assertionMutex sync.Mutex `toml:"-"`
 	// clientMutex protects HTTP client creation from race conditions
 	clientMutex sync.Mutex `toml:"-"`
 

--- a/pkg/tokenexchange/exchanger.go
+++ b/pkg/tokenexchange/exchanger.go
@@ -64,7 +64,7 @@ func injectClientAuth(ctx context.Context, cfg *TargetTokenExchangeConfig, data 
 		credentials := cfg.ClientID + ":" + cfg.ClientSecret
 		header.Set(HeaderAuthorization, "Basic "+base64.StdEncoding.EncodeToString([]byte(credentials)))
 	case AuthStyleAssertion:
-		assertion, err := cfg.GetOrBuildAssertion(ctx)
+		assertion, err := cfg.BuildAssertion(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to build client assertion: %w", err)
 		}


### PR DESCRIPTION
Fix a correctness bug in JWT client assertions: remove the assertion
cache from TargetTokenExchangeConfig and mint a fresh assertion (with a
unique jti) on every token exchange. OIDC private_key_jwt requires
single-use jti values, and Keycloak rejects reused assertions with
"Token reuse detected". Also add the iat claim, which strict validators
require to bound token age. Rename GetOrBuildAssertion → BuildAssertion
to reflect the new semantics.