### PR TITLE
feat(kubevirt): redact inline cloud-init payloads from VM tool responses

### DIFF
--- a/pkg/toolsets/kubevirt/internal/redact/vm.go
+++ b/pkg/toolsets/kubevirt/internal/redact/vm.go
@@ -1,0 +1,41 @@
+package redact
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// VMCloudInitFields replaces inline cloud-init payloads in a VirtualMachine
+// object with "[REDACTED]". This prevents passwords, SSH keys, and other
+// credentials embedded in userData/networkData from appearing in LLM context
+// windows and audit logs. The object is modified in-place; the function is a
+// no-op for objects that have no cloud-init volumes.
+func VMCloudInitFields(vm *unstructured.Unstructured) {
+	if vm == nil {
+		return
+	}
+	volumes, found, err := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	if err != nil || !found {
+		return
+	}
+	changed := false
+	for i, vol := range volumes {
+		volMap, ok := vol.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, ciKey := range []string{"cloudInitNoCloud", "cloudInitConfigDrive"} {
+			ciData, ok := volMap[ciKey].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, field := range []string{"userData", "userDataBase64", "networkData", "networkDataBase64"} {
+				if _, has := ciData[field]; has {
+					ciData[field] = "[REDACTED]"
+					changed = true
+				}
+			}
+		}
+		volumes[i] = volMap
+	}
+	if changed {
+		_ = unstructured.SetNestedSlice(vm.Object, volumes, "spec", "template", "spec", "volumes")
+	}
+}

--- a/pkg/toolsets/kubevirt/internal/redact/vm_test.go
+++ b/pkg/toolsets/kubevirt/internal/redact/vm_test.go
@@ -1,0 +1,154 @@
+package redact
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func vmWithVolumes(volumes []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"volumes": volumes,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestVMCloudInitFields_NilVM(t *testing.T) {
+	// Should not panic
+	VMCloudInitFields(nil)
+}
+
+func TestVMCloudInitFields_NoVolumes(t *testing.T) {
+	vm := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	VMCloudInitFields(vm) // no-op, must not panic
+}
+
+func TestVMCloudInitFields_NoCloudInit(t *testing.T) {
+	vm := vmWithVolumes([]interface{}{
+		map[string]interface{}{
+			"name":                  "rootdisk",
+			"containerDisk":         map[string]interface{}{"image": "quay.io/containerdisks/fedora:latest"},
+		},
+	})
+	VMCloudInitFields(vm)
+	vols, _, _ := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	disk := vols[0].(map[string]interface{})
+	if disk["containerDisk"] == nil {
+		t.Fatal("containerDisk unexpectedly removed")
+	}
+}
+
+func TestVMCloudInitFields_CloudInitNoCloud_Plain(t *testing.T) {
+	vm := vmWithVolumes([]interface{}{
+		map[string]interface{}{
+			"name": "cloudinitdisk",
+			"cloudInitNoCloud": map[string]interface{}{
+				"userData":    "#cloud-config\npassword: secret\n",
+				"networkData": "version: 2\n",
+			},
+		},
+	})
+	VMCloudInitFields(vm)
+	vols, _, _ := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	ci := vols[0].(map[string]interface{})["cloudInitNoCloud"].(map[string]interface{})
+	if ci["userData"] != "[REDACTED]" {
+		t.Errorf("userData not redacted: %v", ci["userData"])
+	}
+	if ci["networkData"] != "[REDACTED]" {
+		t.Errorf("networkData not redacted: %v", ci["networkData"])
+	}
+}
+
+func TestVMCloudInitFields_CloudInitNoCloud_Base64(t *testing.T) {
+	vm := vmWithVolumes([]interface{}{
+		map[string]interface{}{
+			"name": "cloudinitdisk",
+			"cloudInitNoCloud": map[string]interface{}{
+				"userDataBase64":    "I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogc2VjcmV0Cg==",
+				"networkDataBase64": "dmVyc2lvbjogMgo=",
+			},
+		},
+	})
+	VMCloudInitFields(vm)
+	vols, _, _ := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	ci := vols[0].(map[string]interface{})["cloudInitNoCloud"].(map[string]interface{})
+	if ci["userDataBase64"] != "[REDACTED]" {
+		t.Errorf("userDataBase64 not redacted: %v", ci["userDataBase64"])
+	}
+	if ci["networkDataBase64"] != "[REDACTED]" {
+		t.Errorf("networkDataBase64 not redacted: %v", ci["networkDataBase64"])
+	}
+}
+
+func TestVMCloudInitFields_CloudInitConfigDrive(t *testing.T) {
+	vm := vmWithVolumes([]interface{}{
+		map[string]interface{}{
+			"name": "cloudinitdisk",
+			"cloudInitConfigDrive": map[string]interface{}{
+				"userData": "#cloud-config\nssh_authorized_keys:\n  - ssh-rsa AAAA...\n",
+			},
+		},
+	})
+	VMCloudInitFields(vm)
+	vols, _, _ := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	ci := vols[0].(map[string]interface{})["cloudInitConfigDrive"].(map[string]interface{})
+	if ci["userData"] != "[REDACTED]" {
+		t.Errorf("userData not redacted: %v", ci["userData"])
+	}
+}
+
+func TestVMCloudInitFields_PreservesOtherFields(t *testing.T) {
+	vm := vmWithVolumes([]interface{}{
+		map[string]interface{}{
+			"name": "cloudinitdisk",
+			"cloudInitNoCloud": map[string]interface{}{
+				"userData":          "#cloud-config\npassword: secret\n",
+				"userDataSecretRef": map[string]interface{}{"name": "my-secret"},
+			},
+		},
+	})
+	VMCloudInitFields(vm)
+	vols, _, _ := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	ci := vols[0].(map[string]interface{})["cloudInitNoCloud"].(map[string]interface{})
+	if ci["userData"] != "[REDACTED]" {
+		t.Errorf("userData not redacted: %v", ci["userData"])
+	}
+	// userDataSecretRef is a reference, not a payload — must be preserved
+	if ci["userDataSecretRef"] == nil {
+		t.Error("userDataSecretRef unexpectedly removed")
+	}
+}
+
+func TestVMCloudInitFields_MultipleVolumes(t *testing.T) {
+	vm := vmWithVolumes([]interface{}{
+		map[string]interface{}{
+			"name":          "rootdisk",
+			"containerDisk": map[string]interface{}{"image": "quay.io/containerdisks/fedora:latest"},
+		},
+		map[string]interface{}{
+			"name": "cloudinitdisk",
+			"cloudInitNoCloud": map[string]interface{}{
+				"userData": "#cloud-config\npassword: secret\n",
+			},
+		},
+	})
+	VMCloudInitFields(vm)
+	vols, _, _ := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	// First volume untouched
+	root := vols[0].(map[string]interface{})
+	if root["containerDisk"] == nil {
+		t.Error("containerDisk unexpectedly removed from rootdisk volume")
+	}
+	// Second volume redacted
+	ci := vols[1].(map[string]interface{})["cloudInitNoCloud"].(map[string]interface{})
+	if ci["userData"] != "[REDACTED]" {
+		t.Errorf("userData not redacted: %v", ci["userData"])
+	}
+}

--- a/pkg/toolsets/kubevirt/vm/create/tool.go
+++ b/pkg/toolsets/kubevirt/vm/create/tool.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/redact"
 	"github.com/google/jsonschema-go/jsonschema"
 	"k8s.io/utils/ptr"
 )
