### PR TITLE
feat(e2e): add MCP client connectivity smoke tests

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -1,0 +1,43 @@
+name: MCP Conformance Tests
+
+on:
+  pull_request:
+    branches: ['main']
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - '**/*.md'
+      - 'docs/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  conformance:
+    name: MCP Protocol Conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: '22'
+
+      - name: Run conformance tests
+        run: make conformance-test

--- a/build/conformance.mk
+++ b/build/conformance.mk
@@ -1,0 +1,63 @@
+# MCP protocol conformance tests
+# Runs the official MCP conformance suite (modelcontextprotocol/conformance)
+# against the server binary started locally with a fake kubeconfig.
+
+CONFORMANCE_PORT ?= 8085
+CONFORMANCE_BASELINE ?= test/conformance/conformance-baseline.yml
+CONFORMANCE_VERSION ?= 0.1.16
+CONFORMANCE_HEALTH_TIMEOUT ?= 30
+CONFORMANCE_HEALTH_INTERVAL ?= 1
+CONFORMANCE_SUITE ?=
+
+##@ Conformance
+
+.PHONY: conformance-test
+conformance-test: build ## Run MCP protocol conformance tests against a local server
+	@echo "Starting MCP server on port $(CONFORMANCE_PORT) for conformance testing..."
+	@mkdir -p _output
+	@printf '%s\n' \
+		'apiVersion: v1' \
+		'kind: Config' \
+		'clusters:' \
+		'- cluster:' \
+		'    server: https://127.0.0.1:6443' \
+		'  name: conformance' \
+		'contexts:' \
+		'- context:' \
+		'    cluster: conformance' \
+		'    user: conformance' \
+		'  name: conformance' \
+		'current-context: conformance' \
+		'users:' \
+		'- name: conformance' \
+		'  user:' \
+		'    token: fake-token' \
+		> _output/conformance-kubeconfig
+	@./$(BINARY_NAME) --port $(CONFORMANCE_PORT) --kubeconfig _output/conformance-kubeconfig & echo $$! > .conformance-server.pid
+	@echo "Waiting for server to be ready..."
+	@elapsed=0; \
+	while [ $$elapsed -lt $(CONFORMANCE_HEALTH_TIMEOUT) ]; do \
+		if curl -fsS http://localhost:$(CONFORMANCE_PORT)/healthz > /dev/null 2>&1; then \
+			echo "Server is ready"; \
+			break; \
+		fi; \
+		sleep $(CONFORMANCE_HEALTH_INTERVAL); \
+		elapsed=$$((elapsed + $(CONFORMANCE_HEALTH_INTERVAL))); \
+	done; \
+	if [ $$elapsed -ge $(CONFORMANCE_HEALTH_TIMEOUT) ]; then \
+		echo "ERROR: Server failed to start within $(CONFORMANCE_HEALTH_TIMEOUT)s"; \
+		kill $$(cat .conformance-server.pid) 2>/dev/null || true; \
+		rm -f .conformance-server.pid; \
+		exit 1; \
+	fi
+	@echo "Running MCP conformance tests..."
+	@rc=0; \
+	npx -y @modelcontextprotocol/conformance@$(CONFORMANCE_VERSION) server \
+		--url http://localhost:$(CONFORMANCE_PORT)/mcp \
+		--expected-failures $(CONFORMANCE_BASELINE) \
+		$(if $(CONFORMANCE_SUITE),--suite $(CONFORMANCE_SUITE)) \
+		|| rc=$$?; \
+	echo "Stopping server..."; \
+	kill $$(cat .conformance-server.pid) 2>/dev/null || true; \
+	rm -f .conformance-server.pid; \
+	exit $$rc

--- a/test/conformance/conformance-baseline.yml
+++ b/test/conformance/conformance-baseline.yml
@@ -1,0 +1,50 @@
+# MCP conformance test expected failures.
+# Scenarios listed here are known to fail and are excluded from CI regression detection.
+# Remove entries as features are implemented — stale entries cause CI failure.
+#
+# Format: list scenario names under the server: key.
+# Per-check baselining: "scenario:check-id" (no space after colon).
+# See: https://github.com/modelcontextprotocol/conformance
+server:
+  ## Not implemented — genuine feature gaps
+  # No completion handler exists in the server.
+  - completion-complete
+  # No resource subscription support.
+  - resources-subscribe
+  - resources-unsubscribe
+  # No tool emits progress notifications.
+  - tools-call-with-progress
+  # Sampling (createMessage) not implemented.
+  - tools-call-sampling
+
+  ## Fixture mismatch — conformance expects synthetic test tools/resources/prompts
+  ## (echo, error-trigger, image-returning, etc.) that a real Kubernetes MCP server
+  ## does not provide. The protocol wiring for these features works; it's the
+  ## specific fixture names/behaviors that are missing.
+
+  # Tool calls — no conformance-specific test tools (echo, image, audio, etc.)
+  - tools-call-simple-text
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-logging
+  - tools-call-error
+  - tools-call-elicitation
+
+  # Elicitation — fully implemented, but no tool triggers it for conformance.
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums
+
+  # Resources — capability advertised, infrastructure implemented, but no toolset
+  # registers any resources. resources-list passes (empty list is valid).
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+
+  # Prompts — server has real prompts (cluster-health-check), but they don't match
+  # the conformance suite's expected fixture names/arguments.
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image


### PR DESCRIPTION
Add the official MCP conformance suite (modelcontextprotocol/conformance) as a lightweight CI check that runs against a local server with a fake kubeconfig — no Minikube required. Baseline 22 expected failures (5 unimplemented features, 17 fixture mismatches).

xref: [OCPMCP-295](https://redhat.atlassian.net/browse/OCPMCP-295)