### PR TITLE
feat(kubevirt): add VM console screenshot tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ and only needed for the project-specific scenarios noted.
 | [Istio](https://istio.io) | `kiali` | 5 |
 | [Kiali](https://kiali.io) | `kiali` | 16 |
 | [Kubernetes](https://kubernetes.io) | - | 32 |
-| [KubeVirt](https://kubevirt.io) | `kubevirt`, `tekton` | 26 |
+| [KubeVirt](https://kubevirt.io) | `kubevirt`, `tekton` | 27 |
 | [NetObserv](https://netobserv.io) | `netobserv` | 4 |
 | [Tekton](https://tekton.dev) | `tekton` | 9 |
 
@@ -538,6 +538,11 @@ In case multi-cluster support is enabled (default) and you have access to multip
 <details>
 
 <summary>kubevirt</summary>
+
+- **vm_console_screenshot** - Capture a screenshot of a KubeVirt VirtualMachine's graphical (VNC) console as a PNG image. Use this to see what is currently displayed on the VM's screen (for example firmware, a bootloader, or a login prompt). Read-only: it never sends input to the guest.
+  - `name` (`string`) **(required)** - The name of the virtual machine
+  - `namespace` (`string`) **(required)** - The namespace of the virtual machine
+  - `wake_screen` (`boolean`) - Move the mouse cursor before capturing to wake a blanked screen. Defaults to false.
 
 - **vm_clone** - Clone a VirtualMachine on KubeVirt by creating a VirtualMachineClone resource. This creates a copy of the source VM with a new name using the KubeVirt Clone API
   - `name` (`string`) **(required)** - The name of the source virtual machine to clone

--- a/evals/tasks/kubevirt/vm-console-screenshot/task.yaml
+++ b/evals/tasks/kubevirt/vm-console-screenshot/task.yaml
@@ -1,0 +1,82 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  labels:
+    suite: kubevirt
+    project: kubevirt
+    requires: kubevirt
+  annotations:
+    project-name: "KubeVirt"
+    project-url: "https://kubevirt.io"
+  name: "vm-console-screenshot"
+  difficulty: easy
+spec:
+  requires:
+    - extension: kubernetes
+      as: k8s
+  setup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-console-screenshot
+        ignoreNotFound: true
+    - k8s.create:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-console-screenshot
+    - k8s.create:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-console-screenshot
+        spec:
+          runStrategy: Always
+          template:
+            spec:
+              domain:
+                devices:
+                  disks:
+                    - name: containerdisk
+                      disk:
+                        bus: virtio
+                memory:
+                  guest: 5Gi
+              terminationGracePeriodSeconds: 0
+              volumes:
+                - name: containerdisk
+                  containerDisk:
+                    image: quay.io/containerdisks/fedora:latest
+    - k8s.wait:
+        apiVersion: kubevirt.io/v1
+        kind: VirtualMachine
+        metadata:
+          name: test-vm
+          namespace: vm-test-console-screenshot
+        condition: Ready
+        timeout: 300s
+  verify:
+    - script:
+        inline: |-
+          #!/usr/bin/env bash
+          set -e
+          if ! kubectl get vm test-vm -n vm-test-console-screenshot &>/dev/null; then
+            echo "ERROR: VirtualMachine 'test-vm' not found"
+            exit 1
+          fi
+          echo "Verification passed: VM exists"
+          exit 0
+    - llmJudge:
+        contains: "successfully captured a screenshot image from the VM's graphical console and describes what is visible on it"
+  cleanup:
+    - k8s.delete:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: vm-test-console-screenshot
+        ignoreNotFound: true
+  prompt:
+    inline: |
+      Take a screenshot of the graphical console for the virtual machine "test-vm" in the vm-test-console-screenshot namespace, so I can see what's currently displayed on its screen.

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -9,6 +9,35 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 )
 
+// ToolContentType distinguishes text from image content blocks.
+type ToolContentType string
+
+const (
+	ToolContentTypeText  ToolContentType = "text"
+	ToolContentTypeImage ToolContentType = "image"
+)
+
+// ToolContent represents a single content block in a multi-content tool result.
+// Used by tools that return both text and images (e.g., vm_console_screenshot).
+type ToolContent struct {
+	Type     ToolContentType
+	Text     string
+	Data     []byte // for image content, a copy of the image bytes
+	MIMEType string // for image content, e.g. "image/png"
+}
+
+// NewTextToolContent creates a text content block.
+func NewTextToolContent(text string) *ToolContent {
+	return &ToolContent{Type: ToolContentTypeText, Text: text}
+}
+
+// NewImageToolContent creates an image content block, copying the byte slice for safety.
+func NewImageToolContent(data []byte, mimeType string) *ToolContent {
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+	return &ToolContent{Type: ToolContentTypeImage, Data: dataCopy, MIMEType: mimeType}
+}
+
 type ServerTool struct {
 	Tool               Tool
 	Handler            ToolHandlerFunc
@@ -69,6 +98,9 @@ type ToolCallResult struct {
 	// When set, it is passed as structuredContent in the MCP CallToolResult alongside Content.
 	// Must be completely omitted (nil) when not used.
 	StructuredContent any
+	// ContentBlocks are SDK-neutral content blocks (text and/or images) for multi-content tools.
+	// When non-empty, these are used instead of the legacy Content field.
+	ContentBlocks []*ToolContent
 	// Error (non-protocol) to send back to the LLM.
 	Error error
 }
@@ -77,6 +109,16 @@ type ToolCallResult struct {
 // Use this for tools that return human-readable text output.
 func NewToolCallResult(content string, err error) *ToolCallResult {
 	return NewToolCallResultFull(content, nil, err)
+}
+
+// NewToolCallResultWithContent creates a ToolCallResult with content blocks (text and/or images).
+// Use this for multi-content tools like vm_console_screenshot.
+func NewToolCallResultWithContent(blocks []*ToolContent, structured any, err error) *ToolCallResult {
+	return &ToolCallResult{
+		ContentBlocks:     blocks,
+		StructuredContent: structured,
+		Error:             err,
+	}
 }
 
 // NewToolCallResultFull creates a ToolCallResult with both human-readable text

--- a/pkg/api/toolsets_test.go
+++ b/pkg/api/toolsets_test.go
@@ -103,6 +103,57 @@ func (s *ToolsetsSuite) TestNewToolCallResultStructured() {
 	})
 }
 
+func (s *ToolsetsSuite) TestToolContent() {
+	s.Run("NewTextToolContent", func() {
+		content := NewTextToolContent("hello world")
+		s.Equal(ToolContentTypeText, content.Type)
+		s.Equal("hello world", content.Text)
+		s.Empty(content.Data)
+		s.Empty(content.MIMEType)
+	})
+	s.Run("NewImageToolContent copies bytes for safety", func() {
+		original := []byte{0x89, 0x50, 0x4e, 0x47}
+		content := NewImageToolContent(original, "image/png")
+		s.Equal(ToolContentTypeImage, content.Type)
+		s.Equal("image/png", content.MIMEType)
+		s.Equal(original, content.Data)
+		s.Empty(content.Text)
+
+		// Verify mutation safety: modifying original doesn't affect content
+		original[0] = 0xFF
+		s.NotEqual(0xFF, content.Data[0], "NewImageToolContent must copy bytes, not reference")
+	})
+}
+
+func (s *ToolsetsSuite) TestNewToolCallResultWithContent() {
+	s.Run("text-only content", func() {
+		blocks := []*ToolContent{NewTextToolContent("screenshot description")}
+		result := NewToolCallResultWithContent(blocks, nil, nil)
+		s.Len(result.ContentBlocks, 1)
+		s.Equal(blocks, result.ContentBlocks)
+		s.Nil(result.Error)
+		s.Nil(result.StructuredContent)
+	})
+	s.Run("text and image blocks", func() {
+		pngBytes := []byte{0x89, 0x50, 0x4e, 0x47}
+		blocks := []*ToolContent{
+			NewTextToolContent("The VM is showing a boot prompt"),
+			NewImageToolContent(pngBytes, "image/png"),
+		}
+		result := NewToolCallResultWithContent(blocks, nil, nil)
+		s.Len(result.ContentBlocks, 2)
+		s.Equal(ToolContentTypeText, result.ContentBlocks[0].Type)
+		s.Equal(ToolContentTypeImage, result.ContentBlocks[1].Type)
+	})
+	s.Run("preserves error", func() {
+		err := errors.New("graphics not available")
+		blocks := []*ToolContent{NewTextToolContent("error: graphics disabled")}
+		result := NewToolCallResultWithContent(blocks, nil, err)
+		s.Equal(err, result.Error)
+		s.Len(result.ContentBlocks, 1)
+	})
+}
+
 func (s *ToolsetsSuite) TestNewToolCallResultFull() {
 	s.Run("sets text, structured, and nil error", func() {
 		structured := []map[string]any{{"name": "pod-1"}}

--- a/pkg/kubevirt/console_client.go
+++ b/pkg/kubevirt/console_client.go
@@ -1,0 +1,44 @@
+package kubevirt
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+func getVMI(ctx context.Context, dynamicClient dynamic.Interface, namespace, name string) (*unstructured.Unstructured, error) {
+	vmi, err := dynamicClient.Resource(VirtualMachineInstanceGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, &ConsoleError{
+				Code:    ConsoleCodeVMINotFound,
+				Message: fmt.Sprintf("VirtualMachineInstance %q not found in namespace %q", name, namespace),
+			}
+		}
+		return nil, &ConsoleError{Code: ConsoleCodeInternal, Message: "failed to retrieve the VirtualMachineInstance", Cause: err}
+	}
+	return vmi, nil
+}
+
+func vmiPhase(vmi *unstructured.Unstructured) string {
+	if vmi == nil {
+		return ""
+	}
+	phase, _, _ := unstructured.NestedString(vmi.Object, "status", "phase")
+	return phase
+}
+
+func graphicsEnabled(vmi *unstructured.Unstructured) bool {
+	if vmi == nil {
+		return false
+	}
+	enabled, found, err := unstructured.NestedBool(vmi.Object, "spec", "domain", "devices", "autoattachGraphicsDevice")
+	if err != nil || !found {
+		return true
+	}
+	return enabled
+}

--- a/pkg/kubevirt/console_client_test.go
+++ b/pkg/kubevirt/console_client_test.go
@@ -1,0 +1,118 @@
+package kubevirt
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func newTestVMI(namespace, name, phase string, autoattachGraphics *bool) *unstructured.Unstructured {
+	devices := map[string]any{}
+	if autoattachGraphics != nil {
+		devices["autoattachGraphicsDevice"] = *autoattachGraphics
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kubevirt.io/v1",
+		"kind":       "VirtualMachineInstance",
+		"metadata": map[string]any{
+			"namespace": namespace,
+			"name":      name,
+		},
+		"spec": map[string]any{
+			"domain": map[string]any{
+				"devices": devices,
+			},
+		},
+		"status": map[string]any{
+			"phase": phase,
+		},
+	}}
+}
+
+func newFakeDynamicClient(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		VirtualMachineInstanceGVR: "VirtualMachineInstanceList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...)
+}
+
+func requireConsoleCode(t *testing.T, err error, want ConsoleErrorCode) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with code %q, got nil", want)
+	}
+	var ce *ConsoleError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *ConsoleError, got %T: %v", err, err)
+	}
+	if ce.Code != want {
+		t.Fatalf("expected code %q, got %q (%s)", want, ce.Code, ce.Message)
+	}
+}
+
+func TestGetVMI(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("retrieves an existing VMI", func(t *testing.T) {
+		client := newFakeDynamicClient(newTestVMI("default", "test-vm", "Running", nil))
+		vmi, err := getVMI(ctx, client, "default", "test-vm")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if vmi.GetName() != "test-vm" {
+			t.Fatalf("expected name 'test-vm', got %q", vmi.GetName())
+		}
+	})
+
+	t.Run("maps NotFound to vmi_not_found", func(t *testing.T) {
+		client := newFakeDynamicClient()
+		_, err := getVMI(ctx, client, "default", "missing")
+		requireConsoleCode(t, err, ConsoleCodeVMINotFound)
+	})
+
+	t.Run("maps Forbidden to internal", func(t *testing.T) {
+		client := newFakeDynamicClient()
+		client.PrependReactor("get", "virtualmachineinstances", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstances"}, "test-vm", errors.New("nope"))
+		})
+		_, err := getVMI(ctx, client, "default", "test-vm")
+		requireConsoleCode(t, err, ConsoleCodeInternal)
+	})
+}
+
+func TestVMIPhase(t *testing.T) {
+	if got := vmiPhase(newTestVMI("default", "vm", "Running", nil)); got != "Running" {
+		t.Fatalf("expected 'Running', got %q", got)
+	}
+	if got := vmiPhase(nil); got != "" {
+		t.Fatalf("expected empty phase for nil VMI, got %q", got)
+	}
+}
+
+func TestGraphicsEnabled(t *testing.T) {
+	tru, fls := true, false
+	t.Run("enabled by default when field absent", func(t *testing.T) {
+		if !graphicsEnabled(newTestVMI("default", "vm", "Running", nil)) {
+			t.Fatal("expected graphics enabled when autoattachGraphicsDevice is unset")
+		}
+	})
+	t.Run("enabled when explicitly true", func(t *testing.T) {
+		if !graphicsEnabled(newTestVMI("default", "vm", "Running", &tru)) {
+			t.Fatal("expected graphics enabled")
+		}
+	})
+	t.Run("disabled when explicitly false", func(t *testing.T) {
+		if graphicsEnabled(newTestVMI("default", "vm", "Running", &fls)) {
+			t.Fatal("expected graphics disabled")
+		}
+	})
+}

--- a/pkg/kubevirt/console_errors.go
+++ b/pkg/kubevirt/console_errors.go
@@ -1,0 +1,35 @@
+package kubevirt
+
+import "fmt"
+
+type ConsoleErrorCode string
+
+const (
+	ConsoleCodeVMINotFound           ConsoleErrorCode = "vmi_not_found"
+	ConsoleCodeVMINotRunning         ConsoleErrorCode = "vmi_not_running"
+	ConsoleCodeGraphicsDisabled      ConsoleErrorCode = "graphics_disabled"
+	ConsoleCodeScreenshotTooLarge    ConsoleErrorCode = "screenshot_too_large"
+	ConsoleCodeScreenshotUnavailable ConsoleErrorCode = "screenshot_unavailable"
+	ConsoleCodePermissionDenied      ConsoleErrorCode = "permission_denied"
+	ConsoleCodeInternal              ConsoleErrorCode = "internal"
+)
+
+type ConsoleError struct {
+	Code    ConsoleErrorCode
+	Message string
+	Cause   error
+}
+
+func (e *ConsoleError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func (e *ConsoleError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}

--- a/pkg/kubevirt/console_screenshot.go
+++ b/pkg/kubevirt/console_screenshot.go
@@ -1,0 +1,110 @@
+package kubevirt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image/png"
+	"io"
+	"strconv"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// ConsoleMaxScreenshotBytes bounds the size of a VNC screenshot PNG read into
+// memory. Responses larger than this are rejected rather than buffered whole.
+const ConsoleMaxScreenshotBytes = 4 * 1024 * 1024 // 4 MiB
+
+func Screenshot(ctx context.Context, dynamicClient dynamic.Interface, restConfig *rest.Config, namespace, name string, wakeScreen bool) ([]byte, string, error) {
+	vmi, err := getVMI(ctx, dynamicClient, namespace, name)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if err := validateScreenshotEligible(vmi, name); err != nil {
+		return nil, "", err
+	}
+
+	data, err := fetchScreenshot(ctx, restConfig, namespace, name, wakeScreen)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if err := validatePNG(data); err != nil {
+		return nil, "", err
+	}
+
+	return data, "Screenshot captured from the VNC graphical console.", nil
+}
+
+func validateScreenshotEligible(vmi *unstructured.Unstructured, name string) error {
+	if phase := vmiPhase(vmi); phase != "Running" {
+		return &ConsoleError{
+			Code:    ConsoleCodeVMINotRunning,
+			Message: fmt.Sprintf("VirtualMachineInstance %q is in phase %q, not Running", name, phase),
+		}
+	}
+
+	if !graphicsEnabled(vmi) {
+		return &ConsoleError{
+			Code:    ConsoleCodeGraphicsDisabled,
+			Message: fmt.Sprintf("VirtualMachineInstance %q has no graphical console (autoattachGraphicsDevice is false)", name),
+		}
+	}
+
+	return nil
+}
+
+func fetchScreenshot(ctx context.Context, restConfig *rest.Config, namespace, name string, wakeScreen bool) ([]byte, error) {
+	client, err := newSubresourceClient(restConfig)
+	if err != nil {
+		return nil, &ConsoleError{Code: ConsoleCodeInternal, Message: "failed to create subresource client", Cause: err}
+	}
+
+	stream, err := client.Get().
+		Namespace(namespace).
+		Resource("virtualmachineinstances").
+		Name(name).
+		SubResource("vnc", "screenshot").
+		Param("moveCursor", strconv.FormatBool(wakeScreen)).
+		Stream(ctx)
+	if err != nil {
+		return nil, mapScreenshotStreamError(err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Read one byte past the limit so a response exactly at the limit still
+	// succeeds while anything larger is detected as truncated and rejected.
+	data, err := io.ReadAll(io.LimitReader(stream, ConsoleMaxScreenshotBytes+1))
+	if err != nil {
+		return nil, &ConsoleError{Code: ConsoleCodeScreenshotUnavailable, Message: "failed to read screenshot data", Cause: err}
+	}
+	if len(data) > ConsoleMaxScreenshotBytes {
+		return nil, &ConsoleError{
+			Code:    ConsoleCodeScreenshotTooLarge,
+			Message: fmt.Sprintf("screenshot exceeds the maximum allowed size of %d bytes", ConsoleMaxScreenshotBytes),
+		}
+	}
+	if len(data) == 0 {
+		return nil, &ConsoleError{Code: ConsoleCodeScreenshotUnavailable, Message: "the VNC screenshot subresource returned no data"}
+	}
+
+	return data, nil
+}
+
+func validatePNG(data []byte) error {
+	if _, err := png.DecodeConfig(bytes.NewReader(data)); err != nil {
+		return &ConsoleError{Code: ConsoleCodeScreenshotUnavailable, Message: "the screenshot subresource did not return a valid PNG image"}
+	}
+	return nil
+}
+
+func mapScreenshotStreamError(err error) error {
+	if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+		return &ConsoleError{Code: ConsoleCodePermissionDenied, Message: "permission denied accessing the VNC screenshot subresource", Cause: err}
+	}
+	return &ConsoleError{Code: ConsoleCodeScreenshotUnavailable, Message: "failed to fetch the screenshot from the VNC subresource", Cause: err}
+}

--- a/pkg/kubevirt/console_screenshot_test.go
+++ b/pkg/kubevirt/console_screenshot_test.go
@@ -1,0 +1,145 @@
+package kubevirt
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func validPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("failed to encode PNG: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func screenshotTestServer(t *testing.T, handler http.HandlerFunc) *rest.Config {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return &rest.Config{Host: server.URL}
+}
+
+func TestScreenshot(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns PNG and description on success", func(t *testing.T) {
+		png := validPNG(t)
+		cfg := screenshotTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if !strings.HasSuffix(r.URL.Path, "/vnc/screenshot") {
+				t.Errorf("expected path ending in /vnc/screenshot, got %q", r.URL.Path)
+			}
+			if got := r.URL.Query().Get("moveCursor"); got != "false" {
+				t.Errorf("expected moveCursor=false, got %q", got)
+			}
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(png)
+		})
+		dyn := newFakeDynamicClient(newTestVMI("default", "test-vm", "Running", nil))
+
+		data, desc, err := Screenshot(ctx, dyn, cfg, "default", "test-vm", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(data, png) {
+			t.Fatalf("returned PNG bytes differ from server response")
+		}
+		if desc == "" {
+			t.Fatal("expected a non-empty description")
+		}
+	})
+
+	t.Run("passes moveCursor=true when wakeScreen is set", func(t *testing.T) {
+		png := validPNG(t)
+		cfg := screenshotTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("moveCursor"); got != "true" {
+				t.Errorf("expected moveCursor=true, got %q", got)
+			}
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(png)
+		})
+		dyn := newFakeDynamicClient(newTestVMI("default", "test-vm", "Running", nil))
+
+		if _, _, err := Screenshot(ctx, dyn, cfg, "default", "test-vm", true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("VMI not found", func(t *testing.T) {
+		dyn := newFakeDynamicClient()
+		_, _, err := Screenshot(ctx, dyn, &rest.Config{}, "default", "missing", false)
+		requireConsoleCode(t, err, ConsoleCodeVMINotFound)
+	})
+
+	t.Run("VMI not running", func(t *testing.T) {
+		dyn := newFakeDynamicClient(newTestVMI("default", "test-vm", "Pending", nil))
+		_, _, err := Screenshot(ctx, dyn, &rest.Config{}, "default", "test-vm", false)
+		requireConsoleCode(t, err, ConsoleCodeVMINotRunning)
+	})
+
+	t.Run("graphics disabled", func(t *testing.T) {
+		fls := false
+		dyn := newFakeDynamicClient(newTestVMI("default", "test-vm", "Running", &fls))
+		_, _, err := Screenshot(ctx, dyn, &rest.Config{}, "default", "test-vm", false)
+		requireConsoleCode(t, err, ConsoleCodeGraphicsDisabled)
+	})
+
+	t.Run("rejects an oversized screenshot", func(t *testing.T) {
+		cfg := screenshotTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(make([]byte, ConsoleMaxScreenshotBytes+1))
+		})
+		dyn := newFakeDynamicClient(newTestVMI("default", "test-vm", "Running", nil))
+		_, _, err := Screenshot(ctx, dyn, cfg, "default", "test-vm", false)
+		requireConsoleCode(t, err, ConsoleCodeScreenshotTooLarge)
+	})
+
+	t.Run("rejects an empty response", func(t *testing.T) {
+		cfg := screenshotTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+		})
+		dyn := newFakeDynamicClient(newTestVMI("default", "test-vm", "Running", nil))
+		_, _, err := Screenshot(ctx, dyn, cfg, "default", "test-vm", false)
+		requireConsoleCode(t, err, ConsoleCodeScreenshotUnavailable)
+	})
+
+	t.Run("rejects non-PNG data", func(t *testing.T) {
+		cfg := screenshotTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("this is not a png"))
+		})
+		dyn := newFakeDynamicClient(newTestVMI("default", "test-vm", "Running", nil))
+		_, _, err := Screenshot(ctx, dyn, cfg, "default", "test-vm", false)
+		requireConsoleCode(t, err, ConsoleCodeScreenshotUnavailable)
+	})
+
+	t.Run("accepts a screenshot exactly at the size limit", func(t *testing.T) {
+		png := validPNG(t)
+		padded := make([]byte, ConsoleMaxScreenshotBytes)
+		copy(padded, png) // valid PNG header, trailing zero padding tolerated by DecodeConfig
+		cfg := screenshotTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(padded)
+		})
+		dyn := newFakeDynamicClient(newTestVMI("default", "test-vm", "Running", nil))
+		data, _, err := Screenshot(ctx, dyn, cfg, "default", "test-vm", false)
+		if err != nil {
+			t.Fatalf("unexpected error at exactly the limit: %v", err)
+		}
+		if len(data) != ConsoleMaxScreenshotBytes {
+			t.Fatalf("expected %d bytes, got %d", ConsoleMaxScreenshotBytes, len(data))
+		}
+	})
+}

