### PR TITLE
feat(kiali): Filter Kiali tools by configured URL reachability

### DIFF
--- a/docs/KIALI.md
+++ b/docs/KIALI.md
@@ -10,6 +10,7 @@ Config (TOML):
 
 ```toml
 toolsets = ["core", "kiali"]
+experimental_enable_target_compatibility_tool_filters = true
 
 [toolset_configs.kiali]
 url = "https://kiali.example" # Endpoint/route to reach Kiali console
@@ -18,7 +19,11 @@ url = "https://kiali.example" # Endpoint/route to reach Kiali console
 # When url is https and insecure is false, certificate_authority is required.
 ```
 
-When the `kiali` toolset is enabled, a Kiali toolset configuration is required via `[toolset_configs.kiali]`. If missing or invalid, the server will refuse to start.
+URL reachability checks require `experimental_enable_target_compatibility_tool_filters = true` (default `false`). Without it, Kiali tools are always registered and no `/api/status` probe runs.
+
+When that flag is enabled and `[toolset_configs.kiali].url` is set, the server probes `GET {url}/api/status` and only exposes Kiali tools if that call succeeds.
+
+When the `kiali` toolset is enabled with an explicit HTTPS URL and `insecure = false`, `certificate_authority` is still required at config load time.
 
 ### How authentication works
 
@@ -35,8 +40,8 @@ Kiali tools and prompts are not cluster-aware: the MCP server does not inject a 
 
 ### Troubleshooting
 
-- Missing Kiali configuration when `kiali` toolset is enabled → set `[toolset_configs.kiali].url` in the config TOML.
-- Invalid URL → ensure `[toolset_configs.kiali].url` is a valid `http(s)://host` URL.
+- Kiali tools missing from `tools/list` → enable `experimental_enable_target_compatibility_tool_filters = true` and set a reachable `[toolset_configs.kiali].url`.
+- Invalid or unreachable URL → ensure `[toolset_configs.kiali].url` is a valid `http(s)://host` URL and that `GET {url}/api/status` succeeds from the MCP server.
 - TLS certificate validation:
   - If `[toolset_configs.kiali].url` uses HTTPS and `[toolset_configs.kiali].insecure` is false, you must set `[toolset_configs.kiali].certificate_authority` with the path to the CA certificate file. Relative paths are resolved relative to the directory containing the config file.
   - For non-production environments you can set `[toolset_configs.kiali].insecure = true` to skip certificate verification.

--- a/pkg/kiali/gvr.go
+++ b/pkg/kiali/gvr.go
@@ -1,0 +1,56 @@
+package kiali
+
+import (
+	"context"
+	"strings"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+)
+
+// HasKiali reports whether a configured Kiali URL responds to GET /api/status.
+//
+// fp supplies toolset config via ExtendedConfigProvider; kp is the Kubernetes
+// provider used for bearer tokens (may be nil in tests).
+func HasKiali(ctx context.Context, fp api.FilteringProvider, kp kubernetes.Provider) bool {
+	cfg, ok := kialiConfigFromProvider(fp)
+	if !ok || strings.TrimSpace(cfg.Url) == "" {
+		return false
+	}
+
+	token := bearerTokenFromProvider(ctx, kp)
+	ok = probeStatusURL(ctx, cfg.Url, cfg, token)
+	if !ok {
+		klogutil.FromContext(ctx).V(1).Info("configured Kiali URL failed /api/status probe; disabling Kiali tools",
+			"url", cfg.Url)
+	}
+	return ok
+}
+
+func kialiConfigFromProvider(fp api.FilteringProvider) (*Config, bool) {
+	cfgProvider, ok := fp.(api.ExtendedConfigProvider)
+	if !ok || cfgProvider == nil {
+		return nil, false
+	}
+	ext, ok := cfgProvider.GetToolsetConfig("kiali")
+	if !ok {
+		return nil, false
+	}
+	kc, ok := ext.(*Config)
+	if !ok || kc == nil {
+		return nil, false
+	}
+	return kc, true
+}
+
+func bearerTokenFromProvider(ctx context.Context, kp kubernetes.Provider) string {
+	if kp == nil {
+		return ""
+	}
+	k8s, err := kp.GetDerivedKubernetes(ctx, kp.GetDefaultTarget())
+	if err != nil || k8s == nil || k8s.RESTConfig() == nil {
+		return ""
+	}
+	return k8s.RESTConfig().BearerToken
+}

