### PR TITLE
ci(evals): use docker driver for kubevirt evaluation suites and bump kubevirt dependencies

### DIFF
--- a/.github/workflows/mcpchecker.yaml
+++ b/.github/workflows/mcpchecker.yaml
@@ -274,6 +274,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.check-trigger.outputs.matrix) }}
+    env:
+      MINIKUBE_DRIVER: ${{ contains(matrix.toolsets, 'kubevirt') && 'docker' || 'podman' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1

--- a/build/kubevirt.mk
+++ b/build/kubevirt.mk
@@ -1,9 +1,9 @@
 # KubeVirt installation and management
 
 # KubeVirt version configuration
-KUBEVIRT_VERSION ?= v1.8.2
-CDI_VERSION ?= v1.65.0
-MULTUS_VERSION ?= v4.2.4
+KUBEVIRT_VERSION ?= v1.9.0
+CDI_VERSION ?= v1.66.0
+MULTUS_VERSION ?= v4.3.0
 
 # Detect if we're using a released version or main/latest
 KUBEVIRT_RELEASE_URL = https://github.com/kubevirt/kubevirt/releases/download/$(KUBEVIRT_VERSION)


### PR DESCRIPTION
### Summary

1. **Use Docker driver for KubeVirt evaluation suites in CI:**
   Following the migration from Kind to Minikube in PR #1320, `build/minikube.mk` defaults to using the Podman driver in rootless mode on Linux. In rootless mode, `/dev/kvm` is mapped to `nobody:nogroup` (`65534`), causing `virt-handler`'s `node-labeller` init container to fail with `chmod: Operation not permitted` and timing out KubeVirt installation after 15 minutes.
   
   This change sets `MINIKUBE_DRIVER: docker` for any suite that includes the `kubevirt` toolset (both `kubevirt` and `all`) in `.github/workflows/mcpchecker.yaml`. On GitHub Actions `ubuntu-latest` runners, the Docker daemon is active and runs rootful, allowing `virt-handler` to successfully initialize. Other suites (`core`, `helm`, `kiali`, `tekton`, `netobserv`) continue to use the default `podman` driver.

2. **Bump KubeVirt development dependencies:**
   Updates versions in `build/kubevirt.mk`:
   - KubeVirt: `v1.8.2` → `v1.9.0`
   - CDI: `v1.65.0` → `v1.66.0`
   - Multus: `v4.2.4` → `v4.3.0`

---

Closes: #1410
