### PR TITLE
cleanup(http): remove unused code after sse removal

### DIFF
--- a/pkg/http/authorization.go
+++ b/pkg/http/authorization.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
-	internalk8s "github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/oauth"
 )
 
@@ -67,13 +66,6 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 			// SIGHUP-reloaded auth settings take effect immediately.
 			staticConfig := cfgState.Load()
 			if !staticConfig.RequireOAuth {
-				// Always extract the Authorization header so it can be forwarded
-				// to the cluster, even without OAuth validation.
-				if authHeader := r.Header.Get("Authorization"); authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") {
-					ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
-					next.ServeHTTP(w, r.WithContext(ctx))
-					return
-				}
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -113,8 +105,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 				skipJWTWarningOnce.Do(func() {
 					klogutil.LogWarn(logger, "Bearer token forwarded without local validation (skip_jwt_verification=true and no authorization_url) - the cluster is the sole authority")
 				})
-				ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
-				next.ServeHTTP(w, r.WithContext(ctx))
+				next.ServeHTTP(w, r)
 				return
 			}
 
@@ -166,10 +157,7 @@ func AuthorizationMiddleware(cfgState *config.StaticConfigState, oauthState *oau
 				return
 			}
 
-			// Store the validated Authorization header in context for MCP handlers
-			// so cluster passthrough and token exchange can read the bearer token.
-			ctx := context.WithValue(r.Context(), internalk8s.OAuthAuthorizationHeader, authHeader)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			next.ServeHTTP(w, r)
 		})
 	}
 }

--- a/pkg/http/http_mcp_test.go
+++ b/pkg/http/http_mcp_test.go
@@ -22,13 +22,15 @@ func (s *McpTransportSuite) TearDownTest() {
 	s.BaseHttpSuite.TearDownTest()
 }
 
-func (s *McpTransportSuite) TestSseTransportRemoved() {
+func (s *McpTransportSuite) TestSseEndpointsRemoved() {
 	s.StartServer()
 
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s/sse", s.StaticConfig.Port))
-	s.Require().NoError(err, "Expected GET /sse to complete")
-	defer func() { _ = resp.Body.Close() }()
-	s.Equal(http.StatusNotFound, resp.StatusCode, "SSE endpoint must not be served")
+	for _, path := range []string{"/sse", "/message"} {
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s%s", s.StaticConfig.Port, path))
+		s.Require().NoError(err, "Expected GET %s to complete", path)
+		_ = resp.Body.Close()
+		s.Equal(http.StatusNotFound, resp.StatusCode, "SSE endpoint %s must not be served", path)
+	}
 }
 
 func (s *McpTransportSuite) TestStreamableHttpTransport() {

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -169,7 +169,7 @@ func authHeaderPropagationMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
 			}
 		}
 
-		// If no auth header in RequestExtra, context may already have it from HTTP middleware.
+		// No auth header found; pass through unchanged (stdio transport or unauthenticated request).
 		return next(ctx, method, req)
 	}
 }


### PR DESCRIPTION
Removes unnecessary http auth header propagation to context, as the streamable http transport correctly propagates those on the context. 

Also adds a test case to verify `/messages` 404s as that is also an unused enpoint post SSE removal