### PR TITLE
feat(auth): decouple the STS endpoint from authorization_url

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -551,6 +551,7 @@ Configure OAuth/OIDC authentication for HTTP mode deployments.
 | `sts_federated_token_file` | string | `""` | Path to a JWT file from an external identity provider, e.g., SPIRE JWT-SVID (for `federated` auth style). |
 | `sts_subject_token_type` | string | `"urn:ietf:params:oauth:token-type:access_token"` | `subject_token_type` form parameter for RFC 8693 token exchange. Override to `urn:ietf:params:oauth:token-type:jwt` for cross-realm flows. |
 | `sts_requested_token_type` | string | `"urn:ietf:params:oauth:token-type:access_token"` | `requested_token_type` form parameter for RFC 8693 token exchange. The parameter is OPTIONAL per RFC 8693 §2.1, which leaves the issued token type to the authorization server's discretion when unspecified; this server sends `access_token` when the key is unset. Override to `urn:ietf:params:oauth:token-type:jwt` when the STS must mint a fresh JWT rather than echo the subject token shape. |
+| `sts_token_url` | string | `""` | Explicit token endpoint for token exchange. When set, takes precedence over the endpoint discovered from the OIDC provider at `authorization_url`. Use this to point token exchange at a separate STS gateway, or to enable token exchange when no `authorization_url` is configured (e.g., with `skip_jwt_verification=true`). |
 | `cluster_auth_mode` | string | `""` | Cluster auth mode: `passthrough` (forward Authorization header when present, fall back to kubeconfig when absent) or `kubeconfig` (always use kubeconfig credentials). Defaults to `passthrough`. |
 | `certificate_authority` | string | `""` | Path to CA certificate for validating authorization server connections. |
 | `server_url` | string | `""` | Public URL of the MCP server (used for OAuth metadata). |
@@ -579,6 +580,23 @@ sts_auth_style = "assertion"
 sts_client_cert_file = "/path/to/client.crt"
 sts_client_key_file = "/path/to/client.key"
 sts_scopes = ["api://<DOWNSTREAM_API>/.default"]
