### PR TITLE
feat: support cluster CA served over HTTPS via kubeconfig extension

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,6 +238,8 @@ rate_limit_burst = 10        # allow bursts of up to 10 requests
 |-------|------|---------|-------------|
 | `kubeconfig` | string | `""` | Path to the Kubernetes configuration file. If not provided, the server uses the in-cluster configuration or the default kubeconfig location (`~/.kube/config`). |
 | `cluster_provider_strategy` | string | auto-detect | How the server finds clusters. Valid values: `kubeconfig`, `in-cluster`, `kcp`, `disabled`. |
+| `ca_cache_dir` | string | `""` | Directory where CA certificates fetched via the `caURL` kubeconfig cluster extension are cached. Empty means the default: a subdirectory of the system temp dir. The directory must be writable; with a read-only root filesystem, mount an emptyDir there. |
+| `ca_refresh_interval` | duration | `"24h"` | How often cached CA certificates are re-fetched so a rotated cluster CA is picked up without a restart. Use `0s` to disable re-fetching; the CA is then only refreshed when a manager is rebuilt (e.g. kubeconfig change or restart). |
 
 **Example:**
 ```toml
@@ -313,6 +315,33 @@ If the server starts but operations fail (e.g., `failed to list namespaces: unkn
 2. **Kubeconfig validity** — Ensure the kubeconfig contains valid credentials (token, client certificate, etc.) and points to the correct API server address.
 3. **Permissions** — The credentials in the kubeconfig must have sufficient RBAC permissions on the target cluster.
 4. **TLS certificates** — If the external cluster uses a private CA, the CA certificate must be included in the kubeconfig or mounted separately.
+
+#### CA served over HTTPS
+
+When a cluster's API-server CA is served over HTTPS (e.g. an endpoint mirroring the cluster CA for cross-cluster consumers), a kubeconfig cluster entry can point at that URL instead of embedding the CA:
+
+```yaml
+apiVersion: v1
+clusters:
+- name: production
+  cluster:
+    server: https://kubernetes.default.svc
+    extensions:
+    - name: kubernetes-mcp-server
+      extension:
+        caURL: https://ca.production.example.com/
+```
+
+At manager creation the server fetches the CA from `caURL`, caches it to a file and points the Kubernetes client at that file. Because the client reloads CA files it is pointed at, a rotated CA (e.g. after the cluster is re-provisioned) is picked up without a restart; `ca_refresh_interval` controls how often the cache is re-fetched (default `24h`, `0s` disables). Other tools ignore the extension entirely.
+
+Notes:
+
+- The URL must be `https`. A trust root fetched over cleartext could be swapped by a network attacker, who could then impersonate the cluster the CA is meant to authenticate.
+- The response must be a PEM CA certificate; other content fails fast with a clear error.
+- client-go re-checks the cached file every few minutes, so a rotation converges once the refresher writes the new CA; setting `ca_refresh_interval` below that cadence does not speed it up.
+- The cache directory (system temp dir by default, or `ca_cache_dir`) must be writable. With a read-only root filesystem, mount an emptyDir at the cache location — e.g. `emptyDir: {}` mounted at `/tmp`.
+- The initial fetch happens at manager creation; if it fails (unreachable endpoint, non-PEM response), manager creation fails rather than silently using an empty trust store. For the default context that is startup; lazily-created contexts (other targets) surface the error on first use.
+- Applies to every cluster provider strategy backed by a kubeconfig (`kubeconfig` and `kcp`).
 
 ### Access Control
 
@@ -775,6 +804,8 @@ The following options can be set via command-line arguments. CLI arguments overr
 | `--toolsets` | Comma-separated list of toolsets to enable |
 | `--disable-multi-cluster` | Disable multi-cluster support |
 | `--cluster-provider` | Cluster provider strategy (`kubeconfig`, `in-cluster`, `kcp`, `disabled`) |
+| `--ca-cache-dir` | Directory where CA certificates fetched via the `caURL` kubeconfig cluster extension are cached (default: subdirectory of the system temp dir) |
+| `--ca-refresh-interval` | How often cached CA certificates are re-fetched so a rotated cluster CA is picked up without a restart; `0` disables re-fetching (default: `24h`) |
 | `--tls-cert` | Path to TLS certificate file for HTTPS (must be used with `--tls-key`) |
 | `--tls-key` | Path to TLS private key file for HTTPS (must be used with `--tls-cert`) |
 | `--require-tls` | Enforce TLS for server and all outbound connections |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,7 +238,6 @@ rate_limit_burst = 10        # allow bursts of up to 10 requests
 |-------|------|---------|-------------|
 | `kubeconfig` | string | `""` | Path to the Kubernetes configuration file. If not provided, the server uses the in-cluster configuration or the default kubeconfig location (`~/.kube/config`). |
 | `cluster_provider_strategy` | string | auto-detect | How the server finds clusters. Valid values: `kubeconfig`, `in-cluster`, `kcp`, `disabled`. |
-| `ca_cache_dir` | string | `""` | Directory where CA certificates fetched via the `caURL` kubeconfig cluster extension are cached. Empty means the default: a subdirectory of the system temp dir. The directory must be writable; with a read-only root filesystem, mount an emptyDir there. |
 | `ca_refresh_interval` | duration | `"24h"` | How often cached CA certificates are re-fetched so a rotated cluster CA is picked up without a restart. Use `0s` to disable automatic re-fetching; the CA is then only refreshed when a manager is rebuilt (e.g. kubeconfig change or restart) or via an on-demand SIGHUP re-fetch. |
 
 **Example:**
@@ -341,7 +340,7 @@ Notes:
 - The response must be a PEM CA certificate; other content fails fast with a clear error.
 - client-go re-checks the cached file roughly every 5 minutes (the `ClientsAllowCARotation` feature, beta and enabled by default in client-go 1.36+), so a rotation converges once the refresher writes the new CA; setting `ca_refresh_interval` below that cadence does not speed it up. With that feature disabled (e.g. `KUBE_FEATURE_ClientsAllowCARotation=false`), the client no longer re-reads the file, so a changed CA is only picked up when a manager is rebuilt.
 - Sending SIGHUP to reload configuration also triggers an immediate CA re-fetch, so a rotated CA can be picked up without waiting out `ca_refresh_interval` or restarting.
-- The cache directory (system temp dir by default, or `ca_cache_dir`) must be writable. With a read-only root filesystem, mount an emptyDir at the cache location — e.g. `emptyDir: {}` mounted at `/tmp`.
+- The cache directory (a subdirectory of the system temp dir, which honors `$TMPDIR`) must be writable. With a read-only root filesystem, mount an emptyDir at `/tmp` or set `$TMPDIR` to writable storage.
 - The initial fetch happens at manager creation; if it fails (unreachable endpoint, non-PEM response), manager creation fails rather than silently using an empty trust store. For the default context that is startup; lazily-created contexts (other targets) surface the error on first use.
 - Applies to every cluster provider strategy backed by a kubeconfig (`kubeconfig` and `kcp`).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,7 +239,7 @@ rate_limit_burst = 10        # allow bursts of up to 10 requests
 | `kubeconfig` | string | `""` | Path to the Kubernetes configuration file. If not provided, the server uses the in-cluster configuration or the default kubeconfig location (`~/.kube/config`). |
 | `cluster_provider_strategy` | string | auto-detect | How the server finds clusters. Valid values: `kubeconfig`, `in-cluster`, `kcp`, `disabled`. |
 | `ca_cache_dir` | string | `""` | Directory where CA certificates fetched via the `caURL` kubeconfig cluster extension are cached. Empty means the default: a subdirectory of the system temp dir. The directory must be writable; with a read-only root filesystem, mount an emptyDir there. |
-| `ca_refresh_interval` | duration | `"24h"` | How often cached CA certificates are re-fetched so a rotated cluster CA is picked up without a restart. Use `0s` to disable re-fetching; the CA is then only refreshed when a manager is rebuilt (e.g. kubeconfig change or restart). |
+| `ca_refresh_interval` | duration | `"24h"` | How often cached CA certificates are re-fetched so a rotated cluster CA is picked up without a restart. Use `0s` to disable automatic re-fetching; the CA is then only refreshed when a manager is rebuilt (e.g. kubeconfig change or restart) or via an on-demand SIGHUP re-fetch. |
 
 **Example:**
 ```toml
@@ -336,9 +336,11 @@ At manager creation the server fetches the CA from `caURL`, caches it to a file 
 
 Notes:
 
-- The URL must be `https`. A trust root fetched over cleartext could be swapped by a network attacker, who could then impersonate the cluster the CA is meant to authenticate.
+- The URL must be `https`. A trust root fetched over cleartext could be swapped by a network attacker, who could then impersonate the cluster the CA is meant to authenticate. Redirects are followed only to other `https` URLs, and the chain is capped.
+- The endpoint serving `caURL` must present a certificate the MCP process **already trusts** — system roots or `SSL_CERT_FILE` — **not** the cluster CA being fetched. This is a different trust domain from “the URL must be https”: a private-CA-signed endpoint fails at manager creation. Point `caURL` at something trusted by the process, or add its certificate to the process trust store.
 - The response must be a PEM CA certificate; other content fails fast with a clear error.
-- client-go re-checks the cached file every few minutes, so a rotation converges once the refresher writes the new CA; setting `ca_refresh_interval` below that cadence does not speed it up.
+- client-go re-checks the cached file roughly every 5 minutes (the `ClientsAllowCARotation` feature, beta and enabled by default in client-go 1.36+), so a rotation converges once the refresher writes the new CA; setting `ca_refresh_interval` below that cadence does not speed it up. With that feature disabled (e.g. `KUBE_FEATURE_ClientsAllowCARotation=false`), the client no longer re-reads the file, so a changed CA is only picked up when a manager is rebuilt.
+- Sending SIGHUP to reload configuration also triggers an immediate CA re-fetch, so a rotated CA can be picked up without waiting out `ca_refresh_interval` or restarting.
 - The cache directory (system temp dir by default, or `ca_cache_dir`) must be writable. With a read-only root filesystem, mount an emptyDir at the cache location — e.g. `emptyDir: {}` mounted at `/tmp`.
 - The initial fetch happens at manager creation; if it fails (unreachable endpoint, non-PEM response), manager creation fails rather than silently using an empty trust store. For the default context that is startup; lazily-created contexts (other targets) surface the error on first use.
 - Applies to every cluster provider strategy backed by a kubeconfig (`kubeconfig` and `kcp`).

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1,5 +1,7 @@
 package api
 
+import "time"
+
 const (
 	ClusterProviderKubeConfig = "kubeconfig"
 	ClusterProviderInCluster  = "in-cluster"
@@ -34,6 +36,15 @@ type ClusterProvider interface {
 	GetClusterProviderStrategy() string
 	// GetKubeConfigPath returns the path to the kubeconfig file (if configured).
 	GetKubeConfigPath() string
+	// GetCACacheDir returns the directory CA certificates fetched via the
+	// caURL kubeconfig cluster extension are cached in. Empty means the
+	// default (a subdirectory of the system temp dir).
+	GetCACacheDir() string
+	// GetCARefreshInterval returns how often cached CA certificates are
+	// re-fetched so a rotated cluster CA is picked up without a restart.
+	// Zero disables re-fetching; the CA is then only refreshed when a
+	// manager is rebuilt.
+	GetCARefreshInterval() time.Duration
 }
 
 // ExtendedConfig is the interface that all configuration extensions must implement.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -36,10 +36,6 @@ type ClusterProvider interface {
 	GetClusterProviderStrategy() string
 	// GetKubeConfigPath returns the path to the kubeconfig file (if configured).
 	GetKubeConfigPath() string
-	// GetCACacheDir returns the directory CA certificates fetched via the
-	// caURL kubeconfig cluster extension are cached in. Empty means the
-	// default (a subdirectory of the system temp dir).
-	GetCACacheDir() string
 	// GetCARefreshInterval returns how often cached CA certificates are
 	// re-fetched so a rotated cluster CA is picked up without a restart.
 	// Zero disables re-fetching; the CA is then only refreshed when a

--- a/pkg/config/ca_url_config_test.go
+++ b/pkg/config/ca_url_config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CAURLConfigSuite struct {
+	BaseConfigSuite
+}
+
+func TestCAURLConfigSuite(t *testing.T) {
+	suite.Run(t, new(CAURLConfigSuite))
+}
+
+func (s *CAURLConfigSuite) TestDefaultRefreshInterval() {
+	s.Run("refreshes cached CAs daily by default", func() {
+		s.Equal(Duration(24*time.Hour), Default().CARefreshInterval)
+	})
+	s.Run("defaults cache dir to empty meaning system temp dir", func() {
+		s.Empty(Default().CACacheDir)
+	})
+}
+
+func (s *CAURLConfigSuite) TestCAURLConfigFromTOML() {
+	s.Run("parses ca_cache_dir and ca_refresh_interval", func() {
+		path := s.writeConfig(`
+ca_cache_dir = "/var/cache/mcp-ca"
+ca_refresh_interval = "30m"
+`)
+		cfg, err := Read(s.T().Context(), path, "")
+		s.Require().NoError(err)
+		s.Equal("/var/cache/mcp-ca", cfg.GetCACacheDir())
+		s.Equal(30*time.Minute, cfg.GetCARefreshInterval())
+	})
+	s.Run("zero refresh interval disables refresh", func() {
+		path := s.writeConfig(`ca_refresh_interval = "0s"`)
+		cfg, err := Read(s.T().Context(), path, "")
+		s.Require().NoError(err)
+		s.Zero(cfg.GetCARefreshInterval())
+	})
+}

--- a/pkg/config/ca_url_config_test.go
+++ b/pkg/config/ca_url_config_test.go
@@ -19,20 +19,15 @@ func (s *CAURLConfigSuite) TestDefaultRefreshInterval() {
 	s.Run("refreshes cached CAs daily by default", func() {
 		s.Equal(Duration(24*time.Hour), Default().CARefreshInterval)
 	})
-	s.Run("defaults cache dir to empty meaning system temp dir", func() {
-		s.Empty(Default().CACacheDir)
-	})
 }
 
 func (s *CAURLConfigSuite) TestCAURLConfigFromTOML() {
-	s.Run("parses ca_cache_dir and ca_refresh_interval", func() {
+	s.Run("parses ca_refresh_interval", func() {
 		path := s.writeConfig(`