--- a/pkg/mcp/multi_content_result.go
+++ b/pkg/mcp/multi_content_result.go
@@ -1,0 +1,45 @@
+package mcp
+
+import (
+	"fmt"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func NewMultiContentResult(blocks []*api.ToolContent, structured any, err error) *mcp.CallToolResult {
+	if err != nil {
+		return NewTextResult("", err)
+	}
+
+	result := &mcp.CallToolResult{}
+	if structured != nil {
+		result.StructuredContent = ensureStructuredObject(structured)
+	}
+	for _, block := range blocks {
+		if block == nil {
+			continue
+		}
+
+		switch block.Type {
+		case api.ToolContentTypeText:
+			result.Content = append(result.Content, &mcp.TextContent{
+				Text: block.Text,
+			})
+
+		case api.ToolContentTypeImage:
+			if block.MIMEType == "" || len(block.Data) == 0 {
+				return NewTextResult("", fmt.Errorf("image block must have MIME type and data"))
+			}
+			result.Content = append(result.Content, &mcp.ImageContent{
+				MIMEType: block.MIMEType,
+				Data:     block.Data,
+			})
+
+		default:
+			return NewTextResult("", fmt.Errorf("unknown content block type: %s", block.Type))
+		}
+	}
+
+	return result
+}

--- a/pkg/mcp/multi_content_result_test.go
+++ b/pkg/mcp/multi_content_result_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestNewMultiContentResult(t *testing.T) {
+	t.Run("converts text blocks", func(t *testing.T) {
+		blocks := []*api.ToolContent{
+			api.NewTextToolContent("hello"),
+			api.NewTextToolContent("world"),
+		}
+		result := NewMultiContentResult(blocks, nil, nil)
+		if len(result.Content) != 2 {
+			t.Fatalf("expected 2 content blocks, got %d", len(result.Content))
+		}
+
+		text1, ok := result.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("expected TextContent, got %T", result.Content[0])
+		}
+		if text1.Text != "hello" {
+			t.Fatalf("expected 'hello', got %q", text1.Text)
+		}
+	})
+
+	t.Run("converts image blocks", func(t *testing.T) {
+		pngData := []byte{0x89, 0x50, 0x4e, 0x47}
+		blocks := []*api.ToolContent{
+			api.NewImageToolContent(pngData, "image/png"),
+		}
+		result := NewMultiContentResult(blocks, nil, nil)
+		if len(result.Content) != 1 {
+			t.Fatalf("expected 1 content block, got %d", len(result.Content))
+		}
+
+		img, ok := result.Content[0].(*mcp.ImageContent)
+		if !ok {
+			t.Fatalf("expected ImageContent, got %T", result.Content[0])
+		}
+		if img.MIMEType != "image/png" {
+			t.Fatalf("expected MIME type 'image/png', got %q", img.MIMEType)
+		}
+		if len(img.Data) != len(pngData) {
+			t.Fatalf("expected %d bytes, got %d", len(pngData), len(img.Data))
+		}
+	})
+
+	t.Run("preserves block order", func(t *testing.T) {
+		blocks := []*api.ToolContent{
+			api.NewTextToolContent("description"),
+			api.NewImageToolContent([]byte{1, 2, 3}, "image/png"),
+		}
+		result := NewMultiContentResult(blocks, nil, nil)
+		if len(result.Content) != 2 {
+			t.Fatalf("expected 2 blocks, got %d", len(result.Content))
+		}
+
+		_, isText := result.Content[0].(*mcp.TextContent)
+		_, isImage := result.Content[1].(*mcp.ImageContent)
+		if !isText || !isImage {
+			t.Fatal("expected text then image, got different types")
+		}
+	})
+
+	t.Run("returns error on invalid image (missing MIME type)", func(t *testing.T) {
+		block := &api.ToolContent{Type: api.ToolContentTypeImage, Data: []byte{1, 2, 3}}
+		result := NewMultiContentResult([]*api.ToolContent{block}, nil, nil)
+		if !result.IsError {
+			t.Fatal("expected error result")
+		}
+	})
+
+	t.Run("returns error on invalid image (empty data)", func(t *testing.T) {
+		block := &api.ToolContent{Type: api.ToolContentTypeImage, MIMEType: "image/png"}
+		result := NewMultiContentResult([]*api.ToolContent{block}, nil, nil)
+		if !result.IsError {
+			t.Fatal("expected error result")
+		}
+	})
+
+	t.Run("forwards existing error unchanged", func(t *testing.T) {
+		originalErr := errors.New("test error")
+		result := NewMultiContentResult(nil, nil, originalErr)
+		if !result.IsError {
+			t.Fatal("expected error result")
+		}
+	})
+
+	t.Run("handles nil blocks gracefully", func(t *testing.T) {
+		blocks := []*api.ToolContent{
+			api.NewTextToolContent("text"),
+			nil,
+			api.NewImageToolContent([]byte{1, 2}, "image/png"),
+		}
+		result := NewMultiContentResult(blocks, nil, nil)
+		if len(result.Content) != 2 {
+			t.Fatalf("expected 2 non-nil blocks, got %d", len(result.Content))
+		}
+	})
+}