+```
+
+**Example (separate STS gateway from user-token issuer):**
+
+`authorization_url` validates the user's bearer token; `sts_token_url` is the
+distinct gateway that mints the delegated cluster token. The two URLs may
+point at different hosts/realms.
+```toml
+require_oauth     = true
+authorization_url = "https://idp.example.com/realms/users"
+oauth_audience    = "kubernetes-mcp-server"
+
+token_exchange_strategy = "rfc8693"
+sts_token_url           = "https://sts-gateway.internal/oauth/token"
+sts_client_id           = "mcp-backend"
+sts_client_secret       = "your-client-secret"
+sts_audience            = "kubernetes-api"
 ```
 
 **Pure token passthrough (delegate validation to the cluster):**

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -75,6 +75,7 @@ type StsConfigProvider interface {
 	GetStsFederatedTokenFile() string
 	GetStsSubjectTokenType() string
 	GetStsRequestedTokenType() string
+	GetStsTokenURL() string
 }
 
 // CertificateAuthorityProvider provides access to the top-level certificate_authority

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,6 +120,13 @@ type StaticConfig struct {
 	// behaviour; some deployments require "urn:ietf:params:oauth:token-type:jwt" to
 	// signal the AS should mint a fresh JWT rather than echo the subject token type.
 	StsRequestedTokenType string `toml:"sts_requested_token_type,omitempty"`
+	// StsTokenURL is the explicit token endpoint for RFC 8693 / built-in STS exchange.
+	// When set, it takes precedence over the token endpoint discovered from the OIDC
+	// provider at authorization_url. This decouples the trust boundary for user-token
+	// validation (authorization_url) from the trust boundary for delegated-token issuance
+	// (the STS gateway), which is required for cross-realm deployments and for using
+	// token exchange together with skip_jwt_verification=true.
+	StsTokenURL string `toml:"sts_token_url,omitempty"`
 	// ClusterAuthMode determines how the MCP server authenticates to the cluster.
 	// Valid values: "passthrough" (forward Authorization header, with optional exchange), "kubeconfig" (use kubeconfig credentials).
 	// If empty, defaults to passthrough: forwards the token when present, falls back to kubeconfig when absent.
@@ -477,6 +484,10 @@ func (c *StaticConfig) GetStsRequestedTokenType() string {
 	return c.StsRequestedTokenType
 }
 
+func (c *StaticConfig) GetStsTokenURL() string {
+	return c.StsTokenURL
+}
+
 func (c *StaticConfig) GetCertificateAuthority() string {
 	return c.CertificateAuthority
 }
@@ -560,6 +571,7 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 	c.StsFederatedTokenFile = strings.TrimSpace(c.StsFederatedTokenFile)
 	c.StsSubjectTokenType = strings.TrimSpace(c.StsSubjectTokenType)
 	c.StsRequestedTokenType = strings.TrimSpace(c.StsRequestedTokenType)
+	c.StsTokenURL = strings.TrimSpace(c.StsTokenURL)
 	if output.FromString(c.ListOutput) == nil {
 		return fmt.Errorf("invalid output name: %s, valid names are: %s", c.ListOutput, strings.Join(output.Names, ", "))
 	}
@@ -586,6 +598,27 @@ func (c *StaticConfig) Validate(ctx context.Context) error {
 			klogutil.LogWarn(
 				klogutil.FromContext(ctx),
 				"authorization-url is using insecure scheme, this is not recommended production use",
+				klogutil.Field("url.scheme", "http"),
+			)
+		}
+	}
+	if c.StsTokenURL != "" {
+		u, err := url.Parse(c.StsTokenURL)
+		if err != nil {
+			return err
+		}
+		if u.Scheme != "https" && u.Scheme != "http" {
+			return fmt.Errorf("sts_token_url must use the http or https scheme, got %q", u.Scheme)
+		}
+		// url.Parse accepts scheme-only inputs such as "https://", which would
+		// otherwise surface as a confusing failure at exchange time.
+		if u.Host == "" {
+			return fmt.Errorf("sts_token_url must include a host")
+		}
+		if u.Scheme == "http" {
+			klogutil.LogWarn(
+				klogutil.FromContext(ctx),
+				"sts_token_url is using insecure scheme, this is not recommended for production use",
 				klogutil.Field("url.scheme", "http"),
 			)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1148,6 +1148,27 @@ func (s *ConfigSuite) TestStsTokenTypesParsing() {
 	})
 }
 
+func (s *ConfigSuite) TestStsTokenURLParsing() {
+	s.Run("explicit value is parsed and exposed via getter", func() {
+		configPath := s.writeConfig(`
+			sts_token_url = "https://sts-gateway.example.com/oauth/token"
+		`)
+		config, err := Read(s.T().Context(), configPath, "")
+		s.Require().NoError(err)
+		s.Require().NotNil(config)
+		s.Equal("https://sts-gateway.example.com/oauth/token", config.StsTokenURL)
+		s.Equal("https://sts-gateway.example.com/oauth/token", config.GetStsTokenURL())
+	})
+
+	s.Run("defaults to empty when omitted", func() {
+		configPath := s.writeConfig(``)
+		config, err := Read(s.T().Context(), configPath, "")
+		s.Require().NoError(err)
+		s.Require().NotNil(config)
+		s.Empty(config.StsTokenURL, "sts_token_url should default to empty (resolution falls back to OIDC discovery)")
+	})
+}
+
 func (s *ConfigSuite) TestConfirmationRulesDefaults() {
 	configPath := s.writeConfig(``)
 	config, err := Read(s.T().Context(), configPath, "")

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -553,6 +553,64 @@ func (s *ValidateSuite) TestStsTokenTypes() {
 	})
 }
 
+func (s *ValidateSuite) TestStsTokenURL() {
+	s.Run("empty is accepted (resolution falls back to OIDC discovery)", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = ""
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("https URL is accepted", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "https://sts-gateway.example.com/oauth/token"
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("http URL is accepted with warning", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "http://sts-gateway.example.com/oauth/token"
+		s.NoError(cfg.Validate(s.T().Context()))
+	})
+
+	s.Run("invalid scheme is rejected", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "ftp://sts-gateway.example.com/oauth/token"
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "sts_token_url must use the http or https scheme")
+	})
+
+	s.Run("scheme-only URL with no host is rejected", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "https://"
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "sts_token_url must include a host")
+	})
+
+	s.Run("path-only URL with no scheme is rejected", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "/oauth/token"
+		err := cfg.Validate(s.T().Context())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "sts_token_url must use the http or https scheme")
+	})
+
+	s.Run("whitespace-only is trimmed to empty", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "   "
+		s.NoError(cfg.Validate(s.T().Context()))
+		s.Equal("", cfg.StsTokenURL, "whitespace should be trimmed from sts_token_url")
+	})
+
+	s.Run("padded value is trimmed but preserved", func() {
+		cfg := s.validConfig()
+		cfg.StsTokenURL = "  https://sts-gateway.example.com/oauth/token  "
+		s.NoError(cfg.Validate(s.T().Context()))
+		s.Equal("https://sts-gateway.example.com/oauth/token", cfg.StsTokenURL)
+	})
+}
+
 func (s *ValidateSuite) TestConfirmationFallback() {
 	s.Run("empty fallback is accepted", func() {
 		cfg := s.validConfig()

--- a/pkg/http/authorization_mcp_test.go
+++ b/pkg/http/authorization_mcp_test.go
@@ -445,6 +445,112 @@ func (s *AuthorizationSuite) TestAuthorizationOidcTokenExchange() {
 	s.stopRunningServer()
 }
 
+// TestAuthorizationStsTokenURLDecouplesIssuerFromGateway is the integration
+// test that proves the trust boundary actually splits on the wire when
+// sts_token_url points at a different host than authorization_url. The user's
+// JWT must be validated against the issuer (JWKS fetched from
+// authorization_url), but the exchange POST must hit the explicitly-configured
+// STS gateway — not the issuer's discovered token endpoint.
+//
+// Without sts_token_url support this configuration is impossible: the runtime
+// only knows about the issuer's discovered token endpoint, so validation and
+// exchange both end up at the same host.
+func (s *AuthorizationSuite) TestAuthorizationStsTokenURLDecouplesIssuerFromGateway() {
+	// Two independent OIDC test servers: one is the IDP that signs and validates
+	// the user's bearer token, the other is the standalone STS gateway that
+	// mints the exchanged backend token.
+	idp := NewOidcTestServer(s.T())
+	s.T().Cleanup(idp.Close)
+	stsGateway := NewOidcTestServer(s.T())
+	s.T().Cleanup(stsGateway.Close)
+
+	rawClaims := `{
+		"iss": "` + idp.URL + `",
+		"exp": ` + strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10) + `,
+		"aud": "%s"
+	}`
+	validUserToken := oidctest.SignIDToken(idp.PrivateKey, "test-oidc-key-id", oidc.RS256,
+		fmt.Sprintf(rawClaims, "mcp-server"))
+	validBackendToken := oidctest.SignIDToken(stsGateway.PrivateKey, "test-oidc-key-id", oidc.RS256,
+		fmt.Sprintf(rawClaims, "backend-audience"))
+
+	// Each server tracks whether its /token endpoint was hit. Only the gateway
+	// should see exchange traffic; if the IDP receives an exchange request, the
+	// decoupling failed.
+	var idpTokenHits atomic.Int32
+	idp.TokenEndpointHandler = func(w http.ResponseWriter, r *http.Request) {
+		idpTokenHits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"idp /token must not be hit when sts_token_url is set"}`))
+	}
+	var gatewayTokenHits atomic.Int32
+	stsGateway.TokenEndpointHandler = func(w http.ResponseWriter, r *http.Request) {
+		gatewayTokenHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"access_token":"%s","token_type":"Bearer","expires_in":253402297199}`, validBackendToken)
+	}
+
+	// Wire validation against the IDP, exchange against the gateway.
+	s.OidcProvider = idp.Provider
+	s.StaticConfig.AuthorizationURL = idp.URL
+	s.StaticConfig.OAuthAudience = "mcp-server"
+	s.StaticConfig.StsTokenURL = stsGateway.URL + "/token"
+	s.StaticConfig.TokenExchangeStrategy = "rfc8693"
+	s.StaticConfig.StsClientId = "test-sts-client-id"
+	s.StaticConfig.StsClientSecret = "test-sts-client-secret"
+	s.StaticConfig.StsAudience = "backend-audience"
+	s.StaticConfig.StsScopes = []string{"backend-scope"}
+
+	// Capture the Authorization header the MCP server sends to the cluster.
+	s.MockServer.ResetHandlers()
+	var backendAuth atomic.Value
+	s.MockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			backendAuth.Store(auth)
+		}
+	}))
+
+	s.StartServer()
+	s.StartClient(map[string]string{
+		"Authorization": "Bearer " + validUserToken,
+	})
+
+	s.Run("Initialize succeeds — IDP validates user token via JWKS", func() {
+		s.Require().NotNil(s.mcpClient.Session, "Expected session for successful authentication")
+		s.Require().NotNil(s.mcpClient.Session.InitializeResult(), "Expected initialize result to not be nil")
+	})
+
+	s.Run("Tool call triggers exchange against sts_token_url, not authorization_url", func() {
+		toolResult, err := s.mcpClient.Session.CallTool(s.T().Context(), &mcp.CallToolParams{
+			Name:      "events_list",
+			Arguments: map[string]any{},
+		})
+		s.Require().NoError(err, "Expected no error calling tool")
+		s.Require().NotNil(toolResult, "Expected tool result to not be nil")
+	})
+
+	s.Run("STS gateway received the exchange request", func() {
+		s.Greater(gatewayTokenHits.Load(), int32(0),
+			"sts_token_url gateway should have received at least one exchange POST")
+	})
+
+	s.Run("IDP /token endpoint was NOT used for exchange", func() {
+		s.Equal(int32(0), idpTokenHits.Load(),
+			"IDP /token must not be hit when sts_token_url is configured — that would mean the trust boundary did not split")
+	})
+
+	s.Run("Backend receives exchanged token, not original user token", func() {
+		got, _ := backendAuth.Load().(string)
+		s.Require().NotEmpty(got, "Expected backend to receive an Authorization header")
+		s.Equal("Bearer "+validBackendToken, got,
+			"Backend must receive the gateway-minted token; receiving the original user token would mean exchange silently no-op'd")
+	})
+
+	s.mcpClient.Close()
+	s.mcpClient = nil
+	s.stopRunningServer()
+}
+
 func (s *AuthorizationSuite) TestAuthorizationPassthroughWarning() {
 	// When require_oauth=true, skip_jwt_verification=true, and no OIDC provider
 	// is configured (passthrough mode), a warning log should be emitted once.

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -80,14 +80,9 @@ func (p *tokenExchangingProvider) getOrBuildStsConfig(ctx context.Context, snap 
 		return nil
 	}
 
-	var tokenURL string
-	if snap.OIDCProvider != nil {
-		if endpoint := snap.OIDCProvider.Endpoint(); endpoint.TokenURL != "" {
-			tokenURL = endpoint.TokenURL
-		}
-	}
+	tokenURL := resolveStsTokenURL(baseConfig, snap.OIDCProvider)
 	if tokenURL == "" {
-		klogutil.LogWarn(logger, "token exchange strategy configured but OIDC provider returned empty token URL",
+		klogutil.LogWarn(logger, "token exchange strategy configured but no token URL available (set sts_token_url or configure authorization_url for OIDC discovery)",
 			klogutil.Field("token_exchange.strategy", strategy),
 		)
 		return nil

--- a/pkg/kubernetes/sts.go
+++ b/pkg/kubernetes/sts.go
@@ -27,6 +27,9 @@ type SecurityTokenService struct {
 	ClientSecret            string
 	ExternalAccountAudience string
 	ExternalAccountScopes   []string
+	// TokenURL is the resolved STS endpoint: the explicit sts_token_url when
+	// configured, otherwise the discovered token endpoint of the OIDC provider.
+	TokenURL string
 }
 
 func NewFromConfig(stsConfigProvider api.StsConfigProvider, provider *oidc.Provider) *SecurityTokenService {
@@ -36,16 +39,17 @@ func NewFromConfig(stsConfigProvider api.StsConfigProvider, provider *oidc.Provi
 		ClientSecret:            stsConfigProvider.GetStsClientSecret(),
 		ExternalAccountAudience: stsConfigProvider.GetStsAudience(),
 		ExternalAccountScopes:   stsConfigProvider.GetStsScopes(),
+		TokenURL:                resolveStsTokenURL(stsConfigProvider, provider),
 	}
 }
 
 func (sts *SecurityTokenService) IsEnabled() bool {
-	return sts.Provider != nil && sts.ClientId != "" && sts.ExternalAccountAudience != ""
+	return sts.TokenURL != "" && sts.ClientId != "" && sts.ExternalAccountAudience != ""
 }
 
 func (sts *SecurityTokenService) ExternalAccountTokenExchange(ctx context.Context, originalToken *oauth2.Token) (*oauth2.Token, error) {
 	ts, err := externalaccount.NewTokenSource(ctx, externalaccount.Config{
-		TokenURL:             sts.Endpoint().TokenURL,
+		TokenURL:             sts.TokenURL,
 		ClientID:             sts.ClientId,
 		ClientSecret:         sts.ClientSecret,
 		Audience:             sts.ExternalAccountAudience,

--- a/pkg/kubernetes/sts_test.go
+++ b/pkg/kubernetes/sts_test.go
@@ -13,13 +13,14 @@ import (
 )
 
 func TestIsEnabled(t *testing.T) {
+	const tokenURL = "https://sts.example.com/token"
 	disabledCases := []SecurityTokenService{
 		{},
-		{Provider: nil},
-		{Provider: &oidc.Provider{}},
-		{Provider: &oidc.Provider{}, ClientId: "test-client-id", ClientSecret: "test-client-secret"},
+		{TokenURL: ""},
+		{TokenURL: tokenURL},
+		{TokenURL: tokenURL, ClientId: "test-client-id", ClientSecret: "test-client-secret"},
 		{ClientId: "test-client-id", ClientSecret: "test-client-secret", ExternalAccountAudience: "test-audience"},
-		{Provider: &oidc.Provider{}, ClientSecret: "test-client-secret", ExternalAccountAudience: "test-audience"},
+		{TokenURL: tokenURL, ClientSecret: "test-client-secret", ExternalAccountAudience: "test-audience"},
 	}
 	for _, sts := range disabledCases {
 		t.Run(fmt.Sprintf("SecurityTokenService{%+v}.IsEnabled() = false", sts), func(t *testing.T) {
@@ -29,9 +30,9 @@ func TestIsEnabled(t *testing.T) {
 		})
 	}
 	enabledCases := []SecurityTokenService{
-		{Provider: &oidc.Provider{}, ClientId: "test-client-id", ExternalAccountAudience: "test-audience"},
-		{Provider: &oidc.Provider{}, ClientId: "test-client-id", ExternalAccountAudience: "test-audience", ClientSecret: "test-client-secret"},
-		{Provider: &oidc.Provider{}, ClientId: "test-client-id", ExternalAccountAudience: "test-audience", ClientSecret: "test-client-secret", ExternalAccountScopes: []string{"test-scope"}},
+		{TokenURL: tokenURL, ClientId: "test-client-id", ExternalAccountAudience: "test-audience"},
+		{TokenURL: tokenURL, ClientId: "test-client-id", ExternalAccountAudience: "test-audience", ClientSecret: "test-client-secret"},
+		{TokenURL: tokenURL, ClientId: "test-client-id", ExternalAccountAudience: "test-audience", ClientSecret: "test-client-secret", ExternalAccountScopes: []string{"test-scope"}},
 	}
 	for _, sts := range enabledCases {
 		t.Run(fmt.Sprintf("SecurityTokenService{%+v}.IsEnabled() = true", sts), func(t *testing.T) {
@@ -74,7 +75,7 @@ func TestExternalAccountTokenExchange(t *testing.T) {
 		t.Fatalf("oidc.NewProvider() error = %v; want nil", err)
 	}
 	// With missing Token Source information
-	_, err = (&SecurityTokenService{Provider: provider}).ExternalAccountTokenExchange(t.Context(), &oauth2.Token{})
+	_, err = (&SecurityTokenService{Provider: provider, TokenURL: provider.Endpoint().TokenURL}).ExternalAccountTokenExchange(t.Context(), &oauth2.Token{})
 	t.Run("ExternalAccountTokenExchange with missing token source returns error", func(t *testing.T) {
 		if err == nil {
 			t.Fatalf("ExternalAccountTokenExchange() error = nil; want error")
@@ -86,6 +87,7 @@ func TestExternalAccountTokenExchange(t *testing.T) {
 	// With valid Token Source information
 	sts := SecurityTokenService{
 		Provider:                provider,
+		TokenURL:                provider.Endpoint().TokenURL,
 		ClientId:                "test-client-id",
 		ClientSecret:            "test-client-secret",
 		ExternalAccountAudience: "test-audience",

--- a/pkg/kubernetes/token_exchange.go
+++ b/pkg/kubernetes/token_exchange.go
@@ -14,6 +14,21 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
 )
 
+// resolveStsTokenURL returns the explicit sts_token_url if configured;
+// otherwise falls back to the OIDC provider's discovered token endpoint.
+// The explicit URL decouples the STS gateway from the user-token issuer
+// (authorization_url), which is required for cross-realm RFC 8693 deployments
+// and enables token exchange when skip_jwt_verification=true (no OIDC provider).
+func resolveStsTokenURL(stsConfig api.StsConfigProvider, oidcProvider *oidc.Provider) string {
+	if explicit := stsConfig.GetStsTokenURL(); explicit != "" {
+		return explicit
+	}
+	if oidcProvider != nil {
+		return oidcProvider.Endpoint().TokenURL
+	}
+	return ""
+}
+
 // ExchangeTokenInContext exchanges the OAuth token in the context for a token
 // that can access the target cluster. The optional stsConfig parameter allows
 // callers to reuse a TargetTokenExchangeConfig across calls to benefit from
@@ -153,15 +168,9 @@ func strategyBasedTokenExchange(
 
 	cfg := cachedConfig
 	if cfg == nil {
-		// Build token URL from OIDC provider
-		var tokenURL string
-		if oidcProvider != nil {
-			if endpoint := oidcProvider.Endpoint(); endpoint.TokenURL != "" {
-				tokenURL = endpoint.TokenURL
-			}
-		}
+		tokenURL := resolveStsTokenURL(baseConfig, oidcProvider)
 		if tokenURL == "" {
-			return ctx, fmt.Errorf("token exchange failed: no token URL available from OIDC provider")
+			return ctx, fmt.Errorf("token exchange failed: no token URL available (set sts_token_url or configure authorization_url for OIDC discovery)")
 		}
 
 		authStyle := baseConfig.GetStsAuthStyle()

--- a/pkg/kubernetes/token_exchange_test.go
+++ b/pkg/kubernetes/token_exchange_test.go
@@ -3,13 +3,16 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/config"
 	"github.com/containers/kubernetes-mcp-server/pkg/tokenexchange"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -181,6 +184,47 @@ func (s *TokenExchangeRoutingSuite) TestRequireTLS_BlocksExCfgTokenExchange() {
 		s.Require().NoError(err)
 		auth, _ := result.Value(OAuthAuthorizationHeader).(string)
 		s.Equal("Bearer exchanged-token", auth)
+	})
+}
+
+func (s *TokenExchangeRoutingSuite) TestResolveStsTokenURL() {
+	mockServer := test.NewMockServer()
+	authServer := mockServer.Config().Host
+	mockServer.Handle(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/.well-known/openid-configuration" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+				"issuer": "%s",
+				"authorization_endpoint": "%s/authorize",
+				"token_endpoint": "%s/token"
+			}`, authServer, authServer, authServer)
+		}
+	}))
+	s.T().Cleanup(mockServer.Close)
+	provider, err := oidc.NewProvider(s.T().Context(), authServer)
+	s.Require().NoError(err)
+	discoveredURL := provider.Endpoint().TokenURL
+	s.Require().NotEmpty(discoveredURL, "test prerequisite: OIDC discovery should yield a token endpoint")
+
+	s.Run("explicit sts_token_url wins over discovered endpoint", func() {
+		cfg := config.Default()
+		cfg.StsTokenURL = "https://explicit-sts.example.com/token"
+		got := resolveStsTokenURL(cfg, provider)
+		s.Equal("https://explicit-sts.example.com/token", got, "explicit URL must take precedence over OIDC discovery")
+	})
+
+	s.Run("falls back to OIDC provider endpoint when sts_token_url is empty", func() {
+		cfg := config.Default()
+		cfg.StsTokenURL = ""
+		got := resolveStsTokenURL(cfg, provider)
+		s.Equal(discoveredURL, got, "empty explicit URL should fall back to OIDC-discovered endpoint")
+	})
+
+	s.Run("returns empty when neither source is available", func() {
+		cfg := config.Default()
+		cfg.StsTokenURL = ""
+		got := resolveStsTokenURL(cfg, nil)
+		s.Equal("", got, "no explicit URL and no provider should yield empty string")
 	})
 }
 