-ca_cache_dir = "/var/cache/mcp-ca"
 ca_refresh_interval = "30m"
 `)
 		cfg, err := Read(s.T().Context(), path, "")
 		s.Require().NoError(err)
-		s.Equal("/var/cache/mcp-ca", cfg.GetCACacheDir())
 		s.Equal(30*time.Minute, cfg.GetCARefreshInterval())
 	})
 	s.Run("zero refresh interval disables refresh", func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 
@@ -45,7 +46,19 @@ type StaticConfig struct {
 	Port        string `toml:"port,omitempty"`
 	BindAddress string `toml:"bind_address,omitempty"`
 	KubeConfig  string `toml:"kubeconfig,omitempty"`
-	ListOutput  string `toml:"list_output,omitempty"`
+	// CACacheDir is where CA certificates fetched via the caURL kubeconfig
+	// cluster extension are cached. Empty means the default: a subdirectory
+	// of the system temp dir, which must be writable (mount an emptyDir
+	// there when the root filesystem is read-only).
+	CACacheDir string `toml:"ca_cache_dir,omitempty"`
+	// CARefreshInterval is how often cached CA certificates are re-fetched
+	// so a rotated cluster CA is picked up without a restart. Zero disables
+	// re-fetching; the CA is then only refreshed when a manager is rebuilt.
+	// omitzero (not omitempty): the toml encoder never omits a zero
+	// int64-backed Duration with omitempty, which would clobber the
+	// BaseDefault value during Default()'s merge round-trip.
+	CARefreshInterval Duration `toml:"ca_refresh_interval,omitzero"`
+	ListOutput        string   `toml:"list_output,omitempty"`
 	// Stateless configures the MCP server to operate in stateless mode.
 	// When true, the server will not send notifications to clients (e.g., tools/list_changed, prompts/list_changed).
 	// This is useful for container deployments, load balancing, and serverless environments where
@@ -412,6 +425,14 @@ func ReadToml(configData []byte, opts ...ReadConfigOpt) (*StaticConfig, error) {
 
 func (c *StaticConfig) GetClusterProviderStrategy() string {
 	return c.ClusterProviderStrategy
+}
+
+func (c *StaticConfig) GetCACacheDir() string {
+	return c.CACacheDir
+}
+
+func (c *StaticConfig) GetCARefreshInterval() time.Duration {
+	return c.CARefreshInterval.Duration()
 }
 
 func (c *StaticConfig) GetDeniedResources() []api.GroupVersionKind {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,11 +46,6 @@ type StaticConfig struct {
 	Port        string `toml:"port,omitempty"`
 	BindAddress string `toml:"bind_address,omitempty"`
 	KubeConfig  string `toml:"kubeconfig,omitempty"`
-	// CACacheDir is where CA certificates fetched via the caURL kubeconfig
-	// cluster extension are cached. Empty means the default: a subdirectory
-	// of the system temp dir, which must be writable (mount an emptyDir
-	// there when the root filesystem is read-only).
-	CACacheDir string `toml:"ca_cache_dir,omitempty"`
 	// CARefreshInterval is how often cached CA certificates are re-fetched
 	// so a rotated cluster CA is picked up without a restart. Zero disables
 	// re-fetching; the CA is then only refreshed when a manager is rebuilt
@@ -434,10 +429,6 @@ func ReadToml(configData []byte, opts ...ReadConfigOpt) (*StaticConfig, error) {
 
 func (c *StaticConfig) GetClusterProviderStrategy() string {
 	return c.ClusterProviderStrategy
-}
-
-func (c *StaticConfig) GetCACacheDir() string {
-	return c.CACacheDir
 }
 
 func (c *StaticConfig) GetCARefreshInterval() time.Duration {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,10 +53,19 @@ type StaticConfig struct {
 	CACacheDir string `toml:"ca_cache_dir,omitempty"`
 	// CARefreshInterval is how often cached CA certificates are re-fetched
 	// so a rotated cluster CA is picked up without a restart. Zero disables
-	// re-fetching; the CA is then only refreshed when a manager is rebuilt.
-	// omitzero (not omitempty): the toml encoder never omits a zero
-	// int64-backed Duration with omitempty, which would clobber the
-	// BaseDefault value during Default()'s merge round-trip.
+	// re-fetching; the CA is then only refreshed when a manager is rebuilt
+	// or on an on-demand SIGHUP re-fetch.
+	//
+	// Zero is ambiguous here: as a toml value it means "not set" and the
+	// merge keeps the BaseDefault, while an explicit `"0s"` in a config
+	// file or --ca-refresh-interval=0 means "disabled" and is honored
+	// (config files merge by key presence, the flag assigns directly). The
+	// one exception: a build-time defaultOverride cannot express the
+	// disabled value, because mergeConfig drops zero Durations (omitzero;
+	// omitempty would clobber the BaseDefault — the encoder never omits a
+	// zero int64-backed Duration). Downstream builds that need refresh off
+	// by default must set a different value or this field becomes a
+	// *Duration.
 	CARefreshInterval Duration `toml:"ca_refresh_interval,omitzero"`
 	ListOutput        string   `toml:"list_output,omitempty"`
 	// Stateless configures the MCP server to operate in stateless mode.

--- a/pkg/config/config_default.go
+++ b/pkg/config/config_default.go
@@ -16,6 +16,7 @@ func BaseDefault() *StaticConfig {
 		ListOutput:           "table",
 		Toolsets:             []string{"core", "config"},
 		ConfirmationFallback: "allow",
+		CARefreshInterval:    Duration(24 * time.Hour),
 		HTTP: HTTPConfig{
 			ReadHeaderTimeout: Duration(10 * time.Second), // Slowloris protection
 			MaxBodyBytes:      16 << 20,                   // 16 MB for large K8s manifests

--- a/pkg/config/http_config.go
+++ b/pkg/config/http_config.go
@@ -10,7 +10,7 @@ const DefaultRateLimitBurst = 10
 type HTTPConfig struct {
 	// ReadHeaderTimeout is the amount of time allowed to read request headers.
 	// This is the primary defense against Slowloris attacks.
-	ReadHeaderTimeout Duration `toml:"read_header_timeout,omitempty"`
+	ReadHeaderTimeout Duration `toml:"read_header_timeout,omitzero"`
 
 	// MaxBodyBytes is the maximum size of request body in bytes.
 	// MCP payloads (tools/call with Kubernetes manifests) can be large,

--- a/pkg/config/http_config.go
+++ b/pkg/config/http_config.go
@@ -10,7 +10,7 @@ const DefaultRateLimitBurst = 10
 type HTTPConfig struct {
 	// ReadHeaderTimeout is the amount of time allowed to read request headers.
 	// This is the primary defense against Slowloris attacks.
-	ReadHeaderTimeout Duration `toml:"read_header_timeout,omitzero"`
+	ReadHeaderTimeout Duration `toml:"read_header_timeout,omitempty"`
 
 	// MaxBodyBytes is the maximum size of request body in bytes.
 	// MCP payloads (tools/call with Kubernetes manifests) can be large,

--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -104,6 +104,20 @@ func (p *kcpClusterProvider) reset(ctx context.Context) error {
 		return fmt.Errorf("failed to create base manager: %w", err)
 	}
 
+	// The base manager may have resolved the cluster CA from the caURL
+	// kubeconfig extension. Propagate that trust anchor to the provider's
+	// REST config so workspace discovery and per-workspace managers verify
+	// the API server against the same CA; without this, caURL clusters
+	// would make workspace TLS verification fail with the kubeconfig CA.
+	baseRESTConfig := baseManager.RESTConfig()
+	if baseRESTConfig.CAFile != "" {
+		p.restConfig.CAFile = baseRESTConfig.CAFile
+		p.restConfig.CAData = nil
+	} else if len(baseRESTConfig.CAData) > 0 {
+		p.restConfig.CAData = baseRESTConfig.CAData
+		p.restConfig.CAFile = ""
+	}
+
 	// Discover workspaces
 	workspaceList, err := p.discoverWorkspaces(baseManager)
 	if err != nil {
@@ -114,6 +128,10 @@ func (p *kcpClusterProvider) reset(ctx context.Context) error {
 		}
 	}
 
+	// Close managers from the previous reset so their background CA
+	// refreshers and HTTP transports are released before being replaced.
+	closeManagers(p.managers)
+
 	// Initialize workspace managers (lazily, set to nil first)
 	p.managers = make(map[string]*kubernetes.Manager, len(workspaceList))
 	for _, ws := range workspaceList {
@@ -122,8 +140,10 @@ func (p *kcpClusterProvider) reset(ctx context.Context) error {
 	// Store the base manager for the default workspace
 	p.managers[p.defaultWorkspace] = baseManager
 
-	// Setup watchers
-	p.Close()
+	// Setup watchers. Only the previous watchers are closed here; the fresh
+	// base manager stored above must stay alive (its CA refresher keeps the
+	// default workspace's CA cache fresh).
+	p.closeWatchers()
 	k8s, err := baseManager.Derived(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get kubernetes client: %w", err)
@@ -330,10 +350,26 @@ func (p *kcpClusterProvider) WatchTargets(ctx context.Context, reload kubernetes
 	p.clusterStateWatcher.Watch(ctx, reload)
 }
 
-func (p *kcpClusterProvider) Close() {
+// closeWatchers stops the workspace and cluster-state watchers if present.
+func (p *kcpClusterProvider) closeWatchers() {
 	for _, w := range []watcher.Watcher{p.workspaceWatcher, p.clusterStateWatcher} {
 		if w != nil && !reflect.ValueOf(w).IsNil() {
 			w.Close()
 		}
 	}
+}
+
+// closeManagers stops every non-nil manager in the map, releasing their
+// HTTP transports and background CA refreshers.
+func closeManagers(managers map[string]*kubernetes.Manager) {
+	for _, m := range managers {
+		if m != nil {
+			m.Close()
+		}
+	}
+}
+
+func (p *kcpClusterProvider) Close() {
+	p.closeWatchers()
+	closeManagers(p.managers)
 }

--- a/pkg/kcp/provider.go
+++ b/pkg/kcp/provider.go
@@ -103,6 +103,16 @@ func (p *kcpClusterProvider) reset(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create base manager: %w", err)
 	}
+	// NewKubeconfigManager starts the base manager's background CA refresher
+	// on construction. Keep it alive only when this reset succeeds; every
+	// error path below must release it, or provider construction fails with
+	// a live refresh goroutine and HTTP transport left behind.
+	baseManagerCommitted := false
+	defer func() {
+		if !baseManagerCommitted {
+			baseManager.Close()
+		}
+	}()
 
 	// The base manager may have resolved the cluster CA from the caURL
 	// kubeconfig extension. Propagate that trust anchor to the provider's
@@ -137,12 +147,10 @@ func (p *kcpClusterProvider) reset(ctx context.Context) error {
 	for _, ws := range workspaceList {
 		p.managers[ws] = nil
 	}
-	// Store the base manager for the default workspace
-	p.managers[p.defaultWorkspace] = baseManager
 
-	// Setup watchers. Only the previous watchers are closed here; the fresh
-	// base manager stored above must stay alive (its CA refresher keeps the
-	// default workspace's CA cache fresh).
+	// Setup watchers from the base manager. Only the previous watchers are
+	// closed here; the base manager, committed below, must stay alive (its
+	// CA refresher keeps the default workspace's CA cache fresh).
 	p.closeWatchers()
 	k8s, err := baseManager.Derived(ctx)
 	if err != nil {
@@ -150,6 +158,10 @@ func (p *kcpClusterProvider) reset(ctx context.Context) error {
 	}
 	p.workspaceWatcher = NewWorkspaceWatcher(ctx, k8s.DynamicClient(), p.defaultWorkspace)
 	p.clusterStateWatcher = watcher.NewClusterState(ctx, k8s.DiscoveryClient())
+
+	// Commit the base manager as the default workspace's manager.
+	p.managers[p.defaultWorkspace] = baseManager
+	baseManagerCommitted = true
 
 	return nil
 }
@@ -372,4 +384,23 @@ func closeManagers(managers map[string]*kubernetes.Manager) {
 func (p *kcpClusterProvider) Close() {
 	p.closeWatchers()
 	closeManagers(p.managers)
+}
+
+// RefreshCAs re-fetches every live workspace manager's cluster CA now, so
+// a rotated CA is picked up on SIGHUP without waiting out
+// ca_refresh_interval. The snapshot keeps the fetch (bounded by
+// caFetchMaxDuration) outside the lock so a reset triggered meanwhile is
+// not blocked on the network.
+func (p *kcpClusterProvider) RefreshCAs() {
+	p.mu.RLock()
+	managers := make([]*kubernetes.Manager, 0, len(p.managers))
+	for _, m := range p.managers {
+		if m != nil {
+			managers = append(managers, m)
+		}
+	}
+	p.mu.RUnlock()
+	for _, m := range managers {
+		m.RefreshCAs()
+	}
 }

--- a/pkg/kcp/provider_test.go
+++ b/pkg/kcp/provider_test.go
@@ -1,0 +1,131 @@
+package kcp
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type KcpProviderSuite struct {
+	suite.Suite
+}
+
+func TestKcpProviderSuite(t *testing.T) {
+	suite.Run(t, new(KcpProviderSuite))
+}
+
+// kcpSelfSignedPEM returns a fresh self-signed CA certificate in PEM form.
+func kcpSelfSignedPEM() []byte {
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "kcp-test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		panic(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func (s *KcpProviderSuite) TestResetKeepsDefaultWorkspaceCARefresherAlive() {
+	// A reset runs during provider construction. It must not close the
+	// freshly built base manager: that would kill the background CA
+	// refresher and the default workspace would never pick up a rotated
+	// cluster CA. The cache file following the served CA is the observable
+	// proof the refresher survived.
+	caA := kcpSelfSignedPEM()
+	caB := kcpSelfSignedPEM()
+	var mu sync.Mutex
+	currentCA := caA
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		_, _ = w.Write(currentCA)
+	}))
+	defer srv.Close()
+
+	// The caURL fetch client must trust the test TLS server; pin its cert
+	// via the injectable factory without touching the system cert pool.
+	serverPool := x509.NewCertPool()
+	serverPool.AddCert(srv.Certificate())
+	originalFactory := kubernetes.CAFetchClientFactory
+	kubernetes.CAFetchClientFactory = func() *http.Client {
+		return &http.Client{
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: serverPool}},
+		}
+	}
+	defer func() { kubernetes.CAFetchClientFactory = originalFactory }()
+
+	raw, _ := json.Marshal(map[string]string{"caURL": srv.URL})
+	kc := clientcmdapi.NewConfig()
+	kc.Clusters["fake"] = &clientcmdapi.Cluster{
+		// Never dialed: the API server port is closed, so workspace
+		// discovery fails fast and falls back to the kubeconfig entries.
+		Server: "https://127.0.0.1:1/clusters/root",
+		Extensions: map[string]runtime.Object{
+			"kubernetes-mcp-server": &runtime.Unknown{Raw: raw},
+		},
+	}
+	kc.Contexts["fake"] = &clientcmdapi.Context{Cluster: "fake", AuthInfo: "fake"}
+	kc.AuthInfos["fake"] = &clientcmdapi.AuthInfo{Token: "test-token"}
+	kc.CurrentContext = "fake"
+	kubeconfigPath := test.KubeconfigFile(s.T(), kc)
+
+	provider, err := newKcpClusterProvider(s.T().Context(), &config.StaticConfig{
+		KubeConfig:        kubeconfigPath,
+		CACacheDir:        filepath.Join(s.T().TempDir(), "ca-cache"),
+		CARefreshInterval: config.Duration(100 * time.Millisecond),
+	})
+	s.Require().NoError(err)
+	defer provider.Close()
+
+	p := provider.(*kcpClusterProvider)
+	baseManager := p.managers[p.defaultWorkspace]
+	s.Require().NotNil(baseManager, "base manager should back the default workspace")
+	caFile := baseManager.RESTConfig().CAFile
+	s.Require().NotEmpty(caFile, "base manager should resolve the caURL extension to a cached CA file")
+
+	got, err := os.ReadFile(caFile)
+	s.Require().NoError(err)
+	s.Equal(caA, got, "cached CA should match the CA served at construction")
+
+	// Rotate the served CA; only a live refresher (one reset did not close)
+	// converges the cache file.
+	mu.Lock()
+	currentCA = caB
+	mu.Unlock()
+	require.Eventually(s.T(), func() bool {
+		got, err := os.ReadFile(caFile)
+		return err == nil && bytes.Equal(got, caB)
+	}, 5*time.Second, 50*time.Millisecond, "the cache file should follow the served CA rotation")
+}

--- a/pkg/kcp/provider_test.go
+++ b/pkg/kcp/provider_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -103,7 +102,6 @@ func (s *KcpProviderSuite) TestResetKeepsDefaultWorkspaceCARefresherAlive() {
 
 	provider, err := newKcpClusterProvider(s.T().Context(), &config.StaticConfig{
 		KubeConfig:        kubeconfigPath,
-		CACacheDir:        filepath.Join(s.T().TempDir(), "ca-cache"),
 		CARefreshInterval: config.Duration(100 * time.Millisecond),
 	})
 	s.Require().NoError(err)

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -84,6 +84,8 @@ const (
 	flagCertificateAuthority = "certificate-authority"
 	flagDisableMultiCluster  = "disable-multi-cluster"
 	flagClusterProvider      = "cluster-provider"
+	flagCACacheDir           = "ca-cache-dir"
+	flagCARefreshInterval    = "ca-refresh-interval"
 	flagTLSCert              = "tls-cert"
 	flagTLSKey               = "tls-key"
 	flagRequireTLS           = "require-tls"
@@ -109,6 +111,8 @@ type MCPServerOptions struct {
 	ServerURL            string
 	DisableMultiCluster  bool
 	ClusterProvider      string
+	CACacheDir           string
+	CARefreshInterval    time.Duration
 	TLSCert              string
 	TLSKey               string
 	RequireTLS           bool
@@ -122,9 +126,11 @@ type MCPServerOptions struct {
 }
 
 func NewMCPServerOptions(streams genericiooptions.IOStreams) *MCPServerOptions {
+	defaults := config.Default()
 	return &MCPServerOptions{
-		IOStreams:    streams,
-		StaticConfig: config.Default(),
+		IOStreams:         streams,
+		StaticConfig:      defaults,
+		CARefreshInterval: defaults.CARefreshInterval.Duration(),
 	}
 }
 
@@ -191,6 +197,8 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	_ = cmd.Flags().MarkHidden(flagCertificateAuthority)
 	cmd.Flags().BoolVar(&o.DisableMultiCluster, flagDisableMultiCluster, o.DisableMultiCluster, "Disable multi cluster tools. Optional. If true, all tools will be run against the default cluster/context.")
 	cmd.Flags().StringVar(&o.ClusterProvider, flagClusterProvider, o.ClusterProvider, "Cluster provider strategy to use (one of: "+strings.Join(kubernetes.GetRegisteredStrategies(), ", ")+"). If not set, the server will auto-detect based on the environment.")
+	cmd.Flags().StringVar(&o.CACacheDir, flagCACacheDir, o.CACacheDir, "Directory used to cache CA certificates fetched via the caURL kubeconfig cluster extension. Defaults to a subdirectory of the system temp dir, which must be writable (with a read-only root filesystem, mount an emptyDir there).")
+	cmd.Flags().DurationVar(&o.CARefreshInterval, flagCARefreshInterval, o.CARefreshInterval, "How often to re-fetch CA certificates fetched via the caURL kubeconfig cluster extension, so a rotated cluster CA is picked up without a restart. Set to 0 to disable re-fetching.")
 	cmd.Flags().StringVar(&o.TLSCert, flagTLSCert, o.TLSCert, "Path to TLS certificate file for HTTPS. Must be used together with --tls-key.")
 	cmd.Flags().StringVar(&o.TLSKey, flagTLSKey, o.TLSKey, "Path to TLS private key file for HTTPS. Must be used together with --tls-cert.")
 	cmd.Flags().BoolVar(&o.RequireTLS, flagRequireTLS, o.RequireTLS, "Require TLS for server and all outbound connections")
@@ -298,6 +306,12 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 	if cmd.Flag(flagClusterProvider).Changed {
 		m.StaticConfig.ClusterProviderStrategy = m.ClusterProvider
+	}
+	if cmd.Flag(flagCACacheDir).Changed {
+		m.StaticConfig.CACacheDir = m.CACacheDir
+	}
+	if cmd.Flag(flagCARefreshInterval).Changed {
+		m.StaticConfig.CARefreshInterval = config.Duration(m.CARefreshInterval)
 	}
 	if cmd.Flag(flagDisableMultiCluster).Changed && m.DisableMultiCluster {
 		m.StaticConfig.ClusterProviderStrategy = api.ClusterProviderDisabled

--- a/pkg/kubernetes-mcp-server/cmd/root.go
+++ b/pkg/kubernetes-mcp-server/cmd/root.go
@@ -84,7 +84,6 @@ const (
 	flagCertificateAuthority = "certificate-authority"
 	flagDisableMultiCluster  = "disable-multi-cluster"
 	flagClusterProvider      = "cluster-provider"
-	flagCACacheDir           = "ca-cache-dir"
 	flagCARefreshInterval    = "ca-refresh-interval"
 	flagTLSCert              = "tls-cert"
 	flagTLSKey               = "tls-key"
@@ -111,7 +110,6 @@ type MCPServerOptions struct {
 	ServerURL            string
 	DisableMultiCluster  bool
 	ClusterProvider      string
-	CACacheDir           string
 	CARefreshInterval    time.Duration
 	TLSCert              string
 	TLSKey               string
@@ -197,7 +195,6 @@ func NewMCPServer(streams genericiooptions.IOStreams) *cobra.Command {
 	_ = cmd.Flags().MarkHidden(flagCertificateAuthority)
 	cmd.Flags().BoolVar(&o.DisableMultiCluster, flagDisableMultiCluster, o.DisableMultiCluster, "Disable multi cluster tools. Optional. If true, all tools will be run against the default cluster/context.")
 	cmd.Flags().StringVar(&o.ClusterProvider, flagClusterProvider, o.ClusterProvider, "Cluster provider strategy to use (one of: "+strings.Join(kubernetes.GetRegisteredStrategies(), ", ")+"). If not set, the server will auto-detect based on the environment.")
-	cmd.Flags().StringVar(&o.CACacheDir, flagCACacheDir, o.CACacheDir, "Directory used to cache CA certificates fetched via the caURL kubeconfig cluster extension. Defaults to a subdirectory of the system temp dir, which must be writable (with a read-only root filesystem, mount an emptyDir there).")
 	cmd.Flags().DurationVar(&o.CARefreshInterval, flagCARefreshInterval, o.CARefreshInterval, "How often to re-fetch CA certificates fetched via the caURL kubeconfig cluster extension, so a rotated cluster CA is picked up without a restart. Set to 0 to disable re-fetching.")
 	cmd.Flags().StringVar(&o.TLSCert, flagTLSCert, o.TLSCert, "Path to TLS certificate file for HTTPS. Must be used together with --tls-key.")
 	cmd.Flags().StringVar(&o.TLSKey, flagTLSKey, o.TLSKey, "Path to TLS private key file for HTTPS. Must be used together with --tls-cert.")
@@ -306,9 +303,6 @@ func (m *MCPServerOptions) loadFlags(cmd *cobra.Command) {
 	}
 	if cmd.Flag(flagClusterProvider).Changed {
 		m.StaticConfig.ClusterProviderStrategy = m.ClusterProvider
-	}
-	if cmd.Flag(flagCACacheDir).Changed {
-		m.StaticConfig.CACacheDir = m.CACacheDir
 	}
 	if cmd.Flag(flagCARefreshInterval).Changed {
 		m.StaticConfig.CARefreshInterval = config.Duration(m.CARefreshInterval)

--- a/pkg/kubernetes/ca.go
+++ b/pkg/kubernetes/ca.go
@@ -1,0 +1,359 @@
+package kubernetes
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+)
+
+// A cluster's API-server CA can be served over HTTPS (e.g. an endpoint that
+// mirrors the cluster CA for cross-cluster consumers). A kubeconfig cluster
+// entry opts into this with the kubernetes-mcp-server extension:
+//
+//	clusters:
+//	  - name: prod
+//	    cluster:
+//	      server: https://kubernetes.default.svc
+//	      extensions:
+//	        - name: kubernetes-mcp-server
+//	          extension:
+//	            caURL: https://ca.example.com/
+//
+// The CA is fetched into a cache file and the Kubernetes client is pointed at
+// that file (rest.Config TLSClientConfig.CAFile). client-go reloads CA files
+// it is pointed at and swaps the TLS transport when the content changes, so a
+// rotated CA converges without a restart. A background refresher keeps the
+// cache file in sync with the served CA.
+
+const (
+	// caExtensionName is the kubeconfig cluster extension key carrying caURL.
+	caExtensionName = "kubernetes-mcp-server"
+	// caCacheSubdir is the default cache directory below the system temp dir.
+	caCacheSubdir = "kubernetes-mcp-server-ca"
+	// caFetchTimeout bounds each CA fetch so a hung endpoint cannot stall
+	// manager creation.
+	caFetchTimeout = 15 * time.Second
+	// caFetchAttempts bounds transient failures (first DNS lookup from a
+	// fresh pod can race the network).
+	caFetchAttempts = 3
+	// caMaxBodyBytes bounds CA response size; bundles are a few KB.
+	caMaxBodyBytes = 1 << 20 // 1 MiB
+)
+
+// CAFetchClientFactory builds the HTTP client used to fetch CA certificates
+// from caURL endpoints. It is a variable so tests can pin a TLS test
+// server's certificate without touching the process-wide system pool.
+var CAFetchClientFactory = func() *http.Client {
+	return &http.Client{Timeout: caFetchTimeout}
+}
+
+func caURLFromClusterExtensions(cluster *clientcmdapi.Cluster) string {
+	obj, ok := cluster.Extensions[caExtensionName]
+	if !ok || obj == nil {
+		return ""
+	}
+	// Extensions decode to runtime.Object; concrete shapes vary by codec
+	// (RawExtension, unstructured), so JSON round-trip covers all of them.
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return ""
+	}
+	var ext struct {
+		CAURL string `json:"caURL"`
+	}
+	if err := json.Unmarshal(data, &ext); err != nil {
+		return ""
+	}
+	return ext.CAURL
+}
+
+func validateCAURL(caURL string) error {
+	u, err := url.Parse(caURL)
+	if err != nil {
+		return fmt.Errorf("invalid caURL %q: %w", caURL, err)
+	}
+	// A CA is a trust root; fetching it over cleartext would let a
+	// network attacker substitute their own CA and then impersonate the
+	// cluster the CA is meant to authenticate.
+	if u.Scheme != "https" {
+		return fmt.Errorf("caURL %q must be an https URL", caURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("caURL %q has no host", caURL)
+	}
+	return nil
+}
+
+func caCacheDir(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	return filepath.Join(os.TempDir(), caCacheSubdir)
+}
+
+func caCacheFilePath(cacheDir, caURL string) string {
+	sum := sha256.Sum256([]byte(caURL))
+	return filepath.Join(cacheDir, hex.EncodeToString(sum[:8])+".crt")
+}
+
+// applyClusterCAURL points restConfig's TLS at a cached copy of the CA served
+// by the resolved context's cluster caURL extension. It returns a refresher
+// that keeps the cache file in sync, or nil when the cluster has no caURL.
+func applyClusterCAURL(
+	ctx context.Context,
+	config api.BaseConfig,
+	rawConfig *clientcmdapi.Config,
+	contextName string,
+	restConfig *rest.Config,
+) (*caRefresher, error) {
+	logger := klogutil.FromContext(ctx)
+	if rawConfig == nil || restConfig == nil {
+		return nil, nil
+	}
+	contextInfo, ok := rawConfig.Contexts[contextName]
+	if !ok || contextInfo == nil {
+		return nil, nil
+	}
+	cluster, ok := rawConfig.Clusters[contextInfo.Cluster]
+	if !ok || cluster == nil {
+		return nil, nil
+	}
+	caURL := caURLFromClusterExtensions(cluster)
+	if caURL == "" {
+		return nil, nil
+	}
+	if err := validateCAURL(caURL); err != nil {
+		return nil, err
+	}
+
+	cacheFile := caCacheFilePath(caCacheDir(config.GetCACacheDir()), caURL)
+	client := CAFetchClientFactory()
+	fetchCtx, cancel := context.WithTimeout(ctx, caFetchTimeout)
+	defer cancel()
+	data, err := fetchCA(fetchCtx, client, caURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch CA for context %q from %s: %w", contextName, caURL, err)
+	}
+	if err := writeCAFile(cacheFile, data); err != nil {
+		return nil, fmt.Errorf("cache CA for context %q: %w", contextName, err)
+	}
+	logger.V(2).Info("Using CA fetched from kubeconfig extension", "context", contextName, "ca_url", caURL, "ca_file", cacheFile)
+
+	// The fetched CA wins over any certificate-authority-data so the cached
+	// file is the single source client-go watches for rotation.
+	restConfig.CAFile = cacheFile
+	restConfig.CAData = nil
+
+	interval := config.GetCARefreshInterval()
+	if interval <= 0 {
+		logger.V(2).Info("CA refresh disabled; cached CA only refreshes when a manager is rebuilt", "context", contextName)
+		return nil, nil
+	}
+	return newCARefresher(ctx, cacheFile, caURL, client, interval, logger), nil
+}
+
+// fetchCA downloads the CA served at caURL, retrying transient failures.
+func fetchCA(ctx context.Context, client *http.Client, caURL string) ([]byte, error) {
+	for attempt := 1; ; attempt++ {
+		data, retryable, err := fetchCAOnce(ctx, client, caURL)
+		if err == nil {
+			return data, nil
+		}
+		if !retryable || attempt >= caFetchAttempts {
+			return nil, err
+		}
+		select {
+		case <-time.After(time.Duration(attempt) * time.Second):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func fetchCAOnce(ctx context.Context, client *http.Client, caURL string) (data []byte, retryable bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, caURL, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, true, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		// Permanent client errors never become retryable; transient 5xx and
+		// 429 responses and network errors are worth a retry.
+		retryable := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
+		return nil, retryable, fmt.Errorf("CA URL %s returned status %d", caURL, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, caMaxBodyBytes+1))
+	if err != nil {
+		return nil, true, err
+	}
+	if len(body) > caMaxBodyBytes {
+		return nil, false, fmt.Errorf("CA URL %s response exceeds %d bytes", caURL, caMaxBodyBytes)
+	}
+	block, _ := pem.Decode(body)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, false, fmt.Errorf("CA URL %s response is not a PEM CA certificate", caURL)
+	}
+	// AppendCertsFromPEM validates the whole bundle (it handles multi-block
+	// PEM where ParseCertificates expects raw DER).
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(body) {
+		return nil, false, fmt.Errorf("CA URL %s response is not a valid CA certificate bundle", caURL)
+	}
+	return body, false, nil
+}
+
+// writeCAFile atomically writes data to path so readers (client-go's CA-file
+// rotation) never observe a partially written certificate.
+func writeCAFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".ca-*.tmp")
+	if err != nil {
+		return err
+	}
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		cleanup()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return err
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		_ = os.Remove(tmp.Name())
+		return err
+	}
+	return nil
+}
+
+// caRefresher re-fetches a cluster's CA on an interval so a rotated CA (e.g.
+// after the cluster is re-provisioned) lands in the cache file client-go is
+// pointed at; client-go then swaps to the new CA within its own refresh cycle.
+type caRefresher struct {
+	ctx       context.Context
+	cacheFile string
+	caURL     string
+	client    *http.Client
+	interval  time.Duration
+	logger    klog.Logger
+
+	// started records whether the refresh loop was launched so Close can
+	// skip waiting on a loop that never ran (a refresher may be discarded
+	// before start without a goroutine existing to stop).
+	started   atomic.Bool
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+	closeOnce sync.Once
+}
+
+func newCARefresher(
+	ctx context.Context,
+	cacheFile, caURL string,
+	client *http.Client,
+	interval time.Duration,
+	logger klog.Logger,
+) *caRefresher {
+	return &caRefresher{
+		ctx:       ctx,
+		cacheFile: cacheFile,
+		caURL:     caURL,
+		client:    client,
+		interval:  interval,
+		logger:    logger,
+		stopCh:    make(chan struct{}),
+		doneCh:    make(chan struct{}),
+	}
+}
+
+func (r *caRefresher) start() {
+	// NewKubeconfigManager is the only caller and starts the loop only
+	// after the manager is fully built, so a construction error leaves no
+	// goroutine behind that would need stopping.
+	r.started.Store(true)
+	go r.loop()
+}
+
+func (r *caRefresher) loop() {
+	defer close(r.doneCh)
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			r.refreshOnce()
+		case <-r.stopCh:
+			return
+		}
+	}
+}
+
+func (r *caRefresher) refreshOnce() {
+	// WithoutCancel keeps the caller's log/trace values without letting a
+	// shutdown cancel the fetch; the timeout below still bounds it.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.ctx), caFetchTimeout)
+	defer cancel()
+	data, err := fetchCA(ctx, r.client, r.caURL)
+	if err != nil {
+		// Keep the previous CA; it worked until now and a bad transient
+		// refresh must not break a healthy client.
+		r.logger.Error(err, "failed to refresh cached CA, keeping previous CA", "ca_url", r.caURL, "ca_file", r.cacheFile)
+		return
+	}
+	// Skip the rewrite when the served CA is unchanged; pointless temp-file
+	// churn and client-go re-reads on every tick.
+	if current, err := os.ReadFile(r.cacheFile); err == nil && bytes.Equal(current, data) {
+		return
+	}
+	if err := writeCAFile(r.cacheFile, data); err != nil {
+		r.logger.Error(err, "failed to write refreshed CA", "ca_file", r.cacheFile)
+	}
+}
+
+// Close stops the refresh loop and blocks until it has exited. Safe to call
+// multiple times.
+func (r *caRefresher) Close() {
+	if r == nil {
+		return
+	}
+	r.closeOnce.Do(func() {
+		if !r.started.Load() {
+			return
+		}
+		close(r.stopCh)
+		<-r.doneCh
+	})
+}

--- a/pkg/kubernetes/ca.go
+++ b/pkg/kubernetes/ca.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"k8s.io/client-go/rest"
@@ -139,13 +140,17 @@ func validateCAURL(caURL string) error {
 	return nil
 }
 
+// caCacheRoot is the base directory cached CA certificates live under.
+// It is a variable (defaulting to the system temp dir, which honors
+// $TMPDIR) so tests can redirect the cache away from the shared system
+// temp dir; production never changes it. Operators with a read-only root
+// filesystem point TMPDIR at writable storage or mount an emptyDir at
+// /tmp.
+var caCacheRoot = os.TempDir()
+
 func caCacheFilePath(caURL string) string {
-	// The cache lives in a subdirectory of the system temp dir (which
-	// honors $TMPDIR), so an operator with a read-only root filesystem can
-	// point the cache at writable storage by setting $TMPDIR or mounting
-	// an emptyDir at /tmp.
 	sum := sha256.Sum256([]byte(caURL))
-	return filepath.Join(os.TempDir(), caCacheSubdir, hex.EncodeToString(sum[:8])+".crt")
+	return filepath.Join(caCacheRoot, caCacheSubdir, hex.EncodeToString(sum[:8])+".crt")
 }
 
 // applyClusterCAURL points restConfig's TLS at a cached copy of the CA served
@@ -281,10 +286,39 @@ func fetchCAOnce(ctx context.Context, client *http.Client, caURL string) (data [
 	return body, false, nil
 }
 
-// writeCAFile atomically writes data to path so readers (client-go's CA-file
-// rotation) never observe a partially written certificate.
+// ensurePrivateCacheDir makes dir exist and be private before CA files
+// go there. MkdirAll's mode only applies when it creates the directory,
+// so a predictable path beneath the shared system temp dir must be
+// checked rather than trusted: another local user could otherwise
+// pre-create it writable or as a symlink and substitute their own
+// certificate. Fails closed on symlinks, group/world writable
+// directories, and foreign ownership. World-readable is tolerated: the
+// CA files themselves are 0600, and read access cannot swap a trust
+// anchor.
+func ensurePrivateCacheDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create CA cache directory %s: %w", dir, err)
+	}
+	fi, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("stat CA cache directory %s: %w", dir, err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("CA cache directory %s must not be a symlink", dir)
+	}
+	if perm := fi.Mode().Perm(); perm&0o022 != 0 {
+		return fmt.Errorf("CA cache directory %s is group or world writable (mode %#o)", dir, perm)
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok && st.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("CA cache directory %s is owned by uid %d, not the current user", dir, st.Uid)
+	}
+	return nil
+}
+
+// writeCAFile atomically writes data to path so readers (client-go's
+// CA-file rotation) never observe a partially written certificate.
 func writeCAFile(path string, data []byte) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	if err := ensurePrivateCacheDir(filepath.Dir(path)); err != nil {
 		return err
 	}
 	tmp, err := os.CreateTemp(filepath.Dir(path), ".ca-*.tmp")

--- a/pkg/kubernetes/ca.go
+++ b/pkg/kubernetes/ca.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,6 +19,7 @@ import (
 
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -58,13 +58,48 @@ const (
 	caFetchAttempts = 3
 	// caMaxBodyBytes bounds CA response size; bundles are a few KB.
 	caMaxBodyBytes = 1 << 20 // 1 MiB
+	// caMaxRedirects bounds redirect hops from the CA endpoint. A CA is a
+	// trust root fetched on each refresh; any real deployment serves it
+	// directly, and a long chain is a redirect-loop or abuse signal.
+	caMaxRedirects = 3
+	// caFetchMaxBackoff is the cumulative 1s+2s... backoff between retries.
+	caFetchMaxBackoff = time.Duration(caFetchAttempts*(caFetchAttempts-1)/2) * time.Second
+	// caFetchMaxDuration bounds a whole fetch with retries: caFetchAttempts
+	// timeout-bounded attempts plus the backoff between them. Each attempt
+	// gets its own caFetchTimeout (see fetchCA), so a hung first attempt
+	// cannot consume the retry budget.
+	caFetchMaxDuration = caFetchTimeout*caFetchAttempts + caFetchMaxBackoff
 )
+
+// errCARedirectPolicy marks a redirect rejected by the CA client's redirect
+// policy (non-https hop or too many hops). Rejections are deterministic, so
+// they must not be retried.
+var errCARedirectPolicy = errors.New("caURL redirect rejected")
 
 // CAFetchClientFactory builds the HTTP client used to fetch CA certificates
 // from caURL endpoints. It is a variable so tests can pin a TLS test
 // server's certificate without touching the process-wide system pool.
+// The client verifies caURL against the system trust store (system roots or
+// SSL_CERT_FILE), not against the cluster CA being fetched; the redirect
+// policy applies only to clients built by this factory, so callers that
+// replace the factory inherit the responsibility of rejecting non-https
+// redirects.
 var CAFetchClientFactory = func() *http.Client {
-	return &http.Client{Timeout: caFetchTimeout}
+	return &http.Client{
+		Timeout: caFetchTimeout,
+		// A hostile or misconfigured CA host could redirect the fetch to
+		// cleartext, letting a network attacker substitute a CA. Follow
+		// only https hops, and cap the chain.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= caMaxRedirects {
+				return fmt.Errorf("%w: too many redirects (max %d)", errCARedirectPolicy, caMaxRedirects)
+			}
+			if req.URL.Scheme != "https" {
+				return fmt.Errorf("%w: redirect target must be https", errCARedirectPolicy)
+			}
+			return nil
+		},
+	}
 }
 
 func caURLFromClusterExtensions(cluster *clientcmdapi.Cluster) string {
@@ -145,10 +180,19 @@ func applyClusterCAURL(
 	if err := validateCAURL(caURL); err != nil {
 		return nil, err
 	}
+	// client-go rejects a CAFile combined with insecure-skip-tls-verify
+	// ("specifying a root certificates file with the insecure flag is not
+	// allowed"), so fail here with a message that names the conflict
+	// instead of surfacing that cryptic error later, after the fetch.
+	if restConfig.Insecure {
+		return nil, fmt.Errorf("cluster %q sets insecure-skip-tls-verify and serves its CA via caURL; remove one of them", contextName)
+	}
 
 	cacheFile := caCacheFilePath(caCacheDir(config.GetCACacheDir()), caURL)
 	client := CAFetchClientFactory()
-	fetchCtx, cancel := context.WithTimeout(ctx, caFetchTimeout)
+	// Bounds the whole fetch-with-retries so manager creation cannot hang
+	// for longer than the attempt-and-backoff envelope (see fetchCA).
+	fetchCtx, cancel := context.WithTimeout(ctx, caFetchMaxDuration)
 	defer cancel()
 	data, err := fetchCA(fetchCtx, client, caURL)
 	if err != nil {
@@ -166,16 +210,23 @@ func applyClusterCAURL(
 
 	interval := config.GetCARefreshInterval()
 	if interval <= 0 {
-		logger.V(2).Info("CA refresh disabled; cached CA only refreshes when a manager is rebuilt", "context", contextName)
-		return nil, nil
+		logger.V(2).Info("CA auto-refresh disabled; cached CA refreshes on SIGHUP or when a manager is rebuilt", "context", contextName)
 	}
+	// The refresher is kept even when auto-refresh is disabled so SIGHUP
+	// reload (Manager.RefreshCAs) can still fetch on demand; its background
+	// loop just never starts (see caRefresher.start).
 	return newCARefresher(ctx, cacheFile, caURL, client, interval, logger), nil
 }
 
 // fetchCA downloads the CA served at caURL, retrying transient failures.
 func fetchCA(ctx context.Context, client *http.Client, caURL string) ([]byte, error) {
 	for attempt := 1; ; attempt++ {
-		data, retryable, err := fetchCAOnce(ctx, client, caURL)
+		// Bound each attempt individually so a hung first attempt cannot
+		// consume the retry budget; the caller's outer deadline (see
+		// caFetchMaxDuration) still caps the whole fetch-with-retries.
+		attemptCtx, cancel := context.WithTimeout(ctx, caFetchTimeout)
+		data, retryable, err := fetchCAOnce(attemptCtx, client, caURL)
+		cancel()
 		if err == nil {
 			return data, nil
 		}
@@ -197,9 +248,19 @@ func fetchCAOnce(ctx context.Context, client *http.Client, caURL string) (data [
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, true, err
+		// Redirect-policy rejections are deterministic; retrying them only
+		// burns the retry budget.
+		return nil, !errors.Is(err, errCARedirectPolicy), err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	// Clients built outside CAFetchClientFactory (tests, callers that
+	// replaced it) may follow redirects without a policy; re-check the
+	// final URL so a scheme downgrade (https to http) is still caught.
+	startURL, err := url.Parse(caURL)
+	if err == nil && resp.Request != nil && resp.Request.URL.Scheme != startURL.Scheme {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return nil, false, fmt.Errorf("CA URL %s redirected from %s to %s", caURL, startURL.Scheme, resp.Request.URL.Scheme)
+	}
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 		// Permanent client errors never become retryable; transient 5xx and
@@ -214,15 +275,11 @@ func fetchCAOnce(ctx context.Context, client *http.Client, caURL string) (data [
 	if len(body) > caMaxBodyBytes {
 		return nil, false, fmt.Errorf("CA URL %s response exceeds %d bytes", caURL, caMaxBodyBytes)
 	}
-	block, _ := pem.Decode(body)
-	if block == nil || block.Type != "CERTIFICATE" {
-		return nil, false, fmt.Errorf("CA URL %s response is not a PEM CA certificate", caURL)
-	}
-	// AppendCertsFromPEM validates the whole bundle (it handles multi-block
-	// PEM where ParseCertificates expects raw DER).
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(body) {
-		return nil, false, fmt.Errorf("CA URL %s response is not a valid CA certificate bundle", caURL)
+	// certutil.ParseCertsPEM validates the whole bundle: every CERTIFICATE
+	// block parses, and at least one is required.
+	served, err := certutil.ParseCertsPEM(body)
+	if err != nil || len(served) == 0 {
+		return nil, false, fmt.Errorf("CA URL %s response is not a PEM CA certificate: %w", caURL, err)
 	}
 	return body, false, nil
 }
@@ -303,6 +360,12 @@ func (r *caRefresher) start() {
 	// NewKubeconfigManager is the only caller and starts the loop only
 	// after the manager is fully built, so a construction error leaves no
 	// goroutine behind that would need stopping.
+	// A zero interval disables the background loop entirely; the refresher
+	// then only fetches on demand (Manager.RefreshCAs on SIGHUP). Close
+	// sees started=false and skips waiting on a loop that never ran.
+	if r.interval <= 0 {
+		return
+	}
 	r.started.Store(true)
 	go r.loop()
 }
@@ -323,8 +386,9 @@ func (r *caRefresher) loop() {
 
 func (r *caRefresher) refreshOnce() {
 	// WithoutCancel keeps the caller's log/trace values without letting a
-	// shutdown cancel the fetch; the timeout below still bounds it.
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.ctx), caFetchTimeout)
+	// shutdown cancel the fetch; caFetchMaxDuration below still bounds a
+	// fetch-with-retries.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.ctx), caFetchMaxDuration)
 	defer cancel()
 	data, err := fetchCA(ctx, r.client, r.caURL)
 	if err != nil {

--- a/pkg/kubernetes/ca.go
+++ b/pkg/kubernetes/ca.go
@@ -139,16 +139,13 @@ func validateCAURL(caURL string) error {
 	return nil
 }
 
-func caCacheDir(configured string) string {
-	if configured != "" {
-		return configured
-	}
-	return filepath.Join(os.TempDir(), caCacheSubdir)
-}
-
-func caCacheFilePath(cacheDir, caURL string) string {
+func caCacheFilePath(caURL string) string {
+	// The cache lives in a subdirectory of the system temp dir (which
+	// honors $TMPDIR), so an operator with a read-only root filesystem can
+	// point the cache at writable storage by setting $TMPDIR or mounting
+	// an emptyDir at /tmp.
 	sum := sha256.Sum256([]byte(caURL))
-	return filepath.Join(cacheDir, hex.EncodeToString(sum[:8])+".crt")
+	return filepath.Join(os.TempDir(), caCacheSubdir, hex.EncodeToString(sum[:8])+".crt")
 }
 
 // applyClusterCAURL points restConfig's TLS at a cached copy of the CA served
@@ -188,7 +185,7 @@ func applyClusterCAURL(
 		return nil, fmt.Errorf("cluster %q sets insecure-skip-tls-verify and serves its CA via caURL; remove one of them", contextName)
 	}
 
-	cacheFile := caCacheFilePath(caCacheDir(config.GetCACacheDir()), caURL)
+	cacheFile := caCacheFilePath(caURL)
 	client := CAFetchClientFactory()
 	// Bounds the whole fetch-with-retries so manager creation cannot hang
 	// for longer than the attempt-and-backoff envelope (see fetchCA).

--- a/pkg/kubernetes/ca_test.go
+++ b/pkg/kubernetes/ca_test.go
@@ -1,0 +1,349 @@
+package kubernetes
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/internal/test"
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type ClusterCACASuite struct {
+	suite.Suite
+	originalEnv []string
+}
+
+func (s *ClusterCACASuite) SetupTest() {
+	s.originalEnv = os.Environ()
+}
+
+func (s *ClusterCACASuite) TearDownTest() {
+	test.RestoreEnv(s.originalEnv)
+}
+
+func TestClusterCASuite(t *testing.T) {
+	suite.Run(t, new(ClusterCACASuite))
+}
+
+// selfSignedPEM returns a fresh self-signed CA certificate in PEM form, so
+// tests never depend on a bundled static certificate.
+func selfSignedPEM() []byte {
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		panic(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// kubeconfigWithCAURL builds a kubeconfig whose cluster carries the
+// kubernetes-mcp-server extension pointing at caURL, writes it to disk and
+// returns its path.
+func kubeconfigWithCAURL(t *testing.T, caURL string) string {
+	t.Helper()
+	kc := clientcmdapi.NewConfig()
+	kc.Clusters["fake"] = &clientcmdapi.Cluster{
+		Server: "https://127.0.0.1:1", // never dialed at manager creation
+		Extensions: map[string]runtime.Object{
+			caExtensionName: extensionObject(caURL),
+		},
+	}
+	kc.Contexts["fake"] = &clientcmdapi.Context{Cluster: "fake", AuthInfo: "fake"}
+	kc.AuthInfos["fake"] = &clientcmdapi.AuthInfo{Token: "test-token"}
+	kc.CurrentContext = "fake"
+	return test.KubeconfigFile(t, kc)
+}
+
+func extensionObject(caURL string) runtime.Object {
+	raw, _ := json.Marshal(map[string]string{"caURL": caURL})
+	return &runtime.Unknown{Raw: raw}
+}
+
+func (s *ClusterCACASuite) TestCAURLFromClusterExtensions() {
+	s.Run("reads caURL from the kubernetes-mcp-server extension", func() {
+		cluster := &clientcmdapi.Cluster{
+			Extensions: map[string]runtime.Object{
+				caExtensionName: extensionObject("https://ca.example.com/"),
+			},
+		}
+		s.Equal("https://ca.example.com/", caURLFromClusterExtensions(cluster))
+	})
+	s.Run("returns empty without the extension", func() {
+		s.Empty(caURLFromClusterExtensions(&clientcmdapi.Cluster{}))
+	})
+	s.Run("returns empty when the extension is not an object", func() {
+		cluster := &clientcmdapi.Cluster{
+			Extensions: map[string]runtime.Object{
+				caExtensionName: &runtime.Unknown{Raw: []byte(`"just-a-string"`)},
+			},
+		}
+		s.Empty(caURLFromClusterExtensions(cluster))
+	})
+	s.Run("survives a write/load round-trip of a real kubeconfig file", func() {
+		// The kubeconfig path exercises the actual clientcmd decode of
+		// extensions (runtime.Unknown payloads).
+		path := kubeconfigWithCAURL(s.T(), "https://ca.example.com/")
+		cfg := &config.StaticConfig{KubeConfig: path, CACacheDir: s.T().TempDir()}
+		s.Equal("https://ca.example.com/", caURLOfResolvedCluster(s.T(), cfg))
+	})
+}
+
+func (s *ClusterCACASuite) TestValidateCAURL() {
+	s.Run("accepts https", func() {
+		s.NoError(validateCAURL("https://ca.example.com/"))
+	})
+	s.Run("rejects http as a trust root would be interceptable", func() {
+		s.Error(validateCAURL("http://ca.example.com/"))
+	})
+	s.Run("rejects non-http scheme", func() {
+		s.Error(validateCAURL("file:///etc/ssl/ca.pem"))
+	})
+	s.Run("rejects missing host", func() {
+		s.Error(validateCAURL("https:///path"))
+	})
+}
+
+func (s *ClusterCACASuite) TestFetchCA() {
+	s.Run("fetches a PEM certificate", func() {
+		want := selfSignedPEM()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(want)
+		}))
+		defer srv.Close()
+		got, err := fetchCA(context.Background(), &http.Client{}, srv.URL)
+		s.Require().NoError(err)
+		s.Equal(want, got)
+	})
+	s.Run("errors on non-200 response", func() {
+		srv := httptest.NewServer(http.NotFoundHandler())
+		defer srv.Close()
+		_, err := fetchCA(context.Background(), &http.Client{}, srv.URL)
+		s.Require().Error(err)
+		s.ErrorContains(err, "status 404")
+	})
+	s.Run("fails fast on permanent client errors without retrying", func() {
+		var hits atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			http.NotFound(w, nil)
+		}))
+		defer srv.Close()
+		_, err := fetchCA(context.Background(), &http.Client{}, srv.URL)
+		s.Require().Error(err)
+		s.Equal(int32(1), hits.Load(), "a permanent 404 must not be retried")
+	})
+	s.Run("retries transient server errors", func() {
+		var hits atomic.Int32
+		want := selfSignedPEM()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if hits.Add(1) == 1 {
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write(want)
+		}))
+		defer srv.Close()
+		got, err := fetchCA(context.Background(), &http.Client{}, srv.URL)
+		s.Require().NoError(err)
+		s.Equal(want, got)
+		s.GreaterOrEqual(hits.Load(), int32(2), "transient 5xx must be retried")
+	})
+	s.Run("errors on non-PEM response without retrying forever", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("not a certificate"))
+		}))
+		defer srv.Close()
+		_, err := fetchCA(context.Background(), &http.Client{}, srv.URL)
+		s.Require().Error(err)
+		s.ErrorContains(err, "not a PEM CA certificate")
+	})
+	s.Run("errors on a non-certificate PEM block", func() {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		s.Require().NoError(err)
+		keyPEM, err := x509.MarshalECPrivateKey(key)
+		s.Require().NoError(err)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyPEM}))
+		}))
+		defer srv.Close()
+		_, err = fetchCA(context.Background(), &http.Client{}, srv.URL)
+		s.Require().Error(err)
+		s.ErrorContains(err, "not a PEM CA certificate")
+	})
+}
+
+func (s *ClusterCACASuite) TestRefreshOnceSkipsUnchangedCA() {
+	s.Run("does not rewrite an unchanged CA", func() {
+		want := selfSignedPEM()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(want)
+		}))
+		defer srv.Close()
+		cacheDir := s.T().TempDir()
+		cacheFile := filepath.Join(cacheDir, "ca.crt")
+		s.Require().NoError(writeCAFile(cacheFile, want))
+		// Backdate the file so a rewrite is detectable via mtime.
+		old := time.Now().Add(-time.Hour)
+		s.Require().NoError(os.Chtimes(cacheFile, old, old))
+
+		r := newCARefresher(context.Background(), cacheFile, srv.URL, &http.Client{}, time.Minute, klogutil.FromContext(context.Background()))
+		r.refreshOnce()
+
+		info, err := os.Stat(cacheFile)
+		s.Require().NoError(err)
+		s.True(info.ModTime().Before(time.Now().Add(-30*time.Minute)), "an unchanged CA must not be rewritten")
+
+		// No temp files left behind either.
+		matches, _ := filepath.Glob(filepath.Join(cacheDir, ".ca-*.tmp"))
+		s.Empty(matches)
+	})
+}
+
+func (s *ClusterCACASuite) TestApplyClusterCAURL() {
+	s.Run("fetches, caches and refresh the CA over https", func() {
+		// Mutable CA server: first CA, then a rotated one. TLS is required
+		// for caURL (a trust root must not travel over cleartext), so the
+		// fetch client is pointed at the test server's cert via the
+		// injectable CAFetchClientFactory; the process-wide system cert pool is
+		// deliberately left alone.
+		var mu sync.Mutex
+		currentCA := selfSignedPEM()
+		rotatedCA := selfSignedPEM()
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			_, _ = w.Write(currentCA)
+		}))
+		defer srv.Close()
+		serverPool := x509.NewCertPool()
+		serverPool.AddCert(srv.Certificate())
+		originalFetchClient := CAFetchClientFactory
+		CAFetchClientFactory = func() *http.Client {
+			return &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{RootCAs: serverPool},
+				},
+			}
+		}
+		defer func() { CAFetchClientFactory = originalFetchClient }()
+
+		cfg := &config.StaticConfig{
+			KubeConfig:        kubeconfigWithCAURL(s.T(), srv.URL),
+			CACacheDir:        filepath.Join(s.T().TempDir(), "ca-cache"),
+			CARefreshInterval: config.Duration(100 * time.Millisecond),
+		}
+		manager, err := NewKubeconfigManager(s.T().Context(), cfg, "")
+		s.Require().NoError(err)
+		defer manager.Close()
+
+		// The rest config must point at the cached file, not inline data,
+		// so client-go's CA-file rotation applies.
+		caFile := manager.kubernetes.RESTConfig().CAFile
+		s.NotEmpty(caFile)
+		s.Empty(manager.kubernetes.RESTConfig().CAData)
+		got, err := os.ReadFile(caFile)
+		s.Require().NoError(err)
+		s.Equal(currentCA, got, "cached CA should match the initially served CA")
+
+		// Rotate the served CA and wait for the refresher to pick it up.
+		mu.Lock()
+		currentCA = rotatedCA
+		mu.Unlock()
+		require.Eventually(s.T(), func() bool {
+			got, err := os.ReadFile(caFile)
+			return err == nil && string(got) == string(rotatedCA)
+		}, 5*time.Second, 50*time.Millisecond)
+
+		// Close is safe to call twice; the refresh goroutine must not leak.
+		manager.Close()
+		manager.Close()
+	})
+	s.Run("leaves rest config untouched without an extension", func() {
+		path := s.mockServerKubeconfig()
+		manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{
+			KubeConfig:        path,
+			CACacheDir:        s.T().TempDir(),
+			CARefreshInterval: config.Duration(time.Minute),
+		}, "")
+		s.Require().NoError(err)
+		defer manager.Close()
+		s.Empty(manager.kubernetes.RESTConfig().CAFile)
+	})
+}
+
+// caURLOfResolvedCluster loads the kubeconfig behind cfg and returns the caURL
+// of its current context's cluster, exercising the real decode path.
+func caURLOfResolvedCluster(t testing.TB, cfg *config.StaticConfig) string {
+	t.Helper()
+	raw, err := loadKubeconfigRaw(cfg.GetKubeConfigPath())
+	require.NoError(t, err)
+	ctxInfo := raw.Contexts[raw.CurrentContext]
+	require.NotNil(t, ctxInfo)
+	return caURLFromClusterExtensions(raw.Clusters[ctxInfo.Cluster])
+}
+
+func loadKubeconfigRaw(path string) (*clientcmdapi.Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return clientcmd.Load(data)
+}
+
+func (s *ClusterCACASuite) mockServerKubeconfig() string {
+	// Reuse the mock server's kubeconfig shape but with a dummy endpoint;
+	// the API server is never dialed during manager creation.
+	raw, err := clientcmd.Load([]byte(`
+apiVersion: v1
+kind: Config
+clusters:
+- name: fake
+  cluster:
+    server: https://127.0.0.1:1
+contexts:
+- name: fake
+  context:
+    cluster: fake
+    user: fake
+current-context: fake
+users:
+- name: fake
+  user:
+    token: test-token
+`))
+	require.NoError(s.T(), err)
+	return test.KubeconfigFile(s.T(), raw)
+}

--- a/pkg/kubernetes/ca_test.go
+++ b/pkg/kubernetes/ca_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -136,6 +137,23 @@ func (s *ClusterCACASuite) TestValidateCAURL() {
 	})
 }
 
+func (s *ClusterCACASuite) TestCAFetchClientRedirectPolicy() {
+	s.Run("rejects a redirect to a non-https target", func() {
+		client := CAFetchClientFactory()
+		httpTarget := &http.Request{URL: &url.URL{Scheme: "http", Host: "ca.example.com"}}
+		err := client.CheckRedirect(httpTarget, nil)
+		s.Require().Error(err)
+		s.ErrorIs(err, errCARedirectPolicy)
+	})
+	s.Run("caps the redirect chain", func() {
+		client := CAFetchClientFactory()
+		httpsTarget := &http.Request{URL: &url.URL{Scheme: "https", Host: "ca.example.com"}}
+		via := make([]*http.Request, caMaxRedirects)
+		s.Require().Error(client.CheckRedirect(httpsTarget, via), "max redirects reached must be rejected")
+		s.NoError(client.CheckRedirect(httpsTarget, via[:caMaxRedirects-1]), "still within the cap must be allowed")
+	})
+}
+
 func (s *ClusterCACASuite) TestFetchCA() {
 	s.Run("fetches a PEM certificate", func() {
 		want := selfSignedPEM()
@@ -180,6 +198,29 @@ func (s *ClusterCACASuite) TestFetchCA() {
 		s.Require().NoError(err)
 		s.Equal(want, got)
 		s.GreaterOrEqual(hits.Load(), int32(2), "transient 5xx must be retried")
+	})
+	s.Run("rejects a redirect that downgrades https to http", func() {
+		want := selfSignedPEM()
+		// The CA endpoint (https) bounces the fetch to a cleartext host.
+		httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(want)
+		}))
+		defer httpSrv.Close()
+		tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, httpSrv.URL, http.StatusFound)
+		}))
+		defer tlsSrv.Close()
+		// A client without a redirect policy (simulating a caller that
+		// replaced CAFetchClientFactory): the post-Do scheme check must
+		// still catch the downgrade.
+		pool := x509.NewCertPool()
+		pool.AddCert(tlsSrv.Certificate())
+		downgradingClient := &http.Client{
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}},
+		}
+		_, err := fetchCA(context.Background(), downgradingClient, tlsSrv.URL)
+		s.Require().Error(err)
+		s.ErrorContains(err, "redirected from https to http")
 	})
 	s.Run("errors on non-PEM response without retrying forever", func() {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -290,6 +331,81 @@ func (s *ClusterCACASuite) TestApplyClusterCAURL() {
 		// Close is safe to call twice; the refresh goroutine must not leak.
 		manager.Close()
 		manager.Close()
+	})
+	s.Run("RefreshCAs picks up a rotated CA on demand (SIGHUP path)", func() {
+		// Auto-refresh disabled; the refresher must still serve on-demand
+		// refreshes via Manager.RefreshCAs so SIGHUP can unbreak a server
+		// without waiting out an interval or restarting.
+		var mu sync.Mutex
+		currentCA := selfSignedPEM()
+		rotatedCA := selfSignedPEM()
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			_, _ = w.Write(currentCA)
+		}))
+		defer srv.Close()
+		serverPool := x509.NewCertPool()
+		serverPool.AddCert(srv.Certificate())
+		originalFetchClient := CAFetchClientFactory
+		CAFetchClientFactory = func() *http.Client {
+			return &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{RootCAs: serverPool},
+				},
+			}
+		}
+		defer func() { CAFetchClientFactory = originalFetchClient }()
+
+		cfg := &config.StaticConfig{
+			KubeConfig:        kubeconfigWithCAURL(s.T(), srv.URL),
+			CACacheDir:        filepath.Join(s.T().TempDir(), "ca-cache"),
+			CARefreshInterval: config.Duration(0), // no background re-fetch
+		}
+		manager, err := NewKubeconfigManager(s.T().Context(), cfg, "")
+		s.Require().NoError(err)
+		defer manager.Close()
+		caFile := manager.kubernetes.RESTConfig().CAFile
+		s.Require().NotEmpty(caFile)
+
+		// Rotate the served CA: without a refresher loop the cache file
+		// must stay on the old CA until RefreshCAs is called.
+		mu.Lock()
+		currentCA = rotatedCA
+		mu.Unlock()
+		got, err := os.ReadFile(caFile)
+		s.Require().NoError(err)
+		s.NotEqual(rotatedCA, got, "cache must not change without an explicit refresh at interval 0")
+
+		manager.RefreshCAs()
+		got, err = os.ReadFile(caFile)
+		s.Require().NoError(err)
+		s.Equal(rotatedCA, got, "RefreshCAs must rewrite the cache with the rotated CA")
+	})
+	s.Run("rejects insecure-skip-tls-verify combined with a caURL", func() {
+		// client-go would reject the CAFile later with a cryptic error
+		// ("specifying a root certificates file with the insecure flag is
+		// not allowed"); the manager must fail fast with a message naming
+		// the conflict. Fails before any fetch, so no server is needed.
+		kc := clientcmdapi.NewConfig()
+		kc.Clusters["fake"] = &clientcmdapi.Cluster{
+			Server:                "https://127.0.0.1:1",
+			InsecureSkipTLSVerify: true,
+			Extensions: map[string]runtime.Object{
+				caExtensionName: extensionObject("https://ca.example.com/"),
+			},
+		}
+		kc.Contexts["fake"] = &clientcmdapi.Context{Cluster: "fake", AuthInfo: "fake"}
+		kc.AuthInfos["fake"] = &clientcmdapi.AuthInfo{Token: "test-token"}
+		kc.CurrentContext = "fake"
+		cfg := &config.StaticConfig{
+			KubeConfig:        test.KubeconfigFile(s.T(), kc),
+			CACacheDir:        s.T().TempDir(),
+			CARefreshInterval: config.Duration(0),
+		}
+		_, err := NewKubeconfigManager(s.T().Context(), cfg, "")
+		s.Require().Error(err)
+		s.ErrorContains(err, "insecure-skip-tls-verify")
 	})
 	s.Run("leaves rest config untouched without an extension", func() {
 		path := s.mockServerKubeconfig()

--- a/pkg/kubernetes/ca_test.go
+++ b/pkg/kubernetes/ca_test.go
@@ -117,7 +117,7 @@ func (s *ClusterCACASuite) TestCAURLFromClusterExtensions() {
 		// The kubeconfig path exercises the actual clientcmd decode of
 		// extensions (runtime.Unknown payloads).
 		path := kubeconfigWithCAURL(s.T(), "https://ca.example.com/")
-		cfg := &config.StaticConfig{KubeConfig: path, CACacheDir: s.T().TempDir()}
+		cfg := &config.StaticConfig{KubeConfig: path}
 		s.Equal("https://ca.example.com/", caURLOfResolvedCluster(s.T(), cfg))
 	})
 }
@@ -303,7 +303,6 @@ func (s *ClusterCACASuite) TestApplyClusterCAURL() {
 
 		cfg := &config.StaticConfig{
 			KubeConfig:        kubeconfigWithCAURL(s.T(), srv.URL),
-			CACacheDir:        filepath.Join(s.T().TempDir(), "ca-cache"),
 			CARefreshInterval: config.Duration(100 * time.Millisecond),
 		}
 		manager, err := NewKubeconfigManager(s.T().Context(), cfg, "")
@@ -359,7 +358,6 @@ func (s *ClusterCACASuite) TestApplyClusterCAURL() {
 
 		cfg := &config.StaticConfig{
 			KubeConfig:        kubeconfigWithCAURL(s.T(), srv.URL),
-			CACacheDir:        filepath.Join(s.T().TempDir(), "ca-cache"),
 			CARefreshInterval: config.Duration(0), // no background re-fetch
 		}
 		manager, err := NewKubeconfigManager(s.T().Context(), cfg, "")
@@ -400,7 +398,6 @@ func (s *ClusterCACASuite) TestApplyClusterCAURL() {
 		kc.CurrentContext = "fake"
 		cfg := &config.StaticConfig{
 			KubeConfig:        test.KubeconfigFile(s.T(), kc),
-			CACacheDir:        s.T().TempDir(),
 			CARefreshInterval: config.Duration(0),
 		}
 		_, err := NewKubeconfigManager(s.T().Context(), cfg, "")
@@ -411,7 +408,6 @@ func (s *ClusterCACASuite) TestApplyClusterCAURL() {
 		path := s.mockServerKubeconfig()
 		manager, err := NewKubeconfigManager(s.T().Context(), &config.StaticConfig{
 			KubeConfig:        path,
-			CACacheDir:        s.T().TempDir(),
 			CARefreshInterval: config.Duration(time.Minute),
 		}, "")
 		s.Require().NoError(err)

--- a/pkg/kubernetes/ca_test.go
+++ b/pkg/kubernetes/ca_test.go
@@ -33,19 +33,74 @@ import (
 
 type ClusterCACASuite struct {
 	suite.Suite
-	originalEnv []string
+	originalEnv       []string
+	originalCacheRoot string
 }
 
 func (s *ClusterCACASuite) SetupTest() {
 	s.originalEnv = os.Environ()
+	// Redirect the CA cache into a per-test temp dir so tests stay
+	// hermetic and never touch the shared system temp dir.
+	s.originalCacheRoot = caCacheRoot
+	caCacheRoot = s.T().TempDir()
 }
 
 func (s *ClusterCACASuite) TearDownTest() {
 	test.RestoreEnv(s.originalEnv)
+	caCacheRoot = s.originalCacheRoot
 }
 
 func TestClusterCASuite(t *testing.T) {
 	suite.Run(t, new(ClusterCACASuite))
+}
+
+// TestWriteCAFileRejectsUnsafeCacheDirs guards the cache directory against
+// another local user pre-creating the predictable path beneath the system
+// temp dir as writable or as a symlink, then swapping in their own CA.
+func (s *ClusterCACASuite) TestWriteCAFileRejectsUnsafeCacheDirs() {
+	base := caCacheRoot // per-test temp dir, owned by us
+
+	s.Run("world-writable pre-existing cache dir is rejected", func() {
+		dir := filepath.Join(base, "world-writable")
+		s.Require().NoError(os.MkdirAll(dir, 0o700))
+		s.Require().NoError(os.Chmod(dir, 0o777))
+		err := writeCAFile(filepath.Join(dir, "ca.crt"), selfSignedPEM())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "group or world writable")
+	})
+
+	s.Run("symlinked cache dir is rejected", func() {
+		target := filepath.Join(base, "elsewhere")
+		s.Require().NoError(os.MkdirAll(target, 0o700))
+		dir := filepath.Join(base, "symlinked")
+		s.Require().NoError(os.Symlink(target, dir))
+		err := writeCAFile(filepath.Join(dir, "ca.crt"), selfSignedPEM())
+		s.Require().Error(err)
+		s.Contains(err.Error(), "must not be a symlink")
+	})
+
+	s.Run("private pre-existing cache dir is accepted", func() {
+		dir := filepath.Join(base, "private")
+		s.Require().NoError(os.MkdirAll(dir, 0o700))
+		pemBytes := selfSignedPEM()
+		s.Require().NoError(writeCAFile(filepath.Join(dir, "ca.crt"), pemBytes))
+		got, err := os.ReadFile(filepath.Join(dir, "ca.crt"))
+		s.Require().NoError(err)
+		s.Equal(pemBytes, got)
+	})
+
+	s.Run("final file symlink is replaced, not followed", func() {
+		dir := filepath.Join(base, "final-symlink")
+		s.Require().NoError(os.MkdirAll(dir, 0o700))
+		victimPath := filepath.Join(dir, "victim.crt")
+		s.Require().NoError(os.WriteFile(victimPath, []byte("victim"), 0o600))
+		link := filepath.Join(dir, "ca.crt")
+		s.Require().NoError(os.Symlink(victimPath, link))
+		s.Require().NoError(writeCAFile(link, selfSignedPEM()))
+		got, err := os.ReadFile(victimPath)
+		s.Require().NoError(err)
+		s.Equal("victim", string(got), "rename must replace the symlink, not write through it")
+	})
 }
 
 // selfSignedPEM returns a fresh self-signed CA certificate in PEM form, so

--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -20,7 +20,8 @@ import (
 type Manager struct {
 	kubernetes *Kubernetes
 
-	config api.BaseConfig
+	config      api.BaseConfig
+	caRefresher *caRefresher
 }
 
 var (
@@ -55,7 +56,31 @@ func NewKubeconfigManager(ctx context.Context, config api.BaseConfig, kubeconfig
 		return nil, fmt.Errorf("failed to create kubernetes rest config from kubeconfig: %w", err)
 	}
 
-	return NewManager(ctx, config, restConfig, clientCmdConfig)
+	// A cluster entry may serve its CA over HTTPS via the caURL kubeconfig
+	// extension. Fetch it into a cache file so client-go reloads the CA when
+	// it rotates, then keep the cache fresh in the background. RawConfig
+	// reuses the kubeconfig already loaded by ClientConfig above instead of
+	// parsing the file a third time.
+	rawConfig, err := clientCmdConfig.RawConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+	caRefresher, err := applyClusterCAURL(ctx, config, &rawConfig, resolvedContext, restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	manager, err := NewManager(ctx, config, restConfig, clientCmdConfig)
+	if err != nil {
+		return nil, err
+	}
+	// Start the refresher only once the manager is fully built so a
+	// construction error leaves no goroutine behind to stop.
+	if caRefresher != nil {
+		caRefresher.start()
+	}
+	manager.caRefresher = caRefresher
+	return manager, nil
 }
 
 // resolveKubeconfigContext determines which kubeconfig context to use.
@@ -220,10 +245,19 @@ func (m *Manager) Derived(ctx context.Context) (*Kubernetes, error) {
 	return derived, nil
 }
 
-// Close releases HTTP transport resources held by this manager.
+// RESTConfig returns the REST config this manager's clients are built from.
+func (m *Manager) RESTConfig() *rest.Config {
+	return m.kubernetes.RESTConfig()
+}
+
+// Close releases HTTP transport resources held by this manager and stops
+// any background CA refresh loop.
 func (m *Manager) Close() {
 	if m != nil {
 		m.kubernetes.close()
+		if m.caRefresher != nil {
+			m.caRefresher.Close()
+		}
 	}
 }
 

--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -250,6 +250,17 @@ func (m *Manager) RESTConfig() *rest.Config {
 	return m.kubernetes.RESTConfig()
 }
 
+// RefreshCAs fetches the cluster CA now and rewrites the cache file when the
+// served CA changed (no-op without a refresher). SIGHUP config reload calls
+// this so a rotated CA can be picked up without waiting out
+// ca_refresh_interval or restarting the process. A failed fetch keeps the
+// previous CA; refreshes never fail closed.
+func (m *Manager) RefreshCAs() {
+	if m != nil && m.caRefresher != nil {
+		m.caRefresher.refreshOnce()
+	}
+}
+
 // Close releases HTTP transport resources held by this manager and stops
 // any background CA refresh loop.
 func (m *Manager) Close() {

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -31,15 +31,13 @@ type Provider interface {
 	GetDerivedKubernetes(ctx context.Context, target string) (*Kubernetes, error)
 	// WatchTargets sets up a watcher for changes in the cluster targets and calls the provided McpReload function when changes are detected
 	WatchTargets(ctx context.Context, reload McpReload)
-	Close()
-}
-
-// CARefresherProvider is implemented by providers that hold managers with
-// background CA refreshers. SIGHUP config reload calls RefreshCAs so a
-// rotated cluster CA (e.g. after the cluster is re-provisioned) can be
-// picked up without waiting out the refresh interval or restarting.
-type CARefresherProvider interface {
+	// RefreshCAs re-fetches every held manager's cluster CA now, so a
+	// rotated cluster CA is picked up on SIGHUP config reload without
+	// waiting out the refresh interval. It lives on the interface rather
+	// than as an optional capability so no provider can silently miss the
+	// refresh.
 	RefreshCAs()
+	Close()
 }
 
 // TokenExchangeProvider is an optional interface that providers can implement to suport per-target token exchange.

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -34,6 +34,14 @@ type Provider interface {
 	Close()
 }
 
+// CARefresherProvider is implemented by providers that hold managers with
+// background CA refreshers. SIGHUP config reload calls RefreshCAs so a
+// rotated cluster CA (e.g. after the cluster is re-provisioned) can be
+// picked up without waiting out the refresh interval or restarting.
+type CARefresherProvider interface {
+	RefreshCAs()
+}
+
 // TokenExchangeProvider is an optional interface that providers can implement to suport per-target token exchange.
 //
 // When a provider implements this interface and GetTokenExchangeConfig returns a non-nil config for a target, token

--- a/pkg/kubernetes/provider_kubeconfig.go
+++ b/pkg/kubernetes/provider_kubeconfig.go
@@ -82,11 +82,12 @@ func (p *kubeConfigClusterProvider) reset(ctx context.Context) error {
 		}
 	}
 
-	for _, old := range p.managers {
-		if old != nil {
-			old.Close()
-		}
-	}
+	// Stop the previous watchers and release the previous managers (with
+	// their background CA refreshers) before the fresh state below replaces
+	// them. The new manager m is installed after this point, so it is
+	// untouched by Close.
+	p.Close()
+
 	p.managers = map[string]*Manager{
 		defaultContext: m,
 	}
@@ -98,7 +99,6 @@ func (p *kubeConfigClusterProvider) reset(ctx context.Context) error {
 		p.managers[name] = nil
 	}
 
-	p.Close()
 	p.kubeconfigWatcher = watcher.NewKubeconfig(ctx, m.kubernetes.clientCmdConfig)
 	p.clusterStateWatcher = watcher.NewClusterState(ctx, m.kubernetes.DiscoveryClient())
 	p.defaultContext = defaultContext
@@ -213,10 +213,38 @@ func (p *kubeConfigClusterProvider) WatchTargets(ctx context.Context, reload Mcp
 	p.clusterStateWatcher.Watch(ctx, reload)
 }
 
+// Close stops the watchers and releases every manager's HTTP transport and
+// background CA refresh loop. reset() closes replaced managers on reload;
+// this ensures shutdown (and tests that only call Close) leave nothing
+// running behind. Manager.Close is idempotent, so calling it here and in
+// reset() is safe.
 func (p *kubeConfigClusterProvider) Close() {
 	for _, w := range []watcher.Watcher{p.kubeconfigWatcher, p.clusterStateWatcher} {
 		if !reflect.ValueOf(w).IsNil() {
 			w.Close()
 		}
+	}
+	for _, m := range p.managers {
+		if m != nil {
+			m.Close()
+		}
+	}
+}
+
+// RefreshCAs re-fetches every live manager's cluster CA now, so a rotated
+// CA is picked up on SIGHUP without waiting out ca_refresh_interval. The
+// snapshot keeps the fetch (bounded by caFetchMaxDuration) outside the
+// lock so a reset triggered meanwhile is not blocked on the network.
+func (p *kubeConfigClusterProvider) RefreshCAs() {
+	p.mu.RLock()
+	managers := make([]*Manager, 0, len(p.managers))
+	for _, m := range p.managers {
+		if m != nil {
+			managers = append(managers, m)
+		}
+	}
+	p.mu.RUnlock()
+	for _, m := range managers {
+		m.RefreshCAs()
 	}
 }

--- a/pkg/kubernetes/provider_single.go
+++ b/pkg/kubernetes/provider_single.go
@@ -69,7 +69,7 @@ func (p *singleClusterProvider) reset(ctx context.Context) error {
 		return err
 	}
 
-	p.Close()
+	p.closeWatchers()
 	p.kubeconfigWatcher = watcher.NewKubeconfig(ctx, p.manager.kubernetes.clientCmdConfig)
 	p.clusterStateWatcher = watcher.NewClusterState(ctx, p.manager.kubernetes.DiscoveryClient())
 	return nil
@@ -115,10 +115,30 @@ func (p *singleClusterProvider) WatchTargets(ctx context.Context, reload McpRelo
 	p.clusterStateWatcher.Watch(ctx, reload)
 }
 
-func (p *singleClusterProvider) Close() {
+// closeWatchers stops the kubeconfig and cluster-state watchers without
+// touching the manager. reset() rebuilds watchers on reload and must not
+// kill the freshly-built manager's transport or CA refresher, so it calls
+// this instead of Close().
+func (p *singleClusterProvider) closeWatchers() {
 	for _, w := range []watcher.Watcher{p.kubeconfigWatcher, p.clusterStateWatcher} {
 		if !reflect.ValueOf(w).IsNil() {
 			w.Close()
 		}
+	}
+}
+
+func (p *singleClusterProvider) Close() {
+	p.closeWatchers()
+	if p.manager != nil {
+		p.manager.Close()
+	}
+}
+
+// RefreshCAs re-fetches the manager's cluster CA now, so a rotated CA is
+// picked up on SIGHUP config reload without waiting out
+// ca_refresh_interval.
+func (p *singleClusterProvider) RefreshCAs() {
+	if p.manager != nil {
+		p.manager.RefreshCAs()
 	}
 }

--- a/pkg/kubernetes/provider_token_exchange.go
+++ b/pkg/kubernetes/provider_token_exchange.go
@@ -206,6 +206,10 @@ func (p *tokenExchangingProvider) Close() {
 	p.provider.Close()
 }
 
+func (p *tokenExchangingProvider) RefreshCAs() {
+	p.provider.RefreshCAs()
+}
+
 func (p *tokenExchangingProvider) AnyTargetHasGVKs(ctx context.Context, gvks []schema.GroupVersionKind) bool {
 	return p.provider.AnyTargetHasGVKs(ctx, gvks)
 }

--- a/pkg/kubernetes/provider_token_exchange_test.go
+++ b/pkg/kubernetes/provider_token_exchange_test.go
@@ -59,6 +59,7 @@ func (fakeDerivedProvider) GetTargets(context.Context) ([]string, error) { retur
 func (fakeDerivedProvider) GetDefaultTarget() string                     { return "" }
 func (fakeDerivedProvider) GetTargetParameterName() string               { return "" }
 func (fakeDerivedProvider) WatchTargets(context.Context, McpReload)      {}
+func (fakeDerivedProvider) RefreshCAs()                                  {}
 func (fakeDerivedProvider) Close()                                       {}
 func (fakeDerivedProvider) GetDerivedKubernetes(context.Context, string) (*Kubernetes, error) {
 	return &Kubernetes{}, nil

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -572,9 +572,7 @@ func (s *Server) ReloadConfiguration(ctx context.Context, newConfig *config.Stat
 	// A successful reload also re-fetches cached cluster CAs right away, so
 	// a rotated CA is picked up on SIGHUP without waiting out
 	// ca_refresh_interval or restarting. Failures keep the previous CA.
-	if refresher, ok := s.p.(internalk8s.CARefresherProvider); ok {
-		refresher.RefreshCAs()
-	}
+	s.p.RefreshCAs()
 
 	logger.V(1).Info("MCP server configuration reloaded successfully")
 	return nil

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -569,6 +569,13 @@ func (s *Server) ReloadConfiguration(ctx context.Context, newConfig *config.Stat
 		return fmt.Errorf("failed to reload toolsets: %w", err)
 	}
 
+	// A successful reload also re-fetches cached cluster CAs right away, so
+	// a rotated CA is picked up on SIGHUP without waiting out
+	// ca_refresh_interval or restarting. Failures keep the previous CA.
+	if refresher, ok := s.p.(internalk8s.CARefresherProvider); ok {
+		refresher.RefreshCAs()
+	}
+
 	logger.V(1).Info("MCP server configuration reloaded successfully")
 	return nil
 }


### PR DESCRIPTION
When a cluster's API-server CA is served over HTTPS, you can now put the URL in the kubeconfig instead of copying the certificate in.

Today, running the server against multiple clusters means pasting certificate-authority-data into every kubeconfig by hand. The CA changes whenever a cluster is rebuilt, so that copy goes stale and API calls start failing until someone updates the kubeconfig again.

Now a cluster entry can point at the URL that serves its CA:

```yaml
clusters:
  - name: production
    cluster:
      server: https://kubernetes.default.svc
      extensions:
        - name: kubernetes-mcp-server
          extension:
            caURL: https://ca.production.example.com/
```

The server fetches the CA when it starts, saves it to a cache file and verifies the cluster against that file. When the CA changes, the server picks up the new one automatically, so nothing breaks when a cluster is rebuilt. A background task keeps the cache fresh on a schedule you control with ca_refresh_interval (24h by default). With 0s the background task is disabled, and the CA is then refreshed when a manager is rebuilt or via the immediate re-fetch that SIGHUP config reload now triggers, so a rotated CA can be picked up without a restart in either mode.

The endpoint serving caURL must itself present a certificate the MCP process already trusts (system roots or SSL_CERT_FILE), not the cluster CA being fetched; fetches follow only https redirects, and a CA that cannot be fetched over https fails closed at startup. Other tools reading the kubeconfig ignore the extension, and the CA cache lives in a subdirectory of the system temp dir (honoring `$TMPDIR`), which needs to be writable - with a read-only root filesystem, set `$TMPDIR` to writable storage or mount an emptyDir at `/tmp`.

The Duration/omitzero config pattern on ca_refresh_interval is intentional: a zero value means "not set" and the config merge keeps the default, while an explicit "0s" in a config file or via the --ca-refresh-interval flag is honored. The one exception is build-time default overrides, which cannot express the disabled value; that limitation is documented in config.go.