--- a/pkg/kiali/gvr_test.go
+++ b/pkg/kiali/gvr_test.go
@@ -1,0 +1,112 @@
+package kiali
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+)
+
+type fakeFilteringProvider struct{}
+
+func (f *fakeFilteringProvider) AnyTargetHasGVKs(context.Context, []schema.GroupVersionKind) bool {
+	return false
+}
+
+func (f *fakeFilteringProvider) IsTargetCompatibilityToolFiltersEnabled() bool { return true }
+
+type fakeFilteringProviderWithConfig struct {
+	fakeFilteringProvider
+	configs map[string]api.ExtendedConfig
+}
+
+func (f *fakeFilteringProviderWithConfig) GetProviderConfig(string) (api.ExtendedConfig, bool) {
+	return nil, false
+}
+
+func (f *fakeFilteringProviderWithConfig) GetToolsetConfig(name string) (api.ExtendedConfig, bool) {
+	cfg, ok := f.configs[name]
+	return cfg, ok
+}
+
+func TestProbeStatusURL(t *testing.T) {
+	t.Run("returns true for valid status payload", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/status" {
+				http.NotFound(w, r)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": map[string]any{"Kiali state": "running"},
+			})
+		}))
+		defer srv.Close()
+
+		if !probeStatusURL(context.Background(), srv.URL, &Config{Url: srv.URL}, "") {
+			t.Fatal("expected probe to succeed")
+		}
+	})
+
+	t.Run("returns false for missing status object", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"externalServices":[]}`))
+		}))
+		defer srv.Close()
+		if probeStatusURL(context.Background(), srv.URL, nil, "") {
+			t.Fatal("expected probe to fail")
+		}
+	})
+
+	t.Run("returns false on connection error", func(t *testing.T) {
+		if probeStatusURL(context.Background(), "http://127.0.0.1:1", nil, "") {
+			t.Fatal("expected probe to fail for unreachable URL")
+		}
+	})
+}
+
+func TestHasKiali_ConfiguredURL(t *testing.T) {
+	t.Run("enables when configured URL passes status probe", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": map[string]any{"Kiali state": "running"},
+			})
+		}))
+		defer srv.Close()
+
+		p := &fakeFilteringProviderWithConfig{
+			configs: map[string]api.ExtendedConfig{
+				"kiali": &Config{Url: srv.URL},
+			},
+		}
+		if !HasKiali(context.Background(), p, nil) {
+			t.Fatal("expected HasKiali true for reachable configured URL")
+		}
+	})
+
+	t.Run("disables when configured URL fails status probe", func(t *testing.T) {
+		p := &fakeFilteringProviderWithConfig{
+			configs: map[string]api.ExtendedConfig{
+				"kiali": &Config{Url: "http://127.0.0.1:1"},
+			},
+		}
+		if HasKiali(context.Background(), p, nil) {
+			t.Fatal("expected HasKiali false for unreachable configured URL")
+		}
+	})
+
+	t.Run("disables when URL is not configured", func(t *testing.T) {
+		p := &fakeFilteringProviderWithConfig{
+			configs: map[string]api.ExtendedConfig{
+				"kiali": &Config{},
+			},
+		}
+		if HasKiali(context.Background(), p, nil) {
+			t.Fatal("expected HasKiali false without configured URL")
+		}
+	})
+}

--- a/pkg/kiali/status.go
+++ b/pkg/kiali/status.go
@@ -1,0 +1,94 @@
+package kiali
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+)
+
+const (
+	statusPath         = "/api/status"
+	statusProbeTimeout = time.Second
+)
+
+// statusResponse is the subset of Kiali GET /api/status used for reachability checks.
+type statusResponse struct {
+	Status map[string]any `json:"status"`
+}
+
+// probeStatusURL GETs {baseURL}/api/status and returns true when the response
+// is HTTP 2xx and contains a non-empty status object (Kiali is reachable).
+func probeStatusURL(ctx context.Context, baseURL string, cfg *Config, bearerToken string) bool {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return false
+	}
+	statusURL := baseURL + statusPath
+
+	probeCfg := cfg
+	if probeCfg == nil {
+		probeCfg = &Config{Url: baseURL}
+	} else if strings.TrimSpace(probeCfg.Url) == "" {
+		cp := *probeCfg
+		cp.Url = baseURL
+		probeCfg = &cp
+	}
+
+	k := &Kiali{
+		bearerToken:          bearerToken,
+		kialiURL:             probeCfg.Url,
+		kialiInsecure:        probeCfg.Insecure,
+		certificateAuthority: probeCfg.CertificateAuthority,
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, statusProbeTimeout)
+	defer cancel()
+
+	client, err := k.createHTTPClient(probeCtx)
+	if err != nil {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe: failed to create HTTP client", "error", err)
+		return false
+	}
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, statusURL, nil)
+	if err != nil {
+		return false
+	}
+	if auth := k.authorizationHeader(); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe failed", "url", statusURL, "error", err)
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize+1))
+	if err != nil {
+		return false
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe non-success",
+			"url", statusURL, "status_code", resp.StatusCode)
+		return false
+	}
+
+	var parsed statusResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe: invalid JSON", "error", err)
+		return false
+	}
+	if len(parsed.Status) == 0 {
+		klogutil.FromContext(ctx).V(2).Info("kiali status probe: missing status object", "url", statusURL)
+		return false
+	}
+	klogutil.FromContext(ctx).V(2).Info("kiali status probe succeeded", "url", statusURL)
+	return true
+}

--- a/pkg/mcp/kiali_test.go
+++ b/pkg/mcp/kiali_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"sync"
@@ -672,6 +673,79 @@ func (s *KialiSuite) TestKialiToolsNotClusterAware() {
 			s.Require().True(ok, "expected properties map for tool %s", tool.Name)
 			s.NotContains(properties, "context", "kiali tool %s must not expose context parameter", tool.Name)
 		})
+	}
+}
+
+func (s *KialiSuite) TestToolsFilteredByStatusProbe() {
+	s.Run("tools visible when configured URL passes /api/status", func() {
+		statusSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"status":{"Kiali state":"running"}}`))
+		}))
+		defer statusSrv.Close()
+
+		kubeConfig := s.Cfg.KubeConfig
+		cfg, err := config.ReadToml([]byte(fmt.Sprintf(`
+			toolsets = ["%s"]
+			experimental_enable_target_compatibility_tool_filters = true
+			[toolset_configs.kiali]
+			url = "%s"
+			insecure = true
+		`, s.toolsetName, statusSrv.URL)))
+		s.Require().NoError(err)
+		s.Cfg = cfg
+		s.Cfg.KubeConfig = kubeConfig
+		s.InitMcpClient()
+
+		tools, err := s.ListTools()
+		s.Require().NoError(err)
+		s.Require().NotNil(tools)
+		present := make(map[string]bool, len(tools.Tools))
+		for _, tool := range tools.Tools {
+			present[tool.Name] = true
+		}
+		for _, name := range s.kialiToolNames() {
+			s.Truef(present[name], "expected %s when status probe succeeds", name)
+		}
+	})
+
+	s.Run("tools hidden when configured URL fails /api/status", func() {
+		kubeConfig := s.Cfg.KubeConfig
+		cfg, err := config.ReadToml([]byte(fmt.Sprintf(`
+			toolsets = ["%s"]
+			experimental_enable_target_compatibility_tool_filters = true
+			[toolset_configs.kiali]
+			url = "http://127.0.0.1:1"
+			insecure = true
+		`, s.toolsetName)))
+		s.Require().NoError(err)
+		s.Cfg = cfg
+		s.Cfg.KubeConfig = kubeConfig
+		s.InitMcpClient()
+
+		tools, err := s.ListTools()
+		s.Require().NoError(err)
+		s.Require().NotNil(tools)
+		for _, tool := range tools.Tools {
+			for _, name := range s.kialiToolNames() {
+				s.Require().NotEqual(name, tool.Name, "expected %s hidden when status probe fails", name)
+			}
+		}
+	})
+}
+
+func (s *KialiSuite) kialiToolNames() []string {
+	return []string{
+		s.toolsetName + "_get_logs",
+		s.toolsetName + "_get_mesh_status",
+		s.toolsetName + "_get_mesh_traffic_graph",
+		s.toolsetName + "_get_metrics",
+		s.toolsetName + "_get_pod_performance",
+		s.toolsetName + "_get_resource_details",
+		s.toolsetName + "_get_trace_details",
+		s.toolsetName + "_list_mesh_clusters",
+		s.toolsetName + "_list_traces",
+		s.toolsetName + "_manage_istio_config",
+		s.toolsetName + "_manage_istio_config_read",
 	}
 }
 

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -396,8 +396,12 @@ func (s *Server) collectApplicableTools(cfg *Configuration) []api.ServerTool {
 	)
 
 	tools := make([]api.ServerTool, 0)