### PR DESCRIPTION
## Summary

Second piece of #1181, split out so each change reviews independently — companion to #1378 (token types).

- The STS token endpoint could only ever be the OIDC-discovered endpoint from `authorization_url`. That breaks cross-realm setups, where the STS gateway is a different service than the IDP that issued the user's token, and it breaks token exchange entirely when `skip_jwt_verification=true` (no OIDC provider means nothing to discover an endpoint from).
- Add `sts_token_url` so the STS endpoint can be set explicitly. `resolveStsTokenURL` prefers it when set, falls back to OIDC discovery otherwise — same fallback upstream already relied on.
- `SecurityTokenService.IsEnabled()` now keys off `TokenURL != ""` instead of `Provider != nil` — the real question is "do I have an endpoint to POST to," not "did OIDC discovery succeed." This also means the plain passthrough (`externalaccount`) path now respects `sts_token_url` too, not just the `rfc8693`/`keycloak-v1`/`entra-obo` strategy path — relevant to the gap @theJC flagged on #1378.

## New TOML key

| Key | Default | Purpose |
|---|---|---|
| `sts_token_url` | *(falls back to OIDC discovery)* | Explicit STS/token-exchange endpoint |

## Notable behavior changes

None when unset — `resolveStsTokenURL` falls back to `oidcProvider.Endpoint().TokenURL`, which is exactly what both call sites did before.

- Validates `sts_token_url` as `http`/`https` with a host; rejects scheme-only inputs like `https://` that `url.Parse` would otherwise accept and let fail later with a confusing error at exchange time.
- Warns (doesn't reject) on `http`.
- New integration test spins up two separate OIDC servers to prove the exchange POST hits the gateway, not the issuer — `pkg/http/authorization_mcp_test.go`.

## Example: separate gateway from issuer

```toml
require_oauth     = true
authorization_url = "https://idp.example.com/realms/users"     # validates user JWT
oauth_audience    = "kubernetes-mcp-server"

token_exchange_strategy = "rfc8693"
sts_token_url           = "https://sts-gateway.internal/oauth/token" # mints cluster token
sts_client_id           = "mcp-backend"
sts_client_secret       = "..."
sts_audience            = "kubernetes-api"
```
