### PR TITLE
Parallelize AnyTargetHasGVKs()

### DIFF
--- a/pkg/kubernetes/provider_gvk_filter.go
+++ b/pkg/kubernetes/provider_gvk_filter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 // ProviderGVKFilter provides GVK-based filtering capabilities for providers.
@@ -38,25 +39,59 @@ func (f *ProviderGVKFilter) AnyTargetHasGVKs(ctx context.Context, gvks []schema.
 		return true
 	}
 
-	for _, mgr := range mgrs {
-		k, err := mgr.Derived(ctx)
-		if err != nil {
-			// Can't get discovery client; assume target has the GVKs to avoid
-			// hiding tools due to transient errors
-			klogutil.LogWarn(logger, "AnyTargetHasGVKs couldn't derive a Kubernetes interface for a manager; assuming all GVKs are available", klogutil.Err(err))
-			return true
-		}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-		hasGVKs, err := api.HasGVKs(k.DiscoveryClient(), gvks)
-		if err != nil {
-			// Discovery error; assume target has the GVKs to avoid hiding tools
-			klogutil.LogWarn(logger, "AnyTargetHasGVKs couldn't query a client; assuming all GVKs are available", klogutil.Err(err))
-			return true
-		}
-		if hasGVKs {
-			// One target with all GVKs is enough
+	// Buffered so workers can finish after we return on the first true.
+	results := make(chan bool, len(mgrs))
+	for _, mgr := range mgrs {
+		go func() {
+			results <- targetHasGVKs(ctx, logger, mgr, gvks)
+		}()
+	}
+
+	for range mgrs {
+		if <-results {
+			// One target with all GVKs (or a discovery error) is enough.
+			// Workers that have not reached HasGVKs yet will stop via the deferred cancel() above.
+			// client-go's DiscoveryClient uses context.TODO() (at the time of this writing), so
+			// in-flight ServerResourcesForGroupVersion HTTP is not aborted by this cancel.
 			return true
 		}
 	}
 	return false
+}
+
+func targetHasGVKs(ctx context.Context, logger klog.Logger, mgr *Manager, gvks []schema.GroupVersionKind) bool {
+	// Context errors can happen two ways:
+	// - Another thread returned `true`, triggering cancelation. It doesn't matter what this thread
+	//   returns, as the caller short-circuits `true` regardless.
+	// - The parent context was canceled for some other reason before anyone reported `true` but
+	//   also before everyone finished. We want to treat that like "all threads errored" and fail
+	//   *open* (don't hide tools).
+	if ctx.Err() != nil {
+		return true
+	}
+
+	k, err := mgr.Derived(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return true
+		}
+		// Can't get discovery client; assume target has the GVKs to avoid
+		// hiding tools due to transient errors
+		klogutil.LogWarn(logger, "AnyTargetHasGVKs couldn't derive a Kubernetes interface for a manager; assuming all GVKs are available", klogutil.Err(err))
+		return true
+	}
+
+	hasGVKs, err := api.HasGVKs(k.DiscoveryClient(), gvks)
+	if err != nil {
+		if ctx.Err() != nil {
+			return true
+		}
+		// Discovery error; assume target has the GVKs to avoid hiding tools
+		klogutil.LogWarn(logger, "AnyTargetHasGVKs couldn't query a client; assuming all GVKs are available", klogutil.Err(err))
+		return true
+	}
+	return hasGVKs
 }

--- a/pkg/kubernetes/provider_kubeconfig_test.go
+++ b/pkg/kubernetes/provider_kubeconfig_test.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -62,6 +63,124 @@ func (s *ProviderKubeconfigTestSuite) TestWithNonOpenShiftGVK() {
 		})
 		s.False(hasGVK, "Expected provider to report no nonexistent GVK")
 	})