+	// Wrap the filtering provider with live config so toolsets that type-assert to
+	// ExtendedConfigProvider (e.g. Kiali URL reachability) see toolset_configs.
+	// The kubernetes Provider may be wrapped (token exchange) and not expose config.
+	provider := filteringProviderWithConfig{FilteringProvider: s.p, cfg: cfg.StaticConfig}
 	for _, toolset := range cfg.Toolsets() {
-		for _, tool := range toolset.GetTools(s.p) {
+		for _, tool := range toolset.GetTools(provider) {
 			tool = mutator(tool)
 			if filter(tool) {
 				tools = append(tools, tool)
@@ -405,6 +409,27 @@ func (s *Server) collectApplicableTools(cfg *Configuration) []api.ServerTool {
 		}
 	}
 	return tools
+}
+
+// filteringProviderWithConfig embeds FilteringProvider and exposes the live
+// ExtendedConfigProvider so target-compatibility filters can inspect toolset_configs.
+type filteringProviderWithConfig struct {
+	api.FilteringProvider
+	cfg api.ExtendedConfigProvider
+}
+
+func (f filteringProviderWithConfig) GetProviderConfig(strategy string) (api.ExtendedConfig, bool) {
+	if f.cfg == nil {
+		return nil, false
+	}
+	return f.cfg.GetProviderConfig(strategy)
+}
+
+func (f filteringProviderWithConfig) GetToolsetConfig(name string) (api.ExtendedConfig, bool) {
+	if f.cfg == nil {
+		return nil, false
+	}
+	return f.cfg.GetToolsetConfig(name)
 }
 
 // collectApplicablePrompts returns prompts after applying mutation and merging toolset and config prompts

--- a/pkg/mcp/toolsets_test.go
+++ b/pkg/mcp/toolsets_test.go
@@ -181,6 +181,52 @@ func (s *ToolsetsSuite) TestKubevirtToolsFilteredWithoutCRDs() {
 	})
 }
 