@@ -178,6 +179,11 @@ func create(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	resources, err := kubernetes.NewCore(params).ResourcesCreateOrUpdate(params, vmYaml)
 	if err != nil {
 		return api.NewToolCallResult("", fmt.Errorf("failed to create VirtualMachine: %w", err)), nil
+	}
+
+	// Scrub inline cloud-init payloads before the VM object enters LLM context.
+	for _, r := range resources {
+		redact.VMCloudInitFields(r)
 	}
 
 	// Format the output

--- a/pkg/toolsets/kubevirt/vm/lifecycle/tool.go
+++ b/pkg/toolsets/kubevirt/vm/lifecycle/tool.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/kubevirt"
 	"github.com/containers/kubernetes-mcp-server/pkg/output"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/defaults"
+	"github.com/containers/kubernetes-mcp-server/pkg/toolsets/kubevirt/internal/redact"
 	"github.com/google/jsonschema-go/jsonschema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
@@ -135,6 +136,9 @@ func lifecycle(params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	default:
 		return api.NewToolCallResult("", fmt.Errorf("invalid action '%s': must be one of 'start', 'stop', 'restart', 'pause', 'unpause'", action)), nil
 	}
+
+	// Scrub inline cloud-init payloads before the VM object enters LLM context.
+	redact.VMCloudInitFields(vm)
 
 	// Format the output
 	marshalledYaml, err := output.MarshalYaml([]*unstructured.Unstructured{vm})


### PR DESCRIPTION
## Summary

`vm_lifecycle` and `vm_create` return the full `VirtualMachine` YAML after acting on the cluster object. Any inline cloud-init data (`cloudInitNoCloud`/`cloudInitConfigDrive` `userData`, `userDataBase64`, `networkData`, `networkDataBase64`) would flow into LLM context windows and audit logs unchanged — passwords, SSH keys, and other credentials included.

- Add `pkg/toolsets/kubevirt/internal/redact` with `VMCloudInitFields()`, which replaces those payload fields with `[REDACTED]` in-place on the unstructured object before marshalling
- Wire it into `vm_lifecycle` (most critical — returns the live cluster VM object) and `vm_create` (defensive)
- Secret/ConfigMap references (`userDataSecretRef` etc.) are preserved as they contain no credential values
- The `vm_troubleshoot` tool's existing text-level cloud-init redaction is unaffected
- `vm_clone` returns a `VirtualMachineClone` object (source/target refs only, no VM spec) — no change needed

The `vm_troubleshoot` tool already applied its own `redactCloudInitSensitiveFields()` for the same reason; this change brings the other write tools into line with that precedent.

Relates to: https://redhat.atlassian.net/browse/OLS-3261

## Test plan

- [ ] `go test ./pkg/toolsets/kubevirt/internal/redact/...` — 8 unit tests covering nil VM, no volumes, no cloud-init, `cloudInitNoCloud` plain/base64, `cloudInitConfigDrive`, preservation of non-payload fields, and multiple volumes
- [ ] `go test ./pkg/toolsets/kubevirt/...` — full KubeVirt toolset suite passes
- [ ] Manually verify that a VM with inline `userData` returns `[REDACTED]` in place of the payload after a lifecycle action