--- a/pkg/mcp/testdata/toolsets-kubevirt-tools.json
+++ b/pkg/mcp/testdata/toolsets-kubevirt-tools.json
@@ -35,6 +35,39 @@
   },
   {
     "annotations": {
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": false,
+      "readOnlyHint": true,
+      "title": "Virtual Machine: Console Screenshot"
+    },
+    "description": "Capture a screenshot of a KubeVirt VirtualMachine's graphical (VNC) console as a PNG image. Use this to see what is currently displayed on the VM's screen (for example firmware, a bootloader, or a login prompt). Read-only: it never sends input to the guest.",
+    "inputSchema": {
+      "properties": {
+        "name": {
+          "description": "The name of the virtual machine",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The namespace of the virtual machine",
+          "type": "string"
+        },
+        "wake_screen": {
+          "description": "Move the mouse cursor before capturing to wake a blanked screen. Defaults to false.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "namespace",
+        "name"
+      ],
+      "type": "object"
+    },
+    "name": "vm_console_screenshot",
+    "title": "Virtual Machine: Console Screenshot"
+  },
+  {
+    "annotations": {
       "destructiveHint": true,
       "idempotentHint": true,
       "openWorldHint": false,

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -101,6 +101,11 @@ func ServerToolToGoSdkTool(s *Server, tool api.ServerTool) (*mcp.Tool, mcp.ToolH
 		if result.Error != nil {
 			mcplog.HandleK8sError(ctx, result.Error, tool.Tool.Name)
 		}
+		// If result has multi-content blocks, use the multi-content converter;
+		// otherwise fall back to legacy Content field.
+		if len(result.ContentBlocks) > 0 {
+			return NewMultiContentResult(result.ContentBlocks, result.StructuredContent, result.Error), nil
+		}
 		return NewStructuredResult(result.Content, result.StructuredContent, result.Error), nil
 	}
 	return goSdkTool, goSdkHandler, nil

--- a/pkg/toolsets/kubevirt/toolset.go
+++ b/pkg/toolsets/kubevirt/toolset.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	kubevirtdefaults "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
 	vm_clone "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/clone"
+	vm_console "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/console"
 	vm_create "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/create"
 	vm_guestagent "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/guestagent"
 	vm_lifecycle "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/vm/lifecycle"
@@ -28,6 +29,7 @@ func (t *Toolset) GetDescription() string {
 
 func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
 	return slices.Concat(
+		vm_console.Tools(p),
 		vm_clone.Tools(p),
 		vm_create.Tools(p),
 		vm_guestagent.Tools(p),

--- a/pkg/toolsets/kubevirt/vm/console/tool.go
+++ b/pkg/toolsets/kubevirt/vm/console/tool.go
@@ -1,0 +1,82 @@
+package console
+
+import (
+	"fmt"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
+	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/utils/ptr"
+)
+
+func Tools(p api.FilteringProvider) []api.ServerTool {
+	return []api.ServerTool{
+		{
+			Tool: api.Tool{
+				Name:        "vm_console_screenshot",
+				Description: fmt.Sprintf("Capture a screenshot of a %s VirtualMachine's graphical (VNC) console as a PNG image. Use this to see what is currently displayed on the VM's screen (for example firmware, a bootloader, or a login prompt). Read-only: it never sends input to the guest.", defaults.ProductName()),
+				InputSchema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"namespace": {
+							Type:        "string",
+							Description: "The namespace of the virtual machine",
+						},
+						"name": {
+							Type:        "string",
+							Description: "The name of the virtual machine",
+						},
+						"wake_screen": {
+							Type:        "boolean",
+							Description: "Move the mouse cursor before capturing to wake a blanked screen. Defaults to false.",
+						},
+					},
+					Required: []string{"namespace", "name"},
+				},
+				Annotations: api.ToolAnnotations{
+					Title:           "Virtual Machine: Console Screenshot",
+					ReadOnlyHint:    ptr.To(true),
+					DestructiveHint: ptr.To(false),
+					IdempotentHint:  ptr.To(true),
+					OpenWorldHint:   ptr.To(false),
+				},
+			},
+			Handler: screenshot,
+			TargetCompatibilityFilters: []func() bool{
+				kubevirt.HasVirtualMachine(p),
+			},
+		},
+	}
+}
+
+func screenshot(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
+	p := api.WrapParams(params)
+	namespace := p.RequiredString("namespace")
+	name := p.RequiredString("name")
+	wakeScreen := p.OptionalBool("wake_screen", false)
+	if err := p.Err(); err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+
+	pngBytes, description, err := kubevirt.Screenshot(
+		params.Context,
+		params.DynamicClient(),
+		params.RESTConfig(),
+		namespace,
+		name,
+		wakeScreen,
+	)
+	if err != nil {
+		// ConsoleError.Error() is a safe, client-facing message (it never
+		// includes the underlying cause), so it can be surfaced directly while
+		// the wrapped cause remains available for server-side logging.
+		return api.NewToolCallResult("", err), nil
+	}
+
+	blocks := []*api.ToolContent{
+		api.NewTextToolContent(description),
+		api.NewImageToolContent(pngBytes, "image/png"),
+	}
+	return api.NewToolCallResultWithContent(blocks, nil, nil), nil
+}

--- a/pkg/toolsets/kubevirt/vm/console/tool_test.go
+++ b/pkg/toolsets/kubevirt/vm/console/tool_test.go
@@ -1,0 +1,60 @@
+package console
+
+import (
+	"slices"
+	"testing"
+
+	"k8s.io/utils/ptr"
+)
+
+func TestTools(t *testing.T) {
+	tools := Tools(nil)
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	tool := tools[0].Tool
+	if tool.Name != "vm_console_screenshot" {
+		t.Fatalf("expected name 'vm_console_screenshot', got %q", tool.Name)
+	}
+	if tool.Description == "" {
+		t.Fatal("expected a non-empty description")
+	}
+
+	t.Run("is annotated read-only and non-destructive", func(t *testing.T) {
+		if !ptr.Deref(tool.Annotations.ReadOnlyHint, false) {
+			t.Error("expected ReadOnlyHint true")
+		}
+		if ptr.Deref(tool.Annotations.DestructiveHint, true) {
+			t.Error("expected DestructiveHint false")
+		}
+	})
+
+	t.Run("requires namespace and name", func(t *testing.T) {
+		if !slices.Contains(tool.InputSchema.Required, "namespace") {
+			t.Error("expected 'namespace' to be required")
+		}
+		if !slices.Contains(tool.InputSchema.Required, "name") {
+			t.Error("expected 'name' to be required")
+		}
+	})
+
+	t.Run("exposes an optional wake_screen boolean", func(t *testing.T) {
+		prop, ok := tool.InputSchema.Properties["wake_screen"]
+		if !ok {
+			t.Fatal("expected 'wake_screen' property")
+		}
+		if prop.Type != "boolean" {
+			t.Errorf("expected wake_screen type 'boolean', got %q", prop.Type)
+		}
+		if slices.Contains(tool.InputSchema.Required, "wake_screen") {
+			t.Error("wake_screen should not be required")
+		}
+	})
+
+	t.Run("has a target compatibility filter", func(t *testing.T) {
+		if len(tools[0].TargetCompatibilityFilters) == 0 {
+			t.Error("expected a VirtualMachine compatibility filter")
+		}
+	})
+}


### PR DESCRIPTION
Add the vm_console_screenshot tool for capturing
running VM graphical (VNC) console as PNG
images.

**Note:** This is ported from [codingben/kubevirt-console-mcp](https://github.com/codingben/kubevirt-console-mcp) repository which is the original source of it.