+func (s *ToolsetsSuite) TestKialiToolsFilteredWhenURLUnreachable() {
+	s.Run("Kiali tools are filtered out when configured URL fails /api/status probe", func() {
+		toolsetName := (&kiali.Toolset{}).GetName()
+		kubeConfig := s.Cfg.KubeConfig
+		cfg, err := configuration.ReadToml([]byte(`
+			toolsets = ["kiali"]
+			experimental_enable_target_compatibility_tool_filters = true
+			[toolset_configs.kiali]
+			url = "http://127.0.0.1:1"
+			insecure = true
+		`))
+		s.Require().NoError(err)
+		s.Cfg = cfg
+		s.Cfg.KubeConfig = kubeConfig
+		s.InitMcpClient()
+		tools, err := s.ListTools()
+		s.Run("ListTools returns tools", func() {
+			s.NotNil(tools, "Expected tools from ListTools")
+			s.NoError(err, "Expected no error from ListTools")
+		})
+		s.Run("kiali tools are not present", func() {
+			for _, tool := range tools.Tools {
+				for _, kialiTool := range s.kialiToolNames(toolsetName) {
+					s.Require().NotEqual(kialiTool, tool.Name, "Expected %s to not be present when Kiali URL is unreachable", kialiTool)
+				}
+			}
+		})
+	})
+}
+
+func (s *ToolsetsSuite) kialiToolNames(toolsetName string) []string {
+	return []string{
+		toolsetName + "_get_logs",
+		toolsetName + "_get_mesh_status",
+		toolsetName + "_get_mesh_traffic_graph",
+		toolsetName + "_get_metrics",
+		toolsetName + "_get_pod_performance",
+		toolsetName + "_get_resource_details",
+		toolsetName + "_get_trace_details",
+		toolsetName + "_list_mesh_clusters",
+		toolsetName + "_list_traces",
+		toolsetName + "_manage_istio_config",
+		toolsetName + "_manage_istio_config_read",
+	}
+}
+
 func (s *ToolsetsSuite) TestDefaultToolsetsToolsInMultiCluster() {
 	s.Run("Default configuration toolsets in multi-cluster (with 11 clusters)", func() {
 		kubeconfig := s.Kubeconfig()

--- a/pkg/toolsets/kiali/tools/all.go
+++ b/pkg/toolsets/kiali/tools/all.go
@@ -1,0 +1,24 @@
+package tools
+
+import (
+	"slices"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+)
+
+// All returns every Kiali tool. Reachability filtering is handled by the toolset.
+func All() []api.ServerTool {
+	return slices.Concat(
+		InitGetMeshTrafficGraph(),
+		InitGetMeshStatus(),
+		InitManageIstioConfigRead(),
+		InitManageIstioConfig(),
+		InitListMeshClusters(),
+		InitListOrGetResources(),
+		InitListTraces(),
+		InitGetTraceDetails(),
+		InitGetPodPerformance(),
+		InitGetLogs(),
+		InitGetMetrics(),
+	)
+}

--- a/pkg/toolsets/kiali/tools/get_mesh_status_test.go
+++ b/pkg/toolsets/kiali/tools/get_mesh_status_test.go
@@ -1,0 +1,29 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
+)
+
+type MeshStatusToolSuite struct {
+	suite.Suite
+}
+
+func (s *MeshStatusToolSuite) TestToolRegistration() {
+	s.Run("tool is registered with expected metadata", func() {
+		tools := InitGetMeshStatus()
+		s.Require().Len(tools, 1, "Expected 1 mesh status tool")
+		s.Equal(defaults.ToolsetName()+"_get_mesh_status", tools[0].Tool.Name)
+		s.Equal("Get Mesh Status", tools[0].Tool.Annotations.Title)
+		s.NotNil(tools[0].Tool.InputSchema)
+		s.NotNil(tools[0].Handler)
+		s.Empty(tools[0].TargetCompatibilityFilters, "Reachability filtering is handled by the toolset GetTools")
+	})
+}
+
+func TestMeshStatusToolSuite(t *testing.T) {
+	suite.Run(t, new(MeshStatusToolSuite))
+}

--- a/pkg/toolsets/kiali/toolset.go
+++ b/pkg/toolsets/kiali/toolset.go
@@ -1,16 +1,23 @@
 package kiali
 
 import (
+	"context"
 	"slices"
+	"sync"
 
 	"k8s.io/utils/ptr"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	kialiclient "github.com/containers/kubernetes-mcp-server/pkg/kiali"
+	"github.com/containers/kubernetes-mcp-server/pkg/klogutil"
+	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/internal/defaults"
 	kialiPrompts "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/prompts"
 	kialiTools "github.com/containers/kubernetes-mcp-server/pkg/toolsets/kiali/tools"
 )
+
+var warnKialiValidationDisabledOnce sync.Once
 
 type Toolset struct{}
 
@@ -24,26 +31,31 @@ func (t *Toolset) GetDescription() string {
 	return defaults.ToolsetDescription()
 }
 
-func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
-	tools := slices.Concat(
-		kialiTools.InitGetMeshTrafficGraph(),
-		kialiTools.InitGetMeshStatus(),
-		kialiTools.InitManageIstioConfigRead(),
-		kialiTools.InitManageIstioConfig(),
-		kialiTools.InitListMeshClusters(),
-		kialiTools.InitListOrGetResources(),
-		kialiTools.InitListTraces(),
-		kialiTools.InitGetTraceDetails(),
-		kialiTools.InitGetPodPerformance(),
-		kialiTools.InitGetLogs(),
-		kialiTools.InitGetMetrics(),
-	)
-	// Kiali calls a single configured endpoint; mesh scope is selected via meshCluster,
-	// not the provider-level context parameter injected for core Kubernetes tools.
+func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
+	if p != nil && !p.IsTargetCompatibilityToolFiltersEnabled() {
+		warnKialiValidationDisabledOnce.Do(func() {
+			klogutil.LogWarn(
+				klogutil.FromContext(context.Background()),
+				"experimental_enable_target_compatibility_tool_filters is disabled; Kiali URL reachability is not validated",
+			)
+		})
+	} else if p != nil && p.IsTargetCompatibilityToolFiltersEnabled() && !kialiAvailable(p) {
+		return nil
+	}
+
+	tools := kialiTools.All()
 	for i := range tools {
 		tools[i].ClusterAware = ptr.To(false)
 	}
 	return tools
+}
+
+func kialiAvailable(p api.FilteringProvider) bool {
+	var kp kubernetes.Provider
+	if provider, ok := p.(kubernetes.Provider); ok {
+		kp = provider
+	}
+	return kialiclient.HasKiali(context.Background(), p, kp)
 }
 
 func (t *Toolset) GetPrompts() []api.ServerPrompt {
@@ -60,7 +72,6 @@ func (t *Toolset) GetPrompts() []api.ServerPrompt {
 		kialiPrompts.InitTraceAnalysis(),
 		kialiPrompts.InitIstioConfigReview(),
 	)
-	// Same as tools: mesh scope is not selected via provider context.
 	for i := range prompts {
 		prompts[i].ClusterAware = ptr.To(false)
 	}


### PR DESCRIPTION
Split from: https://github.com/containers/kubernetes-mcp-server/pull/1339 

Filter Kiali tools by configured URL reachability

When experimental_enable_target_compatibility_tool_filters is enabled, probe GET {url}/api/status and hide the Kiali toolset when the configured URL is missing or unreachable. Expose live toolset config during tool collection so the check works with wrapped kubernetes providers.

When merged, rebase https://github.com/containers/kubernetes-mcp-server/pull/1339  