### PR TITLE
feat: add api_resources_list tool for CRD apiVersion discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ and only needed for the project-specific scenarios noted.
 | [Helm](https://helm.sh) | `helm` | 3 |
 | [Istio](https://istio.io) | `kiali` | 5 |
 | [Kiali](https://kiali.io) | `kiali` | 16 |
-| [Kubernetes](https://kubernetes.io) | - | 32 |
+| [Kubernetes](https://kubernetes.io) | - | 33 |
 | [KubeVirt](https://kubevirt.io) | `kubevirt`, `tekton` | 26 |
 | [NetObserv](https://netobserv.io) | `netobserv` | 4 |
 | [Tekton](https://tekton.dev) | `tekton` | 9 |
@@ -417,6 +417,9 @@ In case multi-cluster support is enabled (default) and you have access to multip
   - `name` (`string`) **(required)** - Name of the resource
   - `namespace` (`string`) - Optional Namespace to get/update the namespaced resource scale from (ignored in case of cluster scoped resources). If not provided, will get/update resource scale from configured namespace
   - `scale` (`integer`) - Optional scale to update the resources scale to. If not provided, will return the current scale of the resource, and not update it
+
+- **api_resources_list** - Look up the Kubernetes API resource type(s) matching a specific kind you already have in mind (apiVersion, plural resource name, whether namespaced), using the server's preferred version for each match -- the same data 'kubectl api-resources' shows for that kind. Use this to discover the correct apiVersion for a kind before calling resources_get, resources_list, resources_create_or_update, resources_delete, or resources_scale, especially for CRDs whose apiVersion isn't already known.
+  - `kind` (`string`) **(required)** - Required case-insensitive substring filter on kind (e.g. 'deployment', 'route'). Matches across every API group, so a broad term can match more than one kind (e.g. 'networkpolicy' also matches CiliumNetworkPolicy) -- use the most specific substring you can.
 
 </details>
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -144,7 +144,7 @@ setup is needed.
 A task is "judge-backed" when its verify phase has an `llmJudge` step —
 **including the legacy `verify: contains:` short form, which is judge-evaluated
 (semantic), not a literal string match.** Judge-backed task counts per suite:
-`helm` 0, `core` 4, `kubevirt` 4, `tekton` 5, `config` 3, `kiali` 18. Filter
+`helm` 0, `core` 5, `kubevirt` 4, `tekton` 5, `config` 3, `kiali` 18. Filter
 any config to one suite with `--label-selector suite=<name>`.
 
 ## Agent configuration

--- a/evals/tasks/core/discover-unknown-crd-status/cleanup.sh
+++ b/evals/tasks/core/discover-unknown-crd-status/cleanup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+kubectl delete widgetfleet prod-fleet -n default --ignore-not-found
+kubectl delete crd widgetfleets.mcpeval.example.com --ignore-not-found

--- a/evals/tasks/core/discover-unknown-crd-status/discover-unknown-crd-status.yaml
+++ b/evals/tasks/core/discover-unknown-crd-status/discover-unknown-crd-status.yaml
@@ -1,0 +1,19 @@
+kind: Task
+metadata:
+  labels:
+    suite: core
+    project: kubernetes
+  annotations:
+    project-name: "Kubernetes"
+    project-url: "https://kubernetes.io"
+  name: "discover-unknown-crd-status"
+  difficulty: easy
+steps:
+  setup:
+    file: setup.sh
+  verify:
+    contains: "provisioning-quasar-77123"
+  cleanup:
+    file: cleanup.sh
+  prompt:
+    inline: There's a custom resource named 'prod-fleet' in the 'default' namespace, of kind WidgetFleet. What phase is it currently in?

--- a/evals/tasks/core/discover-unknown-crd-status/setup.sh
+++ b/evals/tasks/core/discover-unknown-crd-status/setup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deleting the CRD (if it already exists from a prior run) cascades to any
+# WidgetFleet instances too, so there's no need to delete those separately --
+# and doing so would fail with "the server doesn't have a resource type" on
+# a first run, before the CRD (and thus the "widgetfleet" resource type)
+# exists at all.
+kubectl delete crd widgetfleets.mcpeval.example.com --ignore-not-found
+
+# A CRD the model cannot already know the apiVersion for from pretraining --
+# the point of this task is to prove discovery, not recall.
+cat <<EOF | kubectl apply -f -
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgetfleets.mcpeval.example.com
+spec:
+  group: mcpeval.example.com
+  names:
+    kind: WidgetFleet
+    listKind: WidgetFleetList
+    plural: widgetfleets
+    singular: widgetfleet
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+EOF
+
+kubectl wait --for=condition=Established crd/widgetfleets.mcpeval.example.com --timeout=30s
+
+# The sentinel value in spec.phase is checked for verbatim in the model's
+# final answer (see verify: contains). It only appears here, so the model
+# can only produce it by actually reading this object.
+cat <<EOF | kubectl apply -f -
+apiVersion: mcpeval.example.com/v1alpha1
+kind: WidgetFleet
+metadata:
+  name: prod-fleet
+  namespace: default
+spec:
+  phase: provisioning-quasar-77123
+EOF

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 
@@ -258,7 +259,22 @@ func (c *Core) APIResourcesList(kindFilter string) ([]APIResourceInfo, error) {
 func (c *Core) resourceFor(gvk *schema.GroupVersionKind) (*schema.GroupVersionResource, error) {
 	m, err := c.RESTMapper().RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
 	if err != nil {
-		return nil, err
+		if !meta.IsNoMatchError(err) {
+			return nil, err
+		}
+		// The RESTMapper builds and caches its full group/resource snapshot on
+		// first use and never refreshes it on its own -- resourcesCreateOrUpdate
+		// resets it, but only when a CustomResourceDefinition is applied
+		// through *this server's own* resources_create_or_update tool. A CRD
+		// installed any other way (kubectl, an operator, Helm, a different MCP
+		// client) after the mapper was already warmed left every other
+		// resource tool permanently unable to find it without a server
+		// restart. Reset once and retry so a fresh CRD resolves without one.
+		c.RESTMapper().Reset()
+		m, err = c.RESTMapper().RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &m.Resource, nil
 }

--- a/pkg/kubernetes/resources.go
+++ b/pkg/kubernetes/resources.go
@@ -205,6 +205,56 @@ func (c *Core) resourcesCreateOrUpdate(ctx context.Context, resources []*unstruc
 	return resources, nil
 }
 
+// APIResourceInfo describes one Kubernetes API resource type registered on
+// the cluster: its preferred apiVersion, kind, plural resource name, and
+// whether it's namespaced. Mirrors the fields `kubectl api-resources` shows.
+type APIResourceInfo struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	Namespaced bool   `json:"namespaced"`
+}
+
+// APIResourcesList returns the API resource types registered on the cluster,
+// using the server's preferred version for each kind -- the same data
+// `kubectl api-resources` shows. Unlike ResourcesList/ResourcesGet, callers
+// don't need to already know a kind's apiVersion; this is how they discover
+// it, including for CRDs the caller has no built-in knowledge of.
+//
+// When kindFilter is non-empty, only kinds whose name contains kindFilter
+// (case-insensitive) are returned; an empty kindFilter returns every
+// registered resource type. This function itself imposes no requirement on
+// kindFilter -- the api_resources_list tool handler is what makes it
+// mandatory, since an LLM caller dumping every API resource type on a
+// cluster with many CRDs into its own context is a token cost and a source
+// of confusion, not a useful default. ServerPreferredResources can return
+// partial results alongside a non-nil error (e.g. one API group temporarily
+// unavailable, or a large CRD catalog slowing discovery -- see
+// containers/kubernetes-mcp-server#283); this returns whatever resources
+// were discovered together with that error rather than discarding them, so
+// callers can decide whether partial results are still useful.
+func (c *Core) APIResourcesList(kindFilter string) ([]APIResourceInfo, error) {
+	lists, err := c.DiscoveryClient().ServerPreferredResources()
+	resources := make([]APIResourceInfo, 0, len(lists))
+	for _, list := range lists {
+		if list == nil {
+			continue
+		}
+		for _, r := range list.APIResources {
+			if kindFilter != "" && !strings.Contains(strings.ToLower(r.Kind), strings.ToLower(kindFilter)) {
+				continue
+			}
+			resources = append(resources, APIResourceInfo{
+				APIVersion: list.GroupVersion,
+				Kind:       r.Kind,
+				Name:       r.Name,
+				Namespaced: r.Namespaced,
+			})
+		}
+	}
+	return resources, err
+}
+
 func (c *Core) resourceFor(gvk *schema.GroupVersionKind) (*schema.GroupVersionResource, error) {
 	m, err := c.RESTMapper().RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
 	if err != nil {

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"regexp"
 	"strings"
@@ -1070,6 +1071,100 @@ func (s *ResourcesSuite) TestResourcesScaleDenied() {
 				"expected descriptive error '%s', got %v", expectedMessage, msg)
 		})
 	})
+}
+
+// apiResourceEntry and apiResourcesListToolResult mirror the JSON shape of
+// the api_resources_list tool's structured output. Defined locally (rather
+// than importing pkg/toolsets/core, whose result type is unexported anyway)
+// to keep this a black-box test of the tool's public wire contract, per
+// docs/dev/testing.md's "test the public API only" rule.
+type apiResourceEntry struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	Namespaced bool   `json:"namespaced"`
+}
+
+type apiResourcesListToolResult struct {
+	Resources []apiResourceEntry `json:"resources"`
+	Warning   string             `json:"warning,omitempty"`
+}
+
+func (s *ResourcesSuite) TestAPIResourcesList() {
+	s.InitMcpClient()
+	s.Run("api_resources_list without a kind filter returns an error", func() {
+		// kind is mandatory: an unfiltered call would dump every API resource
+		// type on the cluster (core kinds plus every CRD from every installed
+		// operator/service mesh) into the LLM's context, which is both a token
+		// cost and a source of confusion when the model already knows which
+		// kind it's after. Forcing a filter keeps this a targeted lookup.
+		toolResult, err := s.CallTool("api_resources_list", map[string]interface{}{})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Truef(toolResult.IsError, "expected an error when kind is omitted, got: %v", toolResult.Content)
+		s.Containsf(toolResult.Content[0].(*mcp.TextContent).Text, "kind",
+			"error message should mention the missing kind parameter, got: %v", toolResult.Content[0].(*mcp.TextContent).Text)
+	})
+	s.Run("api_resources_list with a kind filter returns known core and builtin kinds", func() {
+		s.Run("includes the core Pod resource with its apiVersion and namespaced flag", func() {
+			toolResult, err := s.CallTool("api_resources_list", map[string]interface{}{"kind": "pod"})
+			s.Nilf(err, "call tool failed %v", err)
+			s.Falsef(toolResult.IsError, "call tool failed: %v", toolResult.Content)
+
+			var decoded apiResourcesListToolResult
+			s.Require().NoError(json.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded))
+			pod := findAPIResourceByKind(decoded.Resources, "Pod")
+			s.Require().NotNil(pod, "expected a Pod entry in api_resources_list output")
+			s.Equal("v1", pod.APIVersion, "Pod's apiVersion should be v1")
+			s.Equal("pods", pod.Name, "Pod's plural resource name should be pods")
+			s.True(pod.Namespaced, "Pod should be reported as namespaced")
+		})
+		s.Run("includes the apps/v1 Deployment resource", func() {
+			toolResult, err := s.CallTool("api_resources_list", map[string]interface{}{"kind": "deployment"})
+			s.Nilf(err, "call tool failed %v", err)
+			s.Falsef(toolResult.IsError, "call tool failed: %v", toolResult.Content)
+
+			var decoded apiResourcesListToolResult
+			s.Require().NoError(json.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded))
+			deployment := findAPIResourceByKind(decoded.Resources, "Deployment")
+			s.Require().NotNil(deployment, "expected a Deployment entry in api_resources_list output")
+			s.Equal("apps/v1", deployment.APIVersion, "Deployment's apiVersion should be apps/v1")
+		})
+	})
+	s.Run("api_resources_list with kind filter narrows the results", func() {
+		toolResult, err := s.CallTool("api_resources_list", map[string]interface{}{"kind": "deployment"})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(toolResult.IsError, "call tool failed: %v", toolResult.Content)
+
+		var decoded apiResourcesListToolResult
+		s.Require().NoError(json.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded))
+		s.Run("only matching kinds are returned", func() {
+			for _, r := range decoded.Resources {
+				s.Containsf(strings.ToLower(r.Kind), "deployment",
+					"expected only kinds containing 'deployment', got %s", r.Kind)
+			}
+		})
+		s.Run("still finds the known Deployment kind", func() {
+			s.NotNilf(findAPIResourceByKind(decoded.Resources, "Deployment"), "expected filter to still match Deployment")
+		})
+	})
+	s.Run("api_resources_list with a filter matching nothing returns an empty list, not an error", func() {
+		toolResult, err := s.CallTool("api_resources_list", map[string]interface{}{"kind": "nonexistentkindxyz"})
+		s.Nilf(err, "call tool failed %v", err)
+		s.Falsef(toolResult.IsError, "call tool failed: %v", toolResult.Content)
+
+		var decoded apiResourcesListToolResult
+		s.Require().NoError(json.Unmarshal([]byte(toolResult.Content[0].(*mcp.TextContent).Text), &decoded))
+		s.Empty(decoded.Resources, "expected no resources to match a nonexistent kind filter")
+	})
+}
+
+func findAPIResourceByKind(resources []apiResourceEntry, kind string) *apiResourceEntry {
+	for _, r := range resources {
+		if r.Kind == kind {
+			return &r
+		}
+	}
+	return nil
 }
 
 func TestResources(t *testing.T) {

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/containers/kubernetes-mcp-server/internal/test"
 	"regexp"
@@ -14,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
+	apiextensionsapiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -608,6 +610,74 @@ func (s *ResourcesSuite) TestResourcesCreateOrUpdate() {
 			s.Falsef(hasStatus, "status should not be present on the persisted resource")
 		})
 	})