+}
+
+func (s *ProviderKubeconfigTestSuite) TestAnyTargetHasGVKsAcrossContexts() {
+	projectGVK := []schema.GroupVersionKind{
+		{Group: "project.openshift.io", Version: "v1", Kind: "Project"},
+	}
+
+	s.Run("returns true when one of several targets has the GVK", func() {
+		openshift := test.NewMockServer()
+		s.T().Cleanup(openshift.Close)
+		openshift.Handle(test.NewInOpenShiftHandler())
+
+		vanilla := test.NewMockServer()
+		s.T().Cleanup(vanilla.Close)
+		vanilla.Handle(test.NewDiscoveryClientHandler())
+
+		provider, err := NewProvider(s.T().Context(), &config.StaticConfig{
+			KubeConfig: kubeconfigForMockServers(s.T(), "openshift", map[string]*test.MockServer{
+				"openshift": openshift,
+				"vanilla":   vanilla,
+			}),
+		})
+		s.Require().NoError(err, "Expected no error creating multi-context provider")
+		s.T().Cleanup(provider.Close)
+
+		s.True(provider.AnyTargetHasGVKs(s.T().Context(), projectGVK), "Expected Project GVK when at least one target is OpenShift")
+	})
+
+	s.Run("returns false when no target has the GVK", func() {
+		a := test.NewMockServer()
+		s.T().Cleanup(a.Close)
+		a.Handle(test.NewDiscoveryClientHandler())
+
+		b := test.NewMockServer()
+		s.T().Cleanup(b.Close)
+		b.Handle(test.NewDiscoveryClientHandler())
+
+		provider, err := NewProvider(s.T().Context(), &config.StaticConfig{
+			KubeConfig: kubeconfigForMockServers(s.T(), "a", map[string]*test.MockServer{
+				"a": a,
+				"b": b,
+			}),
+		})
+		s.Require().NoError(err, "Expected no error creating multi-context provider")
+		s.T().Cleanup(provider.Close)
+
+		s.False(provider.AnyTargetHasGVKs(s.T().Context(), projectGVK), "Expected no Project GVK when no target is OpenShift")
+	})
+
+	s.Run("returns true when the parent context is canceled", func() {
+		a := test.NewMockServer()
+		s.T().Cleanup(a.Close)
+		a.Handle(test.NewDiscoveryClientHandler())
+
+		b := test.NewMockServer()
+		s.T().Cleanup(b.Close)
+		b.Handle(test.NewDiscoveryClientHandler())
+
+		provider, err := NewProvider(s.T().Context(), &config.StaticConfig{
+			KubeConfig: kubeconfigForMockServers(s.T(), "a", map[string]*test.MockServer{
+				"a": a,
+				"b": b,
+			}),
+		})
+		s.Require().NoError(err, "Expected no error creating multi-context provider")
+		s.T().Cleanup(provider.Close)
+
+		ctx, cancel := context.WithCancel(s.T().Context())
+		cancel()
+
+		s.True(provider.AnyTargetHasGVKs(ctx, projectGVK), "Expected fail-open when parent context is canceled")
+	})
+
+	s.Run("returns true without waiting for a hanging target", func() {
+		openshift := test.NewMockServer()
+		s.T().Cleanup(openshift.Close)
+		openshift.Handle(test.NewInOpenShiftHandler())
+
+		hang := make(chan struct{})
+		hanging := test.NewMockServer()
+		// Unblock the handler before MockServer.Close, which waits for in-flight requests.
+		s.T().Cleanup(hanging.Close)
+		s.T().Cleanup(func() { close(hang) })
+		hanging.Handle(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			<-hang
+		}))
+
+		provider, err := NewProvider(s.T().Context(), &config.StaticConfig{
+			KubeConfig: kubeconfigForMockServers(s.T(), "openshift", map[string]*test.MockServer{
+				"openshift": openshift,
+				"hanging":   hanging,
+			}),
+		})
+		s.Require().NoError(err, "Expected no error creating multi-context provider")
+		s.T().Cleanup(provider.Close)
+
+		start := time.Now()
+		has := provider.AnyTargetHasGVKs(s.T().Context(), projectGVK)
+		s.True(has, "Expected Project GVK from the OpenShift target")
+		s.Less(time.Since(start), 2*time.Second, "Expected to return before the hanging target's discovery timeout")
+	})
+}
+
+func kubeconfigForMockServers(t *testing.T, currentContext string, servers map[string]*test.MockServer) string {
+	t.Helper()
+	cfg := clientcmdapi.NewConfig()
+	for name, srv := range servers {
+		cluster := clientcmdapi.NewCluster()
+		cluster.Server = srv.Config().Host
+		cfg.Clusters[name] = cluster
+		cfg.AuthInfos[name] = clientcmdapi.NewAuthInfo()
+		ctx := clientcmdapi.NewContext()
+		ctx.Cluster = name
+		ctx.AuthInfo = name
+		cfg.Contexts[name] = ctx
+	}
+	cfg.CurrentContext = currentContext
+	return test.KubeconfigFile(t, cfg)
 }
 
 func (s *ProviderKubeconfigTestSuite) TestGetTargets() {


### PR DESCRIPTION
The expensive part of target compatibility tool filtering is iterating over all targets querying whether any target has particular GVKs. In serial, one or more slow/unreachable targets could delay the whole operation, potentially until their discovery call times out, greatly slowing the entire startup process.

With this change, we run each target's discovery in its own goroutine, and pop out of the whole thing as soon as any one of them returns `true`. Thus cases where any target returns `true` should respond very quickly, regardless of whether slow/unreachable targets exist elsewhere.

Now the worst case looks like:
- All live targets respond `false`
- One or more targets is slow/unreachable

...whereupon the overall response time is reduced to that of the slowest target.

Note that we preserve the "fail open" behavior: if any target is unreachable, we assume `true` so that we do *not* hide tools. With this change, that behavior extends to when the parent context is canceled for any reason before all goroutines have responded.

Partially-Addresses: #1288
Co-Authored-By: cursor/grok