+}
+
+// TestResourcesGetSelfHealsStaleRESTMapperForExternallyCreatedCRD proves
+// resources_get succeeds for a CRD kind that was installed directly against
+// the cluster (kubectl, an operator, Helm -- anything other than this
+// server's own resources_create_or_update tool) after the RESTMapper had
+// already cached its group/resource snapshot. resourceFor's only existing
+// cache-invalidation path is resourcesCreateOrUpdate noticing a
+// CustomResourceDefinition apply through *this* tool; a CRD installed any
+// other way left resources_get/list/delete/scale permanently unable to find
+// it without a server restart, which api_resources_list (its own fresh,
+// uncached discovery.ServerPreferredResources() call) surfaced as a live
+// discrepancy: discovery reports the kind, but every "regular" resource tool
+// still can't resolve it.
+func (s *ResourcesSuite) TestResourcesGetSelfHealsStaleRESTMapperForExternallyCreatedCRD() {
+	s.InitMcpClient()
+
+	// Force the RESTMapper to build and cache its full group/resource
+	// snapshot now, before the CRD below exists -- DeferredDiscoveryRESTMapper
+	// fetches everything in one shot on first use, not per-GVK, so any
+	// resourceFor call is enough to reproduce the staleness.
+	warmupResult, err := s.CallTool("resources_get", map[string]interface{}{"apiVersion": "v1", "kind": "Namespace", "name": "default"})
+	s.Require().NoError(err)
+	s.Require().False(warmupResult.IsError, "warm-up call should succeed: %v", warmupResult.Content)
+
+	apiExtensionsV1Client := apiextensionsv1.NewForConfigOrDie(test.EnvTestRestConfig())
+	crd := &apiextensionsapiv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "freshwidgets.freshgroup.example.com"},
+		Spec: apiextensionsapiv1.CustomResourceDefinitionSpec{
+			Group: "freshgroup.example.com",
+			Names: apiextensionsapiv1.CustomResourceDefinitionNames{Plural: "freshwidgets", Singular: "freshwidget", Kind: "FreshWidget"},
+			Scope: apiextensionsapiv1.NamespaceScoped,
+			Versions: []apiextensionsapiv1.CustomResourceDefinitionVersion{{
+				Name: "v1", Served: true, Storage: true,
+				Schema: &apiextensionsapiv1.CustomResourceValidation{OpenAPIV3Schema: &apiextensionsapiv1.JSONSchemaProps{
+					Type:                   "object",
+					XPreserveUnknownFields: ptr.To(true),
+				}},
+			}},
+		},
+	}
+	_, err = apiExtensionsV1Client.CustomResourceDefinitions().Create(s.T().Context(), crd, metav1.CreateOptions{})
+	s.Require().NoError(err, "failed to create freshwidgets CRD directly against the cluster (bypassing resources_create_or_update)")
+	s.T().Cleanup(func() {
+		_ = apiExtensionsV1Client.CustomResourceDefinitions().Delete(context.Background(), crd.Name, metav1.DeleteOptions{})
+	})
+	s.Require().NoError(EnvTestWaitForAPIResourceCondition(s.T().Context(), "freshgroup.example.com", "v1", "freshwidgets", true))
+
+	dynamicClient := dynamic.NewForConfigOrDie(test.EnvTestRestConfig())
+	_, err = dynamicClient.Resource(schema.GroupVersionResource{Group: "freshgroup.example.com", Version: "v1", Resource: "freshwidgets"}).
+		Namespace("default").
+		Create(s.T().Context(), &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "freshgroup.example.com/v1",
+			"kind":       "FreshWidget",
+			"metadata":   map[string]interface{}{"name": "fresh-instance"},
+		}}, metav1.CreateOptions{})
+	s.Require().NoError(err, "failed to create the FreshWidget instance directly against the cluster")
+
+	toolResult, err := s.CallTool("resources_get", map[string]interface{}{
+		"apiVersion": "freshgroup.example.com/v1",
+		"kind":       "FreshWidget",
+		"namespace":  "default",
+		"name":       "fresh-instance",
+	})
+	s.Require().NoError(err)
+	s.Falsef(toolResult.IsError,
+		"resources_get must succeed for a CRD installed directly against the cluster after the RESTMapper's cache was already warmed -- "+
+			"got: %v", toolResult.Content)
 }
 
 func (s *ResourcesSuite) TestResourcesCreateOrUpdateForcesSSA() {

--- a/pkg/mcp/testdata/toolsets-core-tools.json
+++ b/pkg/mcp/testdata/toolsets-core-tools.json
@@ -2,6 +2,30 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "API Resources: List by Kind"
+    },
+    "description": "Look up the Kubernetes API resource type(s) matching a specific kind you already have in mind (apiVersion, plural resource name, whether namespaced), using the server's preferred version for each match -- the same data 'kubectl api-resources' shows for that kind. Use this to discover the correct apiVersion for a kind before calling resources_get, resources_list, resources_create_or_update, resources_delete, or resources_scale, especially for CRDs whose apiVersion isn't already known.",
+    "inputSchema": {
+      "properties": {
+        "kind": {
+          "description": "Required case-insensitive substring filter on kind (e.g. 'deployment', 'route'). Matches across every API group, so a broad term can match more than one kind (e.g. 'networkpolicy' also matches CiliumNetworkPolicy) -- use the most specific substring you can.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "name": "api_resources_list",
+    "title": "API Resources: List by Kind"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
       "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,

--- a/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-multicluster.json
@@ -3,6 +3,34 @@
     "annotations": {
       "destructiveHint": false,
       "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "API Resources: List by Kind"
+    },
+    "description": "Look up the Kubernetes API resource type(s) matching a specific kind you already have in mind (apiVersion, plural resource name, whether namespaced), using the server's preferred version for each match -- the same data 'kubectl api-resources' shows for that kind. Use this to discover the correct apiVersion for a kind before calling resources_get, resources_list, resources_create_or_update, resources_delete, or resources_scale, especially for CRDs whose apiVersion isn't already known.",
+    "inputSchema": {
+      "properties": {
+        "context": {
+          "description": "Optional parameter selecting which context to run the tool in. Defaults to fake-context if not set",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Required case-insensitive substring filter on kind (e.g. 'deployment', 'route'). Matches across every API group, so a broad term can match more than one kind (e.g. 'networkpolicy' also matches CiliumNetworkPolicy) -- use the most specific substring you can.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "name": "api_resources_list",
+    "title": "API Resources: List by Kind"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
       "openWorldHint": false,
       "readOnlyHint": true,
       "title": "Configuration: Contexts List"

--- a/pkg/mcp/testdata/toolsets-full-tools-openshift.json
+++ b/pkg/mcp/testdata/toolsets-full-tools-openshift.json
@@ -2,6 +2,30 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "API Resources: List by Kind"
+    },
+    "description": "Look up the Kubernetes API resource type(s) matching a specific kind you already have in mind (apiVersion, plural resource name, whether namespaced), using the server's preferred version for each match -- the same data 'kubectl api-resources' shows for that kind. Use this to discover the correct apiVersion for a kind before calling resources_get, resources_list, resources_create_or_update, resources_delete, or resources_scale, especially for CRDs whose apiVersion isn't already known.",
+    "inputSchema": {
+      "properties": {
+        "kind": {
+          "description": "Required case-insensitive substring filter on kind (e.g. 'deployment', 'route'). Matches across every API group, so a broad term can match more than one kind (e.g. 'networkpolicy' also matches CiliumNetworkPolicy) -- use the most specific substring you can.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "name": "api_resources_list",
+    "title": "API Resources: List by Kind"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
       "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,

--- a/pkg/mcp/testdata/toolsets-full-tools.json
+++ b/pkg/mcp/testdata/toolsets-full-tools.json
@@ -2,6 +2,30 @@
   {
     "annotations": {
       "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true,
+      "readOnlyHint": true,
+      "title": "API Resources: List by Kind"
+    },
+    "description": "Look up the Kubernetes API resource type(s) matching a specific kind you already have in mind (apiVersion, plural resource name, whether namespaced), using the server's preferred version for each match -- the same data 'kubectl api-resources' shows for that kind. Use this to discover the correct apiVersion for a kind before calling resources_get, resources_list, resources_create_or_update, resources_delete, or resources_scale, especially for CRDs whose apiVersion isn't already known.",
+    "inputSchema": {
+      "properties": {
+        "kind": {
+          "description": "Required case-insensitive substring filter on kind (e.g. 'deployment', 'route'). Matches across every API group, so a broad term can match more than one kind (e.g. 'networkpolicy' also matches CiliumNetworkPolicy) -- use the most specific substring you can.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "name": "api_resources_list",
+    "title": "API Resources: List by Kind"
+  },
+  {
+    "annotations": {
+      "destructiveHint": false,
       "idempotentHint": false,
       "openWorldHint": true,
       "readOnlyHint": true,

--- a/pkg/toolsets/core/resources.go
+++ b/pkg/toolsets/core/resources.go
@@ -195,7 +195,59 @@ func initResources(p api.FilteringProvider) []api.ServerTool {
 				OpenWorldHint:   ptr.To(true),
 			},
 		}, Handler: resourcesScale},
+		{Tool: api.Tool{
+			Name:        "api_resources_list",
+			Description: "Look up the Kubernetes API resource type(s) matching a specific kind you already have in mind (apiVersion, plural resource name, whether namespaced), using the server's preferred version for each match -- the same data 'kubectl api-resources' shows for that kind. Use this to discover the correct apiVersion for a kind before calling resources_get, resources_list, resources_create_or_update, resources_delete, or resources_scale, especially for CRDs whose apiVersion isn't already known.",
+			InputSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"kind": {
+						Type:        "string",
+						Description: "Required case-insensitive substring filter on kind (e.g. 'deployment', 'route'). Matches across every API group, so a broad term can match more than one kind (e.g. 'networkpolicy' also matches CiliumNetworkPolicy) -- use the most specific substring you can.",
+					},
+				},
+				Required: []string{"kind"},
+			},
+			Annotations: api.ToolAnnotations{
+				Title:           "API Resources: List by Kind",
+				ReadOnlyHint:    ptr.To(true),
+				DestructiveHint: ptr.To(false),
+				IdempotentHint:  ptr.To(true),
+				OpenWorldHint:   ptr.To(true),
+			},
+		}, Handler: apiResourcesList},
 	}
+}
+
+// apiResourcesListResult wraps APIResourceInfo in an object (rather than
+// returning a bare slice) per the MCP spec's requirement that
+// structuredContent be a JSON object, and carries a warning when discovery
+// returned partial results instead of silently dropping them.
+type apiResourcesListResult struct {
+	Resources []kubernetes.APIResourceInfo `json:"resources"`
+	Warning   string                       `json:"warning,omitempty"`
+}
+
+func apiResourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	kindFilter := p.RequiredString("kind")
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResultStructured(nil, fmt.Errorf("failed to list API resources: %w", err)), nil
+	}
+
+	resources, err := kubernetes.NewCore(params).APIResourcesList(kindFilter)
+	if err != nil && len(resources) == 0 {
+		return api.NewToolCallResultStructured(nil, fmt.Errorf("failed to list API resources: %w", err)), nil
+	}
+
+	result := apiResourcesListResult{Resources: resources}
+	if err != nil {
+		// Partial discovery failure (e.g. one API group unavailable): still
+		// return what was found instead of discarding it -- see
+		// kubernetes.Core.APIResourcesList's doc comment.
+		result.Warning = fmt.Sprintf("some API groups could not be queried and are omitted from this list: %v", err)
+	}
+	return api.NewToolCallResultStructured(result, nil), nil
 }
 
 func resourcesList(params api.ToolHandlerParams) (*api.ToolCallResult, error) {


### PR DESCRIPTION
An LLM working through this server to inspect a CRD instance has to supply `apiVersion` itself, and it usually doesn't have it. Unlike core kinds, a CRD's `apiVersion` depends entirely on which operator or product installed it. It isn't guessable from the kind name and it isn't something a model would know from training data. `kubectl` handles this transparently: `kubectl get widgetfleet prod-fleet` resolves the apiVersion for you via its own RESTMapper and API discovery. This server has no equivalent, so today it forces the caller to already know the one thing Kubernetes itself would need a discovery call to find out.

Concretely: `resources_get`, `resources_list`, `resources_create_or_update`, `resources_delete`, and `resources_scale` all require `apiVersion` up front. For a CRD the caller usually doesn't have it, so an LLM agent either guesses and gets "no matches for kind," or has no path forward at all.

This adds `api_resources_list(kind)`, backed by `discovery.ServerPreferredResources()`, the same data `kubectl api-resources` shows. `kind` is required, not optional: dumping every API resource type on a cluster with many CRDs installed wastes tokens and confuses a caller that already knows which kind it's after. A broad substring can still match more than one kind across groups (e.g. `networkpolicy` also matches `CiliumNetworkPolicy`), so the result is a list, not a single lookup.

Building the eval task for this (`evals/tasks/core/discover-unknown-crd-status`) turned up a second, pre-existing bug. `resourceFor`'s RESTMapper cache is built once and never refreshed, except when a CRD is applied through this server's own `resources_create_or_update`. A CRD installed any other way (`kubectl`, an operator, a different MCP client) after the mapper had already warmed left every other resource tool unable to find it until a server restart. So `api_resources_list` could report a kind that `resources_get` then failed to resolve. Fixed by resetting the RESTMapper and retrying once on a `NoMatchError`.

Testing:
- Unit/integration tests for `api_resources_list` (kind filter, no match, missing kind error) and for the RESTMapper self-heal path (CRD created directly against envtest, bypassing `resources_create_or_update`)
- `evals/tasks/core/discover-unknown-crd-status`: prompts for a CRD status field with no apiVersion given, verified against a sentinel value only present on the live object. Baseline (no tool) fails: it guesses an apiVersion, gets "no matches for kind," and asks the user instead of retrying. With the tool, 3/3 runs (Claude/haiku via ACP) call `api_resources_list` then `resources_get` and pass.